### PR TITLE
fix(bb-cron-job): stepped cron ranges ignored their upper bound

### DIFF
--- a/.changeset/cron-stepped-range-bounds.md
+++ b/.changeset/cron-stepped-range-bounds.md
@@ -1,0 +1,5 @@
+---
+"@aws-blocks/bb-cron-job": patch
+---
+
+fix(bb-cron-job): respect the upper bound of stepped cron ranges (e.g. `0-30/10`) instead of stepping past it

--- a/.changeset/cron-stepped-range-bounds.md
+++ b/.changeset/cron-stepped-range-bounds.md
@@ -2,4 +2,4 @@
 "@aws-blocks/bb-cron-job": patch
 ---
 
-fix(bb-cron-job): respect the upper bound of stepped cron ranges (e.g. `0-30/10`) instead of stepping past it
+fix(bb-cron-job): respect the upper bound of stepped cron ranges (e.g. `0-30/10`) instead of stepping past it, and reject inverted (`30-10`) or out-of-bounds (`100`, `0-100/5`) field values instead of silently producing empty or invalid schedules

--- a/packages/bb-cron-job/src/index.mock.ts
+++ b/packages/bb-cron-job/src/index.mock.ts
@@ -176,10 +176,24 @@ function expandField(field: string, min: number, max: number, original: string):
 	for (const part of field.split(',')) {
 		if (part.includes('/')) {
 			const [base, stepStr] = part.split('/');
-			const start = base === '*' ? min : parseInt(base, 10);
 			const step = parseInt(stepStr, 10);
+			// `base` may be `*` (whole field), a single value (`15` → from 15 to
+			// max), or a range (`0-30` → bounded by the range's upper end). A
+			// stepped range must stop at the range's `hi`, not run to `max`.
+			let start: number;
+			let end = max;
+			if (base === '*') {
+				start = min;
+			} else if (base.includes('-')) {
+				const [lo, hi] = base.split('-').map(Number);
+				if (isNaN(lo) || isNaN(hi)) throw scheduleError(original);
+				start = lo;
+				end = hi;
+			} else {
+				start = parseInt(base, 10);
+			}
 			if (isNaN(start) || isNaN(step) || step <= 0) throw scheduleError(original);
-			for (let i = start; i <= max; i += step) values.push(i);
+			for (let i = start; i <= end; i += step) values.push(i);
 		} else if (part.includes('-')) {
 			const [lo, hi] = part.split('-').map(Number);
 			if (isNaN(lo) || isNaN(hi)) throw scheduleError(original);

--- a/packages/bb-cron-job/src/index.mock.ts
+++ b/packages/bb-cron-job/src/index.mock.ts
@@ -180,27 +180,27 @@ function expandField(field: string, min: number, max: number, original: string):
 			// `base` may be `*` (whole field), a single value (`15` → from 15 to
 			// max), or a range (`0-30` → bounded by the range's upper end). A
 			// stepped range must stop at the range's `hi`, not run to `max`.
-			let start: number;
-			let end = max;
+			let lo: number;
+			let hi = max;
 			if (base === '*') {
-				start = min;
+				lo = min;
 			} else if (base.includes('-')) {
-				const [lo, hi] = base.split('-').map(Number);
-				if (isNaN(lo) || isNaN(hi)) throw scheduleError(original);
-				start = lo;
-				end = hi;
+				const [loStr, hiStr] = base.split('-');
+				lo = Number(loStr);
+				hi = Number(hiStr);
 			} else {
-				start = parseInt(base, 10);
+				lo = parseInt(base, 10);
 			}
-			if (isNaN(start) || isNaN(step) || step <= 0) throw scheduleError(original);
-			for (let i = start; i <= end; i += step) values.push(i);
+			if (isNaN(step) || step <= 0) throw scheduleError(original);
+			assertBounds(lo, hi, min, max, original);
+			for (let i = lo; i <= hi; i += step) values.push(i);
 		} else if (part.includes('-')) {
 			const [lo, hi] = part.split('-').map(Number);
-			if (isNaN(lo) || isNaN(hi)) throw scheduleError(original);
+			assertBounds(lo, hi, min, max, original);
 			for (let i = lo; i <= hi; i++) values.push(i);
 		} else {
 			const n = parseInt(part, 10);
-			if (isNaN(n)) throw scheduleError(original);
+			assertBounds(n, n, min, max, original);
 			values.push(n);
 		}
 	}
