### PR TITLE
docs(hosting): document custom domain configuration

### DIFF
--- a/.changeset/hosting-custom-domain-docs.md
+++ b/.changeset/hosting-custom-domain-docs.md
@@ -1,0 +1,5 @@
+---
+"@aws-blocks/hosting": patch
+---
+
+docs(hosting): document custom domain configuration (Route 53 and bring-your-own DNS)

--- a/packages/hosting/README.md
+++ b/packages/hosting/README.md
@@ -76,6 +76,87 @@ import { HostingError } from '@aws-blocks/hosting/error';
 └──────────────────────────────────────────────┘
 ```
 
+## Custom domains
+
+Configure a custom domain through the `domain` prop on `HostingConstruct`
+(`HostingDomainConfig`). CloudFront only accepts ACM certificates in
+**us-east-1**, so every certificate, whether auto-provisioned or
+bring-your-own, must live in us-east-1. There are two paths, depending on where
+you manage DNS.
+
+### Route 53 (automatic)
+
+Provide `hostedZone` (the zone domain name) or `hostedZoneId`. The construct
+provisions a DNS-validated ACM certificate and creates the A and AAAA alias
+records for you. Validation is automatic when the hosted zone is in the same
+account as the deployment, because the construct writes the ACM validation
+records into the zone itself.
+
+```ts
+new HostingConstruct(stack, 'Hosting', {
+  manifest,
+  domain: {
+    domainName: 'app.example.com',
+    hostedZone: 'example.com', // a Route 53 zone you control
+  },
+});
+```
+
+Use `hostedZoneId` to skip `HostedZone.fromLookup()`, which otherwise requires
+`env: { account, region }` on the stack. This is useful in pipeline stages:
+
+```ts
+domain: {
+  domainName: 'app.example.com',
+  hostedZone: 'example.com',
+  hostedZoneId: 'Z0123456789ABCDEFGHIJ',
+}
+```
+
+### Bring your own DNS (manual)
+
+If you manage DNS elsewhere (your registrar, Cloudflare, or another provider),
+omit `hostedZone` and `hostedZoneId` and pass a pre-validated `certificate`, an
+ACM certificate in us-east-1. The construct creates no DNS records. Instead it
+emits the CloudFront distribution domain as a `DistributionDomainName`
+CloudFormation output, so you can point a CNAME at it from your own DNS
+provider.
+
+```ts
+new HostingConstruct(stack, 'Hosting', {
+  manifest,
+  domain: {
+    domainName: 'app.example.com',
+    // no hostedZone: you manage DNS externally
+    certificate: myPreValidatedCert, // ACM cert in us-east-1, pre-validated
+  },
+});
+```
+
+### Error behavior
+
+Omitting both `hostedZone` / `hostedZoneId` and `certificate` throws
+`MissingCertificateError` at synth time. Synthesis fails immediately, so the
+deploy never starts and there is no 72-hour CloudFormation wait on an
+unvalidated certificate. A bring-your-own certificate outside us-east-1 fails
+synthesis with `InvalidCertificateRegionError`.
+
+### Two-phase workflow for external DNS
+
+A certificate must be validated before CloudFront will serve the domain, and
+the CloudFront domain is only known after deploy. Set up external DNS in two
+phases around the deploy:
+
+1. **Before deploy:** request an ACM certificate in **us-east-1** for your
+   domain and validate it (add the ACM validation CNAME to your DNS, or use
+   email validation). Wait until the certificate status is **Issued**.
+2. **Deploy:** deploy the stack with `domain: { domainName, certificate }`. The
+   stack emits the `DistributionDomainName` output (for example
+   `d1234abcd.cloudfront.net`).
+3. **After deploy:** in your DNS provider, create a CNAME from your domain
+   (`app.example.com`) to the `DistributionDomainName` value. For an apex
+   domain, use an ALIAS or ANAME record if your provider supports it.
+
 ## Development
 
 ```bash


### PR DESCRIPTION
## Summary

Adds a custom domains section to the hosting package README covering both the Route 53 (automatic) and bring-your-own-DNS (manual) paths.

This is the documentation piece from the earlier hosting work that hadn't yet landed in the public repo. The Lambda@Edge log retention code fix is already present in this repo.

## Changes
- packages/hosting/README.md: new Custom domains section (Route 53 + BYO DNS, error behavior, two-phase external-DNS flow, code example)

## Testing
- Doc-only change; build verified (`npx tsc --noEmit -p packages/hosting/tsconfig.json` passes)
