### PR TITLE
feat: add code coverage reporting to unit tests

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -87,8 +87,8 @@ jobs:
       - name: Check API backward compatibility
         run: npm run check:api
 
-      - name: Unit Tests
-        run: npm run test:unit
+      - name: Unit Tests (with coverage)
+        run: npm run test:coverage
 
       - name: E2E Test Local
         run: npm run test:e2e:local

--- a/package.json
+++ b/package.json
@@ -62,6 +62,8 @@
     "nuke": "rm -rf node_modules packages/*/node_modules test-apps/*/node_modules packages/*/dist test-apps/*/dist test-apps/*/.next packages/*/*.tsbuildinfo test-apps/*/*.tsbuildinfo",
     "test": "npm run test --workspaces",
     "test:unit": "npm run test --workspaces",
+    "test:coverage": "node scripts/coverage.mjs",
+    "test:coverage:local": "npm run build:packages && node scripts/coverage.mjs",
     "test:e2e:local": "cd test-apps/comprehensive && npm run test:e2e:local && cd ../.. && npm run test:vendorize",
     "test:e2e:sandbox": "cd test-apps/comprehensive && npm run test:e2e:sandbox",
     "test:e2e:production": "cd test-apps/comprehensive && npm run test:e2e:production",

--- a/scripts/coverage.mjs
+++ b/scripts/coverage.mjs
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+/**
+ * Code-coverage runner using Node's built-in test coverage.
+ *
+ * Runs each package's own test script with --experimental-test-coverage
+ * injected, executed in the package directory. This preserves per-package cwd
+ * (needed by packages like core whose tests use process.cwd()).
+ *
+ * Coverage is REPORTING-ONLY — numbers never fail the build. Test failures
+ * DO fail the build (exit non-zero).
+ *
+ * Improvements over a naive single-run approach:
+ * - --test-coverage-include scopes coverage to the package's own source
+ * - --test-coverage-exclude removes test files from coverage stats
+ */
+import { readFileSync, readdirSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
+const packagesDir = join(repoRoot, 'packages');
+
+const COVERAGE_FLAGS = [
+  '--experimental-test-coverage',
+  "--test-coverage-include='dist/**/*.js'",
+  "--test-coverage-exclude='dist/**/*.test.js'",
+].join(' ');
+
+const pkgDirs = readdirSync(packagesDir, { withFileTypes: true })
+  .filter((e) => e.isDirectory())
+  .map((e) => e.name)
+  .sort();
+
+let ran = 0;
+let failed = 0;
+
+for (const name of pkgDirs) {
+  const cwd = join(packagesDir, name);
+  let pkg;
+  try {
+    pkg = JSON.parse(readFileSync(join(cwd, 'package.json'), 'utf8'));
+  } catch {
+    continue;
+  }
+
+  const testScript = pkg.scripts?.test ?? '';
+  if (!testScript.startsWith('node --test')) {
+    continue;
+  }
+
+  const covScript = testScript.replace(
+    /^node --test/,
+    `node --test ${COVERAGE_FLAGS}`,
+  );
+
+  console.log(`\n=== Coverage: ${pkg.name ?? name} ===`);
+  const result = spawnSync(covScript, {
+    cwd,
+    stdio: 'inherit',
+    shell: true,
+  });
+  ran += 1;
+  if (result.status !== 0) {
+    failed += 1;
+    console.log(`(${pkg.name ?? name}: unit tests FAILED)`);
+  }
+}
+
+console.log(
+  `\nCoverage complete: ${ran} package(s)` +
+    (failed ? `, ${failed} FAILED` : ', all passed'),
+);
+
+process.exit(failed > 0 ? 1 : 0);

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -9,6 +9,7 @@
     "forceConsistentCasingInFileNames": true,
     "declaration": true,
     "declarationMap": true,
+    "sourceMap": true,
     "composite": true,
     "incremental": true
   }


### PR DESCRIPTION
## Summary

Adds code coverage reporting to unit tests using Node 22's built-in `--experimental-test-coverage`.

## Changes

- **`scripts/coverage.mjs`** — Per-package runner that injects coverage flags into each workspace's test command, preserving per-package cwd (required by packages like core that use `process.cwd()`)
- **`tsconfig.base.json`** — Enable `sourceMap` for TS→JS line mapping
- **`package.json`** — Add `test:coverage` (CI) and `test:coverage:local` (standalone with build)
- **`.github/workflows/pr-checks.yml`** — Replace "Unit Tests" step with "Unit Tests (with coverage)"

## Behavior

- **Test failures block the build** — exit non-zero if any unit test fails
- **Coverage is reporting-only** — numbers are printed but never fail the run
- **Test files excluded** from coverage stats (`--test-coverage-exclude`)
- **Coverage scoped** to package source only (`--test-coverage-include`)

## Usage

```bash
# In CI (build already ran):
npm run test:coverage

# Locally (includes build step):
npm run test:coverage:local
```