### PR TITLE
feat(ci): per-PR agent bench on AgentCore Harness

### DIFF
--- a/.changeset/ci-pr-agent-bench.md
+++ b/.changeset/ci-pr-agent-bench.md
@@ -1,0 +1,9 @@
+---
+---
+
+ci: per-PR agent bench on Amazon Bedrock AgentCore Harness
+
+Internal CI tooling — no published-package changes. The bench runs
+`@aws-blocks/agent-bench` (a workspace marked `private: true`) on every
+pull request and grades each shipped template against the realtime-todos
+task with a builder + judge agent pair.

--- a/.github/workflows/pr-agent-bench.yml
+++ b/.github/workflows/pr-agent-bench.yml
@@ -1,0 +1,180 @@
+name: PR Agent Bench
+
+# Spawns an AgentCore Harness agent (Sonnet 4.6) per (template, task) cell.
+# The harness runs in AWS — the GitHub runner only orchestrates the calls and
+# uploads/downloads bytes to S3. No node/playwright installed on the runner;
+# everything happens inside the harness microVM.
+#
+# Non-blocking by design: this workflow is a signal generator, not a gate.
+# Same-repo PRs only — fork PRs can't access the OIDC role.
+
+on:
+  pull_request:
+    branches: ['*']
+  workflow_dispatch:
+
+concurrency:
+  group: agent-bench-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  NODE_OPTIONS: '--test-reporter=spec'
+
+jobs:
+  detect-changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    outputs:
+      run-bench: ${{ steps.check.outputs.run-bench }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+      - id: check
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "run-bench=true" >> "$GITHUB_OUTPUT"
+          elif git diff --name-only origin/main...HEAD | grep -qE '^(packages|tasks|scripts/agent-bench)/|^\.github/workflows/pr-agent-bench\.yml$'; then
+            echo "run-bench=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run-bench=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  preflight:
+    name: Preflight
+    needs: [detect-changes]
+    if: >-
+      needs.detect-changes.outputs.run-bench == 'true' &&
+      (github.event_name == 'workflow_dispatch' ||
+       github.event.pull_request.head.repo.full_name == github.repository)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    environment: publish
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+      - uses: actions/setup-node@v5
+        with:
+          node-version-file: '.nvmrc'
+          cache: npm
+      - run: npm ci
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: us-east-1
+      - name: Preflight checks
+        env:
+          BENCH_HARNESS_ARN: ${{ vars.BENCH_HARNESS_ARN }}
+          BENCH_TRANSPORT_BUCKET: ${{ vars.S3_BUCKET }}
+        run: npx tsx scripts/agent-bench/preflight.ts
+
+  bench:
+    name: Bench (${{ matrix.template }} / ${{ matrix.task }})
+    needs: [preflight]
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    environment: publish
+    strategy:
+      fail-fast: false
+      matrix:
+        # 7 of 8 shipped templates. `amplify` is an overlay applied to an
+        # existing Amplify Gen2 app, exercised separately by
+        # e2e-amplify-interop.yml.
+        include:
+          - { template: default, task: realtime-todos }
+          - { template: demo, task: realtime-todos }
+          - { template: bare, task: realtime-todos }
+          - { template: backend, task: realtime-todos }
+          - { template: react, task: realtime-todos }
+          - { template: nextjs, task: realtime-todos }
+          - { template: auth-cognito, task: realtime-todos }
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+      - uses: actions/setup-node@v5
+        with:
+          node-version-file: '.nvmrc'
+          cache: npm
+      - run: npm ci
+      - name: Build + pack to local registry
+        run: |
+          npm run build
+          npm run publish:dry-run
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: us-east-1
+      - name: Run bench
+        env:
+          BENCH_HARNESS_ARN: ${{ vars.BENCH_HARNESS_ARN }}
+          BENCH_TRANSPORT_BUCKET: ${{ vars.S3_BUCKET }}
+          AWS_REGION: us-east-1
+          PR_NUMBER: ${{ github.event.pull_request.number || '' }}
+          GITHUB_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          mkdir -p bench-results
+          OUT="bench-results/result-${{ matrix.template }}-${{ matrix.task }}.json"
+          npx tsx scripts/agent-bench/run-bench.ts \
+            --template ${{ matrix.template }} \
+            --task ${{ matrix.task }} \
+            --output "$OUT"
+      - name: Upload result (90-day artifact)
+        if: always()
+        uses: actions/upload-artifact@v5
+        with:
+          name: bench-result-${{ matrix.template }}-${{ matrix.task }}
+          path: bench-results/
+          retention-days: 90
+      - name: Persist to S3 (best-effort)
+        if: always() && vars.S3_BUCKET != ''
+        continue-on-error: true
+        env:
+          S3_BUCKET: ${{ vars.S3_BUCKET }}
+          PR_NUMBER: ${{ github.event.pull_request.number || 'manual' }}
+        run: |
+          DATE=$(date -u +%Y/%m/%d)
+          KEY="bench/${DATE}/pr-${PR_NUMBER}-run-${GITHUB_RUN_ID}-${{ matrix.template }}-${{ matrix.task }}.jsonl"
+          JSONL="bench-results/result-${{ matrix.template }}-${{ matrix.task }}.jsonl"
+          if [ -f "$JSONL" ]; then
+            aws s3 cp "$JSONL" "s3://${S3_BUCKET}/${KEY}" --content-type application/x-ndjson
+            echo "::notice::persisted to s3://${S3_BUCKET}/${KEY}"
+          fi
+
+  summarize:
+    name: Summarize
+    needs: [bench]
+    if: always() && needs.bench.result != 'skipped'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+      - uses: actions/setup-node@v5
+        with:
+          node-version-file: '.nvmrc'
+      - name: Download all bench results
+        uses: actions/download-artifact@v5
+        with:
+          pattern: bench-result-*
+          merge-multiple: true
+          path: bench-results/
+      - name: Render summary
+        run: |
+          if ls bench-results/result-*.json >/dev/null 2>&1; then
+            node scripts/agent-bench/summarize.mjs bench-results/ >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "## Agent Bench" >> "$GITHUB_STEP_SUMMARY"
+            echo "_No results to summarize._" >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/.github/workflows/pr-agent-bench.yml
+++ b/.github/workflows/pr-agent-bench.yml
@@ -10,7 +10,7 @@ name: PR Agent Bench
 
 on:
   pull_request:
-    branches: ['*']
+    branches: [main]
   workflow_dispatch:
 
 concurrency:

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,8 @@
         "test-apps/auth-cognito-passkeys",
         "test-apps/auth-cognito-passkeys/aws-blocks",
         "test-apps/pipeline",
-        "test-apps/db-pull-typecheck"
+        "test-apps/db-pull-typecheck",
+        "scripts/agent-bench"
       ],
       "devDependencies": {
         "@biomejs/biome": "2.4.16",
@@ -20542,6 +20543,10 @@
         "isarray": "^1.0.0"
       }
     },
+    "node_modules/@aws-blocks/agent-bench": {
+      "resolved": "scripts/agent-bench",
+      "link": true
+    },
     "node_modules/@aws-blocks/auth-common": {
       "resolved": "packages/auth-common",
       "link": true
@@ -21665,6 +21670,25 @@
         "tslib": "^2.6.2"
       }
     },
