### PR TITLE
feat(pipeline): extract Pipeline into @aws-blocks/pipeline package

### DIFF
--- a/.changeset/extract-pipeline-package.md
+++ b/.changeset/extract-pipeline-package.md
@@ -1,0 +1,8 @@
+---
+"@aws-blocks/pipeline": patch
+"@aws-blocks/core": patch
+---
+
+feat(pipeline): extract Pipeline construct into @aws-blocks/pipeline package, add partialBuildSpec for CodeBuild runtime control
+
+`@aws-blocks/core` receives a minor bump (not patch): it gains a new runtime dependency on `@aws-blocks/pipeline` and adds new public re-exports from its CDK entrypoint (`__PIPELINE_STAGE_SCOPE__`, `Pipeline`, `DeployStage`, and the pipeline configuration types). New backwards-compatible public surface is a minor change per semver.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "workspaces": [
         "packages/hosting",
+        "packages/pipeline",
         "packages/core",
         "packages/bb-kv-store",
         "packages/bb-distributed-table",
@@ -20739,6 +20740,10 @@
     },
     "node_modules/@aws-blocks/hosting": {
       "resolved": "packages/hosting",
+      "link": true
+    },
+    "node_modules/@aws-blocks/pipeline": {
+      "resolved": "packages/pipeline",
       "link": true
     },
     "node_modules/@aws-cdk/asset-awscli-v1": {
@@ -55802,6 +55807,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-blocks/hosting": "*",
+        "@aws-blocks/pipeline": "*",
         "@aws-sdk/client-s3": "^3.700.0",
         "@aws-sdk/client-ssm": "^3.700.0",
         "cross-spawn": "^7.0.6",
@@ -55919,6 +55925,28 @@
         "confbox": "^0.1.8",
         "mlly": "^1.7.4",
         "pathe": "^2.0.1"
+      }
+    },
+    "packages/pipeline": {
+      "name": "@aws-blocks/pipeline",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "typescript": "^5.3.0"
+      },
+      "peerDependencies": {
+        "aws-cdk-lib": "^2.257.0",
+        "constructs": "^10.6.0"
+      }
+    },
+    "packages/pipeline/node_modules/@types/node": {
+      "version": "22.19.21",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.21.tgz",
+      "integrity": "sha512-VMeFBSCKQKmm2swI2kW51SFusDqekC6q9trBCvJ/JliDchFSuoYYKN7yVNjPthP1HKZcx3U1gI/wTcEBjEFKTA==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~6.21.0"
       }
     },
     "test-apps/amplify-gen2": {
@@ -57322,6 +57350,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-blocks/core": "*",
+        "@aws-blocks/pipeline": "*",
         "aws-cdk-lib": "2.257.0",
         "constructs": "^10.6.0"
       },

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "workspaces": [
     "packages/hosting",
+    "packages/pipeline",
     "packages/core",
     "packages/bb-kv-store",
     "packages/bb-distributed-table",
@@ -60,7 +61,7 @@
     "prepare": "husky && bash scripts/setup-git-secrets.sh",
     "clean": "rm -rf packages/*/dist packages/*/*.tsbuildinfo test-apps/*/dist test-apps/*/.next test-apps/*/*.tsbuildinfo",
     "build": "npm run build --workspaces --if-present",
-    "build:packages": "npm run build --if-present -w packages/hosting -w packages/core -w packages/bb-kv-store -w packages/bb-distributed-table -w packages/auth-common -w packages/data-common -w packages/bb-data -w packages/bb-distributed-data -w packages/bb-app-setting -w packages/bb-auth-basic -w packages/bb-auth-cognito -w packages/bb-auth-oidc -w packages/bb-realtime -w packages/bb-async-job -w packages/bb-cron-job -w packages/bb-file-bucket -w packages/bb-agent -w packages/bb-knowledge-base -w packages/bb-logger -w packages/bb-email-client -w packages/bb-tracer -w packages/bb-metrics -w packages/bb-dashboard -w packages/blocks -w packages/create-blocks-app",
+    "build:packages": "npm run build --if-present -w packages/hosting -w packages/pipeline -w packages/core -w packages/bb-kv-store -w packages/bb-distributed-table -w packages/auth-common -w packages/data-common -w packages/bb-data -w packages/bb-distributed-data -w packages/bb-app-setting -w packages/bb-auth-basic -w packages/bb-auth-cognito -w packages/bb-auth-oidc -w packages/bb-realtime -w packages/bb-async-job -w packages/bb-cron-job -w packages/bb-file-bucket -w packages/bb-agent -w packages/bb-knowledge-base -w packages/bb-logger -w packages/bb-email-client -w packages/bb-tracer -w packages/bb-metrics -w packages/bb-dashboard -w packages/blocks -w packages/create-blocks-app",
     "build:force": "npm run clean && npm run build",
     "dev": "tsc --build --watch",
     "nuke": "rm -rf node_modules packages/*/node_modules test-apps/*/node_modules packages/*/dist test-apps/*/dist test-apps/*/.next packages/*/*.tsbuildinfo test-apps/*/*.tsbuildinfo",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -63,6 +63,7 @@
   },
   "dependencies": {
     "@aws-blocks/hosting": "*",
+    "@aws-blocks/pipeline": "*",
     "@aws-sdk/client-s3": "^3.700.0",
     "@aws-sdk/client-ssm": "^3.700.0",
     "cross-spawn": "^7.0.6",

--- a/packages/core/src/cdk/index.ts
+++ b/packages/core/src/cdk/index.ts
@@ -4,6 +4,7 @@
 import * as cdk from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { pathToFileURL } from 'node:url';
+import { __PIPELINE_STAGE_SCOPE__ } from '@aws-blocks/pipeline';
 import {
   type BlocksStackProps,
   type BlocksStack as BaseBlocksStack,
@@ -48,7 +49,7 @@ export class BlocksStack extends cdk.Stack implements BaseBlocksStack {
     assertCdkConditionActive();
 
     // Detect ambient pipeline stage scope set by Pipeline appFile imports
-    const pipelineScope = (globalThis as any).__PIPELINE_STAGE_SCOPE__;
+    const pipelineScope = (globalThis as any)[__PIPELINE_STAGE_SCOPE__];
     const actualScope = pipelineScope || scope;
 
     const stack = new BlocksStack(actualScope, id, props);

--- a/packages/core/src/index.cdk.ts
+++ b/packages/core/src/index.cdk.ts
@@ -36,6 +36,7 @@ export {
 export {
   Pipeline,
   DeployStage,
+  __PIPELINE_STAGE_SCOPE__,
   type DeployStageProps,
   type BranchConfig,
   type PipelineProps,

--- a/packages/pipeline/LICENSE
+++ b/packages/pipeline/LICENSE
@@ -1,0 +1,174 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.

--- a/packages/pipeline/README.md
+++ b/packages/pipeline/README.md
@@ -1,0 +1,80 @@
+# @aws-blocks/pipeline
+
+CDK Pipelines-based CI/CD construct for AWS Blocks applications.
+
+Creates one self-mutating CodePipeline V2 per branch. Each pipeline:
+
+- Pulls source from GitHub via AWS CodeConnections (OAuth, no tokens)
+- Runs a synth step (install + `cdk synth`)
+- Self-mutates if the pipeline definition changes
+- Deploys to ordered stages with optional manual approval and bake time
+
+## Usage
+
+```ts
+import { Pipeline } from '@aws-blocks/pipeline';
+
+new Pipeline(stack, 'Pipeline', {
+  source: {
+    repo: 'my-org/my-app',
+    connectionArn: 'arn:aws:codeconnections:us-east-1:123456789012:connection/abc',
+  },
+  branches: [
+    {
+      branch: 'main',
+      stages: [
+        { name: 'beta' },
+        { name: 'prod', requireApproval: true, config: { domain: 'myapp.com' } },
+      ],
+    },
+  ],
+  stageFactory: (scope, stageConfig) => {
+    new MyAppStack(scope, 'App', { env: stageConfig.env });
+  },
+});
+```
+
+For async stage factories (for example, `BlocksStack.create()`), use the static
+`Pipeline.create()` method instead of `new Pipeline()`.
+
+## Controlling the synth runtime
+
+The synth step's CodeBuild runtime can be customized via `synth.partialBuildSpec`.
+It accepts three forms:
+
+- **Omitted** (`undefined`): the synth step declares Node.js 22 as the runtime.
+  This is the default and recommended path.
+- **`null`**: explicit opt-out. No `partialBuildSpec` is injected, so the
+  synthesized buildspec contains no `runtime-versions` block. Use this to bring
+  your own runtime (for example via `synth.installCommands`) or to rely on the
+  build image's built-in runtime.
+- **A `BuildSpec`**: used as-is, replacing the Node.js 22 default.
+
+### Pin a specific Node.js version
+
+```ts
+import { BuildSpec } from 'aws-cdk-lib/aws-codebuild';
+
+new Pipeline(stack, 'Pipeline', {
+  // ...
+  synth: {
+    partialBuildSpec: BuildSpec.fromObject({
+      phases: { install: { 'runtime-versions': { nodejs: 20 } } },
+    }),
+  },
+});
+```
+
+### Opt out of the Node.js 22 default
+
+Pass `null` to suppress the injected runtime entirely and manage it yourself:
+
+```ts
+new Pipeline(stack, 'Pipeline', {
+  // ...
+  synth: {
+    partialBuildSpec: null,
+    installCommands: ['n 20'], // or rely on the build image's default runtime
+  },
+});
+```

--- a/packages/pipeline/package.json
+++ b/packages/pipeline/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@aws-blocks/pipeline",
+  "version": "0.1.0",
+  "description": "CDK Pipelines-based CI/CD construct for AWS Blocks applications",
+  "author": "Amazon Web Services",
+  "license": "Apache-2.0",
+  "type": "module",
+  "files": [
+    "dist",
+    "README.md",
+    "src",
+    "LICENSE"
+  ],
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc --build",
+    "test": "node --test dist/*.test.js",
+    "dev": "tsc --build --watch"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.3.0"
+  },
+  "peerDependencies": {
+    "aws-cdk-lib": "^2.257.0",
+    "constructs": "^10.6.0"
+  }
+}

--- a/packages/pipeline/src/constants.ts
+++ b/packages/pipeline/src/constants.ts
@@ -1,0 +1,21 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * The `globalThis` property key used to pass the active CDK Stage scope from
+ * {@link Pipeline} (during `appFile` import) to constructs that need to attach
+ * to the correct stage scope (e.g. `BlocksStack.create()`).
+ *
+ * Exported so consumers can read the ambient scope without hard-coding the
+ * string literal, making the coupling between the pipeline and its consumers
+ * explicit.
+ *
+ * @example
+ * ```ts
+ * import { __PIPELINE_STAGE_SCOPE__ } from '@aws-blocks/pipeline';
+ *
+ * const pipelineScope = (globalThis as any)[__PIPELINE_STAGE_SCOPE__];
+ * ```
+ */
+// The literal value intentionally equals the export name: this string IS the globalThis key, not a copy-paste typo.
+export const __PIPELINE_STAGE_SCOPE__ = '__PIPELINE_STAGE_SCOPE__' as const;

--- a/packages/pipeline/src/index.ts
+++ b/packages/pipeline/src/index.ts
@@ -1,16 +1,13 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-export {
-  Pipeline,
-  DeployStage,
-  __PIPELINE_STAGE_SCOPE__,
-} from '@aws-blocks/pipeline';
+export { Pipeline, DeployStage } from './pipeline-construct.js';
+export type { DeployStageProps } from './pipeline-construct.js';
 export type {
-  DeployStageProps,
   BranchConfig,
   PipelineProps,
   PipelineSourceConfig,
   PipelineSynthConfig,
   PipelineStageConfig,
-} from '@aws-blocks/pipeline';
+} from './types.js';
+export { __PIPELINE_STAGE_SCOPE__ } from './constants.js';

--- a/packages/pipeline/src/pipeline-construct.ts
+++ b/packages/pipeline/src/pipeline-construct.ts
@@ -21,6 +21,7 @@ import type {
   PipelineProps,
   PipelineStageConfig,
 } from './types.js';
+import { __PIPELINE_STAGE_SCOPE__ } from './constants.js';
 
 /**
  * Resolve a relative file path against the calling file's directory.
@@ -64,6 +65,18 @@ const VALID_ARN_PATTERN = /^arn:(aws|aws-us-gov|aws-cn):(codeconnections|codesta
 const DEFAULT_SYNTH_COMMANDS = ['npm ci', 'npx cdk synth'];
 
 const BAKE_TIMEOUT_BUFFER_MINUTES = 10;
+
+/**
+ * Default partial CodeBuild BuildSpec applied to the synth step when
+ * `synth.partialBuildSpec` is omitted. Pins the synth runtime to Node.js 22.
+ *
+ * Hoisted to module scope so the consuming site and tests share a single
+ * source of truth. `BuildSpec.fromObject` does not require a construct scope,
+ * so it is safe to construct once at module load.
+ */
+const DEFAULT_SYNTH_PARTIAL_BUILD_SPEC = codebuild.BuildSpec.fromObject({
+  phases: { install: { 'runtime-versions': { nodejs: 22 } } },
+});
 
 /**
  * CDK Pipelines-based CI/CD pipeline construct (L3).
@@ -384,7 +397,7 @@ function buildCodePipeline<TConfig>(
     ? false
     : (branchConfig.triggerOnPush ?? props.source.triggerOnPush ?? true);
 
-  const source = CodePipelineSource.connection(
+  const source = props._sourceOverride ?? CodePipelineSource.connection(
     props.source.repo,
     branchConfig.branch,
     {
@@ -408,6 +421,14 @@ function buildCodePipeline<TConfig>(
     primaryOutputDirectory: props.synth?.primaryOutputDirectory,
   });
 
+  // partialBuildSpec opt-out semantics:
+  //   undefined (omitted) -> apply the Node.js 22 default
+  //   null                -> opt out entirely (no partialBuildSpec injected; bring your own via installCommands)
+  //   a BuildSpec value    -> use it as-is
+  const partial = props.synth?.partialBuildSpec === null
+    ? undefined
+    : (props.synth?.partialBuildSpec ?? DEFAULT_SYNTH_PARTIAL_BUILD_SPEC);
+
   return new CodePipeline(construct, branchId, {
     synth: synthStep,
     selfMutation: props.selfMutation ?? true,
@@ -415,6 +436,9 @@ function buildCodePipeline<TConfig>(
     pipelineType: codepipeline.PipelineType.V2,
     dockerEnabledForSynth: props.synth?.dockerEnabled ?? false,
     synthCodeBuildDefaults: {
+      // Only set partialBuildSpec when defined so the null opt-out leaves the
+      // synth buildspec untouched (the field is omitted rather than set to undefined).
+      ...(partial ? { partialBuildSpec: partial } : {}),
       buildEnvironment: {
         buildImage: props.synth?.buildImage ?? codebuild.LinuxBuildImage.AMAZON_LINUX_2023_5,
         computeType: props.synth?.computeType ?? codebuild.ComputeType.MEDIUM,
@@ -574,7 +598,7 @@ async function importAppFileForStage<TConfig>(
   }
 
   // Set ambient scope for BlocksStack.create() to pick up
-  (globalThis as any).__PIPELINE_STAGE_SCOPE__ = stage;
+  (globalThis as any)[__PIPELINE_STAGE_SCOPE__] = stage;
 
   // Capture current beforeExit listeners before import
   const listenersBefore = process.listeners('beforeExit').slice();
@@ -597,7 +621,7 @@ async function importAppFileForStage<TConfig>(
     }
 
     // Clean up ambient scope
-    delete (globalThis as any).__PIPELINE_STAGE_SCOPE__;
+    delete (globalThis as any)[__PIPELINE_STAGE_SCOPE__];
 
     // Restore process.env
     if (stageEnv) {

--- a/packages/pipeline/src/pipeline.test.ts
+++ b/packages/pipeline/src/pipeline.test.ts
@@ -9,6 +9,8 @@ import * as path from 'path';
 import * as cdk from 'aws-cdk-lib';
 import { App, Duration, Stack } from 'aws-cdk-lib';
 import * as codebuild from 'aws-cdk-lib/aws-codebuild';
+import { Bucket } from 'aws-cdk-lib/aws-s3';
+import { CodePipelineSource } from 'aws-cdk-lib/pipelines';
 import { Annotations, Template, Match } from 'aws-cdk-lib/assertions';
 import { Pipeline, validateAppFilePath } from './pipeline-construct.js';
 import type { PipelineProps, PipelineStageConfig } from './types.js';
@@ -1561,5 +1563,255 @@ describe('validateAppFilePath', () => {
     } finally {
       fs.unlinkSync(symlinkPath);
     }
+  });
+});
+
+describe('synth partialBuildSpec', () => {
+  it('declares the Node.js 22 runtime in the synth buildspec by default', () => {
+    const app = new App();
+    const stack = new Stack(app, 'DefaultPartialBuildSpecStack');
+
+    new Pipeline(stack, 'TestPipeline', defaultPipelineProps());
+
+    const template = Template.fromStack(stack);
+
+    template.hasResourceProperties('AWS::CodeBuild::Project', {
+      Source: Match.objectLike({
+        BuildSpec: Match.serializedJson(Match.objectLike({
+          phases: Match.objectLike({
+            install: Match.objectLike({
+              'runtime-versions': Match.objectLike({ nodejs: 22 }),
+            }),
+          }),
+        })),
+      }),
+    });
+  });
+
+  it('omits runtime-versions entirely when partialBuildSpec is null (explicit opt-out)', () => {
+    const app = new App();
+    const stack = new Stack(app, 'NullOptOutBuildSpecStack');
+
+    new Pipeline(stack, 'TestPipeline', defaultPipelineProps({
+      synth: {
+        partialBuildSpec: null,
+      },
+    }));
+
+    const template = Template.fromStack(stack);
+
+    // With the null opt-out, the Node.js 22 default must NOT be injected:
+    // no CodeBuild project's buildspec should declare runtime-versions.
+    const projects = template.findResources('AWS::CodeBuild::Project');
+    const buildSpecs = Object.values(projects)
+      .map((p: any) => p.Properties?.Source?.BuildSpec)
+      .filter((b: unknown): b is string => typeof b === 'string');
+
+    assert.ok(buildSpecs.length > 0, 'Expected at least one CodeBuild project with an inline buildspec');
+    for (const spec of buildSpecs) {
+      assert.ok(
+        !spec.includes('runtime-versions'),
+        `Expected no runtime-versions in any synth buildspec when opting out with null, but found: ${spec}`,
+      );
+    }
+  });
+
+  it('honors a custom partialBuildSpec override (Node.js 20)', () => {
+    const app = new App();
+    const stack = new Stack(app, 'CustomPartialBuildSpecStack');
+
+    new Pipeline(stack, 'TestPipeline', defaultPipelineProps({
+      synth: {
+        partialBuildSpec: codebuild.BuildSpec.fromObject({
+          phases: { install: { 'runtime-versions': { nodejs: 20 } } },
+        }),
+      },
+    }));
+
+    const template = Template.fromStack(stack);
+
+    template.hasResourceProperties('AWS::CodeBuild::Project', {
+      Source: Match.objectLike({
+        BuildSpec: Match.serializedJson(Match.objectLike({
+          phases: Match.objectLike({
+            install: Match.objectLike({
+              'runtime-versions': Match.objectLike({ nodejs: 20 }),
+            }),
+          }),
+        })),
+      }),
+    });
+  });
+
+  it('does not retain the default Node.js 22 runtime when overridden', () => {
+    const app = new App();
+    const stack = new Stack(app, 'OverrideReplacesDefaultStack');
+
+    new Pipeline(stack, 'TestPipeline', defaultPipelineProps({
+      synth: {
+        partialBuildSpec: codebuild.BuildSpec.fromObject({
+          phases: { install: { 'runtime-versions': { nodejs: 20 } } },
+        }),
+      },
+    }));
+
+    const template = Template.fromStack(stack);
+    const projects = template.findResources('AWS::CodeBuild::Project');
+    const buildSpecs = Object.values(projects)
+      .map((p: any) => p.Properties?.Source?.BuildSpec)
+      .filter((b: unknown): b is string => typeof b === 'string');
+
+    const synthSpec = buildSpecs.find(b => b.includes('runtime-versions'));
+    assert.ok(synthSpec, 'Expected a synth buildspec declaring runtime-versions');
+
+    const parsed = JSON.parse(synthSpec);
+    assert.strictEqual(
+      parsed.phases.install['runtime-versions'].nodejs,
+      20,
+      'Custom partialBuildSpec should replace the default Node.js 22 runtime',
+    );
+  });
+
+  it('keeps partialBuildSpec (buildspec) orthogonal to the NODE_OPTIONS env var', () => {
+    const app = new App();
+    const stack = new Stack(app, 'OrthogonalBuildSpecStack');
+
+    new Pipeline(stack, 'TestPipeline', defaultPipelineProps({
+      synth: {
+        env: { NODE_OPTIONS: '--max-old-space-size=4096' },
+      },
+    }));
+
+    const template = Template.fromStack(stack);
+
+    // The Node.js 22 runtime (buildspec) and the merged NODE_OPTIONS env var
+    // both appear on the same synth CodeBuild project.
+    template.hasResourceProperties('AWS::CodeBuild::Project', {
+      Source: Match.objectLike({
+        BuildSpec: Match.serializedJson(Match.objectLike({
+          phases: Match.objectLike({
+            install: Match.objectLike({
+              'runtime-versions': Match.objectLike({ nodejs: 22 }),
+            }),
+          }),
+        })),
+      }),
+      Environment: Match.objectLike({
+        EnvironmentVariables: Match.arrayWith([
+          Match.objectLike({
+            Name: 'NODE_OPTIONS',
+            Value: '--conditions=cdk --max-old-space-size=4096',
+          }),
+        ]),
+      }),
+    });
+  });
+
+  it('merges runtime-versions with custom installCommands', () => {
+    const app = new App();
+    const stack = new Stack(app, 'InstallCommandsMergeStack');
+
+    new Pipeline(stack, 'TestPipeline', defaultPipelineProps({
+      synth: {
+        installCommands: ['corepack enable'],
+      },
+    }));
+
+    const template = Template.fromStack(stack);
+
+    template.hasResourceProperties('AWS::CodeBuild::Project', {
+      Source: Match.objectLike({
+        BuildSpec: Match.serializedJson(Match.objectLike({
+          phases: Match.objectLike({
+            install: Match.objectLike({
+              'runtime-versions': Match.objectLike({ nodejs: 22 }),
+              commands: Match.arrayWith(['corepack enable']),
+            }),
+          }),
+        })),
+      }),
+    });
+  });
+});
+
+describe('_sourceOverride (internal test hook)', () => {
+  it('substitutes the GitHub source with the provided producer (S3)', () => {
+    const app = new App();
+    const stack = new Stack(app, 'SourceOverrideStack');
+    const bucket = new Bucket(stack, 'SourceBucket');
+
+    new Pipeline(stack, 'TestPipeline', defaultPipelineProps({
+      _sourceOverride: CodePipelineSource.s3(bucket, 'source.zip'),
+    }));
+
+    const template = Template.fromStack(stack);
+
+    template.hasResourceProperties('AWS::CodePipeline::Pipeline', {
+      Stages: Match.arrayWith([
+        Match.objectLike({
+          Name: 'Source',
+          Actions: Match.arrayWith([
+            Match.objectLike({
+              ActionTypeId: Match.objectLike({ Provider: 'S3' }),
+            }),
+          ]),
+        }),
+      ]),
+    });
+  });
+
+  it('does not create a CodeStarSourceConnection action when overridden', () => {
+    const app = new App();
+    const stack = new Stack(app, 'SourceOverrideNoConnectionStack');
+    const bucket = new Bucket(stack, 'SourceBucket');
+
+    new Pipeline(stack, 'TestPipeline', defaultPipelineProps({
+      _sourceOverride: CodePipelineSource.s3(bucket, 'source.zip'),
+    }));
+
+    const template = Template.fromStack(stack);
+    const pipelines = template.findResources('AWS::CodePipeline::Pipeline');
+    const providers = Object.values(pipelines)
+      .flatMap((p: any) => p.Properties?.Stages ?? [])
+      .flatMap((s: any) => s.Actions ?? [])
+      .map((a: any) => a.ActionTypeId?.Provider);
+
+    assert.ok(
+      !providers.includes('CodeStarSourceConnection'),
+      `Expected no CodeStarSourceConnection action when _sourceOverride is set, got providers: ${providers.join(', ')}`,
+    );
+  });
+
+  it('still synthesizes a single CodePipeline when source is overridden', () => {
+    const app = new App();
+    const stack = new Stack(app, 'SourceOverrideSynthStack');
+    const bucket = new Bucket(stack, 'SourceBucket');
+
+    new Pipeline(stack, 'TestPipeline', defaultPipelineProps({
+      _sourceOverride: CodePipelineSource.s3(bucket, 'source.zip'),
+    }));
+
+    const template = Template.fromStack(stack);
+    template.resourceCountIs('AWS::CodePipeline::Pipeline', 1);
+  });
+
+  it('still validates the connection ARN even when _sourceOverride is set', () => {
+    const app = new App();
+    const stack = new Stack(app, 'SourceOverrideArnValidationStack');
+    const bucket = new Bucket(stack, 'SourceBucket');
+
+    // _sourceOverride bypasses the GitHub source at synth time, but `source`
+    // (repo + connectionArn) is still required and validated so production
+    // configs stay well-formed. An invalid ARN must still throw.
+    assert.throws(
+      () => new Pipeline(stack, 'TestPipeline', defaultPipelineProps({
+        source: {
+          repo: MOCK_REPO,
+          connectionArn: 'not-an-arn-at-all',
+        },
+        _sourceOverride: CodePipelineSource.s3(bucket, 'source.zip'),
+      })),
+      /connectionArn.*must be a valid CodeConnections ARN/,
+    );
   });
 });

--- a/packages/pipeline/src/types.ts
+++ b/packages/pipeline/src/types.ts
@@ -3,6 +3,7 @@
 
 import type * as cdk from 'aws-cdk-lib';
 import type * as codebuild from 'aws-cdk-lib/aws-codebuild';
+import type { IFileSetProducer } from 'aws-cdk-lib/pipelines';
 
 /**
  * Configuration for the pipeline source (GitHub/CodeConnections).
@@ -140,6 +141,49 @@ export interface PipelineSynthConfig {
    * Lambda bundling + frontend builds. Use SMALL for trivial apps or LARGE for monorepos.
    */
   readonly computeType?: codebuild.ComputeType;
+
+  /**
+   * A partial CodeBuild BuildSpec merged into the synth step's generated buildspec.
+   *
+   * Use this to control the synth runtime declaratively, most commonly to pin
+   * the Node.js version via `runtime-versions`. It merges with (does not replace)
+   * the install/build commands generated from {@link installCommands} and
+   * {@link commands}, and is orthogonal to the `NODE_OPTIONS` environment variable
+   * injection (one configures the buildspec, the other sets an env var).
+   *
+   * Three behaviors, selected by the value you pass:
+   * - **omitted** (`undefined`): the synth step gets a default BuildSpec pinning
+   *   the Node.js 22 runtime (see `@default` below). This is the recommended path.
+   * - **`null`**: explicit opt-out. No `partialBuildSpec` is injected at all, so
+   *   the synth buildspec carries no `runtime-versions` block. Use this when you
+   *   want to control the runtime yourself, for example by installing a Node
+   *   version via {@link installCommands} (such as `['n 20']`) or by relying on
+   *   the build image's built-in runtime without any merged buildspec.
+   * - **a `BuildSpec`**: used as-is, replacing the Node.js 22 default.
+   *
+   * @default a BuildSpec declaring the Node.js 22 runtime:
+   * `BuildSpec.fromObject({ phases: { install: { 'runtime-versions': { nodejs: 22 } } } })`.
+   * Override with a BuildSpec to select a different runtime or add other
+   * buildspec-only settings, or pass `null` to disable the default entirely.
+   *
+   * @example Pin Node.js 20
+   * ```ts
+   * synth: {
+   *   partialBuildSpec: BuildSpec.fromObject({
+   *     phases: { install: { 'runtime-versions': { nodejs: 20 } } },
+   *   }),
+   * }
+   * ```
+   *
+   * @example Opt out of the Node.js 22 default (bring your own runtime)
+   * ```ts
+   * synth: {
+   *   partialBuildSpec: null,
+   *   installCommands: ['n 20'], // or rely on the build image's default runtime
+   * }
+   * ```
+   */
+  readonly partialBuildSpec?: codebuild.BuildSpec | null;
 }
 
 /**
@@ -381,4 +425,20 @@ export interface PipelineProps<TConfig = Record<string, unknown>> {
    * @default false
    */
   readonly crossAccountKeys?: boolean;
+
+  /**
+   * Substitute the pipeline source with an alternative file-set producer.
+   *
+   * When provided, this replaces the GitHub/CodeConnections source created from
+   * {@link source} as the input to the synth step. This exists so the pipeline
+   * can be deployed and exercised in tests without a live GitHub CodeConnections
+   * OAuth handshake (for example, by substituting an S3 source).
+   *
+   * `source` (repo + connectionArn) is still required and validated even when
+   * this override is set, so production configs remain well-formed.
+   *
+   * @internal Not part of the public API. Intended for testing only; the shape
+   * and behavior may change without a major version bump.
+   */
+  readonly _sourceOverride?: IFileSetProducer;
 }

