### PR TITLE
fix(hosting): atomic redeploys, eliminate deploy-window 403

### DIFF
--- a/.changeset/hosting-atomic-deploy-window.md
+++ b/.changeset/hosting-atomic-deploy-window.md
@@ -1,0 +1,5 @@
+---
+"@aws-blocks/hosting": patch
+---
+
+fix(hosting): make redeploys atomic by uploading assets before the CloudFront build-id cutover, eliminating the 403 window for new visitors during deployment

--- a/packages/hosting/src/constructs/cdn_construct.ts
+++ b/packages/hosting/src/constructs/cdn_construct.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'node:crypto';
-import { Construct } from 'constructs';
+import { Construct, IDependable } from 'constructs';
 import { CfnOutput, Duration, Fn, Stack } from 'aws-cdk-lib';
 import * as iam from 'aws-cdk-lib/aws-iam';
 import {
@@ -191,6 +191,15 @@ export class CdnConstruct extends Construct {
   readonly errorPageHtml: string;
 
   /**
+   * CloudFront Functions that bake the deploy's buildId into the request
+   * rewrite (`/builds/<buildId>/...`). Publishing one of these is the moment
+   * the distribution starts routing new/cookieless traffic at the new build,
+   * so they must not update until that build's assets have been uploaded.
+   * See {@link addBuildAssetDependency}.
+   */
+  private readonly buildIdFunctions: CloudFrontFunction[] = [];
+
+  /**
    * Creates the CDN distribution with routes mapped to origins.
    */
   constructor(scope: Construct, id: string, props: CdnConstructProps) {
@@ -276,6 +285,10 @@ export class CdnConstruct extends Construct {
       manifest.basePath,
       { spaFallback: isSpaFallback, wwwRedirect: props.wwwRedirect },
     );
+    // The viewer-request function rewrites every request to the new
+    // build's `/builds/<buildId>/` prefix - gate its publish on the asset
+    // uploads (see addBuildAssetDependency).
+    this.buildIdFunctions.push(viewerRequestFunction);
 
     // ---- Skew protection viewer-response function ----
     const viewerResponseFunction = this.createViewerResponseFunction(
@@ -752,6 +765,10 @@ export class CdnConstruct extends Construct {
           forwardedHostFunction ??
           viewerRequestFunction,
       );
+      // Also bakes in the buildId (`/builds/<buildId>/`), so it must wait
+      // for the asset uploads before publishing - same as the viewer-request
+      // function above.
+      this.buildIdFunctions.push(stripFunction);
       const prefixedStaticBehavior: BehaviorOptions = {
         origin: s3Origin,
         viewerProtocolPolicy: ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
@@ -1171,6 +1188,28 @@ export class CdnConstruct extends Construct {
         value: primaryDomain,
         description: 'Custom domain name for the hosted site',
       });
+    }
+  }
+
+  /**
+   * Register a dependency that must finish before the build-id cutover.
+   *
+   * The viewer-request (and Next.js assetPrefix-strip) CloudFront Functions
+   * bake the deploy's buildId into the request rewrite, sending traffic to
+   * `/builds/<buildId>/...` in the OAC-protected S3 bucket. If those
+   * functions publish before the new build's assets land at that prefix,
+   * new/cookieless visitors get 403 Access Denied for the duration of the
+   * deploy window (returning visitors with a `__dpl` skew cookie keep hitting
+   * the previous build and are unaffected).
+   *
+   * The hosting construct calls this with every asset `BucketDeployment` for
+   * the new build, so CloudFormation uploads the assets first and only then
+   * publishes the functions (and the distribution that references them).
+   * This makes redeploys atomic from a new visitor's perspective.
+   */
+  addBuildAssetDependency(dependency: IDependable): void {
+    for (const fn of this.buildIdFunctions) {
+      fn.node.addDependency(dependency);
     }
   }
 

--- a/packages/hosting/src/constructs/cdn_construct.ts
+++ b/packages/hosting/src/constructs/cdn_construct.ts
@@ -33,6 +33,7 @@ import {
   S3BucketOrigin,
 } from 'aws-cdk-lib/aws-cloudfront-origins';
 import { IBucket } from 'aws-cdk-lib/aws-s3';
+import { BucketDeployment } from 'aws-cdk-lib/aws-s3-deployment';
 import {
   CfnPermission,
   IFunction,
@@ -198,6 +199,15 @@ export class CdnConstruct extends Construct {
    * See {@link addBuildAssetDependency}.
    */
   private readonly buildIdFunctions: CloudFrontFunction[] = [];
+
+  /**
+   * Count of asset deployments registered via {@link addBuildAssetDependency}.
+   * The synth-time validation added in the constructor uses this to detect a
+   * regression where the build-id cutover is left ungated (every build-id
+   * function would publish before the new build's assets are uploaded,
+   * re-opening the 403 deploy window).
+   */
+  private buildAssetDependencyCount = 0;
 
   /**
    * Creates the CDN distribution with routes mapped to origins.
@@ -1189,6 +1199,43 @@ export class CdnConstruct extends Construct {
         description: 'Custom domain name for the hosted site',
       });
     }
+
+    // ---- Self-enforcing atomic-deploy guard ----
+    // The build-id CloudFront functions rewrite every request to
+    // `/builds/<buildId>/...`. If they publish before that build's assets are
+    // uploaded to the OAC-protected bucket, new/cookieless visitors get 403
+    // for the whole deploy window. `addBuildAssetDependency` wires each asset
+    // BucketDeployment as a dependency so CloudFormation uploads first. This
+    // validation fails synth if build-id functions exist alongside asset
+    // deployments but NONE were registered - i.e. the wiring loop in the
+    // hosting construct was removed/broken, silently re-opening the 403
+    // window. It runs at synth, after all `addBuildAssetDependency` calls.
+    this.node.addValidation({
+      validate: (): string[] => {
+        // No build-id functions -> nothing to gate.
+        if (this.buildIdFunctions.length === 0) return [];
+        // At least one asset deployment was wired -> invariant holds.
+        if (this.buildAssetDependencyCount > 0) return [];
+        // Nothing was wired. Only fail if asset BucketDeployments actually
+        // exist in this stack; a standalone CdnConstruct with no assets (or a
+        // hypothetical asset-less deploy) is legitimate and must not
+        // false-positive.
+        const hasAssetDeployments = Stack.of(this)
+          .node.findAll()
+          .some((c) => c instanceof BucketDeployment);
+        if (!hasAssetDeployments) return [];
+        return [
+          `CdnConstruct '${this.node.path}' has ${this.buildIdFunctions.length} ` +
+            'build-id CloudFront function(s) that rewrite requests to ' +
+            "'/builds/<buildId>/...', but no asset BucketDeployment was " +
+            'registered via addBuildAssetDependency(). The build-id cutover ' +
+            'would publish before the new build assets are uploaded, ' +
+            'returning 403 Access Denied to new/cookieless visitors for the ' +
+            'entire deploy window. An asset BucketDeployment was likely added ' +
+            'without calling cdn.addBuildAssetDependency(deployment).',
+        ];
+      },
+    });
   }
 
   /**
@@ -1211,6 +1258,7 @@ export class CdnConstruct extends Construct {
     for (const fn of this.buildIdFunctions) {
       fn.node.addDependency(dependency);
     }
+    this.buildAssetDependencyCount += 1;
   }
 
   /**

--- a/packages/hosting/src/constructs/hosting_construct.atomic_deploy.test.ts
+++ b/packages/hosting/src/constructs/hosting_construct.atomic_deploy.test.ts
@@ -1,0 +1,251 @@
+import { describe, it, afterEach } from 'node:test';
+import assert from 'node:assert';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { App, Stack } from 'aws-cdk-lib';
+import { Template } from 'aws-cdk-lib/assertions';
+import { HostingConstruct } from './hosting_construct.js';
+import { DeployManifest } from '../manifest/types.js';
+import { SkewProtectionConfig } from './skew_protection.js';
+
+// ============================================================================
+// Atomic deploy window (403 elimination)
+// ============================================================================
+//
+// Redeploys must be atomic for new/cookieless visitors: the CloudFront
+// build-id functions rewrite every request to `/builds/<buildId>/...`, so
+// they must NOT publish until that build's assets have been uploaded to the
+// OAC-protected S3 bucket. Otherwise the new buildId propagates globally
+// before the objects exist and CloudFront returns 403 Access Denied for the
+// duration of the deploy.
+//
+// These tests assert the synthesized CloudFormation ordering:
+//   1. the viewer-request (and assetPrefix strip) CF Function DependsOn every
+//      asset BucketDeployment custom resource, and
+//   2. no BucketDeployment carries a `/*` CloudFront invalidation anymore
+//      (which is both useless under immutable build-id prefixes and was the
+//      bad dependency that forced uploads to run AFTER the distribution).
+
+type CfnTemplate = {
+  Resources: Record<
+    string,
+    { Type: string; DependsOn?: string[]; Properties?: Record<string, unknown> }
+  >;
+};
+
+let tmpDir: string;
+
+const createStaticDir = (): string => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hosting-atomic-test-'));
+  fs.writeFileSync(path.join(tmpDir, 'index.html'), '<html></html>');
+  // a content-hashed (immutable) asset and a mutable one so multiple asset
+  // deployments are emitted.
+  fs.writeFileSync(path.join(tmpDir, 'app.abcd1234.js'), 'console.log(1)');
+  fs.writeFileSync(path.join(tmpDir, 'logo.png'), 'PNG');
+  return tmpDir;
+};
+
+const createBundleDir = (): string => {
+  const dir = path.join(tmpDir, 'bundle');
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, 'index.mjs'),
+    'export const handler = async () => {};',
+  );
+  return dir;
+};
+
+const synth = (
+  manifest: DeployManifest,
+  skewProtection?: SkewProtectionConfig,
+): CfnTemplate => {
+  const app = new App();
+  const stack = new Stack(app, 'TestStack');
+  new HostingConstruct(stack, 'Hosting', {
+    manifest,
+    skipRegionValidation: true,
+    ...(skewProtection ? { skewProtection } : {}),
+  });
+  return Template.fromStack(stack).toJSON() as CfnTemplate;
+};
+
+const resourceIdsOfType = (tpl: CfnTemplate, type: string): string[] =>
+  Object.entries(tpl.Resources)
+    .filter(([, r]) => r.Type === type)
+    .map(([id]) => id);
+
+/**
+ * Logical ids of the CloudFront Functions that bake the buildId into the
+ * request rewrite (the ones that flip routing to the new build). Excludes the
+ * viewer-RESPONSE skew function and the compute forwarded-host function, which
+ * do not rewrite to `/builds/<id>/`.
+ */
+const buildIdFunctionIds = (tpl: CfnTemplate): string[] =>
+  Object.entries(tpl.Resources)
+    .filter(
+      ([id, r]) =>
+        r.Type === 'AWS::CloudFront::Function' &&
+        /(SkewProtectionRequestFunction|BuildIdRewriteFunction|AssetPrefixStripFunction)/.test(
+          id,
+        ),
+    )
+    .map(([id]) => id);
+
+const assertFunctionsWaitForDeployments = (
+  tpl: CfnTemplate,
+  fnIds: string[],
+  deployments: string[],
+): void => {
+  assert.ok(fnIds.length >= 1, 'expected at least one build-id CF Function');
+  assert.ok(
+    deployments.length >= 1,
+    'expected at least one asset BucketDeployment',
+  );
+  for (const fnId of fnIds) {
+    const dependsOn = tpl.Resources[fnId].DependsOn ?? [];
+    for (const dep of deployments) {
+      assert.ok(
+        dependsOn.includes(dep),
+        `build-id function ${fnId} must DependsOn asset deployment ${dep} ` +
+          `(found: ${JSON.stringify(dependsOn)})`,
+      );
+    }
+  }
+};
+
+void describe('Atomic deploy - build-id cutover waits for asset uploads', () => {
+  afterEach(() => {
+    if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  void it('viewer-request function DependsOn every asset BucketDeployment (skew enabled, default)', () => {
+    const staticDir = createStaticDir();
+    const tpl = synth({
+      version: 1,
+      compute: {},
+      staticAssets: {
+        directory: staticDir,
+        immutablePaths: ['*.abcd1234.js'],
+      },
+      routes: [{ pattern: '/*', target: 'static' }],
+      buildId: 'atomic-skew-1',
+    });
+
+    const deployments = resourceIdsOfType(tpl, 'Custom::CDKBucketDeployment');
+    assert.ok(
+      deployments.length >= 2,
+      `expected multiple asset deployments, got ${deployments.length}`,
+    );
+    // Default skew protection is on -> the viewer-request function is the
+    // SkewProtectionRequestFunction.
+    assertFunctionsWaitForDeployments(
+      tpl,
+      buildIdFunctionIds(tpl),
+      deployments,
+    );
+  });
+
+  void it('build-id rewrite function DependsOn asset deployments (skew disabled)', () => {
+    const staticDir = createStaticDir();
+    const tpl = synth(
+      {
+        version: 1,
+        compute: {},
+        staticAssets: {
+          directory: staticDir,
+          immutablePaths: ['*.abcd1234.js'],
+        },
+        routes: [{ pattern: '/*', target: 'static' }],
+        buildId: 'atomic-noskew-1',
+      },
+      { enabled: false },
+    );
+
+    const rewriteFns = Object.keys(tpl.Resources).filter((id) =>
+      /BuildIdRewriteFunction/.test(id),
+    );
+    assert.ok(
+      rewriteFns.length >= 1,
+      'expected a BuildIdRewriteFunction when skew protection is disabled',
+    );
+    assertFunctionsWaitForDeployments(
+      tpl,
+      rewriteFns,
+      resourceIdsOfType(tpl, 'Custom::CDKBucketDeployment'),
+    );
+  });
+
+  void it('does NOT emit a /* CloudFront invalidation on any BucketDeployment', () => {
+    const staticDir = createStaticDir();
+    const tpl = synth({
+      version: 1,
+      compute: {},
+      staticAssets: {
+        directory: staticDir,
+        immutablePaths: ['*.abcd1234.js'],
+      },
+      routes: [{ pattern: '/*', target: 'static' }],
+      buildId: 'atomic-noinval-1',
+    });
+
+    // With immutable build-id prefixes there is nothing stale to invalidate:
+    // each deploy writes to a brand-new builds/<id>/ prefix that was never
+    // requested. A `/*` invalidation served no purpose AND created the
+    // BucketDeployment -> Distribution dependency that re-opened the 403
+    // window, so it was intentionally removed. The CDK BucketDeployment only
+    // renders DistributionId / DistributionPaths when `distribution` is set,
+    // so their absence proves the invalidation is gone.
+    for (const [id, r] of Object.entries(tpl.Resources)) {
+      const props = r.Properties ?? {};
+      assert.ok(
+        !('DistributionId' in props),
+        `resource ${id} unexpectedly carries a DistributionId (invalidation)`,
+      );
+      assert.ok(
+        !('DistributionPaths' in props),
+        `resource ${id} unexpectedly carries DistributionPaths (invalidation)`,
+      );
+    }
+  });
+
+  void it('SSR build-id function waits for the error-page deployment too', () => {
+    const staticDir = createStaticDir();
+    const bundleDir = createBundleDir();
+    const tpl = synth({
+      version: 1,
+      compute: {
+        default: {
+          type: 'handler',
+          bundle: bundleDir,
+          handler: 'index.handler',
+          placement: 'regional',
+          streaming: true,
+          runtime: 'nodejs20.x',
+        },
+      },
+      staticAssets: {
+        directory: staticDir,
+        immutablePaths: ['*.abcd1234.js'],
+      },
+      routes: [
+        { pattern: '/_next/static/*', target: 'static' },
+        { pattern: '/*', target: 'default' },
+      ],
+      buildId: 'atomic-ssr-1',
+    });
+
+    const deployments = resourceIdsOfType(tpl, 'Custom::CDKBucketDeployment');
+    // SSR mode ships the built-in error page under builds/<id>/ as well, and
+    // it must also land before the cutover.
+    assert.ok(
+      deployments.some((id) => /ErrorPageDeployment/.test(id)),
+      `expected an ErrorPageDeployment in SSR mode, got ${JSON.stringify(deployments)}`,
+    );
+    assertFunctionsWaitForDeployments(
+      tpl,
+      buildIdFunctionIds(tpl),
+      deployments,
+    );
+  });
+});

--- a/packages/hosting/src/constructs/hosting_construct.atomic_deploy.test.ts
+++ b/packages/hosting/src/constructs/hosting_construct.atomic_deploy.test.ts
@@ -5,7 +5,11 @@ import * as path from 'path';
 import * as os from 'os';
 import { App, Stack } from 'aws-cdk-lib';
 import { Template } from 'aws-cdk-lib/assertions';
+import { Bucket } from 'aws-cdk-lib/aws-s3';
+import { BucketDeployment, Source } from 'aws-cdk-lib/aws-s3-deployment';
 import { HostingConstruct } from './hosting_construct.js';
+import { CdnConstruct } from './cdn_construct.js';
+import { createSecurityHeadersPolicy } from './security_headers.js';
 import { DeployManifest } from '../manifest/types.js';
 import { SkewProtectionConfig } from './skew_protection.js';
 
@@ -76,6 +80,19 @@ const resourceIdsOfType = (tpl: CfnTemplate, type: string): string[] =>
     .map(([id]) => id);
 
 /**
+ * Logical ids of the asset BucketDeployments that write the new build's
+ * `builds/<id>/` prefix. Excludes `IsrCacheSeed`: that deployment targets the
+ * separate ISR cache bucket (NOT the build prefix) and is intentionally not a
+ * dependency of the build-id functions, so a future ISR test that adds a
+ * `cache.seedDirectory` must not make these "DependsOn every deployment"
+ * assertions fail.
+ */
+const assetDeploymentIds = (tpl: CfnTemplate): string[] =>
+  resourceIdsOfType(tpl, 'Custom::CDKBucketDeployment').filter(
+    (id) => !/IsrCacheSeed/.test(id),
+  );
+
+/**
  * Logical ids of the CloudFront Functions that bake the buildId into the
  * request rewrite (the ones that flip routing to the new build). Excludes the
  * viewer-RESPONSE skew function and the compute forwarded-host function, which
@@ -132,7 +149,7 @@ void describe('Atomic deploy - build-id cutover waits for asset uploads', () => 
       buildId: 'atomic-skew-1',
     });
 
-    const deployments = resourceIdsOfType(tpl, 'Custom::CDKBucketDeployment');
+    const deployments = assetDeploymentIds(tpl);
     assert.ok(
       deployments.length >= 2,
       `expected multiple asset deployments, got ${deployments.length}`,
@@ -169,11 +186,7 @@ void describe('Atomic deploy - build-id cutover waits for asset uploads', () => 
       rewriteFns.length >= 1,
       'expected a BuildIdRewriteFunction when skew protection is disabled',
     );
-    assertFunctionsWaitForDeployments(
-      tpl,
-      rewriteFns,
-      resourceIdsOfType(tpl, 'Custom::CDKBucketDeployment'),
-    );
+    assertFunctionsWaitForDeployments(tpl, rewriteFns, assetDeploymentIds(tpl));
   });
 
   void it('does NOT emit a /* CloudFront invalidation on any BucketDeployment', () => {
@@ -235,7 +248,7 @@ void describe('Atomic deploy - build-id cutover waits for asset uploads', () => 
       buildId: 'atomic-ssr-1',
     });
 
-    const deployments = resourceIdsOfType(tpl, 'Custom::CDKBucketDeployment');
+    const deployments = assetDeploymentIds(tpl);
     // SSR mode ships the built-in error page under builds/<id>/ as well, and
     // it must also land before the cutover.
     assert.ok(
@@ -247,5 +260,127 @@ void describe('Atomic deploy - build-id cutover waits for asset uploads', () => 
       buildIdFunctionIds(tpl),
       deployments,
     );
+  });
+
+  void it('assetPrefix strip function DependsOn every asset BucketDeployment (Next.js)', () => {
+    const staticDir = createStaticDir();
+    const tpl = synth({
+      version: 1,
+      compute: {},
+      assetPrefix: '/cdn-static',
+      staticAssets: {
+        directory: staticDir,
+        immutablePaths: ['*.abcd1234.js'],
+      },
+      routes: [{ pattern: '/*', target: 'static' }],
+      buildId: 'atomic-prefix-1',
+    });
+
+    // When the manifest carries `assetPrefix` (Next.js), the CDN adds an
+    // AssetPrefixStripFunction that ALSO bakes in the `/builds/<buildId>/`
+    // prefix, so it is a build-id cutover function and must wait for the asset
+    // uploads exactly like the viewer-request function.
+    const stripFns = Object.keys(tpl.Resources).filter((id) =>
+      /AssetPrefixStripFunction/.test(id),
+    );
+    assert.ok(
+      stripFns.length >= 1,
+      'expected an AssetPrefixStripFunction when assetPrefix is set',
+    );
+    assertFunctionsWaitForDeployments(tpl, stripFns, assetDeploymentIds(tpl));
+  });
+});
+
+// ============================================================================
+// Self-enforcing guard (synth-time validation in CdnConstruct)
+// ============================================================================
+//
+// The wiring that gates the build-id cutover on the asset uploads lives in the
+// hosting construct (a loop calling `cdn.addBuildAssetDependency(dep)`). If a
+// future change removes that loop - or adds a new asset BucketDeployment
+// without registering it - the build-id functions would publish before the
+// assets land and the 403 window silently re-opens. CdnConstruct carries a
+// node validation that fails synth in that case, scoped so it never
+// false-positives on a CdnConstruct that genuinely has no asset deployments.
+
+void describe('Atomic deploy - CdnConstruct self-enforcing dependency guard', () => {
+  afterEach(() => {
+    if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  const guardManifest = (
+    buildId: string,
+    directory: string,
+  ): DeployManifest => ({
+    version: 1,
+    compute: {},
+    staticAssets: { directory },
+    routes: [{ pattern: '/*', target: 'static' }],
+    buildId,
+  });
+
+  void it('synth fails when an asset BucketDeployment is left unregistered', () => {
+    const staticDir = createStaticDir();
+    const app = new App();
+    const stack = new Stack(app, 'TestStack');
+    const bucket = new Bucket(stack, 'Bucket');
+    const policy = createSecurityHeadersPolicy(stack, 'SH', {});
+    // CdnConstruct creates the build-id CloudFront function(s)...
+    new CdnConstruct(stack, 'Cdn', {
+      bucket,
+      manifest: guardManifest('guard-violate-1', staticDir),
+      securityHeadersPolicy: policy,
+    });
+    // ...and an asset BucketDeployment writes the build prefix, but we
+    // deliberately DON'T call cdn.addBuildAssetDependency(dep). This is the
+    // exact regression that re-opens the 403 deploy window, so synth must fail.
+    new BucketDeployment(stack, 'OrphanAssetDeployment', {
+      sources: [Source.asset(staticDir)],
+      destinationBucket: bucket,
+      destinationKeyPrefix: 'builds/guard-violate-1/',
+      prune: false,
+    });
+    assert.throws(
+      () => Template.fromStack(stack),
+      /addBuildAssetDependency/,
+      'expected synth to fail when an asset deployment is left unregistered',
+    );
+  });
+
+  void it('synth succeeds when the asset BucketDeployment IS registered', () => {
+    const staticDir = createStaticDir();
+    const app = new App();
+    const stack = new Stack(app, 'TestStack');
+    const bucket = new Bucket(stack, 'Bucket');
+    const policy = createSecurityHeadersPolicy(stack, 'SH', {});
+    const cdn = new CdnConstruct(stack, 'Cdn', {
+      bucket,
+      manifest: guardManifest('guard-ok-1', staticDir),
+      securityHeadersPolicy: policy,
+    });
+    const dep = new BucketDeployment(stack, 'AssetDeployment', {
+      sources: [Source.asset(staticDir)],
+      destinationBucket: bucket,
+      destinationKeyPrefix: 'builds/guard-ok-1/',
+      prune: false,
+    });
+    cdn.addBuildAssetDependency(dep);
+    assert.doesNotThrow(() => Template.fromStack(stack));
+  });
+
+  void it('synth succeeds for a standalone CdnConstruct with no asset deployments', () => {
+    const staticDir = createStaticDir();
+    const app = new App();
+    const stack = new Stack(app, 'TestStack');
+    const bucket = new Bucket(stack, 'Bucket');
+    const policy = createSecurityHeadersPolicy(stack, 'SH', {});
+    // No BucketDeployment in the stack at all -> the guard must not fire
+    // (mirrors the 50 standalone CdnConstruct unit tests).
+    new CdnConstruct(stack, 'Cdn', {
+      bucket,
+      manifest: guardManifest('guard-noassets-1', staticDir),
+      securityHeadersPolicy: policy,
+    });
+    assert.doesNotThrow(() => Template.fromStack(stack));
   });
 });

--- a/packages/hosting/src/constructs/hosting_construct.ts
+++ b/packages/hosting/src/constructs/hosting_construct.ts
@@ -1244,13 +1244,21 @@ export class HostingConstruct extends Construct {
     }
 
     // ---- 11. Error page deployment (SSR only) ----
+    // Every BucketDeployment that writes to the new build's
+    // `builds/${buildId}/` prefix is collected here. After they are all
+    // declared, the CloudFront build-id functions are made to depend on
+    // them (see `cdn.addBuildAssetDependency` at the end of this method) so
+    // the buildId cutover never races ahead of the asset uploads.
+    const buildAssetDeployments: BucketDeployment[] = [];
     if (hasCompute) {
-      new BucketDeployment(this, 'ErrorPageDeployment', {
-        sources: [Source.data(ERROR_PAGE_KEY, cdn.errorPageHtml)],
-        destinationBucket: this.bucket,
-        destinationKeyPrefix: `builds/${buildId}/`,
-        prune: false,
-      });
+      buildAssetDeployments.push(
+        new BucketDeployment(this, 'ErrorPageDeployment', {
+          sources: [Source.data(ERROR_PAGE_KEY, cdn.errorPageHtml)],
+          destinationBucket: this.bucket,
+          destinationKeyPrefix: `builds/${buildId}/`,
+          prune: false,
+        }),
+      );
     }
 
     // ---- 11a. Custom error pages ----
@@ -1282,12 +1290,14 @@ export class HostingConstruct extends Construct {
             'Ensure the file contains valid HTML (should include <html> or <!DOCTYPE> tag).',
         });
       }
-      new BucketDeployment(this, 'Custom404Deployment', {
-        sources: [Source.data('404.html', notFoundContent)],
-        destinationBucket: this.bucket,
-        destinationKeyPrefix: `builds/${buildId}/`,
-        prune: false,
-      });
+      buildAssetDeployments.push(
+        new BucketDeployment(this, 'Custom404Deployment', {
+          sources: [Source.data('404.html', notFoundContent)],
+          destinationBucket: this.bucket,
+          destinationKeyPrefix: `builds/${buildId}/`,
+          prune: false,
+        }),
+      );
     }
     if (props.errorPages?.serverError) {
       if (!fs.existsSync(props.errorPages.serverError)) {
@@ -1317,12 +1327,14 @@ export class HostingConstruct extends Construct {
             'Ensure the file contains valid HTML (should include <html> or <!DOCTYPE> tag).',
         });
       }
-      new BucketDeployment(this, 'Custom500Deployment', {
-        sources: [Source.data('500.html', serverErrorContent)],
-        destinationBucket: this.bucket,
-        destinationKeyPrefix: `builds/${buildId}/`,
-        prune: false,
-      });
+      buildAssetDeployments.push(
+        new BucketDeployment(this, 'Custom500Deployment', {
+          sources: [Source.data('500.html', serverErrorContent)],
+          destinationBucket: this.bucket,
+          destinationKeyPrefix: `builds/${buildId}/`,
+          prune: false,
+        }),
+      );
     }
 
     // ---- 11b. Build cache bucket ----
@@ -1357,6 +1369,21 @@ export class HostingConstruct extends Construct {
     }
 
     // ---- 12. Atomic Deployment (static assets) ----
+    // Atomicity: every object below is written under a brand-new, immutable
+    // `builds/${buildId}/` prefix that was never requested before, so there
+    // is nothing stale to invalidate. The CloudFront build-id functions are
+    // gated on these uploads (`cdn.addBuildAssetDependency`, end of method)
+    // so the distribution only starts routing at the new buildId AFTER the
+    // assets land - closing the window where new/cookieless visitors would
+    // otherwise hit 403 Access Denied on the not-yet-uploaded prefix.
+    //
+    // This is also why these deployments deliberately carry NO
+    // `distribution` / `distributionPaths: ['/*']` invalidation: with
+    // immutable build-id prefixes a `/*` invalidation is useless (the new
+    // prefix was never cached) AND it would force the uploads to run AFTER
+    // the distribution update, which is the exact ordering that re-opens
+    // the 403 window.
+    //
     // Cache-Control split (3 tiers):
     //
     //   1. Hashed assets (`immutablePaths`): `max-age=31536000, immutable`
@@ -1364,8 +1391,10 @@ export class HostingConstruct extends Construct {
     //      must always revalidate so new deploys propagate immediately.
     //   3. Other mutable assets (images, JSON, etc.):
     //      `s-maxage=31536000, max-age=0, must-revalidate` — CloudFront
-    //      edge caches for 1y (flushed via `/*` invalidation on deploy);
-    //      browsers always revalidate.
+    //      edge caches for 1y. Each deploy writes them under a fresh
+    //      `builds/<id>/` prefix (the path is part of the cache key), so the
+    //      new objects are cold-fetched on first request with no
+    //      invalidation needed; browsers always revalidate.
     //
     // Font MIME pass (12b below): aws s3 sync (driver inside
     // BucketDeployment) infers Content-Type via Python's mimetypes which
@@ -1423,8 +1452,6 @@ export class HostingConstruct extends Construct {
             CacheControl.fromString('public, max-age=31536000, immutable'),
           ],
           prune: false,
-          distribution: this.distribution,
-          distributionPaths: ['/*'],
         }),
       );
       assetDeployments.push(
@@ -1458,8 +1485,6 @@ export class HostingConstruct extends Construct {
           include: htmlGlobs,
           cacheControl: [CacheControl.fromString(htmlCacheControl)],
           prune: false,
-          distribution: this.distribution,
-          distributionPaths: ['/*'],
         }),
       );
       assetDeployments.push(
@@ -1473,6 +1498,7 @@ export class HostingConstruct extends Construct {
         }),
       );
     }
+    buildAssetDeployments.push(...assetDeployments);
 
     // ---- 12b. Font Content-Type pass ----
     // S3's `binary/octet-stream` default for font extensions makes
@@ -1542,6 +1568,19 @@ export class HostingConstruct extends Construct {
       for (const dep of assetDeployments) {
         fontDeployment.node.addDependency(dep);
       }
+      buildAssetDeployments.push(fontDeployment);
+    }
+
+    // ---- 12c. Gate the build-id cutover on the asset uploads ----
+    // Make the CloudFront build-id functions (viewer-request, and the
+    // Next.js assetPrefix strip function) depend on every BucketDeployment
+    // that writes the new build's `builds/${buildId}/` prefix. CloudFormation
+    // therefore uploads all assets FIRST and only then publishes the
+    // functions / updates the distribution to route at the new buildId.
+    // Without this, the buildId could propagate globally before the assets
+    // landed, 403-ing new/cookieless visitors for the deploy window.
+    for (const dep of buildAssetDeployments) {
+      cdn.addBuildAssetDependency(dep);
     }
   }
 


### PR DESCRIPTION
## Problem

On every redeploy, new/cookieless visitors could get 403 Access Denied during a window. The CloudFront Function's new buildId propagated globally BEFORE the BucketDeployment finished uploading assets to builds/<newBuildId>/, so requests were rewritten to a prefix that did not exist yet in the private OAC bucket.

Returning users with a __dpl skew cookie were unaffected (routed to the still-existing previous build). New visitors, incognito, and expired-cookie users hit the window.

## Fix

Make the deploy truly atomic by reversing the dependency direction:
1. Removed the unnecessary /* CloudFront invalidation from asset BucketDeployments. With immutable build-id prefixes, each deploy writes to a brand-new builds/<id>/ prefix that was never cached, so /* invalidation served no purpose and was forcing uploads to run after the distribution update.
2. Made the CloudFront Function build-id cutover depend on all asset uploads completing. Now: upload assets to builds/<newId>/ -> then flip the function/distribution to route at <newId>.

This matches the upload-first-switch-second pattern used by managed hosting platforms.

## Testing
- New unit test asserting the dependency ordering (function depends on asset deployments)
- Updated assertions that previously expected the /* invalidation
- All hosting unit tests pass