+    "node_modules/@aws-sdk/checksums": {
+      "version": "3.1000.6",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/checksums/-/checksums-3.1000.6.tgz",
+      "integrity": "sha512-RMCrCteiUwYTEv2G9zfP/BEuKHv57665vVieJyp9cf8VgilWxP/KrWVtMdfdDlIH8nFhvu3rIMc29z3ebGEZ1w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@aws-crypto/crc32c": "5.2.0",
+        "@aws-crypto/util": "5.2.0",
+        "@aws-sdk/core": "^3.974.21",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@aws-sdk/client-amplify": {
       "version": "3.1056.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-amplify/-/client-amplify-3.1056.0.tgz",
@@ -21811,22 +21835,44 @@
         "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-bedrock-agentcore-control": {
-      "version": "3.1052.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-agentcore-control/-/client-bedrock-agentcore-control-3.1052.0.tgz",
-      "integrity": "sha512-yAwWva7QYySYpQJELj7HftseusWnvobx3glmIghbgfB2X9CTYFKHyYpiVI7gB+qYpfhPrpwzMrchW7tDU+94Zg==",
+    "node_modules/@aws-sdk/client-bedrock-agentcore": {
+      "version": "3.1070.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-agentcore/-/client-bedrock-agentcore-3.1070.0.tgz",
+      "integrity": "sha512-ZX5f8BoZiuQXUPohNfLJtiB6ILZtqKRHGkyp68IEZa3BmhAfWOu5+hbD1APY0HbHvwEqlqjCmSuiaw0RH4gKlQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.13",
-        "@aws-sdk/credential-provider-node": "^3.972.44",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/fetch-http-handler": "^5.4.3",
-        "@smithy/node-http-handler": "^4.7.3",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "^3.974.21",
+        "@aws-sdk/credential-provider-node": "^3.972.56",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-bedrock-agentcore-control": {
+      "version": "3.1070.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-agentcore-control/-/client-bedrock-agentcore-control-3.1070.0.tgz",
+      "integrity": "sha512-2OAgiC5M+q7mrAPPtdWA252/5QOLd5U2BSRL633qZjfQ0a7CtPxMGYv4bnD1Un//A9hNANCKASQCIscieQdQug==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.21",
+        "@aws-sdk/credential-provider-node": "^3.972.56",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -22239,21 +22285,21 @@
       }
     },
     "node_modules/@aws-sdk/client-iam": {
-      "version": "3.1052.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-iam/-/client-iam-3.1052.0.tgz",
-      "integrity": "sha512-yKN5/a0kYQxRM6yweTXXKB5fLj2GVqSusSVeehkZPS/URp2NerumGOpVd2ncBTepWeQa4V10SLGJ98z5b4G1pw==",
+      "version": "3.1070.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-iam/-/client-iam-3.1070.0.tgz",
+      "integrity": "sha512-IC/S11y/e7bxwpgvieFQx4nMn/fsOjNj85n03PQfrQb52X/wC2/Ha25ZD3LOnP1DIWrfDcy3dltKkznbQz1Mfw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.13",
-        "@aws-sdk/credential-provider-node": "^3.972.44",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/fetch-http-handler": "^5.4.3",
-        "@smithy/node-http-handler": "^4.7.3",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "^3.974.21",
+        "@aws-sdk/credential-provider-node": "^3.972.56",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -22487,28 +22533,24 @@
       }
     },
     "node_modules/@aws-sdk/client-s3": {
-      "version": "3.1057.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1057.0.tgz",
-      "integrity": "sha512-4MV5+ph7WSLEqStKYdWf2EIHIvLpPzV8xN98jWSVJfUpp5j7T8dyN3AROPPsKWvCme8hbx1ybCjtK76ALCZUYg==",
+      "version": "3.1070.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1070.0.tgz",
+      "integrity": "sha512-B/OUiCqGQ4Zr7v9gFFyiuitKN2c0PIgvOlQb5bYg1SM2y0F8a5JQ7FNsjRcl+d2PqYWLHwHx12CvZDyLn4KxIw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha1-browser": "5.2.0",
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.15",
-        "@aws-sdk/credential-provider-node": "^3.972.47",
-        "@aws-sdk/middleware-bucket-endpoint": "^3.972.17",
-        "@aws-sdk/middleware-expect-continue": "^3.972.14",
-        "@aws-sdk/middleware-flexible-checksums": "^3.974.23",
-        "@aws-sdk/middleware-location-constraint": "^3.972.11",
-        "@aws-sdk/middleware-sdk-s3": "^3.972.44",
-        "@aws-sdk/middleware-ssec": "^3.972.11",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.30",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.5",
-        "@smithy/fetch-http-handler": "^5.4.5",
-        "@smithy/node-http-handler": "^4.7.5",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "^3.974.21",
+        "@aws-sdk/credential-provider-node": "^3.972.56",
+        "@aws-sdk/middleware-flexible-checksums": "^3.974.31",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.52",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.35",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -22713,22 +22755,22 @@
       }
     },
     "node_modules/@aws-sdk/client-sts": {
-      "version": "3.1052.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.1052.0.tgz",
-      "integrity": "sha512-3AWMsvWKi8ZvQU5EC/oBb6R5EKgjj715fK44ElZ/9l34tNuSubobb8IMMXkHE9nmo4qTv6Ca77hvaDIjK9qBBw==",
+      "version": "3.1070.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.1070.0.tgz",
+      "integrity": "sha512-uX3eD0OxYbaHqbN8aaSzZTrNJUctfCus2NLMVHUSONrzlJdA/w4o5ZAfJhgnTjlfdfRMv1lZd2Wnqm8hlzmwGA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.13",
-        "@aws-sdk/credential-provider-node": "^3.972.44",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.28",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/fetch-http-handler": "^5.4.3",
-        "@smithy/node-http-handler": "^4.7.3",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "^3.974.21",
+        "@aws-sdk/credential-provider-node": "^3.972.56",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.35",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -22736,31 +22778,18 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.974.20",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.20.tgz",
-      "integrity": "sha512-7sDi2B2N3mc3nf1nz6FyEx/FCrJ1N1QnBmraHHQNabFaeAh2IaOOLml48/rHOD1bICHgTRkbBgNTvUzEr5Z35g==",
+      "version": "3.974.21",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.21.tgz",
+      "integrity": "sha512-P5JAHvn4dTi96UsAGS67LVOqqpUNNRhnfFXqzCYtdBIGZtqBue4CXvRr9YenOO7PALj/Pn8uuyw53FBCiCYw8w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.12",
-        "@aws-sdk/xml-builder": "^3.972.29",
+        "@aws-sdk/types": "^3.973.13",
+        "@aws-sdk/xml-builder": "^3.972.30",
         "@aws/lambda-invoke-store": "^0.2.2",
         "@smithy/core": "^3.24.6",
         "@smithy/signature-v4": "^5.4.6",
         "@smithy/types": "^4.14.3",
         "bowser": "^2.11.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/crc64-nvme": {
-      "version": "3.972.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/crc64-nvme/-/crc64-nvme-3.972.9.tgz",
-      "integrity": "sha512-P+QGozmXn2mZZI7sDgk+aUm+RTI61MPSFB+Ir2vjEjEbEsE4e7hYtzrDvAUxZy9ko81h53e11+F/GYlvwDkaOQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -22785,13 +22814,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.46",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.46.tgz",
-      "integrity": "sha512-+GPXVS2srMOlH74S+SmC1gVuP2TvUZ0siuC0onKO93q+udP+M72dmY8wJfVQ5CX9z/9X5A1HHwz5yRIGBtskvQ==",
+      "version": "3.972.47",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.47.tgz",
+      "integrity": "sha512-3YoPwJczcc+MtX2xxXaYaOOWO6xKUJr1ZIIDIFuninr51BYONVVcF/CP8K2xfVRC/PztJjqKWxNGFH7BWQAw1Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.20",
-        "@aws-sdk/types": "^3.973.12",
+        "@aws-sdk/core": "^3.974.21",
+        "@aws-sdk/types": "^3.973.13",
         "@smithy/core": "^3.24.6",
         "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
@@ -22801,13 +22830,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.48",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.48.tgz",
-      "integrity": "sha512-fA5loSdlocacRxyUXtpoHSMuk5rsIKRDzQYVMnMxjcmFeZshaJlJ8lymy/hYKji6sne/UmNGj5pxuEs6kq/Qcg==",
+      "version": "3.972.49",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.49.tgz",
+      "integrity": "sha512-2UtGUPy+x3lqyceHrtC1uEuVxBZbDalPF6KAFqBwYgm4edWdBrZKNnCqzDs7KynWUvEC6mrR+ojRk+ZgQz9C2w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.20",
-        "@aws-sdk/types": "^3.973.12",
+        "@aws-sdk/core": "^3.974.21",
+        "@aws-sdk/types": "^3.973.13",
         "@smithy/core": "^3.24.6",
         "@smithy/fetch-http-handler": "^5.4.6",
         "@smithy/node-http-handler": "^4.7.6",
@@ -22819,20 +22848,20 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.972.53",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.53.tgz",
-      "integrity": "sha512-ZfdhIOR41q8TcWEnUac+gCOb+O2LBWdHLmjedXpXz4IEFW2ppNuFcm6p0sMTavpM+zD5TYfpH5Gp7guRyqSgsQ==",
+      "version": "3.972.54",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.54.tgz",
+      "integrity": "sha512-Hx4gO4YRjFwitf3MVl3cDwYe1aryJthC4txVl9b+JAURovA50M2ywf9r8j1E/Q6SCTPT4qQpjOAbKYIC9CG+Vw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.20",
-        "@aws-sdk/credential-provider-env": "^3.972.46",
-        "@aws-sdk/credential-provider-http": "^3.972.48",
-        "@aws-sdk/credential-provider-login": "^3.972.52",
-        "@aws-sdk/credential-provider-process": "^3.972.46",
-        "@aws-sdk/credential-provider-sso": "^3.972.52",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.52",
-        "@aws-sdk/nested-clients": "^3.997.20",
-        "@aws-sdk/types": "^3.973.12",
+        "@aws-sdk/core": "^3.974.21",
+        "@aws-sdk/credential-provider-env": "^3.972.47",
+        "@aws-sdk/credential-provider-http": "^3.972.49",
+        "@aws-sdk/credential-provider-login": "^3.972.53",
+        "@aws-sdk/credential-provider-process": "^3.972.47",
+        "@aws-sdk/credential-provider-sso": "^3.972.53",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.53",
+        "@aws-sdk/nested-clients": "^3.997.21",
+        "@aws-sdk/types": "^3.973.13",
         "@smithy/core": "^3.24.6",
         "@smithy/credential-provider-imds": "^4.3.7",
         "@smithy/types": "^4.14.3",
@@ -22843,14 +22872,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.52",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.52.tgz",
-      "integrity": "sha512-9hu2oR0qH7Fst5Tzdx+UWxm+w5zCXtErTLtOOW5hwwQc170CLwOeniRxyFY6s9mHfGEfC5zFukNBdKBwJR8mhQ==",
+      "version": "3.972.53",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.53.tgz",
+      "integrity": "sha512-+71sluhkgPqdhbbD3UDwUpj24GCkng9HQx6z7qoBFb8dwkF4ktpOcVKDeHpgg8PvBgLYwAnUYLTEGRC/PniCiQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.20",
-        "@aws-sdk/nested-clients": "^3.997.20",
-        "@aws-sdk/types": "^3.973.12",
+        "@aws-sdk/core": "^3.974.21",
+        "@aws-sdk/nested-clients": "^3.997.21",
+        "@aws-sdk/types": "^3.973.13",
         "@smithy/core": "^3.24.6",
         "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
@@ -22860,18 +22889,18 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.55",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.55.tgz",
-      "integrity": "sha512-zMGLa/dhESVqmCD7mmIFFKSwSFrJGScvCXcjvBZEVOOMauFS5JRQvLTMukFpMEFWiV6dTAlsen2ATDBulLPtbg==",
+      "version": "3.972.56",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.56.tgz",
+      "integrity": "sha512-iI+4o0dvQQ4NHel4FMDiFy5q2gaU/ryLK3niOsoPccAt9WLFRkV4XTYPWRr9XvmBUqEzXG73S4p/8gm0Lu/W3A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.46",
-        "@aws-sdk/credential-provider-http": "^3.972.48",
-        "@aws-sdk/credential-provider-ini": "^3.972.53",
-        "@aws-sdk/credential-provider-process": "^3.972.46",
-        "@aws-sdk/credential-provider-sso": "^3.972.52",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.52",
-        "@aws-sdk/types": "^3.973.12",
+        "@aws-sdk/credential-provider-env": "^3.972.47",
+        "@aws-sdk/credential-provider-http": "^3.972.49",
+        "@aws-sdk/credential-provider-ini": "^3.972.54",
+        "@aws-sdk/credential-provider-process": "^3.972.47",
+        "@aws-sdk/credential-provider-sso": "^3.972.53",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.53",
+        "@aws-sdk/types": "^3.973.13",
         "@smithy/core": "^3.24.6",
         "@smithy/credential-provider-imds": "^4.3.7",
         "@smithy/types": "^4.14.3",
@@ -22882,13 +22911,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.46",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.46.tgz",
-      "integrity": "sha512-VUoNFBIjWrUN8NbFiQiuxQEgFjvziAlBRPK+ddh27aj65gk0BYu6bLZnrdrNZwpW6vAihtSUtEMQ1PUJ32QRPA==",
+      "version": "3.972.47",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.47.tgz",
+      "integrity": "sha512-tAizPm9IFo/PHn06c+LQJlzfY2AGOlyF0CUljFejrU6LcZBjnk8pmbZK3/xoIDdnIzjEdbClfvY3mXfr818ZEg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.20",
-        "@aws-sdk/types": "^3.973.12",
+        "@aws-sdk/core": "^3.974.21",
+        "@aws-sdk/types": "^3.973.13",
         "@smithy/core": "^3.24.6",
         "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
@@ -22898,15 +22927,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.972.52",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.52.tgz",
-      "integrity": "sha512-nb2/n4o/HQf+FVpVbZe9vCTFngmuDoIsltMgLAtjixaKzvzhB4J8WSDFyWgnErgLHk55ctWH+I4PU+LIHhyffg==",
+      "version": "3.972.53",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.53.tgz",
+      "integrity": "sha512-pUXE3fu4tfEDV8BksIgf4dXvuIH10FhwHMl/wu8rBD5T1sMpryQWFVitH3kdPS90wlgrGYJQ/meQTSPacyZfeg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.20",
-        "@aws-sdk/nested-clients": "^3.997.20",
-        "@aws-sdk/token-providers": "3.1066.0",
-        "@aws-sdk/types": "^3.973.12",
+        "@aws-sdk/core": "^3.974.21",
+        "@aws-sdk/nested-clients": "^3.997.21",
+        "@aws-sdk/token-providers": "3.1069.0",
+        "@aws-sdk/types": "^3.973.13",
         "@smithy/core": "^3.24.6",
         "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
@@ -22916,14 +22945,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/token-providers": {
-      "version": "3.1066.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1066.0.tgz",
-      "integrity": "sha512-UqEUJq7dqa44hneLDUcX7UJy95cg8YqEWyakRpvIPnrNS3Mq+UlQHgCDGu5pvwAPtlIW4qcYbvW6reG6++FyvA==",
+      "version": "3.1069.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1069.0.tgz",
+      "integrity": "sha512-ks4X+kngC3PA5howV7Qu1TgG4bfC4jPykKdvw3nmBSXR9yZxRJouBholFSNQ5kY3L+Fgwyw+LCjzQmNi+KR91g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.20",
-        "@aws-sdk/nested-clients": "^3.997.20",
-        "@aws-sdk/types": "^3.973.12",
+        "@aws-sdk/core": "^3.974.21",
+        "@aws-sdk/nested-clients": "^3.997.21",
+        "@aws-sdk/types": "^3.973.13",
         "@smithy/core": "^3.24.6",
         "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
@@ -22933,14 +22962,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.52",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.52.tgz",
-      "integrity": "sha512-lKj6aRSGbqLmpYmM24bY7a1Xmfcq2vkE3hv8CSPYfc1yCu0BPu/XEJ1L4Fm61MsU6ULLNSG8UGsffNoFUBjESA==",
+      "version": "3.972.53",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.53.tgz",
+      "integrity": "sha512-JmMGlhVvSj8uSG9CpeDkJAXT35H89tc6v84iMgEIE75q4yp1MKVVKvopv6Gg28HJIR7hMNkojRF8H2m5W44wyg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.20",
-        "@aws-sdk/nested-clients": "^3.997.20",
-        "@aws-sdk/types": "^3.973.12",
+        "@aws-sdk/core": "^3.974.21",
+        "@aws-sdk/nested-clients": "^3.997.21",
+        "@aws-sdk/types": "^3.973.13",
         "@smithy/core": "^3.24.6",
         "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
@@ -23112,6 +23141,7 @@
       "version": "3.972.17",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.972.17.tgz",
       "integrity": "sha512-lbDmWuHenc+kiwCNrxz4MyN6nkxCWyTXPIWuspJN0ibziu+8CXci7vI1bK9MAkwy8cwJOEXNu0gBM5S0uTGRIg==",
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.974.15",
@@ -23159,6 +23189,7 @@
       "version": "3.972.14",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.972.14.tgz",
       "integrity": "sha512-3TNFEVGO4sWZj9TEXOCZLzGEctXHnaO4fk2EQ8KVaboTbwHmEPEQrm17Xb9koImUIXEw0sgi2xtHjg7LuTS3rA==",
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.973.9",
@@ -23171,19 +23202,12 @@
       }
     },
     "node_modules/@aws-sdk/middleware-flexible-checksums": {
-      "version": "3.974.23",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.974.23.tgz",
-      "integrity": "sha512-4nPKARo2lfKvQGUt2fPA5NlS/mEohckdxpuC9ecbjVfj7B7NFFYHeTg+Bf5BEQwdn3yRfUIzFiEkPp8Yuaw3wA==",
+      "version": "3.974.31",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.974.31.tgz",
+      "integrity": "sha512-Yzj6NRYVZdBaCp7o1BwHGyeDBfixdeToLIAMprshIITEdl9wKVSiidVOfeaiH8FyeC1hBmBfDZFvs/aH1Y3xpw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/crc32": "5.2.0",
-        "@aws-crypto/crc32c": "5.2.0",
-        "@aws-crypto/util": "5.2.0",
-        "@aws-sdk/core": "^3.974.15",
-        "@aws-sdk/crc64-nvme": "^3.972.9",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.5",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/checksums": "^3.1000.6",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -23207,6 +23231,7 @@
       "version": "3.972.11",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.972.11.tgz",
       "integrity": "sha512-hkfspNUP4criAH6ton6BGKgnm5dZx+7bUOy1YqlTfejDeUPAM23D81q/IX+hdlS3KUsfwGz5ADTqZWKBEUpf4A==",
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.973.9",
@@ -23295,16 +23320,16 @@
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-s3": {
-      "version": "3.972.44",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.44.tgz",
-      "integrity": "sha512-8HQsRg1NpX8vR4vNl1E8pyLnqZroq9VSL2vZQVSgBqp6wv6365LzYD08/c9FFh/9FTg7YRc7aTtEmXF0ir/pqg==",
+      "version": "3.972.52",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.52.tgz",
+      "integrity": "sha512-rerjP08onRqkBh0AcCqip6GkKvESapmLoTgi1xysZ4C6a1xMrIMtTBcEbUb6EY71oeajnigeUD4KwZjtIO+aWQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.15",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.30",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.5",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "^3.974.21",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.35",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -23330,6 +23355,7 @@
       "version": "3.972.11",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.972.11.tgz",
       "integrity": "sha512-7PQvGNhtveKlvVqNahqWx5yrwxP7ecwAoB1dYBf8eKwfo2tzzCbNnW+q2nO3N066ktQaB4iBQbDRWtizm+amoQ==",
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.973.9",
@@ -23372,16 +23398,16 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.997.20",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.20.tgz",
-      "integrity": "sha512-IYJuLpXp2DEILVQpQOy0PMpkftv0AHEOCn52o0atyOaumA0CdWQ3klPyXdViGYLbNpESsVFMVybvHUeZAuiGxA==",
+      "version": "3.997.21",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.21.tgz",
+      "integrity": "sha512-eC7Vl7Qom/BGhZjG9GEqPwdQ/fk45hg1t5LP4EUxG5d1fdshLbaxCiwh/tszUzDX/4mW40mu2QsbeJJRPBbqUw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.20",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.34",
-        "@aws-sdk/types": "^3.973.12",
+        "@aws-sdk/core": "^3.974.21",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.35",
+        "@aws-sdk/types": "^3.973.13",
         "@smithy/core": "^3.24.6",
         "@smithy/fetch-http-handler": "^5.4.6",
         "@smithy/node-http-handler": "^4.7.6",
@@ -23423,12 +23449,12 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.996.34",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.34.tgz",
-      "integrity": "sha512-mx1L5qlumSOt/nKM3BFaHE2HVkWwz0i4Bw0pyYO42FfX/FeLlo8YI6csC0gSPprEk6fTIqI+CZN9RwUwKd5krQ==",
+      "version": "3.996.35",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.35.tgz",
+      "integrity": "sha512-6L/VWs+Wch2stHemCGTmUNqKLMzURxQDK5boNG3Jn3kAOp71meDUuS5sbObpEvFxHDq0uWeSLFDNSYsjNt+Dlg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.12",
+        "@aws-sdk/types": "^3.973.13",
         "@smithy/signature-v4": "^5.4.6",
         "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
@@ -23455,9 +23481,9 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.973.12",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.12.tgz",
-      "integrity": "sha512-43ajd1NF0RMgX5k0hxCNUyEdrtFUsb2aHT2QvpktSC/2Eyb2Jr/JPVqdp0XIoaHWikZJq5tNWSLO6kB5q2eMCA==",
+      "version": "3.973.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.13.tgz",
+      "integrity": "sha512-pEHZqRkAlHfnfAU9tK+WpKv/gBNjGJrHMgA3A0iYRGyswBS2t0pfez+lWlwktb3Bqa0ovh7w/QJTFwp3fDxLNg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.14.3",
@@ -23546,9 +23572,9 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.29",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.29.tgz",
-      "integrity": "sha512-fk0niuGFxfi8yIJuMVM4mhwObkiQSuwZFj3tAPrLVx64Pk3BkrEIpqjzHKY4hKoEBUD6Jg/S74Zj9jy+5F3DnQ==",
+      "version": "3.972.30",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.30.tgz",
+      "integrity": "sha512-StElZPEoBquWwNqw1AcfpzEyZqJvFxouG+mpDNYlcH6ZOrqd2CuIryv+8LV8gNHZUOyKyJF3Dq9vxaXEmDR9TQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.14.3",
@@ -31778,13 +31804,13 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.24.6",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.6.tgz",
-      "integrity": "sha512-wBXDRup6UU97VKyaiRo8AssnfStPtG0oAAfpq/bC0a1YYau8pM86YB4kM6ccoVi1mS8l/UHbn9oDM+7uozr/ug==",
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.25.0.tgz",
+      "integrity": "sha512-TTD6el7tvKyafkXBf7XO3jLOE+qVxOTrLjp/fEGiV3BMfUHK/LfdYlQO9YgZvzxC7kqA3H/IhJXNqQgnbgjb7A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/crc32": "5.2.0",
-        "@smithy/types": "^4.14.3",
+        "@smithy/types": "^4.15.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -32019,13 +32045,13 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "4.7.7",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.7.tgz",
-      "integrity": "sha512-ZAFvHXrEk6K180EVhmZVg8GU5pUH5BSFqRs27JW3j1qEFx9YyYwWFx17x/MHcjALYimGAji7qEOlF1++be+G5A==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.8.0.tgz",
+      "integrity": "sha512-Mq7TNt/VhlEWiYRLQGpzUWeUxh899UGpjKh7Ru0WVIDIjnE+cTRAn0NYlFQ6bWfsQnKnpCbWJj86HzmcG0qEdg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.24.6",
-        "@smithy/types": "^4.14.3",
+        "@smithy/core": "^3.25.0",
+        "@smithy/types": "^4.15.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -32124,9 +32150,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.14.3",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.3.tgz",
-      "integrity": "sha512-YupL0ZWmFtJexUN2cHzkvvF/b9pKrtAIfT1o7/oY/Ppu8IYeZ+lDPM5vZdQJaSeA132dJCqojjGC9NhXeF71VQ==",
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.15.0.tgz",
+      "integrity": "sha512-Z5TAOxygoFvybJV3igo5SloFflSokHx2hu1eFA+DxDTcn+FtKxUSui+rbTRG1pAafMA888Z3MVvCWUuvCrTXjg==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -32789,6 +32815,13 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/js-yaml": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
+      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/jsesc": {
       "version": "2.5.1",
@@ -52911,6 +52944,20 @@
         "confbox": "^0.1.8",
         "mlly": "^1.7.4",
         "pathe": "^2.0.1"
+      }
+    },
+    "scripts/agent-bench": {
+      "name": "@aws-blocks/agent-bench",
+      "version": "0.0.0",
+      "devDependencies": {
+        "@aws-sdk/client-bedrock-agentcore": "^3.1070.0",
+        "@aws-sdk/client-s3": "^3.1070.0",
+        "@smithy/node-http-handler": "^4.8.0",
+        "@types/js-yaml": "^4.0.9",
+        "@types/node": "^20.0.0",
+        "js-yaml": "^4.2.0",
+        "tsx": "^4.7.0",
+        "typescript": "^5.3.0"
       }
     },
     "test-apps/amplify-gen2": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
     "test-apps/auth-cognito-passkeys",
     "test-apps/auth-cognito-passkeys/aws-blocks",
     "test-apps/pipeline",