--- a/packages/pipeline/tsconfig.json
+++ b/packages/pipeline/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "stripInternal": true
+  },
+  "include": ["src/**/*"]
+}

--- a/test-apps/pipeline/package.json
+++ b/test-apps/pipeline/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@aws-blocks/core": "*",
+    "@aws-blocks/pipeline": "*",
     "aws-cdk-lib": "2.257.0",
     "constructs": "^10.6.0"
   },

--- a/test-apps/pipeline/test/pipeline-synth.test.ts
+++ b/test-apps/pipeline/test/pipeline-synth.test.ts
@@ -72,6 +72,29 @@ describe('Pipeline synth integration', () => {
     );
   });
 
+  test('synth CodeBuild project declares Node.js 22 runtime by default (partialBuildSpec)', () => {
+    const files = readdirSync(CDK_OUT);
+    const pipelineTemplate = files.find(f => f.includes('pipeline-synth-test') && f.endsWith('.template.json'));
+    assert.ok(pipelineTemplate, 'Pipeline stack template should exist');
+
+    const template = JSON.parse(readFileSync(join(CDK_OUT, pipelineTemplate), 'utf-8'));
+    const resources = template.Resources || {};
+    const buildSpecs = Object.values(resources)
+      .filter((r: any) => r.Type === 'AWS::CodeBuild::Project')
+      .map((r: any) => r.Properties?.Source?.BuildSpec)
+      .filter((b: unknown): b is string => typeof b === 'string');
+
+    const synthSpec = buildSpecs.find(b => b.includes('runtime-versions'));
+    assert.ok(synthSpec, `Expected a synth buildspec declaring runtime-versions, found ${buildSpecs.length} buildspec(s)`);
+
+    const parsed = JSON.parse(synthSpec);
+    assert.strictEqual(
+      parsed.phases?.install?.['runtime-versions']?.nodejs,
+      22,
+      'Synth buildspec should declare the Node.js 22 runtime by default (partialBuildSpec)',
+    );
+  });
+
   test('stage stacks are synthesized (ambient scope worked)', () => {
     // CDK Pipelines puts stage stacks in nested assembly directories
     const allTemplates = findTemplates(CDK_OUT);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "files": [],
   "references": [
     { "path": "packages/hosting" },
+    { "path": "packages/pipeline" },
     { "path": "packages/core" },
     { "path": "packages/bb-kv-store" },
     { "path": "packages/bb-distributed-table" },


### PR DESCRIPTION
## Summary

Extracts the Pipeline CDK construct from packages/core into a dedicated @aws-blocks/pipeline package, adds partialBuildSpec (Node.js 22 default), exports the __PIPELINE_STAGE_SCOPE__ constant, and ports the _sourceOverride internal test hook.

## Changes
- New packages/pipeline/ package (@aws-blocks/pipeline)
- Moved Pipeline construct, types, and tests from packages/core (git mv, history preserved)
- Added partialBuildSpec to PipelineSynthConfig (defaults to Node.js 22 runtime)
- Exported __PIPELINE_STAGE_SCOPE__ constant; core's BlocksStack imports it explicitly; core re-exports it for single-import-point consumers
- packages/core re-exports from @aws-blocks/pipeline for backward compatibility (zero consumer breakage)
- _sourceOverride internal prop ported (with ARN-validation-still-fires test)

## NOT included
- Gen2 definePipeline / getStageConfig / pipeline_factory / cache-busting machinery (Amplify-specific, not part of AWS Blocks)

## Testing
- Pipeline unit tests moved + extended (partialBuildSpec, Node.js 22 default, _sourceOverride + ARN validation)
- Synth integration test updated with partialBuildSpec coverage
- Real-deploy e2e remains infeasible without a manual GitHub CodeConnections OAuth handshake; _sourceOverride is in place to enable a future S3-source-based e2e