@@ -213,6 +213,14 @@ function expandDow(field: string, original: string): number[] {
 	const dayMap: Record<string, number> = { SUN: 1, MON: 2, TUE: 3, WED: 4, THU: 5, FRI: 6, SAT: 7 };
 	const replaced = field.replace(/SUN|MON|TUE|WED|THU|FRI|SAT/gi, m => String(dayMap[m.toUpperCase()]));
 	return expandField(replaced, 1, 7, original).map(d => (d - 1) % 7);
+}
+
+// Reject ranges that are non-numeric, inverted (`30-10`), or fall outside the
+// field's valid `[min, max]` window (e.g. minute `100`). Without this an
+// inverted range silently yields [] and an out-of-bounds upper end (`0-100`)
+// produces values EventBridge would never accept.
+function assertBounds(lo: number, hi: number, min: number, max: number, original: string): void {
+	if (isNaN(lo) || isNaN(hi) || lo > hi || lo < min || hi > max) throw scheduleError(original);
 }
 
 function range(lo: number, hi: number): number[] {

--- a/packages/bb-cron-job/src/schedule.test.ts
+++ b/packages/bb-cron-job/src/schedule.test.ts
@@ -138,3 +138,26 @@ describe('parseSchedule – cron day-of-week numeric values', () => {
 		assert.deepStrictEqual(fields.dayOfWeek, [1, 2, 3, 4, 5]);
 	});
 });
+
+describe('parseSchedule – cron step expressions', () => {
+	test('cron(*/15 * * * ? *) expands minutes to every 15 across the whole field', () => {
+		const job = new CronJob(fakeScope, 'step15', opts('cron(*/15 * * * ? *)')) as any;
+		assert.deepStrictEqual(job._schedule.fields.minute, [0, 15, 30, 45]);
+	});
+
+	test('cron(0-30/10 * * * ? *) bounds a stepped range by the range upper end', () => {
+		// Regression: `0-30/10` must stop at 30, not continue to the field max (59).
+		const job = new CronJob(fakeScope, 'stepRange', opts('cron(0-30/10 * * * ? *)')) as any;
+		assert.deepStrictEqual(job._schedule.fields.minute, [0, 10, 20, 30]);
+	});
+
+	test('cron(0 1-23/6 * * ? *) bounds a stepped hour range by its upper end', () => {
+		const job = new CronJob(fakeScope, 'stepHour', opts('cron(0 1-23/6 * * ? *)')) as any;
+		assert.deepStrictEqual(job._schedule.fields.hour, [1, 7, 13, 19]);
+	});
+
+	test('cron(15/30 * * * ? *) steps from a single start value to the field max', () => {
+		const job = new CronJob(fakeScope, 'stepStart', opts('cron(15/30 * * * ? *)')) as any;
+		assert.deepStrictEqual(job._schedule.fields.minute, [15, 45]);
+	});
+});

--- a/packages/bb-cron-job/src/schedule.test.ts
+++ b/packages/bb-cron-job/src/schedule.test.ts
@@ -160,4 +160,32 @@ describe('parseSchedule – cron step expressions', () => {
 		const job = new CronJob(fakeScope, 'stepStart', opts('cron(15/30 * * * ? *)')) as any;
 		assert.deepStrictEqual(job._schedule.fields.minute, [15, 45]);
 	});
+
+	test('cron(30-10/5 * * * ? *) throws — inverted stepped range', () => {
+		assert.throws(
+			() => new CronJob(fakeScope, 'invStep', opts('cron(30-10/5 * * * ? *)')),
+			(err: Error) => err.name === CronJobErrors.InvalidSchedule
+		);
+	});
+
+	test('cron(0-100/5 * * * ? *) throws — stepped range exceeds field max', () => {
+		assert.throws(
+			() => new CronJob(fakeScope, 'oobStep', opts('cron(0-100/5 * * * ? *)')),
+			(err: Error) => err.name === CronJobErrors.InvalidSchedule
+		);
+	});
+
+	test('cron(30-10 * * * ? *) throws — inverted range', () => {
+		assert.throws(
+			() => new CronJob(fakeScope, 'invRange', opts('cron(30-10 * * * ? *)')),
+			(err: Error) => err.name === CronJobErrors.InvalidSchedule
+		);
+	});
+
+	test('cron(100 * * * ? *) throws — minute out of bounds', () => {
+		assert.throws(
+			() => new CronJob(fakeScope, 'oobMin', opts('cron(100 * * * ? *)')),
+			(err: Error) => err.name === CronJobErrors.InvalidSchedule
+		);
+	});
 });


### PR DESCRIPTION
## Problem

expandField() parsed a stepped range like `0-30/10` as start=0 with no upper bound, stepping to the field max (59) and yielding [0,10,20,30,40,50] instead of [0,10,20,30]. A job restricted to minutes 0–30 would also fire at 40 and 50, diverging from EventBridge.

**Issue #, if available:**

## Changes

Detect when the step base is itself a range and use its `hi` as the loop bound. The `*/n` and single-value `n/step` forms are unchanged.
<!--
Summarize the changes introduced in this PR. Call out critical or potentially problematic parts of the change.
-->

## Validation

<!--
Describe how changes have been validated — added/updated unit, integration, or E2E tests, manual verification, etc.
If no automated tests were added, explain why.
-->

## Checklist

- [x] PR description included
- [x] Tests are changed or added
- [x] Relevant documentation is changed or added (and PR referenced)

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