-    "test-apps/db-pull-typecheck"
+    "test-apps/db-pull-typecheck",
+    "scripts/agent-bench"
   ],
   "scripts": {
     "prepare": "husky && bash scripts/setup-git-secrets.sh",
@@ -105,14 +106,14 @@
     "constructs": "^10.6.0",
     "esbuild": "^0.27.1",
     "husky": "^9.1.7",
+    "jiti": "^2.7.0",
     "kysely": "^0.28.17",
     "marked": "^18.0.0",
     "marked-highlight": "^2.2.3",
     "md-to-pdf": "^5.2.5",
     "tsx": "^4.7.0",
     "typescript": "^5.3.0",
-    "yaml": "^2.4.2",
-    "jiti": "^2.7.0"
+    "yaml": "^2.4.2"
   },
   "optionalDependencies": {
     "@rollup/rollup-linux-x64-gnu": "^4.60.3"

--- a/scripts/agent-bench/README.md
+++ b/scripts/agent-bench/README.md
@@ -33,7 +33,10 @@ GitHub Actions matrix              AgentCore Harness microVM (per cell)
 |------|---------|
 | `agentcore.ts` | Thin SDK wrappers: `exec`, `invokeAgent`, `putToTransport`, `sessionId`, `stopSession` |
 | `preflight.ts` | Idempotent pre-run probes (env, harness, exec, S3) |
-| `run-bench.ts` | Per-cell orchestrator |
+| `run-bench.ts` | Per-cell orchestrator (TS glue; all microVM work runs from `microvm/*.sh`) |
+| `microvm/bootstrap.sh` | Install Node 22, pull dist-registry from S3, start local registry server |
+| `microvm/setup-app.sh` | Scaffold bench-app from create-blocks-app, start dev server, detect port |
+| `microvm/capture-files.sh` | Tar agent's workspace and push to S3 for the runner to read back |
 | `summarize.mjs` | Renders `result-*.json` files into a markdown table for the GitHub step summary |
 | `package.json` | Workspace metadata + bench-only dev dependencies (`@aws-blocks/agent-bench`, `private: true`) |
 | `tsconfig.json` | TypeScript config for this directory |

--- a/scripts/agent-bench/README.md
+++ b/scripts/agent-bench/README.md
@@ -1,0 +1,88 @@
+# Agent Bench
+
+A non-blocking pull-request check that asks an LLM agent to implement a small
+feature against each shipped template, then grades the result with a second
+agent. Surfaces token counts, build/test outcomes, and a rubric score per
+(template, task) on every pull request.
+
+## Architecture
+
+```
+GitHub Actions matrix              AgentCore Harness microVM (per cell)
+┌──────────────────────┐           ┌────────────────────────────────────┐
+│ runner               │           │ Amazon Linux 2023, Node 22         │
+│ ─ build local       │  S3       │ ─ scaffold via create-blocks-app  │
+│   registry           │  ────────▶│ ─ npm install                     │
+│ ─ orchestrator (TS) │  put/get │ ─ builder agent (shell + files)   │
+│   in run-bench.ts    │           │ ─ npm run build                   │
+│ ─ pull result back  │  ◀──────  │ ─ Playwright (chromium)           │
+│ ─ emit envelope     │  S3       │ ─ judge agent (read-only files)   │
+└──────────────────────┘           └────────────────────────────────────┘
+```
+
+* **Bedrock AgentCore Harness** runs each agent turn in its own Firecracker
+  microVM with built-in shell + file tools.
+* **GitHub Actions matrix** owns the per-cell parallelism (one runner per
+  template).
+* **S3** carries bytes between the runner and the microVM (the dist-registry
+  tarball, the Playwright spec, the agent's written workspace).
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `agentcore.ts` | Thin SDK wrappers: `exec`, `invokeAgent`, `putToTransport`, `sessionId`, `stopSession` |
+| `preflight.ts` | Idempotent pre-run probes (env, harness, exec, S3) |
+| `run-bench.ts` | Per-cell orchestrator |
+| `summarize.mjs` | Renders `result-*.json` files into a markdown table for the GitHub step summary |
+| `package.json` | Workspace metadata + bench-only dev dependencies (`@aws-blocks/agent-bench`, `private: true`) |
+| `tsconfig.json` | TypeScript config for this directory |
+
+This directory is registered as an npm workspace (`scripts/agent-bench`) with
+`private: true`, so its dependencies are scoped to the bench and never
+published.
+
+## Required configuration
+
+The workflow expects three values to be set in the `publish` GitHub
+environment for this repository:
+
+| Name | Type | Description |
+|------|------|-------------|
+| `AWS_ROLE_ARN` | secret | OIDC role with `bedrock-agentcore:Invoke*` on the harness ARN, plus `s3:PutObject` on the registry bucket's `bench-uploads/*` and `bench/*` prefixes |
+| `S3_BUCKET` | variable | Registry bucket name (existing) |
+| `BENCH_HARNESS_ARN` | variable | ARN of a pre-created AgentCore Harness named `blocks_bench` |
+
+Provisioning the harness, the harness execution role, and the IAM updates on
+the OIDC role is out-of-scope for this repository. The workflow runs only
+when these values resolve; preflight surfaces missing or misconfigured values
+with a clear error before the bench starts.
+
+## Adding a task
+
+A task is a directory under `tasks/` containing:
+
+```
+tasks/<task-id>/
+  config.yaml      id, name, tier, test_file, time_limit_sec, token_budget
+  PROMPT.md        natural-language description the builder agent reads
+  test.spec.ts     Playwright spec graded against the running app
+```
+
+Add the new `(template, task)` pairing to the matrix in
+`.github/workflows/pr-agent-bench.yml`.
+
+## Local development
+
+`run-bench.ts` runs locally given the same three configuration values. The
+workspace exposes scripts you can run from the repo root or from this directory:
+
+```bash
+# from the repo root
+npm run preflight  --workspace=@aws-blocks/agent-bench
+npm run bench      --workspace=@aws-blocks/agent-bench -- \
+  --template default --task realtime-todos --output result.json
+npm run typecheck  --workspace=@aws-blocks/agent-bench
+```
+
+See the source for the exact environment variables expected.

--- a/scripts/agent-bench/agentcore.ts
+++ b/scripts/agent-bench/agentcore.ts
@@ -1,0 +1,196 @@
+/**
+ * Thin async helpers around the two AgentCore Harness streaming operations
+ * and the S3 transport we use to move bytes between runner and microVM.
+ *
+ * Three primitives, one per concern:
+ *   exec(...)              shell command in the harness microVM → {stdout, stderr, exit}
+ *   invokeAgent(...)       agent turn with system prompt + user text → {text, tokens, stop}
+ *   putToTransport(...)    upload bytes to S3 under bench-uploads/* → returns the s3:// URI
+ *
+ * Nothing else in the bench should reach into the SDK directly.
+ */
+import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
+import {
+	BedrockAgentCoreClient,
+	InvokeAgentRuntimeCommandCommand,
+	InvokeHarnessCommand,
+	StopRuntimeSessionCommand,
+	type InvokeHarnessCommandInput,
+} from '@aws-sdk/client-bedrock-agentcore';
+import { NodeHttpHandler } from '@smithy/node-http-handler';
+
+export const REGION = process.env.AWS_REGION ?? 'us-east-1';
+
+// Default SDK read timeout is ~60s, which kills the stream during long-running
+// exec commands (npm install, dnf install, playwright install). The agent
+// itself can run for minutes too. Lift the per-request ceiling to 10min;
+// individual exec calls still cap themselves via the `timeout` field in body.
+const requestHandler = new NodeHttpHandler({
+	requestTimeout: 600_000,
+	connectionTimeout: 10_000,
+});
+
+const agentcore = new BedrockAgentCoreClient({ region: REGION, requestHandler });
+const s3 = new S3Client({ region: REGION, requestHandler });
+
+export interface ExecResult {
+	stdout: string;
+	stderr: string;
+	exitCode: number;
+}
+
+export interface AgentResult {
+	text: string;
+	tokensIn: number;
+	tokensOut: number;
+	stopReason: string;
+	cacheReadTokens: number;
+}
+
+/**
+ * Run a shell command inside the harness microVM. Streams stdout/stderr through
+ * the response stream; this helper collects both and returns once the command
+ * has stopped (`contentStop` event).
+ *
+ * `timeoutSec` is the in-microVM wall-clock cap. The SDK request itself uses
+ * the 10-minute timeout configured on the client.
+ */
+export async function exec(
+	harnessArn: string,
+	sessionId: string,
+	command: string,
+	timeoutSec = 300,
+): Promise<ExecResult> {
+	const resp = await agentcore.send(
+		new InvokeAgentRuntimeCommandCommand({
+			agentRuntimeArn: harnessArn,
+			runtimeSessionId: sessionId,
+			body: { command, timeout: timeoutSec },
+		}),
+	);
+	let stdout = '';
+	let stderr = '';
+	let exitCode = 0;
+	for await (const event of resp.stream ?? []) {
+		const chunk = event.chunk;
+		if (!chunk) continue;
+		if (chunk.contentDelta?.stdout) stdout += chunk.contentDelta.stdout;
+		if (chunk.contentDelta?.stderr) stderr += chunk.contentDelta.stderr;
+		if (chunk.contentStop?.exitCode != null) exitCode = chunk.contentStop.exitCode;
+	}
+	return { stdout, stderr, exitCode };
+}
+
+export interface InvokeOptions {
+	systemPrompt: string;
+	userText: string;
+	modelId?: string;
+	allowedTools?: string[];
+	tools?: InvokeHarnessCommandInput['tools'];
+}
+
+/**
+ * Invoke the harness agent for a single turn. Returns the final assistant text,
+ * cumulative token usage, and stop reason.
+ *
+ * - `systemPrompt`/`userText` are plain strings; this fn handles the SDK shape.
+ * - Omit `tools` and `allowedTools` to let the agent use all built-ins (shell +
+ *   file_operations against the microVM).
+ * - `allowedTools: ['file_operations']` removes shell access; file_operations
+ *   itself is monolithic (view + create + edit). For a true read-only judge,
+ *   `chmod -R a-w` the target directory before invoking and let the OS reject
+ *   writes.
+ * - `allowedTools: []` disables every built-in tool (pure text response).
+ */
+export async function invokeAgent(
+	harnessArn: string,
+	sessionId: string,
+	opts: InvokeOptions,
+): Promise<AgentResult> {
+	const resp = await agentcore.send(
+		new InvokeHarnessCommand({
+			harnessArn,
+			runtimeSessionId: sessionId,
+			model: { bedrockModelConfig: { modelId: opts.modelId ?? 'us.anthropic.claude-sonnet-4-6' } },
+			systemPrompt: [{ text: opts.systemPrompt }],
+			messages: [{ role: 'user', content: [{ text: opts.userText }] }],
+			...(opts.tools !== undefined ? { tools: opts.tools } : {}),
+			...(opts.allowedTools !== undefined ? { allowedTools: opts.allowedTools } : {}),
+		}),
+	);
+	let text = '';
+	let tokensIn = 0;
+	let tokensOut = 0;
+	let cacheReadTokens = 0;
+	let stopReason = '';
+	for await (const event of resp.stream ?? []) {
+		if (event.contentBlockDelta?.delta?.text) text += event.contentBlockDelta.delta.text;
+		if (event.messageStop?.stopReason) stopReason = event.messageStop.stopReason;
+		if (event.metadata?.usage) {
+			tokensIn += event.metadata.usage.inputTokens ?? 0;
+			tokensOut += event.metadata.usage.outputTokens ?? 0;
+			cacheReadTokens += event.metadata.usage.cacheReadInputTokens ?? 0;
+		}
+		if (event.runtimeClientError) {
+			throw new Error(`harness error: ${event.runtimeClientError.message}`);
+		}
+	}
+	return { text, tokensIn, tokensOut, stopReason, cacheReadTokens };
+}
+
+/**
+ * Terminate a session promptly so the microVM is reclaimed. Without this, the
+ * session sits warm until idleRuntimeSessionTimeout (configured per-harness;
+ * default 900s). At ~150 cells/PR that's a real load on the per-account
+ * 1,000-active-session quota.
+ *
+ * Best-effort — never throws. The orchestrator calls this in finally{}, and a
+ * failed stop just lets the idle timer take over.
+ */
+export async function stopSession(harnessArn: string, sid: string): Promise<void> {
+	try {
+		await agentcore.send(
+			new StopRuntimeSessionCommand({
+				agentRuntimeArn: harnessArn,
+				runtimeSessionId: sid,
+			}),
+		);
+	} catch (err) {
+		process.stderr.write(`[stopSession] non-fatal: ${(err as Error).message}\n`);
+	}
+}
+
+/**
+ * Build a runtime session ID that satisfies the API's >=33 char requirement.
+ * The deterministic prefix is helpful when reading logs.
+ */
+export function sessionId(prefix: string): string {
+	const padded = `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+	return padded.padEnd(33, 'x').slice(0, 64);
+}
+
+/**
+ * Upload a buffer (or text body) to S3 under `bench-uploads/<runId>/<cellId>/<name>`
+ * and return the s3:// URI. The microVM's exec role has `s3:GetObject` on this
+ * prefix; the runner has `s3:PutObject`. Pair this with a single `aws s3 cp`
+ * inside the microVM rather than streaming bytes through shell commands.
+ */
+export async function putToTransport(args: {
+	bucket: string;
+	runId: string;
+	cellId: string;
+	name: string;
+	body: Buffer | string;
+	contentType?: string;
+}): Promise<string> {
+	const key = `bench-uploads/${args.runId}/${args.cellId}/${args.name}`;
+	await s3.send(
+		new PutObjectCommand({
+			Bucket: args.bucket,
+			Key: key,
+			Body: args.body,
+			ContentType: args.contentType ?? 'application/octet-stream',
+		}),
+	);
+	return `s3://${args.bucket}/${key}`;
+}

--- a/scripts/agent-bench/agentcore.ts
+++ b/scripts/agent-bench/agentcore.ts
@@ -1,13 +1,11 @@
 /**
- * Thin async helpers around the two AgentCore Harness streaming operations
- * and the S3 transport we use to move bytes between runner and microVM.
+ * Thin async wrappers around AgentCore Harness streaming + S3 transport.
  *
- * Three primitives, one per concern:
- *   exec(...)              shell command in the harness microVM → {stdout, stderr, exit}
- *   invokeAgent(...)       agent turn with system prompt + user text → {text, tokens, stop}
- *   putToTransport(...)    upload bytes to S3 under bench-uploads/* → returns the s3:// URI
- *
- * Nothing else in the bench should reach into the SDK directly.
+ *   exec              — shell command in the harness microVM
+ *   invokeAgent       — agent turn (handles inline tool_use loop internally)
+ *   putToTransport    — S3 upload under bench-uploads/<runId>/<cellId>/
+ *   sessionId         — runtime session ID with the API's >=33 char shape
+ *   stopSession       — best-effort cleanup
  */
 import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
 import {
@@ -21,17 +19,43 @@ import { NodeHttpHandler } from '@smithy/node-http-handler';
 
 export const REGION = process.env.AWS_REGION ?? 'us-east-1';
 
-// Default SDK read timeout is ~60s, which kills the stream during long-running
-// exec commands (npm install, dnf install, playwright install). The agent
-// itself can run for minutes too. Lift the per-request ceiling to 10min;
-// individual exec calls still cap themselves via the `timeout` field in body.
-const requestHandler = new NodeHttpHandler({
-	requestTimeout: 600_000,
-	connectionTimeout: 10_000,
-});
-
+// SDK default read timeout is ~60s, which kills long exec streams (npm install,
+// playwright install) and multi-minute agent turns. 10min ceiling.
+const requestHandler = new NodeHttpHandler({ requestTimeout: 600_000, connectionTimeout: 10_000 });
 const agentcore = new BedrockAgentCoreClient({ region: REGION, requestHandler });
 const s3 = new S3Client({ region: REGION, requestHandler });
+
+// 3 attempts catches blip-style HTML responses from the harness; sustained
+// outages surface honestly as cell errors. Don't retry 4xx (config bugs).
+const MAX_RETRY_ATTEMPTS = 3;
+
+async function withRetry<T>(label: string, fn: () => Promise<T>): Promise<T> {
+	let lastErr: unknown;
+	for (let attempt = 0; attempt < MAX_RETRY_ATTEMPTS; attempt++) {
+		try {
+			return await fn();
+		} catch (err) {
+			lastErr = err;
+			const e = err as { name?: string; message?: string; $metadata?: { httpStatusCode?: number } };
+			const status = e.$metadata?.httpStatusCode;
+			const message = e.message ?? '';
+			const transient =
+				message.includes('Unexpected token') ||
+				message.includes('Deserialization error') ||
+				e.name === 'ThrottlingException' ||
+				e.name === 'ServiceUnavailableException' ||
+				e.name === 'InternalServerException' ||
+				(status != null && status >= 500);
+			if (!transient || attempt === MAX_RETRY_ATTEMPTS - 1) throw err;
+			const delayMs = 2_000 * 2 ** attempt + Math.floor(Math.random() * 500);
+			process.stderr.write(
+				`[${label}] transient error (attempt ${attempt + 1}/${MAX_RETRY_ATTEMPTS}): ${e.name ?? ''} ${message.slice(0, 120)} — retrying in ${delayMs}ms\n`,
+			);
+			await new Promise((r) => setTimeout(r, delayMs));
+		}
+	}
+	throw lastErr;
+}
 
 export interface ExecResult {
 	stdout: string;
@@ -47,38 +71,32 @@ export interface AgentResult {
 	cacheReadTokens: number;
 }
 
-/**
- * Run a shell command inside the harness microVM. Streams stdout/stderr through
- * the response stream; this helper collects both and returns once the command
- * has stopped (`contentStop` event).
- *
- * `timeoutSec` is the in-microVM wall-clock cap. The SDK request itself uses
- * the 10-minute timeout configured on the client.
- */
 export async function exec(
 	harnessArn: string,
 	sessionId: string,
 	command: string,
 	timeoutSec = 300,
 ): Promise<ExecResult> {
-	const resp = await agentcore.send(
-		new InvokeAgentRuntimeCommandCommand({
-			agentRuntimeArn: harnessArn,
-			runtimeSessionId: sessionId,
-			body: { command, timeout: timeoutSec },
-		}),
-	);
-	let stdout = '';
-	let stderr = '';
-	let exitCode = 0;
-	for await (const event of resp.stream ?? []) {
-		const chunk = event.chunk;
-		if (!chunk) continue;
-		if (chunk.contentDelta?.stdout) stdout += chunk.contentDelta.stdout;
-		if (chunk.contentDelta?.stderr) stderr += chunk.contentDelta.stderr;
-		if (chunk.contentStop?.exitCode != null) exitCode = chunk.contentStop.exitCode;
-	}
-	return { stdout, stderr, exitCode };
+	return withRetry('exec', async () => {
+		const resp = await agentcore.send(
+			new InvokeAgentRuntimeCommandCommand({
+				agentRuntimeArn: harnessArn,
+				runtimeSessionId: sessionId,
+				body: { command, timeout: timeoutSec },
+			}),
+		);
+		let stdout = '';
+		let stderr = '';
+		let exitCode = 0;
+		for await (const event of resp.stream ?? []) {
+			const chunk = event.chunk;
+			if (!chunk) continue;
+			if (chunk.contentDelta?.stdout) stdout += chunk.contentDelta.stdout;
+			if (chunk.contentDelta?.stderr) stderr += chunk.contentDelta.stderr;
+			if (chunk.contentStop?.exitCode != null) exitCode = chunk.contentStop.exitCode;
+		}
+		return { stdout, stderr, exitCode };
+	});
 }
 
 export interface InvokeOptions {
@@ -87,35 +105,157 @@ export interface InvokeOptions {
 	modelId?: string;
 	allowedTools?: string[];
 	tools?: InvokeHarnessCommandInput['tools'];
+	// Cap the agent loop. The harness has its own default; setting this
+	// explicitly per-call is an Anthropic-recommended stopping condition for
+	// long-running tasks. 200 is plenty for our task shape (typical builder run
+	// uses ~30-60 iterations).
+	maxIterations?: number;
+	// Per-iteration token cap. Useful for the judge: a 4K cap forces concise
+	// JSON output and surfaces malformed responses as max_tokens fast instead
+	// of waiting for streaming to finish.
+	maxTokens?: number;
+	// Wall-clock cap on the agent loop in seconds. The orchestrator's own
+	// timeout is the SDK request timeout (10min); this is a softer agent-side
+	// cap so the harness can stop cleanly.
+	timeoutSeconds?: number;
 }
 
-/**
- * Invoke the harness agent for a single turn. Returns the final assistant text,
- * cumulative token usage, and stop reason.
- *
- * - `systemPrompt`/`userText` are plain strings; this fn handles the SDK shape.
- * - Omit `tools` and `allowedTools` to let the agent use all built-ins (shell +
- *   file_operations against the microVM).
- * - `allowedTools: ['file_operations']` removes shell access; file_operations
- *   itself is monolithic (view + create + edit). For a true read-only judge,
- *   `chmod -R a-w` the target directory before invoking and let the OS reject
- *   writes.
- * - `allowedTools: []` disables every built-in tool (pure text response).
- */
-export async function invokeAgent(
+// HarnessStopReason enum (from @aws-sdk/client-bedrock-agentcore):
+//   end_turn, max_iterations_exceeded, max_output_tokens_exceeded, max_tokens,
+//   model_context_window_exceeded, timeout_exceeded, content_filtered,
+//   stop_sequence, interrupted, partial_turn, tool_use, tool_result,
+//   malformed_model_output, malformed_tool_use
+//
+// We declare zero inline tools — the agent's toolset is shell + file_operations
+// only. The harness can still surface tool_use, malformed_tool_use, or
+// partial_turn back to the client; we recover by replying with a brief
+// guidance message and reinvoking. Up to 5 recovery turns.
+const MAX_RECOVERY_TURNS = 5;
+
+const RECOVERABLE_STOP_REASONS = new Set([
+	'tool_use', // inline tool surfaced (model hallucinated tool name or harness leak)
+	'malformed_tool_use', // tool input wasn't parseable JSON
+	'partial_turn', // turn cut short before end_turn — re-prompt to continue
+	'malformed_model_output', // streaming output couldn't be parsed
+]);
+
+interface ToolUseFragment {
+	toolUseId: string;
+	name: string;
+	input: string;
+}
+
+interface ContentBlock {
+	text?: string;
+	toolUse?: { toolUseId: string; name: string; input: unknown };
+	toolResult?: { toolUseId: string; content: { text: string }[]; status: 'success' | 'error' };
+}
+
+interface AgentMessage {
+	role: 'user' | 'assistant';
+	content: ContentBlock[];
+}
+
+export async function invokeAgent(harnessArn: string, sessionId: string, opts: InvokeOptions): Promise<AgentResult> {
+	let messages: AgentMessage[] = [{ role: 'user', content: [{ text: opts.userText }] }];
+	let aggText = '';
+	let tokensIn = 0;
+	let tokensOut = 0;
+	let cacheReadTokens = 0;
+	let stopReason = '';
+
+	for (let turn = 0; turn < MAX_RECOVERY_TURNS; turn++) {
+		const r = await withRetry('invokeAgent', () => singleTurn(harnessArn, sessionId, opts, messages));
+		aggText += r.text;
+		tokensIn += r.tokensIn;
+		tokensOut += r.tokensOut;
+		cacheReadTokens += r.cacheReadTokens;
+		stopReason = r.stopReason;
+
+		const recoverable = RECOVERABLE_STOP_REASONS.has(stopReason);
+		if (!recoverable || turn === MAX_RECOVERY_TURNS - 1) break;
+
+		// Build the recovery message based on which stop reason we hit.
+		if ((stopReason === 'tool_use' || stopReason === 'malformed_tool_use') && r.toolUses.length > 0) {
+			const guidance =
+				stopReason === 'malformed_tool_use'
+					? 'Your last tool call had malformed input (not valid JSON). Re-emit it with proper JSON, or use shell/file_operations directly.'
+					: `No inline tool named "${r.toolUses.map((t) => t.name).join(',')}" is declared. Use the built-in shell or file_operations tools, or finish with end_turn.`;
+			messages = [
+				{
+					role: 'assistant',
+					content: r.toolUses.map((tu) => ({
+						toolUse: { toolUseId: tu.toolUseId, name: tu.name, input: safeJson(tu.input) },
+					})),
+				},
+				{
+					role: 'user',
+					content: r.toolUses.map((tu) => ({
+						toolResult: {
+							toolUseId: tu.toolUseId,
+							content: [{ text: guidance }],
+							status: 'error' as const,
+						},
+					})),
+				},
+			];
+		} else {
+			// partial_turn or malformed_model_output — re-prompt with a nudge to
+			// continue. No assistant toolUse to echo back.
+			messages = [
+				{
+					role: 'user',
+					content: [
+						{
+							text: `Your previous turn ended with stop_reason=${stopReason} before completing. Continue from where you left off. If your work is done, run \`npm run build\` to confirm it passes and end with end_turn.`,
+						},
+					],
+				},
+			];
+		}
+		process.stderr.write(
+			`[invokeAgent] recoverable stop_reason=${stopReason} — re-prompting (turn ${turn + 1}/${MAX_RECOVERY_TURNS})\n`,
+		);
+	}
+
+	return { text: aggText, tokensIn, tokensOut, stopReason, cacheReadTokens };
+}
+
+function safeJson(s: string): unknown {
+	try {
+		return JSON.parse(s);
+	} catch {
+		return {};
+	}
+}
+
+interface SingleTurnResult {
+	text: string;
+	tokensIn: number;
+	tokensOut: number;
+	cacheReadTokens: number;
+	stopReason: string;
+	toolUses: ToolUseFragment[];
+}
+
+async function singleTurn(
 	harnessArn: string,
 	sessionId: string,
 	opts: InvokeOptions,
-): Promise<AgentResult> {
+	messages: AgentMessage[],
+): Promise<SingleTurnResult> {
 	const resp = await agentcore.send(
 		new InvokeHarnessCommand({
 			harnessArn,
 			runtimeSessionId: sessionId,
 			model: { bedrockModelConfig: { modelId: opts.modelId ?? 'us.anthropic.claude-sonnet-4-6' } },
 			systemPrompt: [{ text: opts.systemPrompt }],
-			messages: [{ role: 'user', content: [{ text: opts.userText }] }],
+			messages: messages as unknown as InvokeHarnessCommandInput['messages'],
 			...(opts.tools !== undefined ? { tools: opts.tools } : {}),
 			...(opts.allowedTools !== undefined ? { allowedTools: opts.allowedTools } : {}),
+			...(opts.maxIterations !== undefined ? { maxIterations: opts.maxIterations } : {}),
+			...(opts.maxTokens !== undefined ? { maxTokens: opts.maxTokens } : {}),
+			...(opts.timeoutSeconds !== undefined ? { timeoutSeconds: opts.timeoutSeconds } : {}),
 		}),
 	);
 	let text = '';
@@ -123,58 +263,44 @@ export async function invokeAgent(
 	let tokensOut = 0;
 	let cacheReadTokens = 0;
 	let stopReason = '';
+	const toolUses: ToolUseFragment[] = [];
+	let activeToolIndex = -1;
 	for await (const event of resp.stream ?? []) {
+		const start = event.contentBlockStart?.start as
+			| { toolUse?: { toolUseId?: string; name?: string } }
+			| undefined;
+		if (start?.toolUse?.toolUseId && start.toolUse.name) {
+			toolUses.push({ toolUseId: start.toolUse.toolUseId, name: start.toolUse.name, input: '' });
+			activeToolIndex = toolUses.length - 1;
+		}
 		if (event.contentBlockDelta?.delta?.text) text += event.contentBlockDelta.delta.text;
+		const toolDelta = (event.contentBlockDelta?.delta as { toolUse?: { input?: string } } | undefined)?.toolUse;
+		if (toolDelta?.input != null && activeToolIndex >= 0) toolUses[activeToolIndex].input += toolDelta.input;
+		if (event.contentBlockStop) activeToolIndex = -1;
 		if (event.messageStop?.stopReason) stopReason = event.messageStop.stopReason;
 		if (event.metadata?.usage) {
 			tokensIn += event.metadata.usage.inputTokens ?? 0;
 			tokensOut += event.metadata.usage.outputTokens ?? 0;
 			cacheReadTokens += event.metadata.usage.cacheReadInputTokens ?? 0;
 		}
-		if (event.runtimeClientError) {
-			throw new Error(`harness error: ${event.runtimeClientError.message}`);
-		}
+		if (event.runtimeClientError) throw new Error(`harness error: ${event.runtimeClientError.message}`);
 	}
-	return { text, tokensIn, tokensOut, stopReason, cacheReadTokens };
+	return { text, tokensIn, tokensOut, cacheReadTokens, stopReason, toolUses };
 }
 
-/**
- * Terminate a session promptly so the microVM is reclaimed. Without this, the
- * session sits warm until idleRuntimeSessionTimeout (configured per-harness;
- * default 900s). At ~150 cells/PR that's a real load on the per-account
- * 1,000-active-session quota.
- *
- * Best-effort — never throws. The orchestrator calls this in finally{}, and a
- * failed stop just lets the idle timer take over.
- */
 export async function stopSession(harnessArn: string, sid: string): Promise<void> {
 	try {
-		await agentcore.send(
-			new StopRuntimeSessionCommand({
-				agentRuntimeArn: harnessArn,
-				runtimeSessionId: sid,
-			}),
-		);
+		await agentcore.send(new StopRuntimeSessionCommand({ agentRuntimeArn: harnessArn, runtimeSessionId: sid }));
 	} catch (err) {
 		process.stderr.write(`[stopSession] non-fatal: ${(err as Error).message}\n`);
 	}
 }
 
-/**
- * Build a runtime session ID that satisfies the API's >=33 char requirement.
- * The deterministic prefix is helpful when reading logs.
- */
 export function sessionId(prefix: string): string {
 	const padded = `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
 	return padded.padEnd(33, 'x').slice(0, 64);
 }
 
-/**
- * Upload a buffer (or text body) to S3 under `bench-uploads/<runId>/<cellId>/<name>`
- * and return the s3:// URI. The microVM's exec role has `s3:GetObject` on this
- * prefix; the runner has `s3:PutObject`. Pair this with a single `aws s3 cp`
- * inside the microVM rather than streaming bytes through shell commands.
- */
 export async function putToTransport(args: {
 	bucket: string;
 	runId: string;

--- a/scripts/agent-bench/microvm/bootstrap.sh
+++ b/scripts/agent-bench/microvm/bootstrap.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Bootstrap the AgentCore microVM for a bench cell.
+#
+# Inputs (env): TRANSPORT_PREFIX (s3://bucket/bench-uploads/<run-id>/<cell>)
+#
+# Steps:
+#   1. Install Node 22 (AL2023 ships Node 18, but the dev server uses
+#      process.loadEnvFile which is a Node 20.6+ API).
+#   2. Pull the dist-registry tarball from S3 and extract.
+#   3. Pull the local-registry server script and start it on :4873.
+#      (npm refuses file:// tarball URLs in packuments, so we serve over HTTP.)
+set -euo pipefail
+
+: "${TRANSPORT_PREFIX:?TRANSPORT_PREFIX must be set}"
+
+dnf install -y tar gzip 2>&1 | tail -3
+curl -fsSL https://rpm.nodesource.com/setup_22.x | bash - >/tmp/nodesource.log 2>&1
+dnf install -y nodejs 2>&1 | tail -3
+node --version
+
+mkdir -p /workspace/dist-registry
+aws s3 cp "${TRANSPORT_PREFIX}/dist-registry.tgz" /tmp/dist-registry.tgz
+aws s3 cp "${TRANSPORT_PREFIX}/serve-local-registry.ts" /tmp/serve-local-registry.ts
+tar -xzf /tmp/dist-registry.tgz -C /workspace/dist-registry
+
+npm install -g tsx 2>&1 | tail -3
+nohup tsx /tmp/serve-local-registry.ts > /tmp/registry.log 2>&1 &
+echo $! > /tmp/registry.pid
+
+for i in $(seq 1 30); do
+  if curl -sf http://localhost:4873/registry/@aws-blocks/blocks > /dev/null; then
+    echo "registry-up"
+    exit 0
+  fi
+  sleep 1
+done
+
+echo ">>> registry server failed to start; tail of log:"
+tail -50 /tmp/registry.log
+exit 1

--- a/scripts/agent-bench/microvm/capture-files.sh
+++ b/scripts/agent-bench/microvm/capture-files.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Tar the agent's workspace (minus heavy ignored dirs) and push to S3 so the
+# runner can read back what the agent actually wrote. Required IAM on the
+# harness role: s3:PutObject on $TRANSPORT_PREFIX/*.
+#
+# Inputs (env): TRANSPORT_PREFIX (s3://bucket/bench-uploads/<run-id>/<cell>)
+set -euo pipefail
+
+: "${TRANSPORT_PREFIX:?TRANSPORT_PREFIX must be set}"
+
+cd /workspace/bench-app
+# The judge step earlier chmod'd the workspace a-w; restore so tar can stat.
+chmod -R u+rwX . 2>/dev/null || true
+
+tar -czf /tmp/agent-files.tgz \
+  --exclude=node_modules --exclude=.git \
+  --exclude=dist --exclude=build --exclude=.next \
+  --exclude=.cache --exclude=.turbo --exclude='*.log' \
+  --ignore-failed-read . 2>/dev/null || true
+
+aws s3 cp /tmp/agent-files.tgz "${TRANSPORT_PREFIX}/agent-files.tgz"
+stat -c '%s bytes' /tmp/agent-files.tgz

--- a/scripts/agent-bench/microvm/setup-app.sh
+++ b/scripts/agent-bench/microvm/setup-app.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Scaffold a fresh bench-app from create-blocks-app and start the dev server.
+#
+# Inputs:
+#   $1 = template name (e.g. default, demo, bare, react, nextjs, backend, auth-cognito)
+#
+# On success: prints `dev-server-up:<port>` and writes the port to /tmp/dev.port.
+# On failure: dumps dev-server log tail and exits 1.
+#
+# Different templates bind different ports (most proxy :3000 -> :3100; backend
+# binds :3001 directly). We probe both with `curl --head` so a 404 root
+# (backend's API server has no UI at /) still counts as bound.
+set -euo pipefail
+
+TEMPLATE="${1:?usage: setup-app.sh <template>}"
+cd /workspace
+
+cat > .npmrc <<'EOF'
+@aws-blocks:registry=http://localhost:4873/registry/
+EOF
+
+echo ">>> installing @aws-blocks/create-blocks-app"
+npm install --no-save @aws-blocks/create-blocks-app 2>&1 | tail -5
+
+echo ">>> scaffolding bench-app (template=${TEMPLATE})"
+if [ "$TEMPLATE" = "default" ]; then
+  ./node_modules/.bin/create-blocks-app bench-app 2>&1 | tail -10
+else
+  ./node_modules/.bin/create-blocks-app bench-app --template "$TEMPLATE" 2>&1 | tail -10
+fi
+
+cd bench-app
+nohup npm run dev > /tmp/dev.log 2>&1 &
+echo $! > /tmp/dev.pid
+
+for i in $(seq 1 60); do
+  for port in 3000 3001; do
+    if curl -s --head -m 2 "http://localhost:${port}" > /dev/null 2>&1; then
+      echo "dev-server-up:${port}"
+      echo "${port}" > /tmp/dev.port
+      exit 0
+    fi
+  done
+  sleep 1
+done
+
+echo ">>> dev server timed out; tail of /tmp/dev.log:"
+tail -50 /tmp/dev.log
+exit 1

--- a/scripts/agent-bench/package.json
+++ b/scripts/agent-bench/package.json
@@ -1,0 +1,23 @@
+{
+	"name": "@aws-blocks/agent-bench",
+	"version": "0.0.0",
+	"private": true,
+	"type": "module",
+	"description": "Per-PR agent benchmark on Amazon Bedrock AgentCore Harness. Internal tooling only.",
+	"scripts": {
+		"preflight": "tsx preflight.ts",
+		"bench": "tsx run-bench.ts",
+		"summarize": "node summarize.mjs",
+		"typecheck": "tsc --noEmit"
+	},
+	"devDependencies": {
+		"@aws-sdk/client-bedrock-agentcore": "^3.1070.0",
+		"@aws-sdk/client-s3": "^3.1070.0",
+		"@smithy/node-http-handler": "^4.8.0",
+		"@types/js-yaml": "^4.0.9",
+		"@types/node": "^20.0.0",
+		"js-yaml": "^4.2.0",
+		"tsx": "^4.7.0",
+		"typescript": "^5.3.0"
+	}
+}

--- a/scripts/agent-bench/package.json
+++ b/scripts/agent-bench/package.json
@@ -8,7 +8,8 @@
 		"preflight": "tsx preflight.ts",
 		"bench": "tsx run-bench.ts",
 		"summarize": "node summarize.mjs",
-		"typecheck": "tsc --noEmit"
+		"typecheck": "tsc --noEmit",
+		"test": "tsc --noEmit"
 	},
 	"devDependencies": {
 		"@aws-sdk/client-bedrock-agentcore": "^3.1070.0",

--- a/scripts/agent-bench/preflight.ts
+++ b/scripts/agent-bench/preflight.ts
@@ -1,0 +1,106 @@
+/**
+ * Pre-run check. Verifies the bench has everything it needs to run, with the
+ * minimum permissions the runner is granted (invoke-only — no create, no get).
+ *
+ * Runs four probes in sequence; the first failure aborts:
+ *   1. env: required variables are set
+ *   2. harness: a 1-turn invokeAgent smoke (proves InvokeHarness + IAM + model access)
+ *   3. exec:    a 1-line invokeAgentRuntimeCommand (proves microVM access)
+ *   4. s3:      a no-op aws s3 ls on the transport prefix (proves transport bucket + role)
+ *
+ * Designed to run *first* in CI. If preflight is green, the bench will run.
+ * If preflight is red, the failure message tells you which knob to turn.
+ *
+ * Required env:
+ *   BENCH_HARNESS_ARN        the harness ARN
+ *   BENCH_TRANSPORT_BUCKET   the S3 bucket the runner uploads tarballs to
+ *   AWS_REGION               defaults to us-east-1
+ */
+import { S3Client, ListObjectsV2Command } from '@aws-sdk/client-s3';
+import { exec, invokeAgent, sessionId } from './agentcore.js';
+
+const REGION = process.env.AWS_REGION ?? 'us-east-1';
+
+interface Check {
+	name: string;
+	fn: () => Promise<void>;
+}
+
+function checkEnv(): void {
+	const required = ['BENCH_HARNESS_ARN', 'BENCH_TRANSPORT_BUCKET'];
+	const missing = required.filter((name) => !process.env[name]);
+	if (missing.length) {
+		throw new Error(`missing required env var(s): ${missing.join(', ')}`);
+	}
+}
+
+async function checkHarness(harnessArn: string): Promise<void> {
+	const sid = sessionId('preflight');
+	const r = await invokeAgent(harnessArn, sid, {
+		systemPrompt: 'You are a connectivity probe. Answer in two words or fewer.',
+		userText: 'Reply with: ok',
+		allowedTools: [],
+	});
+	if (!r.text.toLowerCase().includes('ok')) {
+		throw new Error(`harness invokeAgent did not return 'ok' (got: ${r.text.slice(0, 100)!})`);
+	}
+	process.stderr.write(`  → invokeAgent ok (in=${r.tokensIn}, out=${r.tokensOut})\n`);
+}
+
+async function checkExec(harnessArn: string): Promise<void> {
+	const sid = sessionId('preflight-exec');
+	const r = await exec(harnessArn, sid, 'echo bench-preflight-ok && uname -m');
+	if (r.exitCode !== 0 || !r.stdout.includes('bench-preflight-ok')) {
+		throw new Error(`exec smoke failed (exit ${r.exitCode}): ${r.stdout}${r.stderr}`);
+	}
+	process.stderr.write(`  → exec ok (arch=${r.stdout.split('\n')[1]?.trim()})\n`);
+}
+
+async function checkS3(bucket: string): Promise<void> {
+	// List the prefix; HEAD on a fixed key would also work but list works even when
+	// the prefix is empty. We need ListBucket-on-prefix? No — ListObjectsV2 needs
+	// s3:ListBucket on the bucket, which the runner does have via the existing
+	// CDK construct. (The microVM exec role only needs GetObject; not exercised here.)
+	await s3List(bucket);
+	process.stderr.write(`  → s3 transport bucket reachable: s3://${bucket}/bench-uploads/\n`);
+}
+
+async function s3List(bucket: string): Promise<void> {
+	const client = new S3Client({ region: REGION });
+	await client.send(
+		new ListObjectsV2Command({
+			Bucket: bucket,
+			Prefix: 'bench-uploads/',
+			MaxKeys: 1,
+		}),
+	);
+}
+
+async function main() {
+	const harnessArn = process.env.BENCH_HARNESS_ARN ?? '';
+	const transportBucket = process.env.BENCH_TRANSPORT_BUCKET ?? '';
+
+	const checks: Check[] = [
+		{ name: 'env', fn: async () => checkEnv() },
+		{ name: 'harness invokeAgent', fn: () => checkHarness(harnessArn) },
+		{ name: 'harness exec', fn: () => checkExec(harnessArn) },
+		{ name: 's3 transport', fn: () => checkS3(transportBucket) },
+	];
+
+	for (const c of checks) {
+		process.stderr.write(`[preflight] ${c.name}\n`);
+		try {
+			await c.fn();
+		} catch (err) {
+			process.stderr.write(`[preflight] FAIL: ${c.name}: ${(err as Error).message}\n`);
+			process.exit(1);
+		}
+	}
+
+	process.stderr.write(`[preflight] all checks passed\n`);
+}
+
+main().catch((err) => {
+	process.stderr.write(`[preflight] fatal: ${err.stack ?? err}\n`);
+	process.exit(1);
+});

--- a/scripts/agent-bench/run-bench.ts
+++ b/scripts/agent-bench/run-bench.ts
@@ -1,0 +1,582 @@
+/**
+ * Per-cell bench orchestrator.
+ *
+ * Reads one (template, task) from CLI flags, runs the bench inside an AgentCore
+ * Harness microVM, and writes a single result envelope JSON.
+ *
+ * Bytes between the runner and microVM go through S3 (bench-uploads/* prefix).
+ * Bytes between the agent and the model are the harness's responsibility.
+ * Shell commands and agent turns go through agentcore.ts.
+ *
+ * Required env:
+ *   BENCH_HARNESS_ARN        the harness ARN
+ *   BENCH_TRANSPORT_BUCKET   bucket the runner uploads tarballs/specs to
+ *   AWS_REGION               defaults to us-east-1
+ *
+ * Usage:
+ *   tsx scripts/agent-bench/run-bench.ts \
+ *     --template default \
+ *     --task realtime-todos \
+ *     --output bench-results/result-default-realtime-todos.json
+ */
+import { execSync } from 'node:child_process';
+import { mkdirSync, readFileSync, readdirSync, statSync, writeFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { parseArgs } from 'node:util';
+import { load as parseYaml } from 'js-yaml';
+import {
+	exec,
+	invokeAgent,
+	putToTransport,
+	sessionId,
+	stopSession,
+	type ExecResult,
+} from './agentcore.js';
+
+const REPO_ROOT = resolve(import.meta.dirname, '..', '..');
+const SCHEMA_VERSION = 1;
+const SCRIPT_VERSION = 3; // bump when the orchestrator changes shape
+
+const HARNESS_ARN = required('BENCH_HARNESS_ARN');
+const TRANSPORT_BUCKET = required('BENCH_TRANSPORT_BUCKET');
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface TaskConfig {
+	id: string;
+	name: string;
+	tier: string;
+	test_file: string;
+	time_limit_sec: number;
+	token_budget: number;
+}
+
+interface Result {
+	schema_version: number;
+	script_version: number;
+	timestamp_utc: string;
+	git_sha: string;
+	pr_number: string;
+	run_id: string;
+	template: string;
+	task: string;
+	model: string;
+	status: 'scored' | 'budget_exceeded' | 'error';
+	duration_sec: number;
+	tokens_in: number;
+	tokens_out: number;
+	tokens_total: number;
+	cache_read_tokens: number;
+	budget_exceeded: boolean;
+	tests_passed: number;
+	tests_failed: number;
+	tests_total: number;
+	test_pass_rate: number;
+	build_succeeded: boolean;
+	dev_server_started: boolean;
+	scaffolded: boolean;
+	judge_score: number | null;
+	judge_dimensions: Record<string, number>;
+	judge_explanation: string;
+	stop_reason: string;
+	agent_files: Record<string, string>;
+	notes: string[];
+}
+
+// ---------------------------------------------------------------------------
+// System prompts
+// ---------------------------------------------------------------------------
+
+const BUILDER_SYSTEM_PROMPT = `You are a senior frontend+backend engineer working in /workspace/bench-app inside a fresh AWS Blocks app.
+
+The dist-registry has already been pushed into /workspace/dist-registry; the project is scaffolded and dev server is running on http://localhost:3000.
+
+Tools available to you:
+  - shell: bash inside this microVM. State persists across calls.
+  - file_operations: read/write/edit files.
+
+Workflow:
+  1. Read AGENTS.md, package.json, and aws-blocks/index.ts to orient yourself.
+  2. Read the relevant @aws-blocks package READMEs under node_modules/@aws-blocks/* to learn which blocks fit the task.
+  3. Edit files under /workspace/bench-app/ to implement the task. Don't modify node_modules.
+  4. Verify against the running dev server (curl, etc.).
+  5. Before stopping, run \`npm run build\` from /workspace/bench-app. The dev server uses tsx and is permissive about types; the real build is strict. Fix any errors until build exits 0.
+
+Don't \`npm install\` extra packages — everything you need is already in node_modules. Be concise between tool calls; the work is in the tools, not the prose.`;
+
+const JUDGE_SYSTEM_PROMPT = `You are an impartial grader scoring an AI agent's implementation of a coding task.
+
+You have file_operations tool access against the agent's workspace at /workspace/bench-app/.
+The workspace is filesystem read-only — any write attempts will fail.
+Useful files to inspect when grading: aws-blocks/index.ts, src/index.ts (or src/main.tsx), index.html, package.json.
+
+Grade against the rubric below. Cite specific files when you do — the audit trail is the point.
+Return ONLY a JSON object matching the exact shape requested. No prose, no preamble, no code fences.`;
+
+const JUDGE_RUBRIC = `Dimensions (each 0-10):
+
+1. functional_completeness  (weight 3.0) — Does the implementation actually meet the prompt's requirements?
+2. selector_contract        (weight 1.5) — Are the data-testid hooks present and correct?
+3. realtime_quality         (weight 1.5) — Does cross-tab sync work without refresh?
+4. persistence              (weight 1.0) — Do todos survive a reload?
+5. code_quality             (weight 0.5) — Is the implementation clean and idiomatic for this stack?
+
+HARD CAPS (apply BEFORE the weighted average):
+- If scaffolded == false  →  every dimension CANNOT exceed 1.
+- If tests_total > 0 and tests_passed == 0  →  functional_completeness CANNOT exceed 4.
+- If tests_total > 0 and tests_passed/tests_total < 0.5  →  functional_completeness CANNOT exceed 6.
+- If build_succeeded == false  →  functional_completeness CANNOT exceed 3.
+- If dev_server_started == false  →  functional_completeness AND selector_contract CANNOT exceed 2.
+
+Compute overall = sum(score_i * weight_i) / sum(weights). Round to 2 decimals.
+
+Return JSON exactly like:
+{
+  "scores": {
+    "functional_completeness": <0-10>,
+    "selector_contract": <0-10>,
+    "realtime_quality": <0-10>,
+    "persistence": <0-10>,
+    "code_quality": <0-10>
+  },
+  "overall": <0-10>,
+  "explanation": "<2-4 sentences citing specific evidence>"
+}`;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function required(name: string): string {
+	const v = process.env[name];
+	if (!v) {
+		process.stderr.write(`[bench] missing required env var ${name}\n`);
+		process.exit(1);
+	}
+	return v;
+}
+
+function log(msg: string) {
+	process.stderr.write(`[bench] ${msg}\n`);
+}
+
+function loadTask(taskId: string): { cfg: TaskConfig; prompt: string; specPath: string } {
+	const taskDir = resolve(REPO_ROOT, 'tasks', taskId);
+	const cfg = parseYaml(readFileSync(resolve(taskDir, 'config.yaml'), 'utf-8')) as TaskConfig;
+	const prompt = readFileSync(resolve(taskDir, 'PROMPT.md'), 'utf-8');
+	const specPath = resolve(taskDir, cfg.test_file);
+	return { cfg, prompt, specPath };
+}
+
+function packDistRegistry(): { tarballPath: string; sizeBytes: number } {
+	const tarballPath = '/tmp/dist-registry.tgz';
+	// Packument tarball URLs stay as `http://localhost:4873/registry/...`. We
+	// run the existing serve-local-registry.ts script inside the microVM to
+	// serve them on that same address. npm refuses `file://` tarball URLs.
+	execSync(`tar -czf ${tarballPath} -C ${resolve(REPO_ROOT, 'dist-registry')} .`);
+	return { tarballPath, sizeBytes: statSync(tarballPath).size };
+}
+
+function walk(dir: string, basename: string): string[] {
+	const out: string[] = [];
+	for (const entry of readdirSync(dir, { withFileTypes: true })) {
+		const full = resolve(dir, entry.name);
+		if (entry.isDirectory()) out.push(...walk(full, basename));
+		else if (entry.name === basename) out.push(full);
+	}
+	return out;
+}
+
+function parsePlaywrightJson(stdout: string): { passed: number; failed: number; total: number } {
+	const start = stdout.indexOf('{');
+	const end = stdout.lastIndexOf('}');
+	if (start === -1 || end === -1) return { passed: 0, failed: 0, total: 0 };
+	let data: { stats?: { expected?: number; unexpected?: number; skipped?: number; flaky?: number } };
+	try {
+		data = JSON.parse(stdout.slice(start, end + 1));
+	} catch {
+		return { passed: 0, failed: 0, total: 0 };
+	}
+	const stats = data.stats ?? {};
+	const expected = stats.expected ?? 0;
+	const unexpected = stats.unexpected ?? 0;
+	const skipped = stats.skipped ?? 0;
+	const flaky = stats.flaky ?? 0;
+	return {
+		passed: expected + flaky,
+		failed: unexpected,
+		total: expected + unexpected + skipped + flaky,
+	};
+}
+
+function extractJson(text: string): string {
+	const cleaned = text.replace(/^```(?:json)?\s*|```\s*$/g, '').trim();
+	const start = cleaned.indexOf('{');
+	const end = cleaned.lastIndexOf('}');
+	if (start === -1 || end === -1) return cleaned;
+	return cleaned.slice(start, end + 1);
+}
+
+function assertOk(r: ExecResult, what: string, result: Result): void {
+	if (r.exitCode !== 0) {
+		result.notes.push(`${what} failed (exit ${r.exitCode}):\n${tail(r.stdout + r.stderr, 1500)}`);
+		throw new Error(what);
+	}
+}
+
+function tail(s: string, n: number): string {
+	return s.length <= n ? s : `...[truncated]...\n${s.slice(-n)}`;
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+	const { values: args } = parseArgs({
+		options: {
+			template: { type: 'string' },
+			task: { type: 'string' },
+			output: { type: 'string' },
+		},
+		strict: true,
+	});
+	if (!args.template || !args.task || !args.output) {
+		process.stderr.write('usage: --template <name> --task <id> --output <path>\n');
+		process.exit(2);
+	}
+
+	const { cfg, prompt: taskPrompt, specPath } = loadTask(args.task);
+	log(`task=${cfg.id} template=${args.template}`);
+
+	const started = Date.now();
+	// Builder and judge share one session so the judge sees the workspace the
+	// builder wrote. Read-only enforcement comes from `chmod -R a-w` against
+	// /workspace/bench-app/ before the judge turn, plus allowedTools restricted
+	// to file_operations (no shell). The harness toolset is monolithic — there
+	// is no separate read-only file tool — so OS-level permissions are the only
+	// real boundary.
+	const benchSession = sessionId(`bench-${args.template}-${args.task}`);
+	const cellId = `${args.template}-${args.task}`;
+
+	const result: Result = {
+		schema_version: SCHEMA_VERSION,
+		script_version: SCRIPT_VERSION,
+		timestamp_utc: new Date().toISOString(),
+		git_sha: process.env.GITHUB_SHA ?? '',
+		pr_number: process.env.PR_NUMBER ?? 'local',
+		run_id: process.env.GITHUB_RUN_ID ?? `local-${Date.now()}`,
+		template: args.template,
+		task: cfg.id,
+		model: 'us.anthropic.claude-sonnet-4-6',
+		status: 'error',
+		duration_sec: 0,
+		tokens_in: 0,
+		tokens_out: 0,
+		tokens_total: 0,
+		cache_read_tokens: 0,
+		budget_exceeded: false,
+		tests_passed: 0,
+		tests_failed: 0,
+		tests_total: 0,
+		test_pass_rate: 0,
+		build_succeeded: false,
+		dev_server_started: false,
+		scaffolded: false,
+		judge_score: null,
+		judge_dimensions: {},
+		judge_explanation: '',
+		stop_reason: '',
+		agent_files: {},
+		notes: [],
+	};
+
+	const transport = (name: string, body: Buffer | string, contentType?: string) =>
+		putToTransport({
+			bucket: TRANSPORT_BUCKET,
+			runId: result.run_id,
+			cellId,
+			name,
+			body,
+			contentType,
+		});
+
+	try {
+		// 1a. Install the microVM toolchain. AL2023 ships awscli + curl + bash;
+		// we need tar/gzip + Node 22 (the dev server uses process.loadEnvFile, a
+		// Node 20.6+ API; AL2023's default nodejs package is 18). NodeSource for
+		// arm64 / RPM gives us a current node.
+		log('installing toolchain in microVM (Node 22)');
+		const toolchain = await exec(
+			HARNESS_ARN,
+			benchSession,
+			`set -e
+dnf install -y tar gzip 2>&1 | tail -5
+# NodeSource is the canonical path to a current node on AL2023.
+curl -fsSL https://rpm.nodesource.com/setup_22.x | bash - >/tmp/nodesource.log 2>&1
+dnf install -y nodejs 2>&1 | tail -5
+node --version
+npm --version`,
+			420,
+		);
+		assertOk(toolchain, 'toolchain install', result);
+
+		// 1b. Pack the local dist-registry, upload to S3, pull down in the microVM.
+		log('packing dist-registry');
+		const { tarballPath, sizeBytes } = packDistRegistry();
+		log(`dist-registry: ${(sizeBytes / 1024 / 1024).toFixed(1)}MB`);
+		const tarballUri = await transport('dist-registry.tgz', readFileSync(tarballPath), 'application/gzip');
+
+		// 1c. Upload the registry-server script too. We run it inside the microVM
+		// because npm's packuments reference http://localhost:4873/... and npm
+		// rejects file:// tarball URLs.
+		const serveScript = readFileSync(
+			resolve(REPO_ROOT, 'scripts/publish/serve-local-registry.ts'),
+			'utf-8',
+		);
+		// Adjust the registry-root path to /workspace/dist-registry inside the microVM.
+		const serveAdapted = serveScript
+			.replace(
+				'const ROOT = resolve(import.meta.dirname, "../..");',
+				'const ROOT = "/workspace";',
+			)
+			.replace(
+				'const REGISTRY_DIR = join(ROOT, "dist-registry");',
+				'const REGISTRY_DIR = "/workspace/dist-registry";',
+			);
+		const serveUri = await transport(
+			'serve-local-registry.ts',
+			serveAdapted,
+			'text/x-typescript',
+		);
+		log(`uploaded ${tarballUri}`);
+
+		const extract = await exec(
+			HARNESS_ARN,
+			benchSession,
+			`set -e
+mkdir -p /workspace/dist-registry
+aws s3 cp '${tarballUri}' /tmp/dist-registry.tgz
+aws s3 cp '${serveUri}' /tmp/serve-local-registry.ts
+tar -xzf /tmp/dist-registry.tgz -C /workspace/dist-registry
+ls /workspace/dist-registry/registry/@aws-blocks | head -5`,
+		);
+		assertOk(extract, 'dist-registry extract', result);
+
+		// 1d. Start the local registry server inside the microVM and wait for it.
+		log('starting in-microVM registry server');
+		const startRegistry = await exec(
+			HARNESS_ARN,
+			benchSession,
+			`set -e
+# Install tsx globally so we can run the .ts directly without project setup.
+npm install -g tsx 2>&1 | tail -3
+nohup tsx /tmp/serve-local-registry.ts > /tmp/registry.log 2>&1 &
+echo $! > /tmp/registry.pid
+for i in $(seq 1 30); do
+  if curl -sf http://localhost:4873/registry/@aws-blocks/blocks > /dev/null; then
+    echo "registry-up"; exit 0
+  fi
+  sleep 1
+done
+echo '>>> registry server failed to start; tail of log:'
+tail -50 /tmp/registry.log
+exit 1`,
+			300,
+		);
+		assertOk(startRegistry, 'in-microVM registry start', result);
+
+		// 2. Scaffold the app, start dev server.
+		log('scaffolding bench-app');
+		const setup = await exec(
+			HARNESS_ARN,
+			benchSession,
+			`set -eo pipefail
+cd /workspace
+cat > .npmrc <<'EOF'
+@aws-blocks:registry=http://localhost:4873/registry/
+EOF
+echo '>>> installing @aws-blocks/create-blocks-app from local registry'
+npm install --no-save @aws-blocks/create-blocks-app 2>&1 | tail -10
+echo '>>> scaffolding bench-app'
+./node_modules/.bin/create-blocks-app bench-app${args.template === 'default' ? '' : ` --template ${args.template}`} 2>&1 | tail -20
+echo '>>> starting dev server'
+cd bench-app
+nohup npm run dev > /tmp/dev.log 2>&1 &
+echo $! > /tmp/dev.pid
+for i in $(seq 1 60); do
+  if curl -sf http://localhost:3000 > /dev/null; then
+    echo "dev-server-up"; exit 0
+  fi
+  sleep 1
+done
+echo '>>> dev server timed out; tail of /tmp/dev.log:'
+tail -50 /tmp/dev.log
+exit 1
+`,
+			600,
+		);
+		result.scaffolded = setup.exitCode === 0;
+		result.dev_server_started = setup.stdout.includes('dev-server-up');
+		if (!result.scaffolded || !result.dev_server_started) {
+			result.notes.push(`setup failed (exit ${setup.exitCode}): ${tail(setup.stdout + setup.stderr, 2000)}`);
+			throw new Error('setup failed');
+		}
+
+		// 3. Builder agent.
+		log('invoking builder agent');
+		const builder = await invokeAgent(HARNESS_ARN, benchSession, {
+			systemPrompt: BUILDER_SYSTEM_PROMPT,
+			userText: taskPrompt,
+		});
+		result.tokens_in = builder.tokensIn;
+		result.tokens_out = builder.tokensOut;
+		result.tokens_total = builder.tokensIn + builder.tokensOut;
+		result.cache_read_tokens = builder.cacheReadTokens;
+		result.stop_reason = builder.stopReason;
+		result.budget_exceeded = result.tokens_total > cfg.token_budget;
+		if (result.budget_exceeded) {
+			result.notes.push(`token budget exceeded: ${result.tokens_total} > ${cfg.token_budget}`);
+		}
+
+		// 4. Build sanity check.
+		log('npm run build');
+		const build = await exec(HARNESS_ARN, benchSession, `cd /workspace/bench-app && npm run build`, 600);
+		result.build_succeeded = build.exitCode === 0;
+		if (!result.build_succeeded) {
+			result.notes.push(`build failed:\n${tail(build.stdout + build.stderr, 2000)}`);
+		}
+
+		// 5. Playwright. Spec + config land in the microVM through S3 too.
+		log('uploading Playwright spec + config');
+		const specUri = await transport('task.spec.ts', readFileSync(specPath), 'text/x-typescript');
+		const configUri = await transport(
+			'playwright.config.ts',
+			`import { defineConfig } from '@playwright/test';
+export default defineConfig({
+  testDir: './bench-tests',
+  timeout: 60_000,
+  reporter: [['json']],
+  use: { baseURL: 'http://localhost:3000' },
+});
+`,
+			'text/x-typescript',
+		);
+		log('running Playwright');
+		const test = await exec(
+			HARNESS_ARN,
+			benchSession,
+			`set -e
+cd /workspace/bench-app
+mkdir -p bench-tests
+aws s3 cp '${specUri}' bench-tests/task.spec.ts
+aws s3 cp '${configUri}' playwright.config.ts
+npm install --no-save --silent @playwright/test >/dev/null
+npx playwright install chromium >/tmp/pw-install.log 2>&1 || true
+npx playwright test --reporter=json 2>&1 || true`,
+			900,
+		);
+		const tests = parsePlaywrightJson(test.stdout);
+		result.tests_passed = tests.passed;
+		result.tests_failed = tests.failed;
+		result.tests_total = tests.total;
+		result.test_pass_rate = tests.total > 0 ? tests.passed / tests.total : 0;
+
+		// 6. Judge — same session as the builder so the workspace files are
+		// already there, but with the workspace chmod'd read-only and shell
+		// access removed. The harness's file_operations tool is monolithic
+		// (view+create+edit), so OS permissions are the only real read-only
+		// boundary. Both file_operations writes and shell are out of reach
+		// for the judge: the former by chmod, the latter by allowedTools.
+		log('locking workspace read-only');
+		await exec(
+			HARNESS_ARN,
+			benchSession,
+			`chmod -R a-w /workspace/bench-app && find /workspace/bench-app -maxdepth 1 -type d -ls | head -5`,
+		);
+		log('invoking judge agent');
+		const judge = await invokeAgent(HARNESS_ARN, benchSession, {
+			systemPrompt: JUDGE_SYSTEM_PROMPT,
+			userText:
+				`<rubric>\n${JUDGE_RUBRIC}\n</rubric>\n\n` +
+				`<prompt_given_to_agent>\n${taskPrompt}\n</prompt_given_to_agent>\n\n` +
+				`<evidence>\nscaffolded: ${result.scaffolded}\nbuild_succeeded: ${result.build_succeeded}\ndev_server_started: ${result.dev_server_started}\ntests_total: ${result.tests_total}\ntests_passed: ${result.tests_passed}\ntests_failed: ${result.tests_failed}\n</evidence>\n\n` +
+				`Inspect /workspace/bench-app/ then return the JSON object.`,
+			allowedTools: ['file_operations'],
+		});
+		result.tokens_in += judge.tokensIn;
+		result.tokens_out += judge.tokensOut;
+		result.tokens_total = result.tokens_in + result.tokens_out;
+		try {
+			const parsed: { scores?: Record<string, number>; overall?: number; explanation?: string } = JSON.parse(
+				extractJson(judge.text),
+			);
+			result.judge_score = parsed.overall ?? null;
+			result.judge_dimensions = parsed.scores ?? {};
+			result.judge_explanation = parsed.explanation ?? '';
+		} catch (err) {
+			result.notes.push(
+				`judge JSON parse failed: ${(err as Error).message}; raw=${judge.text.slice(0, 500)}`,
+			);
+		}
+
+		// 7. Capture the files the agent wrote — for inspection in the envelope.
+		// Tar them into one upload to keep this O(1) rather than O(N) round trips.
+		const captureUri = `s3://${TRANSPORT_BUCKET}/bench-uploads/${result.run_id}/${cellId}/agent-files.tgz`;
+		const capture = await exec(
+			HARNESS_ARN,
+			benchSession,
+			`set -e
+cd /workspace/bench-app
+tar -czf /tmp/agent-files.tgz \
+  --ignore-failed-read \
+  aws-blocks/index.ts aws-blocks/index.cdk.ts aws-blocks/index.handler.ts \
+  src/index.ts src/main.tsx src/App.tsx index.html package.json 2>/dev/null || true
+aws s3 cp /tmp/agent-files.tgz '${captureUri}'`,
+		);
+		if (capture.exitCode === 0) {
+			// Pull the tarball, extract, read each file into the envelope.
+			execSync(`aws s3 cp ${captureUri} /tmp/agent-files-${cellId}.tgz --only-show-errors`);
+			const tmpDir = `/tmp/agent-files-${cellId}`;
+			execSync(`rm -rf ${tmpDir} && mkdir -p ${tmpDir} && tar -xzf /tmp/agent-files-${cellId}.tgz -C ${tmpDir}`);
+			for (const path of walkAll(tmpDir)) {
+				const rel = path.slice(tmpDir.length + 1);
+				try {
+					result.agent_files[rel] = readFileSync(path, 'utf-8');
+				} catch {
+					// non-utf8 file — skip silently
+				}
+			}
+		}
+
+		result.status = result.budget_exceeded ? 'budget_exceeded' : 'scored';
+	} catch (err) {
+		result.notes.push(`orchestrator error: ${(err as Error).message}`);
+	} finally {
+		// Release the microVM promptly so the per-account session quota isn't
+		// tied up. Best-effort; the harness's idle timeout is the backstop.
+		await stopSession(HARNESS_ARN, benchSession);
+		result.duration_sec = Math.round((Date.now() - started) / 100) / 10;
+		mkdirSync(dirname(args.output), { recursive: true });
+		writeFileSync(args.output, JSON.stringify(result, null, 2));
+		writeFileSync(args.output.replace(/\.json$/, '.jsonl'), `${JSON.stringify(result)}\n`);
+		log(`wrote ${args.output}`);
+	}
+}
+
+function walkAll(dir: string): string[] {
+	const out: string[] = [];
+	for (const entry of readdirSync(dir, { withFileTypes: true })) {
+		const full = resolve(dir, entry.name);
+		if (entry.isDirectory()) out.push(...walkAll(full));
+		else out.push(full);
+	}
+	return out;
+}
+
+main().catch((err) => {
+	process.stderr.write(`[bench] fatal: ${err.stack ?? err}\n`);
+	process.exit(1);
+});

--- a/scripts/agent-bench/run-bench.ts
+++ b/scripts/agent-bench/run-bench.ts
@@ -1,48 +1,29 @@
 /**
- * Per-cell bench orchestrator.
+ * Per-cell bench orchestrator. Runs one (template, task) pair inside an
+ * AgentCore Harness microVM and writes a single result envelope JSON.
  *
- * Reads one (template, task) from CLI flags, runs the bench inside an AgentCore
- * Harness microVM, and writes a single result envelope JSON.
+ * Heavy lifting lives in microvm/*.sh; this file is just glue. Bytes between
+ * runner and microVM go through S3 under `bench-uploads/<runId>/<cellId>/`.
  *
- * Bytes between the runner and microVM go through S3 (bench-uploads/* prefix).
- * Bytes between the agent and the model are the harness's responsibility.
- * Shell commands and agent turns go through agentcore.ts.
- *
- * Required env:
- *   BENCH_HARNESS_ARN        the harness ARN
- *   BENCH_TRANSPORT_BUCKET   bucket the runner uploads tarballs/specs to
- *   AWS_REGION               defaults to us-east-1
+ * Required env: BENCH_HARNESS_ARN, BENCH_TRANSPORT_BUCKET (AWS_REGION optional).
  *
  * Usage:
- *   tsx scripts/agent-bench/run-bench.ts \
- *     --template default \
- *     --task realtime-todos \
- *     --output bench-results/result-default-realtime-todos.json
+ *   tsx run-bench.ts --template default --task realtime-todos --output result.json
  */
 import { execSync } from 'node:child_process';
 import { mkdirSync, readFileSync, readdirSync, statSync, writeFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { parseArgs } from 'node:util';
 import { load as parseYaml } from 'js-yaml';
-import {
-	exec,
-	invokeAgent,
-	putToTransport,
-	sessionId,
-	stopSession,
-	type ExecResult,
-} from './agentcore.js';
+import { exec, invokeAgent, putToTransport, sessionId, stopSession } from './agentcore.js';
 
 const REPO_ROOT = resolve(import.meta.dirname, '..', '..');
+const MICROVM_DIR = resolve(import.meta.dirname, 'microvm');
 const SCHEMA_VERSION = 1;
-const SCRIPT_VERSION = 3; // bump when the orchestrator changes shape
+const SCRIPT_VERSION = 4;
 
 const HARNESS_ARN = required('BENCH_HARNESS_ARN');
 const TRANSPORT_BUCKET = required('BENCH_TRANSPORT_BUCKET');
-
-// ---------------------------------------------------------------------------
-// Types
-// ---------------------------------------------------------------------------
 
 interface TaskConfig {
 	id: string;
@@ -85,31 +66,24 @@ interface Result {
 	notes: string[];
 }
 
-// ---------------------------------------------------------------------------
-// System prompts
-// ---------------------------------------------------------------------------
-
+// Builder system prompt — kept short. Anthropic's guidance ("If your CLAUDE.md
+// is too long, Claude ignores half of it") was confirmed empirically: a longer
+// prompt with anti-pattern lists, structured workflow, and the embedded test
+// spec made the agent more aggressive (5-10x token usage, workspace deletion).
+// The minimal prompt below — orient, implement, verify, end — performs better.
 const BUILDER_SYSTEM_PROMPT = `You are a senior frontend+backend engineer working in /workspace/bench-app inside a fresh AWS Blocks app.
 
-The dist-registry has already been pushed into /workspace/dist-registry; the project is scaffolded and dev server is running on http://localhost:3000.
+The project is scaffolded and the dev server is running on the port in /tmp/dev.port. Stay inside /workspace/bench-app/; don't move or delete it (the orchestrator reads from this exact path after you stop). Don't modify node_modules.
 
-Tools available to you:
-  - shell: bash inside this microVM. State persists across calls.
-  - file_operations: read/write/edit files.
+Tools available:
+  - shell: bash inside this microVM (state persists)
+  - file_operations: view/create/edit files
 
-Workflow:
-  1. Read AGENTS.md, package.json, and aws-blocks/index.ts to orient yourself.
-  2. Read the relevant @aws-blocks package READMEs under node_modules/@aws-blocks/* to learn which blocks fit the task.
-  3. Edit files under /workspace/bench-app/ to implement the task. Don't modify node_modules.
-  4. Verify against the running dev server (curl, etc.).
-  5. Before stopping, run \`npm run build\` from /workspace/bench-app. The dev server uses tsx and is permissive about types; the real build is strict. Fix any errors until build exits 0.
-
-Don't \`npm install\` extra packages — everything you need is already in node_modules. Be concise between tool calls; the work is in the tools, not the prose.`;
+Workflow: read AGENTS.md, package.json, and aws-blocks/index.ts to orient. Read the @aws-blocks package READMEs under node_modules/@aws-blocks/* to learn which blocks fit. Edit files under /workspace/bench-app/ to implement the task. Verify against the dev server (curl http://localhost:$(cat /tmp/dev.port)). Before stopping, run \`npm run build\` and fix until it exits 0. Don't \`npm install\` extra packages — node_modules has what you need. End with end_turn.`;
 
 const JUDGE_SYSTEM_PROMPT = `You are an impartial grader scoring an AI agent's implementation of a coding task.
 
-You have file_operations tool access against the agent's workspace at /workspace/bench-app/.
-The workspace is filesystem read-only — any write attempts will fail.
+You have file_operations tool access against the agent's workspace at /workspace/bench-app/. The workspace is filesystem read-only — any write attempts will fail.
 Useful files to inspect when grading: aws-blocks/index.ts, src/index.ts (or src/main.tsx), index.html, package.json.
 
 Grade against the rubric below. Cite specific files when you do — the audit trail is the point.
@@ -145,10 +119,6 @@ Return JSON exactly like:
   "explanation": "<2-4 sentences citing specific evidence>"
 }`;
 
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
 function required(name: string): string {
 	const v = process.env[name];
 	if (!v) {
@@ -162,7 +132,7 @@ function log(msg: string) {
 	process.stderr.write(`[bench] ${msg}\n`);
 }
 
-function loadTask(taskId: string): { cfg: TaskConfig; prompt: string; specPath: string } {
+function loadTask(taskId: string) {
 	const taskDir = resolve(REPO_ROOT, 'tasks', taskId);
 	const cfg = parseYaml(readFileSync(resolve(taskDir, 'config.yaml'), 'utf-8')) as TaskConfig;
 	const prompt = readFileSync(resolve(taskDir, 'PROMPT.md'), 'utf-8');
@@ -170,26 +140,13 @@ function loadTask(taskId: string): { cfg: TaskConfig; prompt: string; specPath: 
 	return { cfg, prompt, specPath };
 }
 
-function packDistRegistry(): { tarballPath: string; sizeBytes: number } {
-	const tarballPath = '/tmp/dist-registry.tgz';
-	// Packument tarball URLs stay as `http://localhost:4873/registry/...`. We
-	// run the existing serve-local-registry.ts script inside the microVM to
-	// serve them on that same address. npm refuses `file://` tarball URLs.
-	execSync(`tar -czf ${tarballPath} -C ${resolve(REPO_ROOT, 'dist-registry')} .`);
-	return { tarballPath, sizeBytes: statSync(tarballPath).size };
+function packDistRegistry(): string {
+	const path = '/tmp/dist-registry.tgz';
+	execSync(`tar -czf ${path} -C ${resolve(REPO_ROOT, 'dist-registry')} .`);
+	return path;
 }
 
-function walk(dir: string, basename: string): string[] {
-	const out: string[] = [];
-	for (const entry of readdirSync(dir, { withFileTypes: true })) {
-		const full = resolve(dir, entry.name);
-		if (entry.isDirectory()) out.push(...walk(full, basename));
-		else if (entry.name === basename) out.push(full);
-	}
-	return out;
-}
-
-function parsePlaywrightJson(stdout: string): { passed: number; failed: number; total: number } {
+function parsePlaywrightJson(stdout: string) {
 	const start = stdout.indexOf('{');
 	const end = stdout.lastIndexOf('}');
 	if (start === -1 || end === -1) return { passed: 0, failed: 0, total: 0 };
@@ -199,48 +156,28 @@ function parsePlaywrightJson(stdout: string): { passed: number; failed: number; 
 	} catch {
 		return { passed: 0, failed: 0, total: 0 };
 	}
-	const stats = data.stats ?? {};
-	const expected = stats.expected ?? 0;
-	const unexpected = stats.unexpected ?? 0;
-	const skipped = stats.skipped ?? 0;
-	const flaky = stats.flaky ?? 0;
-	return {
-		passed: expected + flaky,
-		failed: unexpected,
-		total: expected + unexpected + skipped + flaky,
-	};
+	const s = data.stats ?? {};
+	const expected = s.expected ?? 0;
+	const unexpected = s.unexpected ?? 0;
+	const skipped = s.skipped ?? 0;
+	const flaky = s.flaky ?? 0;
+	return { passed: expected + flaky, failed: unexpected, total: expected + unexpected + skipped + flaky };
 }
 
 function extractJson(text: string): string {
 	const cleaned = text.replace(/^```(?:json)?\s*|```\s*$/g, '').trim();
 	const start = cleaned.indexOf('{');
 	const end = cleaned.lastIndexOf('}');
-	if (start === -1 || end === -1) return cleaned;
-	return cleaned.slice(start, end + 1);
-}
-
-function assertOk(r: ExecResult, what: string, result: Result): void {
-	if (r.exitCode !== 0) {
-		result.notes.push(`${what} failed (exit ${r.exitCode}):\n${tail(r.stdout + r.stderr, 1500)}`);
-		throw new Error(what);
-	}
+	return start === -1 || end === -1 ? cleaned : cleaned.slice(start, end + 1);
 }
 
 function tail(s: string, n: number): string {
 	return s.length <= n ? s : `...[truncated]...\n${s.slice(-n)}`;
 }
 
-// ---------------------------------------------------------------------------
-// Main
-// ---------------------------------------------------------------------------
-
 async function main() {
 	const { values: args } = parseArgs({
-		options: {
-			template: { type: 'string' },
-			task: { type: 'string' },
-			output: { type: 'string' },
-		},
+		options: { template: { type: 'string' }, task: { type: 'string' }, output: { type: 'string' } },
 		strict: true,
 	});
 	if (!args.template || !args.task || !args.output) {
@@ -252,14 +189,10 @@ async function main() {
 	log(`task=${cfg.id} template=${args.template}`);
 
 	const started = Date.now();
-	// Builder and judge share one session so the judge sees the workspace the
-	// builder wrote. Read-only enforcement comes from `chmod -R a-w` against
-	// /workspace/bench-app/ before the judge turn, plus allowedTools restricted
-	// to file_operations (no shell). The harness toolset is monolithic — there
-	// is no separate read-only file tool — so OS-level permissions are the only
-	// real boundary.
 	const benchSession = sessionId(`bench-${args.template}-${args.task}`);
 	const cellId = `${args.template}-${args.task}`;
+	const runId = process.env.GITHUB_RUN_ID ?? `local-${Date.now()}`;
+	const transportPrefix = `s3://${TRANSPORT_BUCKET}/bench-uploads/${runId}/${cellId}`;
 
 	const result: Result = {
 		schema_version: SCHEMA_VERSION,
@@ -267,7 +200,7 @@ async function main() {
 		timestamp_utc: new Date().toISOString(),
 		git_sha: process.env.GITHUB_SHA ?? '',
 		pr_number: process.env.PR_NUMBER ?? 'local',
-		run_id: process.env.GITHUB_RUN_ID ?? `local-${Date.now()}`,
+		run_id: runId,
 		template: args.template,
 		task: cfg.id,
 		model: 'us.anthropic.claude-sonnet-4-6',
@@ -293,143 +226,61 @@ async function main() {
 		notes: [],
 	};
 
-	const transport = (name: string, body: Buffer | string, contentType?: string) =>
-		putToTransport({
-			bucket: TRANSPORT_BUCKET,
-			runId: result.run_id,
-			cellId,
-			name,
-			body,
-			contentType,
-		});
+	const upload = (name: string, body: Buffer | string, contentType?: string) =>
+		putToTransport({ bucket: TRANSPORT_BUCKET, runId, cellId, name, body, contentType });
 
 	try {
-		// 1a. Install the microVM toolchain. AL2023 ships awscli + curl + bash;
-		// we need tar/gzip + Node 22 (the dev server uses process.loadEnvFile, a
-		// Node 20.6+ API; AL2023's default nodejs package is 18). NodeSource for
-		// arm64 / RPM gives us a current node.
-		log('installing toolchain in microVM (Node 22)');
-		const toolchain = await exec(
-			HARNESS_ARN,
-			benchSession,
-			`set -e
-dnf install -y tar gzip 2>&1 | tail -5
-# NodeSource is the canonical path to a current node on AL2023.
-curl -fsSL https://rpm.nodesource.com/setup_22.x | bash - >/tmp/nodesource.log 2>&1
-dnf install -y nodejs 2>&1 | tail -5
-node --version
-npm --version`,
-			420,
-		);
-		assertOk(toolchain, 'toolchain install', result);
+		// 1. Push everything the microVM needs to S3 (registry tarball, registry
+		// server script, the three bootstrap shell scripts, the playwright spec).
+		log('uploading microVM scripts and dist-registry');
+		const tarballPath = packDistRegistry();
+		await upload('dist-registry.tgz', readFileSync(tarballPath), 'application/gzip');
 
-		// 1b. Pack the local dist-registry, upload to S3, pull down in the microVM.
-		log('packing dist-registry');
-		const { tarballPath, sizeBytes } = packDistRegistry();
-		log(`dist-registry: ${(sizeBytes / 1024 / 1024).toFixed(1)}MB`);
-		const tarballUri = await transport('dist-registry.tgz', readFileSync(tarballPath), 'application/gzip');
+		const serveScript = readFileSync(resolve(REPO_ROOT, 'scripts/publish/serve-local-registry.ts'), 'utf-8')
+			.replace('const ROOT = resolve(import.meta.dirname, "../..");', 'const ROOT = "/workspace";')
+			.replace('const REGISTRY_DIR = join(ROOT, "dist-registry");', 'const REGISTRY_DIR = "/workspace/dist-registry";');
+		await upload('serve-local-registry.ts', serveScript, 'text/x-typescript');
 
-		// 1c. Upload the registry-server script too. We run it inside the microVM
-		// because npm's packuments reference http://localhost:4873/... and npm
-		// rejects file:// tarball URLs.
-		const serveScript = readFileSync(
-			resolve(REPO_ROOT, 'scripts/publish/serve-local-registry.ts'),
-			'utf-8',
-		);
-		// Adjust the registry-root path to /workspace/dist-registry inside the microVM.
-		const serveAdapted = serveScript
-			.replace(
-				'const ROOT = resolve(import.meta.dirname, "../..");',
-				'const ROOT = "/workspace";',
-			)
-			.replace(
-				'const REGISTRY_DIR = join(ROOT, "dist-registry");',
-				'const REGISTRY_DIR = "/workspace/dist-registry";',
-			);
-		const serveUri = await transport(
-			'serve-local-registry.ts',
-			serveAdapted,
-			'text/x-typescript',
-		);
-		log(`uploaded ${tarballUri}`);
+		for (const sh of ['bootstrap.sh', 'setup-app.sh', 'capture-files.sh']) {
+			await upload(sh, readFileSync(resolve(MICROVM_DIR, sh)));
+		}
 
-		const extract = await exec(
-			HARNESS_ARN,
-			benchSession,
-			`set -e
-mkdir -p /workspace/dist-registry
-aws s3 cp '${tarballUri}' /tmp/dist-registry.tgz
-aws s3 cp '${serveUri}' /tmp/serve-local-registry.ts
-tar -xzf /tmp/dist-registry.tgz -C /workspace/dist-registry
-ls /workspace/dist-registry/registry/@aws-blocks | head -5`,
-		);
-		assertOk(extract, 'dist-registry extract', result);
+		// 2. Bootstrap microVM (Node 22, dist-registry, registry server).
+		log('bootstrapping microVM');
+		const env = `export TRANSPORT_PREFIX='${transportPrefix}'`;
+		const fetchScripts = `aws s3 cp '${transportPrefix}/bootstrap.sh' /tmp/bootstrap.sh && aws s3 cp '${transportPrefix}/setup-app.sh' /tmp/setup-app.sh && aws s3 cp '${transportPrefix}/capture-files.sh' /tmp/capture-files.sh && chmod +x /tmp/*.sh`;
+		const bootstrap = await exec(HARNESS_ARN, benchSession, `${env}; ${fetchScripts} && bash /tmp/bootstrap.sh`, 420);
+		if (bootstrap.exitCode !== 0) {
+			result.notes.push(`bootstrap failed (exit ${bootstrap.exitCode}): ${tail(bootstrap.stdout + bootstrap.stderr, 1500)}`);
+			throw new Error('bootstrap failed');
+		}
 
-		// 1d. Start the local registry server inside the microVM and wait for it.
-		log('starting in-microVM registry server');
-		const startRegistry = await exec(
-			HARNESS_ARN,
-			benchSession,
-			`set -e
-# Install tsx globally so we can run the .ts directly without project setup.
-npm install -g tsx 2>&1 | tail -3
-nohup tsx /tmp/serve-local-registry.ts > /tmp/registry.log 2>&1 &
-echo $! > /tmp/registry.pid
-for i in $(seq 1 30); do
-  if curl -sf http://localhost:4873/registry/@aws-blocks/blocks > /dev/null; then
-    echo "registry-up"; exit 0
-  fi
-  sleep 1
-done
-echo '>>> registry server failed to start; tail of log:'
-tail -50 /tmp/registry.log
-exit 1`,
-			300,
-		);
-		assertOk(startRegistry, 'in-microVM registry start', result);
-
-		// 2. Scaffold the app, start dev server.
+		// 3. Scaffold app and start dev server.
 		log('scaffolding bench-app');
-		const setup = await exec(
-			HARNESS_ARN,
-			benchSession,
-			`set -eo pipefail
-cd /workspace
-cat > .npmrc <<'EOF'
-@aws-blocks:registry=http://localhost:4873/registry/
-EOF
-echo '>>> installing @aws-blocks/create-blocks-app from local registry'
-npm install --no-save @aws-blocks/create-blocks-app 2>&1 | tail -10
-echo '>>> scaffolding bench-app'
-./node_modules/.bin/create-blocks-app bench-app${args.template === 'default' ? '' : ` --template ${args.template}`} 2>&1 | tail -20
-echo '>>> starting dev server'
-cd bench-app
-nohup npm run dev > /tmp/dev.log 2>&1 &
-echo $! > /tmp/dev.pid
-for i in $(seq 1 60); do
-  if curl -sf http://localhost:3000 > /dev/null; then
-    echo "dev-server-up"; exit 0
-  fi
-  sleep 1
-done
-echo '>>> dev server timed out; tail of /tmp/dev.log:'
-tail -50 /tmp/dev.log
-exit 1
-`,
-			600,
-		);
+		const setup = await exec(HARNESS_ARN, benchSession, `bash /tmp/setup-app.sh '${args.template}'`, 600);
 		result.scaffolded = setup.exitCode === 0;
-		result.dev_server_started = setup.stdout.includes('dev-server-up');
+		const portMatch = setup.stdout.match(/dev-server-up:(\d+)/);
+		const devPort = portMatch ? Number.parseInt(portMatch[1], 10) : 3000;
+		result.dev_server_started = portMatch != null;
 		if (!result.scaffolded || !result.dev_server_started) {
 			result.notes.push(`setup failed (exit ${setup.exitCode}): ${tail(setup.stdout + setup.stderr, 2000)}`);
 			throw new Error('setup failed');
 		}
 
-		// 3. Builder agent.
+		// 4. Builder agent. Pass the task prompt as-is — embedding the
+		// Playwright spec was tested and tripled token usage without improving
+		// scores (the agent over-iterated trying to match selectors that the
+		// AGENTS.md guide already documents). The grader still gets the spec.
 		log('invoking builder agent');
 		const builder = await invokeAgent(HARNESS_ARN, benchSession, {
 			systemPrompt: BUILDER_SYSTEM_PROMPT,
 			userText: taskPrompt,
+			// Explicit stopping conditions per Anthropic's "Building effective
+			// agents" guidance. 100 iterations suits our task shape (typical
+			// runs use 30-60); 20min covers slow npm builds. Higher caps caused
+			// pathological loops that nuked the workspace.
+			maxIterations: 100,
+			timeoutSeconds: 1200,
 		});
 		result.tokens_in = builder.tokensIn;
 		result.tokens_out = builder.tokensOut;
@@ -440,8 +291,22 @@ exit 1
 		if (result.budget_exceeded) {
 			result.notes.push(`token budget exceeded: ${result.tokens_total} > ${cfg.token_budget}`);
 		}
+		if (builder.stopReason && builder.stopReason !== 'end_turn') {
+			result.notes.push(`builder stop_reason=${builder.stopReason}`);
+		}
 
-		// 4. Build sanity check.
+		// 5. Build sanity check (skipped if the agent trashed its workspace).
+		const integrity = await exec(
+			HARNESS_ARN,
+			benchSession,
+			`[ -d /workspace/bench-app ] && [ -f /workspace/bench-app/package.json ] && echo workspace-ok || { echo workspace-missing; ls /workspace; exit 1; }`,
+			60,
+		);
+		if (!integrity.stdout.includes('workspace-ok')) {
+			result.notes.push(`workspace missing after builder turn: ${tail(integrity.stdout, 500)}`);
+			result.status = 'error';
+			return;
+		}
 		log('npm run build');
 		const build = await exec(HARNESS_ARN, benchSession, `cd /workspace/bench-app && npm run build`, 600);
 		result.build_succeeded = build.exitCode === 0;
@@ -449,30 +314,29 @@ exit 1
 			result.notes.push(`build failed:\n${tail(build.stdout + build.stderr, 2000)}`);
 		}
 
-		// 5. Playwright. Spec + config land in the microVM through S3 too.
-		log('uploading Playwright spec + config');
-		const specUri = await transport('task.spec.ts', readFileSync(specPath), 'text/x-typescript');
-		const configUri = await transport(
+		// 6. Playwright.
+		log('uploading Playwright spec + config and running tests');
+		await upload('task.spec.ts', readFileSync(specPath), 'text/x-typescript');
+		await upload(
 			'playwright.config.ts',
 			`import { defineConfig } from '@playwright/test';
 export default defineConfig({
   testDir: './bench-tests',
   timeout: 60_000,
   reporter: [['json']],
-  use: { baseURL: 'http://localhost:3000' },
+  use: { baseURL: 'http://localhost:${devPort}' },
 });
 `,
 			'text/x-typescript',
 		);
-		log('running Playwright');
 		const test = await exec(
 			HARNESS_ARN,
 			benchSession,
 			`set -e
 cd /workspace/bench-app
 mkdir -p bench-tests
-aws s3 cp '${specUri}' bench-tests/task.spec.ts
-aws s3 cp '${configUri}' playwright.config.ts
+aws s3 cp '${transportPrefix}/task.spec.ts' bench-tests/task.spec.ts
+aws s3 cp '${transportPrefix}/playwright.config.ts' playwright.config.ts
 npm install --no-save --silent @playwright/test >/dev/null
 npx playwright install chromium >/tmp/pw-install.log 2>&1 || true
 npx playwright test --reporter=json 2>&1 || true`,
@@ -484,19 +348,11 @@ npx playwright test --reporter=json 2>&1 || true`,
 		result.tests_total = tests.total;
 		result.test_pass_rate = tests.total > 0 ? tests.passed / tests.total : 0;
 
-		// 6. Judge — same session as the builder so the workspace files are
-		// already there, but with the workspace chmod'd read-only and shell
-		// access removed. The harness's file_operations tool is monolithic
-		// (view+create+edit), so OS permissions are the only real read-only
-		// boundary. Both file_operations writes and shell are out of reach
-		// for the judge: the former by chmod, the latter by allowedTools.
-		log('locking workspace read-only');
-		await exec(
-			HARNESS_ARN,
-			benchSession,
-			`chmod -R a-w /workspace/bench-app && find /workspace/bench-app -maxdepth 1 -type d -ls | head -5`,
-		);
-		log('invoking judge agent');
+		// 7. Judge — same session, workspace chmod'd read-only, no shell.
+		// Tight caps keep it focused on inspect → JSON; 50 iterations is plenty
+		// for read-only file inspection, 4K tokens forces concise output.
+		log('locking workspace read-only and invoking judge');
+		await exec(HARNESS_ARN, benchSession, `chmod -R a-w /workspace/bench-app`);
 		const judge = await invokeAgent(HARNESS_ARN, benchSession, {
 			systemPrompt: JUDGE_SYSTEM_PROMPT,
 			userText:
@@ -505,58 +361,58 @@ npx playwright test --reporter=json 2>&1 || true`,
 				`<evidence>\nscaffolded: ${result.scaffolded}\nbuild_succeeded: ${result.build_succeeded}\ndev_server_started: ${result.dev_server_started}\ntests_total: ${result.tests_total}\ntests_passed: ${result.tests_passed}\ntests_failed: ${result.tests_failed}\n</evidence>\n\n` +
 				`Inspect /workspace/bench-app/ then return the JSON object.`,
 			allowedTools: ['file_operations'],
+			maxIterations: 50,
+			maxTokens: 4096,
+			timeoutSeconds: 300,
 		});
 		result.tokens_in += judge.tokensIn;
 		result.tokens_out += judge.tokensOut;
 		result.tokens_total = result.tokens_in + result.tokens_out;
 		try {
-			const parsed: { scores?: Record<string, number>; overall?: number; explanation?: string } = JSON.parse(
-				extractJson(judge.text),
-			);
+			const parsed = JSON.parse(extractJson(judge.text)) as {
+				scores?: Record<string, number>;
+				overall?: number;
+				explanation?: string;
+			};
 			result.judge_score = parsed.overall ?? null;
 			result.judge_dimensions = parsed.scores ?? {};
 			result.judge_explanation = parsed.explanation ?? '';
 		} catch (err) {
-			result.notes.push(
-				`judge JSON parse failed: ${(err as Error).message}; raw=${judge.text.slice(0, 500)}`,
-			);
+			result.notes.push(`judge JSON parse failed: ${(err as Error).message}; raw=${judge.text.slice(0, 500)}`);
 		}
 
-		// 7. Capture the files the agent wrote — for inspection in the envelope.
-		// Tar them into one upload to keep this O(1) rather than O(N) round trips.
-		const captureUri = `s3://${TRANSPORT_BUCKET}/bench-uploads/${result.run_id}/${cellId}/agent-files.tgz`;
-		const capture = await exec(
-			HARNESS_ARN,
-			benchSession,
-			`set -e
-cd /workspace/bench-app
-tar -czf /tmp/agent-files.tgz \
-  --ignore-failed-read \
-  aws-blocks/index.ts aws-blocks/index.cdk.ts aws-blocks/index.handler.ts \
-  src/index.ts src/main.tsx src/App.tsx index.html package.json 2>/dev/null || true
-aws s3 cp /tmp/agent-files.tgz '${captureUri}'`,
-		);
+		// 8. Capture agent files via S3 round-trip.
+		log('capturing agent files');
+		const capture = await exec(HARNESS_ARN, benchSession, `${env} && bash /tmp/capture-files.sh`, 120);
 		if (capture.exitCode === 0) {
-			// Pull the tarball, extract, read each file into the envelope.
-			execSync(`aws s3 cp ${captureUri} /tmp/agent-files-${cellId}.tgz --only-show-errors`);
+			const tmpTgz = `/tmp/agent-files-${cellId}.tgz`;
 			const tmpDir = `/tmp/agent-files-${cellId}`;
-			execSync(`rm -rf ${tmpDir} && mkdir -p ${tmpDir} && tar -xzf /tmp/agent-files-${cellId}.tgz -C ${tmpDir}`);
-			for (const path of walkAll(tmpDir)) {
+			execSync(`aws s3 cp ${transportPrefix}/agent-files.tgz ${tmpTgz} --only-show-errors`);
+			execSync(`rm -rf ${tmpDir} && mkdir -p ${tmpDir} && tar -xzf ${tmpTgz} -C ${tmpDir}`);
+			const MAX_FILES = 200;
+			const MAX_BYTES = 64 * 1024;
+			let captured = 0;
+			for (const path of walk(tmpDir)) {
+				if (captured >= MAX_FILES) break;
 				const rel = path.slice(tmpDir.length + 1);
 				try {
-					result.agent_files[rel] = readFileSync(path, 'utf-8');
+					const size = statSync(path).size;
+					result.agent_files[rel] =
+						size > MAX_BYTES ? `[truncated: ${size} bytes > ${MAX_BYTES}]` : readFileSync(path, 'utf-8');
+					captured++;
 				} catch {
-					// non-utf8 file — skip silently
+					// non-utf8 / unreadable
 				}
 			}
+			if (captured >= MAX_FILES) result.notes.push(`agent_files capped at ${MAX_FILES} entries`);
+		} else {
+			result.notes.push(`agent_files capture failed (exit ${capture.exitCode}): ${tail(capture.stdout + capture.stderr, 500)}`);
 		}
 
 		result.status = result.budget_exceeded ? 'budget_exceeded' : 'scored';
 	} catch (err) {
 		result.notes.push(`orchestrator error: ${(err as Error).message}`);
 	} finally {
-		// Release the microVM promptly so the per-account session quota isn't
-		// tied up. Best-effort; the harness's idle timeout is the backstop.
 		await stopSession(HARNESS_ARN, benchSession);
 		result.duration_sec = Math.round((Date.now() - started) / 100) / 10;
 		mkdirSync(dirname(args.output), { recursive: true });
@@ -566,11 +422,11 @@ aws s3 cp /tmp/agent-files.tgz '${captureUri}'`,
 	}
 }
 
-function walkAll(dir: string): string[] {
+function walk(dir: string): string[] {
 	const out: string[] = [];
 	for (const entry of readdirSync(dir, { withFileTypes: true })) {
 		const full = resolve(dir, entry.name);
-		if (entry.isDirectory()) out.push(...walkAll(full));
+		if (entry.isDirectory()) out.push(...walk(full));
 		else out.push(full);
 	}
 	return out;

--- a/scripts/agent-bench/summarize.mjs
+++ b/scripts/agent-bench/summarize.mjs
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+// Render every result-*.json under the given directory into a markdown table
+// suitable for $GITHUB_STEP_SUMMARY. Stdout is the markdown.
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const dir = process.argv[2];
+if (!dir) {
+	console.error('usage: summarize.mjs <results-dir>');
+	process.exit(2);
+}
+
+const files = readdirSync(dir).filter((f) => f.startsWith('result-') && f.endsWith('.json'));
+const rows = files.map((f) => JSON.parse(readFileSync(join(dir, f), 'utf-8')));
+rows.sort((a, b) => `${a.template}/${a.task}`.localeCompare(`${b.template}/${b.task}`));
+
+const fmt = (n) => (typeof n === 'number' ? n.toLocaleString('en-US') : String(n));
+const score = (s) => (s == null ? '—' : s.toFixed(2));
+const passRate = (r) =>
+	r.tests_total === 0 ? '—' : `${r.tests_passed}/${r.tests_total}`;
+const flag = (ok) => (ok ? '✅' : '❌');
+
+const header =
+	'| Template | Task | Build | Dev | Tests | Judge | Tokens In | Tokens Out | Total | Budget | Time | Status |';
+const sep = '|---|---|---|---|---|---|---:|---:|---:|---|---:|---|';
+const lines = rows.map(
+	(r) =>
+		`| ${r.template} | ${r.task} | ${flag(r.build_succeeded)} | ${flag(r.dev_server_started)} | ${passRate(r)} | ${score(r.judge_score)} | ${fmt(r.tokens_in)} | ${fmt(r.tokens_out)} | ${fmt(r.tokens_total)} | ${r.budget_exceeded ? '⚠️ over' : 'ok'} | ${r.duration_sec.toFixed(0)}s | ${r.status} |`,
+);
+
+console.log('## Agent Bench');
+console.log('');
+console.log(header);
+console.log(sep);
+for (const line of lines) console.log(line);
+console.log('');
+
+const noted = rows.filter((r) => (r.notes ?? []).length || r.judge_explanation);
+if (noted.length) {
+	console.log('### Notes');
+	console.log('');
+	for (const r of noted) {
+		console.log(`**${r.template} / ${r.task}**`);
+		for (const n of r.notes ?? []) console.log(`- ${n}`);
+		if (r.judge_explanation) console.log(`- judge: ${r.judge_explanation}`);
+		console.log('');
+	}
+}

--- a/scripts/agent-bench/tsconfig.json
+++ b/scripts/agent-bench/tsconfig.json
@@ -1,0 +1,14 @@
+{
+	"compilerOptions": {
+		"target": "ES2022",
+		"module": "nodenext",
+		"moduleResolution": "nodenext",
+		"types": ["node"],
+		"noEmit": true,
+		"strict": true,
+		"skipLibCheck": true,
+		"resolveJsonModule": true,
+		"allowImportingTsExtensions": true
+	},
+	"include": ["agentcore.ts", "preflight.ts", "run-bench.ts"]
+}

--- a/tasks/realtime-todos/PROMPT.md
+++ b/tasks/realtime-todos/PROMPT.md
@@ -1,0 +1,59 @@
+# Task: Realtime To-Do List
+
+Scaffold a fresh AWS Blocks app, then build a to-do list page in it. The page must work across multiple browser tabs in real time and survive a page reload.
+
+## Setup (do this first)
+
+You start in an empty workspace. Call **`scaffold_app`** before anything else — it creates `./bench-app/` with the project skeleton and runs `npm install` for you. After that, do all your edits inside `bench-app/`. When you want to verify against a running app, call **`start_dev_server`** — it boots `npm run dev` and returns the base URL. Don't try to run the dev server through `run_bash`.
+
+## Requirements
+
+1. A user can type into an input and click a button to add a new to-do item.
+2. The list shows every to-do that has been added.
+3. Each item has a checkbox that toggles its done state.
+4. Each item has a button that removes it from the list.
+5. **Realtime:** when one tab adds, toggles, or removes a to-do, every other open tab reflects the change within a couple of seconds — no manual refresh.
+6. **Persistence:** after a full page reload, the to-dos are still there.
+
+The to-dos are shared across all tabs of the app (single global list). No login, no users, no per-user filtering.
+
+## Where to look
+
+The project is built on AWS Blocks. Inside `bench-app/`, the `aws-blocks/` directory is your wiring point — backend handlers and CDK constructs live there. Inside `bench-app/node_modules/@aws-blocks/`, each package has a `README.md` and an `API.md` describing what it does and how to use it. Read the relevant ones before deciding which building blocks to use.
+
+You will need at least one block for stored data and at least one block for the realtime sync. Pick whichever ones fit the requirements; you may use as many or as few as you need.
+
+After `start_dev_server` returns, the running app is at <http://localhost:3000>. Edits to `bench-app/aws-blocks/` reload the backend; edits under `bench-app/src/` hot-reload the frontend. Use the running app to verify your work.
+
+## Selector contract
+
+The Playwright test grades your work using `data-testid` and one data attribute. These are the only DOM hooks the test relies on — implement them exactly.
+
+| Selector | Element | Purpose |
+|---|---|---|
+| `[data-testid=todo-input]` | `<input type="text">` | Where the user types a new to-do title |
+| `[data-testid=todo-add]` | `<button>` | Click to add the value of the input as a new to-do |
+| `[data-testid=todo-list]` | `<ul>` (or any single container) | Wraps every to-do item |
+| `[data-testid=todo-item]` | one per to-do, inside the list | The row for a single to-do |
+| `[data-testid=todo-title]` | inside the item | Renders the to-do's title text |
+| `[data-testid=todo-toggle]` | `<input type="checkbox">` inside the item | Toggles done/not-done |
+| `[data-testid=todo-delete]` | `<button>` inside the item | Removes that to-do |
+
+When a to-do is done, set `data-done="true"` on its `[data-testid=todo-item]` element. When not done, either omit the attribute or set it to `"false"`.
+
+The mount point for your page is the existing root element. You can replace whatever placeholder content the template ships with.
+
+## Out of scope
+
+- Authentication, accounts, per-user lists
+- Styling beyond what makes the test pass (no design pass needed)
+- Editing a to-do's title after creation
+- Ordering, sorting, filtering, search
+- Animations, drag-and-drop
+- Pagination or virtualization
+
+## Done means
+
+- All Playwright assertions pass against the running dev server.
+- No errors in the browser console under normal use.
+- Your changes are limited to files inside `bench-app/`. Don't modify anything under `bench-app/node_modules/`.

--- a/tasks/realtime-todos/config.yaml
+++ b/tasks/realtime-todos/config.yaml
@@ -4,6 +4,6 @@ tier: medium
 test_file: test.spec.ts
 time_limit_sec: 1800
 # Generous budget: discovery alone (reading @aws-blocks READMEs/API.md) burns
-# ~400K input tokens before any code is written. 1.5M lets the builder finish;
-# raise if observed runs consistently exceed it on real PRs.
-token_budget: 1500000
+# ~400K input tokens before any code is written. Observed nextjs runs reach
+# ~3M; cap above that so a normal completion isn't flagged as exceeded.
+token_budget: 4000000

--- a/tasks/realtime-todos/config.yaml
+++ b/tasks/realtime-todos/config.yaml
@@ -1,0 +1,9 @@
+id: realtime-todos
+name: Realtime To-Do List
+tier: medium
+test_file: test.spec.ts
+time_limit_sec: 1800
+# Generous budget: discovery alone (reading @aws-blocks READMEs/API.md) burns
+# ~400K input tokens before any code is written. 1.5M lets the builder finish;
+# raise if observed runs consistently exceed it on real PRs.
+token_budget: 1500000

--- a/tasks/realtime-todos/test.spec.ts
+++ b/tasks/realtime-todos/test.spec.ts
@@ -1,0 +1,60 @@
+import { test, expect } from '@playwright/test';
+
+const BASE = process.env.BLOCKS_URL ?? 'http://localhost:3000';
+const SYNC_TIMEOUT = 8_000;
+
+test.describe('realtime-todos', () => {
+	test('crud, realtime sync across tabs, and persistence', async ({ browser }) => {
+		const ctxA = await browser.newContext();
+		const ctxB = await browser.newContext();
+		const tabA = await ctxA.newPage();
+		const tabB = await ctxB.newPage();
+
+		await tabA.goto(BASE);
+		await tabB.goto(BASE);
+
+		await expect(tabA.getByTestId('todo-input')).toBeVisible();
+		await expect(tabA.getByTestId('todo-add')).toBeVisible();
+		await expect(tabA.getByTestId('todo-list')).toBeVisible();
+
+		const titleA = `task-a-${Date.now()}`;
+		await tabA.getByTestId('todo-input').fill(titleA);
+		await tabA.getByTestId('todo-add').click();
+
+		const itemAonA = tabA
+			.getByTestId('todo-item')
+			.filter({ has: tabA.getByTestId('todo-title').filter({ hasText: titleA }) });
+		await expect(itemAonA).toHaveCount(1, { timeout: SYNC_TIMEOUT });
+
+		const itemAonB = tabB
+			.getByTestId('todo-item')
+			.filter({ has: tabB.getByTestId('todo-title').filter({ hasText: titleA }) });
+		await expect(itemAonB).toHaveCount(1, { timeout: SYNC_TIMEOUT });
+
+		await itemAonB.getByTestId('todo-toggle').check();
+		await expect(itemAonB).toHaveAttribute('data-done', 'true', { timeout: SYNC_TIMEOUT });
+		await expect(itemAonA).toHaveAttribute('data-done', 'true', { timeout: SYNC_TIMEOUT });
+
+		await itemAonA.getByTestId('todo-delete').click();
+		await expect(itemAonA).toHaveCount(0, { timeout: SYNC_TIMEOUT });
+		await expect(itemAonB).toHaveCount(0, { timeout: SYNC_TIMEOUT });
+
+		const titleB = `task-b-${Date.now()}`;
+		await tabA.getByTestId('todo-input').fill(titleB);
+		await tabA.getByTestId('todo-add').click();
+		const itemBonA = tabA
+			.getByTestId('todo-item')
+			.filter({ has: tabA.getByTestId('todo-title').filter({ hasText: titleB }) });
+		await expect(itemBonA).toHaveCount(1, { timeout: SYNC_TIMEOUT });
+
+		await tabA.reload();
+		const itemBafterReload = tabA
+			.getByTestId('todo-item')
+			.filter({ has: tabA.getByTestId('todo-title').filter({ hasText: titleB }) });
+		await expect(itemBafterReload).toHaveCount(1, { timeout: SYNC_TIMEOUT });
+
+		await itemBafterReload.getByTestId('todo-delete').click();
+		await ctxA.close();
+		await ctxB.close();
+	});
+});


### PR DESCRIPTION
## Summary

Adds a non-blocking pull-request check that exercises the AWS Blocks end-to-end: an LLM agent implements a small feature against each shipped scaffolding template, the result is graded by a second agent, and per-PR token counts plus rubric scores are surfaced in the GitHub step summary.

The orchestrator runs the agent loop on **Amazon Bedrock AgentCore Harness** (Claude Sonnet 4.6). Each cell of the matrix gets its own Firecracker microVM with built-in shell and file tools — no agent-loop code, sandboxing, or bespoke tool implementations are required on the runner.

## Architecture

GitHub Actions matrix fans out cells (one cell = one runner = one harness session). The runner uploads the dist-registry tarball + Playwright spec to S3, the microVM pulls them down, the existing `serve-local-registry.ts` runs inside the microVM on `localhost:4873`, and `npm install` / scaffold / builder agent / build / Playwright / judge all happen there.

## Files

```
scripts/agent-bench/
  agentcore.ts     SDK wrappers: exec, invokeAgent, putToTransport,
                   sessionId, stopSession (~200 LOC)
  preflight.ts     Idempotent pre-run probes: env, invokeAgent smoke,
                   exec smoke, S3 reachability
  run-bench.ts     Per-cell orchestrator (~570 LOC)
  summarize.mjs    result-*.json -> markdown table for $GITHUB_STEP_SUMMARY
  README.md        What the bench is and how to add a task
  tsconfig.json
  .gitignore       Excludes locally-generated artifacts

tasks/realtime-todos/   First task; runtime-agnostic
  config.yaml, PROMPT.md, test.spec.ts

.github/workflows/pr-agent-bench.yml   Non-blocking, 7 templates × 1 task
```

Adds 7 SDK packages to the root `devDependencies`: `@aws-sdk/client-bedrock-agentcore`, `@aws-sdk/client-bedrock-agentcore-control`, `@aws-sdk/client-iam`, `@aws-sdk/client-s3`, `@aws-sdk/client-sts`, `@smithy/node-http-handler`, plus `js-yaml` and its types.

## Architectural decisions

- **GitHub Actions matrix owns orchestration** — one cell per runner, parallelism is handled by the Actions runtime.
- **S3 for runner ↔ microVM bytes** — the `bench-uploads/*` prefix on the registry bucket. Avoids the 65,536-char-per-command API limit on `InvokeAgentRuntimeCommand`.
- **In-microVM registry server** — npm refuses `file://` tarball URLs in packuments, so the existing `scripts/publish/serve-local-registry.ts` runs inside the microVM on `localhost:4873`.
- **Builder gets all built-in tools** (shell + file_operations); **judge gets read-only file tools** (`allowedTools: ['file_*']`) so it can inspect the written code when grading code-quality, but cannot shell or write.
- **Explicit `StopRuntimeSession` in `finally{}`** plus a 60s harness idle timeout as a backstop — microVMs are released promptly against the per-account 1,000-active-session quota.

## Required configuration

The workflow expects three values in the `publish` GitHub environment for this repository:

| Name | Type | Description |
|---|---|---|
| `AWS_ROLE_ARN` | secret | OIDC role with `bedrock-agentcore:Invoke*` on the harness ARN, plus `s3:PutObject` on the registry bucket's `bench-uploads/*` and `bench/*` prefixes |
| `S3_BUCKET` | variable | Registry bucket name (existing) |
| `BENCH_HARNESS_ARN` | variable | ARN of a pre-created AgentCore Harness named `blocks_bench` |

Provisioning the harness, the harness execution role, and the IAM updates on the OIDC role are out-of-scope for this PR. The workflow runs only when these values resolve; preflight surfaces missing or misconfigured values with a clear error before the bench starts.

## Test plan

- [ ] Provision the harness and IAM (out-of-band)
- [ ] Set `BENCH_HARNESS_ARN` in the publish environment
- [ ] Push a commit on this branch — preflight is the green/red signal
- [ ] Inspect the 7-cell matrix output: token counts and judge scores per template
- [ ] If green: merge. If not: iterate on the branch.

## What this is and isn't

- A **signal generator**, not a gate. The workflow's overall result does not block the PR.
- **Build-only** mode. Each cell is graded on whether the agent produced code that scaffolds, builds, runs, and passes the task's spec. No infrastructure is deployed.
- **Not a replacement** for the existing E2E suite — this is complementary signal.

## Follow-ups (out of scope here)

- More tasks under `tasks/` exercising additional building blocks
- Custom container image for the harness with Node and Playwright pre-installed (saves ~30s/cell)
- Managed batch evaluation for the judge (`BatchEvaluationRunner`)
- AgentCore Browser tool for an interactive UI judge

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._