### PR TITLE
fix(bb-tracer): make sampling a per-trace decision

### DIFF
--- a/.changeset/tracer-per-trace-sampling.md
+++ b/.changeset/tracer-per-trace-sampling.md
@@ -1,0 +1,5 @@
+---
+"@aws-blocks/bb-tracer": patch
+---
+
+fix(bb-tracer): make sampling a per-trace decision so all spans within a trace share the same sampling outcome

--- a/packages/bb-tracer/src/index.mock.ts
+++ b/packages/bb-tracer/src/index.mock.ts
@@ -87,6 +87,13 @@ export class Tracer extends Scope {
 	private rootAnnotations: Record<string, AnnotationValue> = {};
 	private rootMetadata: Record<string, unknown> = {};
 	private segmentStack: TraceRecord[] = [];
+	/**
+	 * Depth tracker for an in-flight *unsampled* trace. The sampled path tracks
+	 * nesting via `segmentStack`, but an unsampled root pushes nothing, so a
+	 * counter is needed to keep its subsegments unsampled too (rather than
+	 * letting them re-roll and spawn their own root traces).
+	 */
+	private unsampledDepth = 0;
 
 	/** @internal Logger for internal operations. Defaults to error-level when not provided. */
 	protected log: ChildLogger;
@@ -113,8 +120,24 @@ export class Tracer extends Scope {
 	 * @returns The return value of `fn`.
 	 */
 	async startSegment<T>(name: string, fn: (segment: ISegment) => Promise<T>): Promise<T> {
-		if (!this.enabled || !this.shouldSample()) {
+		if (!this.enabled) {
 			return fn(NO_OP_SEGMENT);
+		}
+
+		// Sampling is a per-trace decision: roll it once at the root segment and
+		// have every subsegment inherit it, so a trace is recorded whole or not
+		// at all. Rolling per subsegment (the previous behavior) would randomly
+		// drop children from a sampled trace, or promote a subsegment of an
+		// unsampled trace into its own orphan root trace.
+		const inActiveTrace = this.segmentStack.length > 0 || this.unsampledDepth > 0;
+		const sampled = inActiveTrace ? this.unsampledDepth === 0 : this.shouldSample();
+		if (!sampled) {
+			this.unsampledDepth++;
+			try {
+				return await fn(NO_OP_SEGMENT);
+			} finally {
+				this.unsampledDepth--;
+			}
 		}
 
 		if (!this.currentTraceId) {

--- a/packages/bb-tracer/src/index.test.ts
+++ b/packages/bb-tracer/src/index.test.ts
@@ -151,6 +151,47 @@ test('samplingRate: 1 traces everything', async () => {
 	assert.strictEqual(existsSync('.bb-data/root-test/traces.json'), true);
 });
 
+// Sampling is a per-trace decision made at the root; subsegments must inherit
+// it. These tests drive a fractional samplingRate with a scripted Math.random
+// so the root and a nested segment would roll differently if sampling were
+// (incorrectly) re-evaluated per subsegment.
+function withScriptedRandom(values: number[], fn: () => Promise<void>): Promise<void> {
+	const original = Math.random;
+	let i = 0;
+	// After the script is exhausted, return 1 (>= any rate < 1 ⇒ "not sampled")
+	// so an unexpected extra roll can't accidentally sample.
+	Math.random = () => (i < values.length ? values[i++] : 1);
+	return fn().finally(() => { Math.random = original; });
+}
+
+test('a sampled trace keeps all its subsegments even when a subsegment would roll unsampled', async () => {
+	const tracer = new Tracer({ id: 'root' } as any, 'test', { samplingRate: 0.5 });
+	// Root rolls 0.1 (< 0.5 ⇒ sampled); a per-subsegment roll of 0.9 would drop
+	// the child under the buggy behavior.
+	await withScriptedRandom([0.1, 0.9], async () => {
+		await tracer.startSegment('outer', async () => {
+			await tracer.startSegment('inner', async () => {});
+		});
+	});
+	const traces = JSON.parse(readFileSync('.bb-data/root-test/traces.json', 'utf8'));
+	assert.strictEqual(traces.length, 1);
+	assert.strictEqual(traces[0].segment, 'outer');
+	assert.strictEqual(traces[0].children.length, 1);
+	assert.strictEqual(traces[0].children[0].segment, 'inner');
+});
+
+test('an unsampled trace never promotes a subsegment into its own root trace', async () => {
+	const tracer = new Tracer({ id: 'root' } as any, 'test', { samplingRate: 0.5 });
+	// Root rolls 0.9 (>= 0.5 ⇒ not sampled); a per-subsegment roll of 0.1 would
+	// spawn an orphan root trace under the buggy behavior.
+	await withScriptedRandom([0.9, 0.1], async () => {
+		await tracer.startSegment('outer', async () => {
+			await tracer.startSegment('inner', async () => {});
+		});
+	});
+	assert.strictEqual(existsSync('.bb-data/root-test/traces.json'), false);
+});
+
 // ── getTraceId ──────────────────────────────────────────────────────────────
 
 test('getTraceId returns a UUID string', () => {


### PR DESCRIPTION
## Problem
bb-tracer's startSegment() rolled the sampling decision (Math.random() < samplingRate) on every segment. But sampling should be per-trace. With a fractional samplingRate, a sampled trace could randomly drop subsegments, and an unsampled trace could promote a subsegment into its own orphan root trace. Hidden at the default rate of 1.0.

**Issue #, if available:**

## Changes
- Roll sampling once at the root segment; subsegments inherit it (sampled path tracked via segmentStack, unsampled path via a new unsampledDepth counter).
- Added two tests using a scripted Math.random at samplingRate: 0.5: sampled root keeps its child; unsampled root writes no trace (no orphan).

## Validation

<!--
Describe how changes have been validated — added/updated unit, integration, or E2E tests, manual verification, etc.
If no automated tests were added, explain why.
-->

## Checklist

- [x] PR description included
- [x] Tests are changed or added
- [x] Relevant documentation is changed or added (and PR referenced)

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
