### PR TITLE
fix(bb-auth-cognito): discriminate Cognito result unions on string `status`

### DIFF
--- a/.changeset/cognito-status-discriminator.md
+++ b/.changeset/cognito-status-discriminator.md
@@ -1,0 +1,13 @@
+---
+"@aws-blocks/bb-auth-cognito": patch
+---
+
+fix(bb-auth-cognito): discriminate `SignInResult` on a string `status` field
+
+`SignInResult` (from `signIn` / `confirmSignIn` / `autoSignIn`) now discriminates
+on a string `status` (`'signedIn' | 'continueSignIn'`) instead of the `isSignedIn`
+boolean, so native-client codegen (Swift / Kotlin / Dart) emits clean, named,
+switch-decoded variants. Narrow with `if (result.status === 'signedIn')`.
+
+Breaking change to the `SignInResult` shape (pre-release): `isSignedIn` is removed,
+not aliased.

--- a/native/codegen-fixtures/23-cognito-nested-unions/dart/client.dart
+++ b/native/codegen-fixtures/23-cognito-nested-unions/dart/client.dart
@@ -115,28 +115,1420 @@ class CodeDeliveryDetails {
 }
 
 
+enum CONTINUE_SIGN_IN_WITH_MFA_SELECTIONContinueSignInCognitoConfirmSignInResultNextStepAllowedMFATypes {
+  SMS,
+  TOTP,
+  EMAIL
+;
+
+  String toJson() => name;
+  static CONTINUE_SIGN_IN_WITH_MFA_SELECTIONContinueSignInCognitoConfirmSignInResultNextStepAllowedMFATypes fromJson(String json) => values.byName(json);
+}
+
+
+enum CONTINUE_SIGN_IN_WITH_MFA_SETUP_SELECTIONContinueSignInCognitoConfirmSignInResultNextStepAllowedMFATypes {
+  TOTP,
+  EMAIL
+;
+
+  String toJson() => name;
+  static CONTINUE_SIGN_IN_WITH_MFA_SETUP_SELECTIONContinueSignInCognitoConfirmSignInResultNextStepAllowedMFATypes fromJson(String json) => values.byName(json);
+}
+
+
+enum CONTINUE_SIGN_IN_WITH_FIRST_FACTOR_SELECTIONContinueSignInCognitoConfirmSignInResultNextStepAvailableChallenges {
+  PASSWORD,
+  EMAIL_OTP,
+  SMS_OTP,
+  WEB_AUTHN
+;
+
+  String toJson() => name;
+  static CONTINUE_SIGN_IN_WITH_FIRST_FACTOR_SELECTIONContinueSignInCognitoConfirmSignInResultNextStepAvailableChallenges fromJson(String json) => values.byName(json);
+}
+
+
+sealed class ContinueSignInCognitoConfirmSignInResultNextStep {
+  const ContinueSignInCognitoConfirmSignInResultNextStep();
+  Map<String, dynamic> toJson();
+  static ContinueSignInCognitoConfirmSignInResultNextStep fromJson(Map<String, dynamic> json) {
+    switch (json['name'] as String) {
+      case 'CONFIRM_SIGN_IN_WITH_SMS_CODE': return CONFIRM_SIGN_IN_WITH_SMS_CODEContinueSignInCognitoConfirmSignInResultNextStep.fromJson(json);
+      case 'CONFIRM_SIGN_IN_WITH_TOTP_CODE': return CONFIRM_SIGN_IN_WITH_TOTP_CODEContinueSignInCognitoConfirmSignInResultNextStep.fromJson(json);
+      case 'CONFIRM_SIGN_IN_WITH_EMAIL_CODE': return CONFIRM_SIGN_IN_WITH_EMAIL_CODEContinueSignInCognitoConfirmSignInResultNextStep.fromJson(json);
+      case 'CONTINUE_SIGN_IN_WITH_MFA_SELECTION': return CONTINUE_SIGN_IN_WITH_MFA_SELECTIONContinueSignInCognitoConfirmSignInResultNextStep.fromJson(json);
+      case 'CONTINUE_SIGN_IN_WITH_MFA_SETUP_SELECTION': return CONTINUE_SIGN_IN_WITH_MFA_SETUP_SELECTIONContinueSignInCognitoConfirmSignInResultNextStep.fromJson(json);
+      case 'CONTINUE_SIGN_IN_WITH_TOTP_SETUP': return CONTINUE_SIGN_IN_WITH_TOTP_SETUPContinueSignInCognitoConfirmSignInResultNextStep.fromJson(json);
+      case 'CONTINUE_SIGN_IN_WITH_EMAIL_SETUP': return CONTINUE_SIGN_IN_WITH_EMAIL_SETUPContinueSignInCognitoConfirmSignInResultNextStep.fromJson(json);
+      case 'CONFIRM_SIGN_IN_WITH_NEW_PASSWORD_REQUIRED': return CONFIRM_SIGN_IN_WITH_NEW_PASSWORD_REQUIREDContinueSignInCognitoConfirmSignInResultNextStep.fromJson(json);
+      case 'CONTINUE_SIGN_IN_WITH_FIRST_FACTOR_SELECTION': return CONTINUE_SIGN_IN_WITH_FIRST_FACTOR_SELECTIONContinueSignInCognitoConfirmSignInResultNextStep.fromJson(json);
+      case 'CONFIRM_SIGN_IN_WITH_PASSWORD': return CONFIRM_SIGN_IN_WITH_PASSWORDContinueSignInCognitoConfirmSignInResultNextStep.fromJson(json);
+      case 'CONFIRM_SIGN_IN_WITH_FIRST_FACTOR_EMAIL_OTP': return CONFIRM_SIGN_IN_WITH_FIRST_FACTOR_EMAIL_OTPContinueSignInCognitoConfirmSignInResultNextStep.fromJson(json);
+      case 'CONFIRM_SIGN_IN_WITH_FIRST_FACTOR_SMS_OTP': return CONFIRM_SIGN_IN_WITH_FIRST_FACTOR_SMS_OTPContinueSignInCognitoConfirmSignInResultNextStep.fromJson(json);
+      case 'CONFIRM_SIGN_IN_WITH_WEB_AUTHN': return CONFIRM_SIGN_IN_WITH_WEB_AUTHNContinueSignInCognitoConfirmSignInResultNextStep.fromJson(json);
+      case 'RESET_PASSWORD': return RESET_PASSWORDContinueSignInCognitoConfirmSignInResultNextStep.fromJson(json);
+      case 'CONFIRM_SIGN_UP': return CONFIRM_SIGN_UPContinueSignInCognitoConfirmSignInResultNextStep.fromJson(json);
+      default: throw ArgumentError('Unknown name: ${json['name']}');
+    }
+  }
+}
+
+class CONFIRM_SIGN_IN_WITH_SMS_CODEContinueSignInCognitoConfirmSignInResultNextStep extends ContinueSignInCognitoConfirmSignInResultNextStep {
+  final String session;
+  final CodeDeliveryDetails codeDeliveryDetails;
+
+  const CONFIRM_SIGN_IN_WITH_SMS_CODEContinueSignInCognitoConfirmSignInResultNextStep({
+    required this.session,
+    required this.codeDeliveryDetails,
+  });
+
+  factory CONFIRM_SIGN_IN_WITH_SMS_CODEContinueSignInCognitoConfirmSignInResultNextStep.fromJson(Map<String, dynamic> json) {
+    return CONFIRM_SIGN_IN_WITH_SMS_CODEContinueSignInCognitoConfirmSignInResultNextStep(
+      session: json['session'] as String,
+      codeDeliveryDetails: CodeDeliveryDetails.fromJson(json['codeDeliveryDetails'] as Map<String, dynamic>),
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      'name': 'CONFIRM_SIGN_IN_WITH_SMS_CODE',
+      'session': session,
+      'codeDeliveryDetails': codeDeliveryDetails.toJson(),
+    };
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is CONFIRM_SIGN_IN_WITH_SMS_CODEContinueSignInCognitoConfirmSignInResultNextStep &&
+          session == other.session &&
+          codeDeliveryDetails == other.codeDeliveryDetails;
+
+  @override
+  int get hashCode => Object.hash(session, codeDeliveryDetails);
+
+  @override
+  String toString() => 'CONFIRM_SIGN_IN_WITH_SMS_CODEContinueSignInCognitoConfirmSignInResultNextStep(session: $session, codeDeliveryDetails: $codeDeliveryDetails)';
+}
+
+class CONFIRM_SIGN_IN_WITH_TOTP_CODEContinueSignInCognitoConfirmSignInResultNextStep extends ContinueSignInCognitoConfirmSignInResultNextStep {
+  final String session;
+
+  const CONFIRM_SIGN_IN_WITH_TOTP_CODEContinueSignInCognitoConfirmSignInResultNextStep({
+    required this.session,
+  });
+
+  factory CONFIRM_SIGN_IN_WITH_TOTP_CODEContinueSignInCognitoConfirmSignInResultNextStep.fromJson(Map<String, dynamic> json) {
+    return CONFIRM_SIGN_IN_WITH_TOTP_CODEContinueSignInCognitoConfirmSignInResultNextStep(
+      session: json['session'] as String,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      'name': 'CONFIRM_SIGN_IN_WITH_TOTP_CODE',
+      'session': session,
+    };
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is CONFIRM_SIGN_IN_WITH_TOTP_CODEContinueSignInCognitoConfirmSignInResultNextStep &&
+          session == other.session;
+
+  @override
+  int get hashCode => session.hashCode;
+
+  @override
+  String toString() => 'CONFIRM_SIGN_IN_WITH_TOTP_CODEContinueSignInCognitoConfirmSignInResultNextStep(session: $session)';
+}
+
+class CONFIRM_SIGN_IN_WITH_EMAIL_CODEContinueSignInCognitoConfirmSignInResultNextStep extends ContinueSignInCognitoConfirmSignInResultNextStep {
+  final String session;
+  final CodeDeliveryDetails codeDeliveryDetails;
+
+  const CONFIRM_SIGN_IN_WITH_EMAIL_CODEContinueSignInCognitoConfirmSignInResultNextStep({
+    required this.session,
+    required this.codeDeliveryDetails,
+  });
+
+  factory CONFIRM_SIGN_IN_WITH_EMAIL_CODEContinueSignInCognitoConfirmSignInResultNextStep.fromJson(Map<String, dynamic> json) {
+    return CONFIRM_SIGN_IN_WITH_EMAIL_CODEContinueSignInCognitoConfirmSignInResultNextStep(
+      session: json['session'] as String,
+      codeDeliveryDetails: CodeDeliveryDetails.fromJson(json['codeDeliveryDetails'] as Map<String, dynamic>),
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      'name': 'CONFIRM_SIGN_IN_WITH_EMAIL_CODE',
+      'session': session,
+      'codeDeliveryDetails': codeDeliveryDetails.toJson(),
+    };
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is CONFIRM_SIGN_IN_WITH_EMAIL_CODEContinueSignInCognitoConfirmSignInResultNextStep &&
+          session == other.session &&
+          codeDeliveryDetails == other.codeDeliveryDetails;
+
+  @override
+  int get hashCode => Object.hash(session, codeDeliveryDetails);
+
+  @override
+  String toString() => 'CONFIRM_SIGN_IN_WITH_EMAIL_CODEContinueSignInCognitoConfirmSignInResultNextStep(session: $session, codeDeliveryDetails: $codeDeliveryDetails)';
+}
+
+class CONTINUE_SIGN_IN_WITH_MFA_SELECTIONContinueSignInCognitoConfirmSignInResultNextStep extends ContinueSignInCognitoConfirmSignInResultNextStep {
+  final String session;
+  final List<CONTINUE_SIGN_IN_WITH_MFA_SELECTIONContinueSignInCognitoConfirmSignInResultNextStepAllowedMFATypes> allowedMFATypes;
+
+  const CONTINUE_SIGN_IN_WITH_MFA_SELECTIONContinueSignInCognitoConfirmSignInResultNextStep({
+    required this.session,
+    required this.allowedMFATypes,
+  });
+
+  factory CONTINUE_SIGN_IN_WITH_MFA_SELECTIONContinueSignInCognitoConfirmSignInResultNextStep.fromJson(Map<String, dynamic> json) {
+    return CONTINUE_SIGN_IN_WITH_MFA_SELECTIONContinueSignInCognitoConfirmSignInResultNextStep(
+      session: json['session'] as String,
+      allowedMFATypes: (json['allowedMFATypes'] as List<dynamic>).cast<CONTINUE_SIGN_IN_WITH_MFA_SELECTIONContinueSignInCognitoConfirmSignInResultNextStepAllowedMFATypes>(),
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      'name': 'CONTINUE_SIGN_IN_WITH_MFA_SELECTION',
+      'session': session,
+      'allowedMFATypes': allowedMFATypes,
+    };
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is CONTINUE_SIGN_IN_WITH_MFA_SELECTIONContinueSignInCognitoConfirmSignInResultNextStep &&
+          session == other.session &&
+          allowedMFATypes == other.allowedMFATypes;
+
+  @override
+  int get hashCode => Object.hash(session, allowedMFATypes);
+
+  @override
+  String toString() => 'CONTINUE_SIGN_IN_WITH_MFA_SELECTIONContinueSignInCognitoConfirmSignInResultNextStep(session: $session, allowedMFATypes: $allowedMFATypes)';
+}
+
+class CONTINUE_SIGN_IN_WITH_MFA_SETUP_SELECTIONContinueSignInCognitoConfirmSignInResultNextStep extends ContinueSignInCognitoConfirmSignInResultNextStep {
+  final String session;
+  final List<CONTINUE_SIGN_IN_WITH_MFA_SETUP_SELECTIONContinueSignInCognitoConfirmSignInResultNextStepAllowedMFATypes> allowedMFATypes;
+
+  const CONTINUE_SIGN_IN_WITH_MFA_SETUP_SELECTIONContinueSignInCognitoConfirmSignInResultNextStep({
+    required this.session,
+    required this.allowedMFATypes,
+  });
+
+  factory CONTINUE_SIGN_IN_WITH_MFA_SETUP_SELECTIONContinueSignInCognitoConfirmSignInResultNextStep.fromJson(Map<String, dynamic> json) {
+    return CONTINUE_SIGN_IN_WITH_MFA_SETUP_SELECTIONContinueSignInCognitoConfirmSignInResultNextStep(
+      session: json['session'] as String,
+      allowedMFATypes: (json['allowedMFATypes'] as List<dynamic>).cast<CONTINUE_SIGN_IN_WITH_MFA_SETUP_SELECTIONContinueSignInCognitoConfirmSignInResultNextStepAllowedMFATypes>(),
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      'name': 'CONTINUE_SIGN_IN_WITH_MFA_SETUP_SELECTION',
+      'session': session,
+      'allowedMFATypes': allowedMFATypes,
+    };
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is CONTINUE_SIGN_IN_WITH_MFA_SETUP_SELECTIONContinueSignInCognitoConfirmSignInResultNextStep &&
+          session == other.session &&
+          allowedMFATypes == other.allowedMFATypes;
+
+  @override
+  int get hashCode => Object.hash(session, allowedMFATypes);
+
+  @override
+  String toString() => 'CONTINUE_SIGN_IN_WITH_MFA_SETUP_SELECTIONContinueSignInCognitoConfirmSignInResultNextStep(session: $session, allowedMFATypes: $allowedMFATypes)';
+}
+
+class CONTINUE_SIGN_IN_WITH_TOTP_SETUPContinueSignInCognitoConfirmSignInResultNextStep extends ContinueSignInCognitoConfirmSignInResultNextStep {
+  final String session;
+  final String sharedSecret;
+
+  const CONTINUE_SIGN_IN_WITH_TOTP_SETUPContinueSignInCognitoConfirmSignInResultNextStep({
+    required this.session,
+    required this.sharedSecret,
+  });
+
+  factory CONTINUE_SIGN_IN_WITH_TOTP_SETUPContinueSignInCognitoConfirmSignInResultNextStep.fromJson(Map<String, dynamic> json) {
+    return CONTINUE_SIGN_IN_WITH_TOTP_SETUPContinueSignInCognitoConfirmSignInResultNextStep(
+      session: json['session'] as String,
+      sharedSecret: json['sharedSecret'] as String,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      'name': 'CONTINUE_SIGN_IN_WITH_TOTP_SETUP',
+      'session': session,
+      'sharedSecret': sharedSecret,
+    };
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is CONTINUE_SIGN_IN_WITH_TOTP_SETUPContinueSignInCognitoConfirmSignInResultNextStep &&
+          session == other.session &&
+          sharedSecret == other.sharedSecret;
+
+  @override
+  int get hashCode => Object.hash(session, sharedSecret);
+
+  @override
+  String toString() => 'CONTINUE_SIGN_IN_WITH_TOTP_SETUPContinueSignInCognitoConfirmSignInResultNextStep(session: $session, sharedSecret: $sharedSecret)';
+}
+
+class CONTINUE_SIGN_IN_WITH_EMAIL_SETUPContinueSignInCognitoConfirmSignInResultNextStep extends ContinueSignInCognitoConfirmSignInResultNextStep {
+  final String session;
+
+  const CONTINUE_SIGN_IN_WITH_EMAIL_SETUPContinueSignInCognitoConfirmSignInResultNextStep({
+    required this.session,
+  });
+
+  factory CONTINUE_SIGN_IN_WITH_EMAIL_SETUPContinueSignInCognitoConfirmSignInResultNextStep.fromJson(Map<String, dynamic> json) {
+    return CONTINUE_SIGN_IN_WITH_EMAIL_SETUPContinueSignInCognitoConfirmSignInResultNextStep(
+      session: json['session'] as String,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      'name': 'CONTINUE_SIGN_IN_WITH_EMAIL_SETUP',
+      'session': session,
+    };
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is CONTINUE_SIGN_IN_WITH_EMAIL_SETUPContinueSignInCognitoConfirmSignInResultNextStep &&
+          session == other.session;
+
+  @override
+  int get hashCode => session.hashCode;
+
+  @override
+  String toString() => 'CONTINUE_SIGN_IN_WITH_EMAIL_SETUPContinueSignInCognitoConfirmSignInResultNextStep(session: $session)';
+}
+
+class CONFIRM_SIGN_IN_WITH_NEW_PASSWORD_REQUIREDContinueSignInCognitoConfirmSignInResultNextStep extends ContinueSignInCognitoConfirmSignInResultNextStep {
+  final String session;
+  final List<String>? requiredAttributes;
+
+  const CONFIRM_SIGN_IN_WITH_NEW_PASSWORD_REQUIREDContinueSignInCognitoConfirmSignInResultNextStep({
+    required this.session,
+    this.requiredAttributes,
+  });
+
+  factory CONFIRM_SIGN_IN_WITH_NEW_PASSWORD_REQUIREDContinueSignInCognitoConfirmSignInResultNextStep.fromJson(Map<String, dynamic> json) {
+    return CONFIRM_SIGN_IN_WITH_NEW_PASSWORD_REQUIREDContinueSignInCognitoConfirmSignInResultNextStep(
+      session: json['session'] as String,
+      requiredAttributes: (json['requiredAttributes'] as List<dynamic>?)?.cast<String>(),
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      'name': 'CONFIRM_SIGN_IN_WITH_NEW_PASSWORD_REQUIRED',
+      'session': session,
+      if (requiredAttributes != null) 'requiredAttributes': requiredAttributes,
+    };
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is CONFIRM_SIGN_IN_WITH_NEW_PASSWORD_REQUIREDContinueSignInCognitoConfirmSignInResultNextStep &&
+          session == other.session &&
+          requiredAttributes == other.requiredAttributes;
+
+  @override
+  int get hashCode => Object.hash(session, requiredAttributes);
+
+  @override
+  String toString() => 'CONFIRM_SIGN_IN_WITH_NEW_PASSWORD_REQUIREDContinueSignInCognitoConfirmSignInResultNextStep(session: $session, requiredAttributes: $requiredAttributes)';
+}
+
+class CONTINUE_SIGN_IN_WITH_FIRST_FACTOR_SELECTIONContinueSignInCognitoConfirmSignInResultNextStep extends ContinueSignInCognitoConfirmSignInResultNextStep {
+  final String session;
+  final List<CONTINUE_SIGN_IN_WITH_FIRST_FACTOR_SELECTIONContinueSignInCognitoConfirmSignInResultNextStepAvailableChallenges> availableChallenges;
+
+  const CONTINUE_SIGN_IN_WITH_FIRST_FACTOR_SELECTIONContinueSignInCognitoConfirmSignInResultNextStep({
+    required this.session,
+    required this.availableChallenges,
+  });
+
+  factory CONTINUE_SIGN_IN_WITH_FIRST_FACTOR_SELECTIONContinueSignInCognitoConfirmSignInResultNextStep.fromJson(Map<String, dynamic> json) {
+    return CONTINUE_SIGN_IN_WITH_FIRST_FACTOR_SELECTIONContinueSignInCognitoConfirmSignInResultNextStep(
+      session: json['session'] as String,
+      availableChallenges: (json['availableChallenges'] as List<dynamic>).cast<CONTINUE_SIGN_IN_WITH_FIRST_FACTOR_SELECTIONContinueSignInCognitoConfirmSignInResultNextStepAvailableChallenges>(),
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      'name': 'CONTINUE_SIGN_IN_WITH_FIRST_FACTOR_SELECTION',
+      'session': session,
+      'availableChallenges': availableChallenges,
+    };
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is CONTINUE_SIGN_IN_WITH_FIRST_FACTOR_SELECTIONContinueSignInCognitoConfirmSignInResultNextStep &&
+          session == other.session &&
+          availableChallenges == other.availableChallenges;
+
+  @override
+  int get hashCode => Object.hash(session, availableChallenges);
+
+  @override
+  String toString() => 'CONTINUE_SIGN_IN_WITH_FIRST_FACTOR_SELECTIONContinueSignInCognitoConfirmSignInResultNextStep(session: $session, availableChallenges: $availableChallenges)';
+}
+
+class CONFIRM_SIGN_IN_WITH_PASSWORDContinueSignInCognitoConfirmSignInResultNextStep extends ContinueSignInCognitoConfirmSignInResultNextStep {
+  final String session;
+
+  const CONFIRM_SIGN_IN_WITH_PASSWORDContinueSignInCognitoConfirmSignInResultNextStep({
+    required this.session,
+  });
+
+  factory CONFIRM_SIGN_IN_WITH_PASSWORDContinueSignInCognitoConfirmSignInResultNextStep.fromJson(Map<String, dynamic> json) {
+    return CONFIRM_SIGN_IN_WITH_PASSWORDContinueSignInCognitoConfirmSignInResultNextStep(
+      session: json['session'] as String,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      'name': 'CONFIRM_SIGN_IN_WITH_PASSWORD',
+      'session': session,
+    };
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is CONFIRM_SIGN_IN_WITH_PASSWORDContinueSignInCognitoConfirmSignInResultNextStep &&
+          session == other.session;
+
+  @override
+  int get hashCode => session.hashCode;
+
+  @override
+  String toString() => 'CONFIRM_SIGN_IN_WITH_PASSWORDContinueSignInCognitoConfirmSignInResultNextStep(session: $session)';
+}
+
+class CONFIRM_SIGN_IN_WITH_FIRST_FACTOR_EMAIL_OTPContinueSignInCognitoConfirmSignInResultNextStep extends ContinueSignInCognitoConfirmSignInResultNextStep {
+  final String session;
+  final CodeDeliveryDetails codeDeliveryDetails;
+
+  const CONFIRM_SIGN_IN_WITH_FIRST_FACTOR_EMAIL_OTPContinueSignInCognitoConfirmSignInResultNextStep({
+    required this.session,
+    required this.codeDeliveryDetails,
+  });
+
+  factory CONFIRM_SIGN_IN_WITH_FIRST_FACTOR_EMAIL_OTPContinueSignInCognitoConfirmSignInResultNextStep.fromJson(Map<String, dynamic> json) {
+    return CONFIRM_SIGN_IN_WITH_FIRST_FACTOR_EMAIL_OTPContinueSignInCognitoConfirmSignInResultNextStep(
+      session: json['session'] as String,
+      codeDeliveryDetails: CodeDeliveryDetails.fromJson(json['codeDeliveryDetails'] as Map<String, dynamic>),
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      'name': 'CONFIRM_SIGN_IN_WITH_FIRST_FACTOR_EMAIL_OTP',
+      'session': session,
+      'codeDeliveryDetails': codeDeliveryDetails.toJson(),
+    };
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is CONFIRM_SIGN_IN_WITH_FIRST_FACTOR_EMAIL_OTPContinueSignInCognitoConfirmSignInResultNextStep &&
+          session == other.session &&
+          codeDeliveryDetails == other.codeDeliveryDetails;
+
+  @override
+  int get hashCode => Object.hash(session, codeDeliveryDetails);
+
+  @override
+  String toString() => 'CONFIRM_SIGN_IN_WITH_FIRST_FACTOR_EMAIL_OTPContinueSignInCognitoConfirmSignInResultNextStep(session: $session, codeDeliveryDetails: $codeDeliveryDetails)';
+}
+
+class CONFIRM_SIGN_IN_WITH_FIRST_FACTOR_SMS_OTPContinueSignInCognitoConfirmSignInResultNextStep extends ContinueSignInCognitoConfirmSignInResultNextStep {
+  final String session;
+  final CodeDeliveryDetails codeDeliveryDetails;
+
+  const CONFIRM_SIGN_IN_WITH_FIRST_FACTOR_SMS_OTPContinueSignInCognitoConfirmSignInResultNextStep({
+    required this.session,
+    required this.codeDeliveryDetails,
+  });
+
+  factory CONFIRM_SIGN_IN_WITH_FIRST_FACTOR_SMS_OTPContinueSignInCognitoConfirmSignInResultNextStep.fromJson(Map<String, dynamic> json) {
+    return CONFIRM_SIGN_IN_WITH_FIRST_FACTOR_SMS_OTPContinueSignInCognitoConfirmSignInResultNextStep(
+      session: json['session'] as String,
+      codeDeliveryDetails: CodeDeliveryDetails.fromJson(json['codeDeliveryDetails'] as Map<String, dynamic>),
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      'name': 'CONFIRM_SIGN_IN_WITH_FIRST_FACTOR_SMS_OTP',
+      'session': session,
+      'codeDeliveryDetails': codeDeliveryDetails.toJson(),
+    };
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is CONFIRM_SIGN_IN_WITH_FIRST_FACTOR_SMS_OTPContinueSignInCognitoConfirmSignInResultNextStep &&
+          session == other.session &&
+          codeDeliveryDetails == other.codeDeliveryDetails;
+
+  @override
+  int get hashCode => Object.hash(session, codeDeliveryDetails);
+
+  @override
+  String toString() => 'CONFIRM_SIGN_IN_WITH_FIRST_FACTOR_SMS_OTPContinueSignInCognitoConfirmSignInResultNextStep(session: $session, codeDeliveryDetails: $codeDeliveryDetails)';
+}
+
+class CONFIRM_SIGN_IN_WITH_WEB_AUTHNContinueSignInCognitoConfirmSignInResultNextStep extends ContinueSignInCognitoConfirmSignInResultNextStep {
+  final String session;
+  final String credentialRequestOptions;
+
+  const CONFIRM_SIGN_IN_WITH_WEB_AUTHNContinueSignInCognitoConfirmSignInResultNextStep({
+    required this.session,
+    required this.credentialRequestOptions,
+  });
+
+  factory CONFIRM_SIGN_IN_WITH_WEB_AUTHNContinueSignInCognitoConfirmSignInResultNextStep.fromJson(Map<String, dynamic> json) {
+    return CONFIRM_SIGN_IN_WITH_WEB_AUTHNContinueSignInCognitoConfirmSignInResultNextStep(
+      session: json['session'] as String,
+      credentialRequestOptions: json['credentialRequestOptions'] as String,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      'name': 'CONFIRM_SIGN_IN_WITH_WEB_AUTHN',
+      'session': session,
+      'credentialRequestOptions': credentialRequestOptions,
+    };
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is CONFIRM_SIGN_IN_WITH_WEB_AUTHNContinueSignInCognitoConfirmSignInResultNextStep &&
+          session == other.session &&
+          credentialRequestOptions == other.credentialRequestOptions;
+
+  @override
+  int get hashCode => Object.hash(session, credentialRequestOptions);
+
+  @override
+  String toString() => 'CONFIRM_SIGN_IN_WITH_WEB_AUTHNContinueSignInCognitoConfirmSignInResultNextStep(session: $session, credentialRequestOptions: $credentialRequestOptions)';
+}
+
+class RESET_PASSWORDContinueSignInCognitoConfirmSignInResultNextStep extends ContinueSignInCognitoConfirmSignInResultNextStep {
+
+  const RESET_PASSWORDContinueSignInCognitoConfirmSignInResultNextStep();
+
+  factory RESET_PASSWORDContinueSignInCognitoConfirmSignInResultNextStep.fromJson(Map<String, dynamic> json) {
+    return RESET_PASSWORDContinueSignInCognitoConfirmSignInResultNextStep(
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      'name': 'RESET_PASSWORD',
+    };
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is RESET_PASSWORDContinueSignInCognitoConfirmSignInResultNextStep;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  String toString() => 'RESET_PASSWORDContinueSignInCognitoConfirmSignInResultNextStep()';
+}
+
+class CONFIRM_SIGN_UPContinueSignInCognitoConfirmSignInResultNextStep extends ContinueSignInCognitoConfirmSignInResultNextStep {
+  final CodeDeliveryDetails? codeDeliveryDetails;
+
+  const CONFIRM_SIGN_UPContinueSignInCognitoConfirmSignInResultNextStep({
+    this.codeDeliveryDetails,
+  });
+
+  factory CONFIRM_SIGN_UPContinueSignInCognitoConfirmSignInResultNextStep.fromJson(Map<String, dynamic> json) {
+    return CONFIRM_SIGN_UPContinueSignInCognitoConfirmSignInResultNextStep(
+      codeDeliveryDetails: json['codeDeliveryDetails'] != null ? CodeDeliveryDetails.fromJson(json['codeDeliveryDetails'] as Map<String, dynamic>) : null,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      'name': 'CONFIRM_SIGN_UP',
+      if (codeDeliveryDetails != null) 'codeDeliveryDetails': codeDeliveryDetails?.toJson(),
+    };
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is CONFIRM_SIGN_UPContinueSignInCognitoConfirmSignInResultNextStep &&
+          codeDeliveryDetails == other.codeDeliveryDetails;
+
+  @override
+  int get hashCode => codeDeliveryDetails.hashCode;
+
+  @override
+  String toString() => 'CONFIRM_SIGN_UPContinueSignInCognitoConfirmSignInResultNextStep(codeDeliveryDetails: $codeDeliveryDetails)';
+}
+
+
+
+enum CONTINUE_SIGN_IN_WITH_MFA_SELECTIONContinueSignInCognitoSignInResultNextStepAllowedMFATypes {
+  SMS,
+  TOTP,
+  EMAIL
+;
+
+  String toJson() => name;
+  static CONTINUE_SIGN_IN_WITH_MFA_SELECTIONContinueSignInCognitoSignInResultNextStepAllowedMFATypes fromJson(String json) => values.byName(json);
+}
+
+
+enum CONTINUE_SIGN_IN_WITH_MFA_SETUP_SELECTIONContinueSignInCognitoSignInResultNextStepAllowedMFATypes {
+  TOTP,
+  EMAIL
+;
+
+  String toJson() => name;
+  static CONTINUE_SIGN_IN_WITH_MFA_SETUP_SELECTIONContinueSignInCognitoSignInResultNextStepAllowedMFATypes fromJson(String json) => values.byName(json);
+}
+
+
+enum CONTINUE_SIGN_IN_WITH_FIRST_FACTOR_SELECTIONContinueSignInCognitoSignInResultNextStepAvailableChallenges {
+  PASSWORD,
+  EMAIL_OTP,
+  SMS_OTP,
+  WEB_AUTHN
+;
+
+  String toJson() => name;
+  static CONTINUE_SIGN_IN_WITH_FIRST_FACTOR_SELECTIONContinueSignInCognitoSignInResultNextStepAvailableChallenges fromJson(String json) => values.byName(json);
+}
+
+
+sealed class ContinueSignInCognitoSignInResultNextStep {
+  const ContinueSignInCognitoSignInResultNextStep();
+  Map<String, dynamic> toJson();
+  static ContinueSignInCognitoSignInResultNextStep fromJson(Map<String, dynamic> json) {
+    switch (json['name'] as String) {
+      case 'CONFIRM_SIGN_IN_WITH_SMS_CODE': return CONFIRM_SIGN_IN_WITH_SMS_CODEContinueSignInCognitoSignInResultNextStep.fromJson(json);
+      case 'CONFIRM_SIGN_IN_WITH_TOTP_CODE': return CONFIRM_SIGN_IN_WITH_TOTP_CODEContinueSignInCognitoSignInResultNextStep.fromJson(json);
+      case 'CONFIRM_SIGN_IN_WITH_EMAIL_CODE': return CONFIRM_SIGN_IN_WITH_EMAIL_CODEContinueSignInCognitoSignInResultNextStep.fromJson(json);
+      case 'CONTINUE_SIGN_IN_WITH_MFA_SELECTION': return CONTINUE_SIGN_IN_WITH_MFA_SELECTIONContinueSignInCognitoSignInResultNextStep.fromJson(json);
+      case 'CONTINUE_SIGN_IN_WITH_MFA_SETUP_SELECTION': return CONTINUE_SIGN_IN_WITH_MFA_SETUP_SELECTIONContinueSignInCognitoSignInResultNextStep.fromJson(json);
+      case 'CONTINUE_SIGN_IN_WITH_TOTP_SETUP': return CONTINUE_SIGN_IN_WITH_TOTP_SETUPContinueSignInCognitoSignInResultNextStep.fromJson(json);
+      case 'CONTINUE_SIGN_IN_WITH_EMAIL_SETUP': return CONTINUE_SIGN_IN_WITH_EMAIL_SETUPContinueSignInCognitoSignInResultNextStep.fromJson(json);
+      case 'CONFIRM_SIGN_IN_WITH_NEW_PASSWORD_REQUIRED': return CONFIRM_SIGN_IN_WITH_NEW_PASSWORD_REQUIREDContinueSignInCognitoSignInResultNextStep.fromJson(json);
+      case 'CONTINUE_SIGN_IN_WITH_FIRST_FACTOR_SELECTION': return CONTINUE_SIGN_IN_WITH_FIRST_FACTOR_SELECTIONContinueSignInCognitoSignInResultNextStep.fromJson(json);
+      case 'CONFIRM_SIGN_IN_WITH_PASSWORD': return CONFIRM_SIGN_IN_WITH_PASSWORDContinueSignInCognitoSignInResultNextStep.fromJson(json);
+      case 'CONFIRM_SIGN_IN_WITH_FIRST_FACTOR_EMAIL_OTP': return CONFIRM_SIGN_IN_WITH_FIRST_FACTOR_EMAIL_OTPContinueSignInCognitoSignInResultNextStep.fromJson(json);
+      case 'CONFIRM_SIGN_IN_WITH_FIRST_FACTOR_SMS_OTP': return CONFIRM_SIGN_IN_WITH_FIRST_FACTOR_SMS_OTPContinueSignInCognitoSignInResultNextStep.fromJson(json);
+      case 'CONFIRM_SIGN_IN_WITH_WEB_AUTHN': return CONFIRM_SIGN_IN_WITH_WEB_AUTHNContinueSignInCognitoSignInResultNextStep.fromJson(json);
+      case 'RESET_PASSWORD': return RESET_PASSWORDContinueSignInCognitoSignInResultNextStep.fromJson(json);
+      case 'CONFIRM_SIGN_UP': return CONFIRM_SIGN_UPContinueSignInCognitoSignInResultNextStep.fromJson(json);
+      default: throw ArgumentError('Unknown name: ${json['name']}');
+    }
+  }
+}
+
+class CONFIRM_SIGN_IN_WITH_SMS_CODEContinueSignInCognitoSignInResultNextStep extends ContinueSignInCognitoSignInResultNextStep {
+  final String session;
+  final CodeDeliveryDetails codeDeliveryDetails;
+
+  const CONFIRM_SIGN_IN_WITH_SMS_CODEContinueSignInCognitoSignInResultNextStep({
+    required this.session,
+    required this.codeDeliveryDetails,
+  });
+
+  factory CONFIRM_SIGN_IN_WITH_SMS_CODEContinueSignInCognitoSignInResultNextStep.fromJson(Map<String, dynamic> json) {
+    return CONFIRM_SIGN_IN_WITH_SMS_CODEContinueSignInCognitoSignInResultNextStep(
+      session: json['session'] as String,
+      codeDeliveryDetails: CodeDeliveryDetails.fromJson(json['codeDeliveryDetails'] as Map<String, dynamic>),
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      'name': 'CONFIRM_SIGN_IN_WITH_SMS_CODE',
+      'session': session,
+      'codeDeliveryDetails': codeDeliveryDetails.toJson(),
+    };
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is CONFIRM_SIGN_IN_WITH_SMS_CODEContinueSignInCognitoSignInResultNextStep &&
+          session == other.session &&
+          codeDeliveryDetails == other.codeDeliveryDetails;
+
+  @override
+  int get hashCode => Object.hash(session, codeDeliveryDetails);
+
+  @override
+  String toString() => 'CONFIRM_SIGN_IN_WITH_SMS_CODEContinueSignInCognitoSignInResultNextStep(session: $session, codeDeliveryDetails: $codeDeliveryDetails)';
+}
+
+class CONFIRM_SIGN_IN_WITH_TOTP_CODEContinueSignInCognitoSignInResultNextStep extends ContinueSignInCognitoSignInResultNextStep {
+  final String session;
+
+  const CONFIRM_SIGN_IN_WITH_TOTP_CODEContinueSignInCognitoSignInResultNextStep({
+    required this.session,
+  });
+
+  factory CONFIRM_SIGN_IN_WITH_TOTP_CODEContinueSignInCognitoSignInResultNextStep.fromJson(Map<String, dynamic> json) {
+    return CONFIRM_SIGN_IN_WITH_TOTP_CODEContinueSignInCognitoSignInResultNextStep(
+      session: json['session'] as String,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      'name': 'CONFIRM_SIGN_IN_WITH_TOTP_CODE',
+      'session': session,
+    };
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is CONFIRM_SIGN_IN_WITH_TOTP_CODEContinueSignInCognitoSignInResultNextStep &&
+          session == other.session;
+
+  @override
+  int get hashCode => session.hashCode;
+
+  @override
+  String toString() => 'CONFIRM_SIGN_IN_WITH_TOTP_CODEContinueSignInCognitoSignInResultNextStep(session: $session)';
+}
+
+class CONFIRM_SIGN_IN_WITH_EMAIL_CODEContinueSignInCognitoSignInResultNextStep extends ContinueSignInCognitoSignInResultNextStep {
+  final String session;
+  final CodeDeliveryDetails codeDeliveryDetails;
+
+  const CONFIRM_SIGN_IN_WITH_EMAIL_CODEContinueSignInCognitoSignInResultNextStep({
+    required this.session,
+    required this.codeDeliveryDetails,
+  });
+
+  factory CONFIRM_SIGN_IN_WITH_EMAIL_CODEContinueSignInCognitoSignInResultNextStep.fromJson(Map<String, dynamic> json) {
+    return CONFIRM_SIGN_IN_WITH_EMAIL_CODEContinueSignInCognitoSignInResultNextStep(
+      session: json['session'] as String,
+      codeDeliveryDetails: CodeDeliveryDetails.fromJson(json['codeDeliveryDetails'] as Map<String, dynamic>),
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      'name': 'CONFIRM_SIGN_IN_WITH_EMAIL_CODE',
+      'session': session,
+      'codeDeliveryDetails': codeDeliveryDetails.toJson(),
+    };
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is CONFIRM_SIGN_IN_WITH_EMAIL_CODEContinueSignInCognitoSignInResultNextStep &&
+          session == other.session &&
+          codeDeliveryDetails == other.codeDeliveryDetails;
+
+  @override
+  int get hashCode => Object.hash(session, codeDeliveryDetails);
+
+  @override
+  String toString() => 'CONFIRM_SIGN_IN_WITH_EMAIL_CODEContinueSignInCognitoSignInResultNextStep(session: $session, codeDeliveryDetails: $codeDeliveryDetails)';
+}
+
+class CONTINUE_SIGN_IN_WITH_MFA_SELECTIONContinueSignInCognitoSignInResultNextStep extends ContinueSignInCognitoSignInResultNextStep {
+  final String session;
+  final List<CONTINUE_SIGN_IN_WITH_MFA_SELECTIONContinueSignInCognitoSignInResultNextStepAllowedMFATypes> allowedMFATypes;
+
+  const CONTINUE_SIGN_IN_WITH_MFA_SELECTIONContinueSignInCognitoSignInResultNextStep({
+    required this.session,
+    required this.allowedMFATypes,
+  });
+
+  factory CONTINUE_SIGN_IN_WITH_MFA_SELECTIONContinueSignInCognitoSignInResultNextStep.fromJson(Map<String, dynamic> json) {
+    return CONTINUE_SIGN_IN_WITH_MFA_SELECTIONContinueSignInCognitoSignInResultNextStep(
+      session: json['session'] as String,
+      allowedMFATypes: (json['allowedMFATypes'] as List<dynamic>).cast<CONTINUE_SIGN_IN_WITH_MFA_SELECTIONContinueSignInCognitoSignInResultNextStepAllowedMFATypes>(),
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      'name': 'CONTINUE_SIGN_IN_WITH_MFA_SELECTION',
+      'session': session,
+      'allowedMFATypes': allowedMFATypes,
+    };
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is CONTINUE_SIGN_IN_WITH_MFA_SELECTIONContinueSignInCognitoSignInResultNextStep &&
+          session == other.session &&
+          allowedMFATypes == other.allowedMFATypes;
+
+  @override
+  int get hashCode => Object.hash(session, allowedMFATypes);
+
+  @override
+  String toString() => 'CONTINUE_SIGN_IN_WITH_MFA_SELECTIONContinueSignInCognitoSignInResultNextStep(session: $session, allowedMFATypes: $allowedMFATypes)';
+}
+
+class CONTINUE_SIGN_IN_WITH_MFA_SETUP_SELECTIONContinueSignInCognitoSignInResultNextStep extends ContinueSignInCognitoSignInResultNextStep {
+  final String session;
+  final List<CONTINUE_SIGN_IN_WITH_MFA_SETUP_SELECTIONContinueSignInCognitoSignInResultNextStepAllowedMFATypes> allowedMFATypes;
+
+  const CONTINUE_SIGN_IN_WITH_MFA_SETUP_SELECTIONContinueSignInCognitoSignInResultNextStep({
+    required this.session,
+    required this.allowedMFATypes,
+  });
+
+  factory CONTINUE_SIGN_IN_WITH_MFA_SETUP_SELECTIONContinueSignInCognitoSignInResultNextStep.fromJson(Map<String, dynamic> json) {
+    return CONTINUE_SIGN_IN_WITH_MFA_SETUP_SELECTIONContinueSignInCognitoSignInResultNextStep(
+      session: json['session'] as String,
+      allowedMFATypes: (json['allowedMFATypes'] as List<dynamic>).cast<CONTINUE_SIGN_IN_WITH_MFA_SETUP_SELECTIONContinueSignInCognitoSignInResultNextStepAllowedMFATypes>(),
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      'name': 'CONTINUE_SIGN_IN_WITH_MFA_SETUP_SELECTION',
+      'session': session,
+      'allowedMFATypes': allowedMFATypes,
+    };
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is CONTINUE_SIGN_IN_WITH_MFA_SETUP_SELECTIONContinueSignInCognitoSignInResultNextStep &&
+          session == other.session &&
+          allowedMFATypes == other.allowedMFATypes;
+
+  @override
+  int get hashCode => Object.hash(session, allowedMFATypes);
+
+  @override
+  String toString() => 'CONTINUE_SIGN_IN_WITH_MFA_SETUP_SELECTIONContinueSignInCognitoSignInResultNextStep(session: $session, allowedMFATypes: $allowedMFATypes)';
+}
+
+class CONTINUE_SIGN_IN_WITH_TOTP_SETUPContinueSignInCognitoSignInResultNextStep extends ContinueSignInCognitoSignInResultNextStep {
+  final String session;
+  final String sharedSecret;
+
+  const CONTINUE_SIGN_IN_WITH_TOTP_SETUPContinueSignInCognitoSignInResultNextStep({
+    required this.session,
+    required this.sharedSecret,
+  });
+
+  factory CONTINUE_SIGN_IN_WITH_TOTP_SETUPContinueSignInCognitoSignInResultNextStep.fromJson(Map<String, dynamic> json) {
+    return CONTINUE_SIGN_IN_WITH_TOTP_SETUPContinueSignInCognitoSignInResultNextStep(
+      session: json['session'] as String,
+      sharedSecret: json['sharedSecret'] as String,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      'name': 'CONTINUE_SIGN_IN_WITH_TOTP_SETUP',
+      'session': session,
+      'sharedSecret': sharedSecret,
+    };
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is CONTINUE_SIGN_IN_WITH_TOTP_SETUPContinueSignInCognitoSignInResultNextStep &&
+          session == other.session &&
+          sharedSecret == other.sharedSecret;
+
+  @override
+  int get hashCode => Object.hash(session, sharedSecret);
+
+  @override
+  String toString() => 'CONTINUE_SIGN_IN_WITH_TOTP_SETUPContinueSignInCognitoSignInResultNextStep(session: $session, sharedSecret: $sharedSecret)';
+}
+
+class CONTINUE_SIGN_IN_WITH_EMAIL_SETUPContinueSignInCognitoSignInResultNextStep extends ContinueSignInCognitoSignInResultNextStep {
+  final String session;
+
+  const CONTINUE_SIGN_IN_WITH_EMAIL_SETUPContinueSignInCognitoSignInResultNextStep({
+    required this.session,
+  });
+
+  factory CONTINUE_SIGN_IN_WITH_EMAIL_SETUPContinueSignInCognitoSignInResultNextStep.fromJson(Map<String, dynamic> json) {
+    return CONTINUE_SIGN_IN_WITH_EMAIL_SETUPContinueSignInCognitoSignInResultNextStep(
+      session: json['session'] as String,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      'name': 'CONTINUE_SIGN_IN_WITH_EMAIL_SETUP',
+      'session': session,
+    };
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is CONTINUE_SIGN_IN_WITH_EMAIL_SETUPContinueSignInCognitoSignInResultNextStep &&
+          session == other.session;
+
+  @override
+  int get hashCode => session.hashCode;
+
+  @override
+  String toString() => 'CONTINUE_SIGN_IN_WITH_EMAIL_SETUPContinueSignInCognitoSignInResultNextStep(session: $session)';
+}
+
+class CONFIRM_SIGN_IN_WITH_NEW_PASSWORD_REQUIREDContinueSignInCognitoSignInResultNextStep extends ContinueSignInCognitoSignInResultNextStep {
+  final String session;
+  final List<String>? requiredAttributes;
+
+  const CONFIRM_SIGN_IN_WITH_NEW_PASSWORD_REQUIREDContinueSignInCognitoSignInResultNextStep({
+    required this.session,
+    this.requiredAttributes,
+  });
+
+  factory CONFIRM_SIGN_IN_WITH_NEW_PASSWORD_REQUIREDContinueSignInCognitoSignInResultNextStep.fromJson(Map<String, dynamic> json) {
+    return CONFIRM_SIGN_IN_WITH_NEW_PASSWORD_REQUIREDContinueSignInCognitoSignInResultNextStep(
+      session: json['session'] as String,
+      requiredAttributes: (json['requiredAttributes'] as List<dynamic>?)?.cast<String>(),
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      'name': 'CONFIRM_SIGN_IN_WITH_NEW_PASSWORD_REQUIRED',
+      'session': session,
+      if (requiredAttributes != null) 'requiredAttributes': requiredAttributes,
+    };
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is CONFIRM_SIGN_IN_WITH_NEW_PASSWORD_REQUIREDContinueSignInCognitoSignInResultNextStep &&
+          session == other.session &&
+          requiredAttributes == other.requiredAttributes;
+
+  @override
+  int get hashCode => Object.hash(session, requiredAttributes);
+
+  @override
+  String toString() => 'CONFIRM_SIGN_IN_WITH_NEW_PASSWORD_REQUIREDContinueSignInCognitoSignInResultNextStep(session: $session, requiredAttributes: $requiredAttributes)';
+}
+
+class CONTINUE_SIGN_IN_WITH_FIRST_FACTOR_SELECTIONContinueSignInCognitoSignInResultNextStep extends ContinueSignInCognitoSignInResultNextStep {
+  final String session;
+  final List<CONTINUE_SIGN_IN_WITH_FIRST_FACTOR_SELECTIONContinueSignInCognitoSignInResultNextStepAvailableChallenges> availableChallenges;
+
+  const CONTINUE_SIGN_IN_WITH_FIRST_FACTOR_SELECTIONContinueSignInCognitoSignInResultNextStep({
+    required this.session,
+    required this.availableChallenges,
+  });
+
+  factory CONTINUE_SIGN_IN_WITH_FIRST_FACTOR_SELECTIONContinueSignInCognitoSignInResultNextStep.fromJson(Map<String, dynamic> json) {
+    return CONTINUE_SIGN_IN_WITH_FIRST_FACTOR_SELECTIONContinueSignInCognitoSignInResultNextStep(
+      session: json['session'] as String,
+      availableChallenges: (json['availableChallenges'] as List<dynamic>).cast<CONTINUE_SIGN_IN_WITH_FIRST_FACTOR_SELECTIONContinueSignInCognitoSignInResultNextStepAvailableChallenges>(),
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      'name': 'CONTINUE_SIGN_IN_WITH_FIRST_FACTOR_SELECTION',
+      'session': session,
+      'availableChallenges': availableChallenges,
+    };
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is CONTINUE_SIGN_IN_WITH_FIRST_FACTOR_SELECTIONContinueSignInCognitoSignInResultNextStep &&
+          session == other.session &&
+          availableChallenges == other.availableChallenges;
+
+  @override
+  int get hashCode => Object.hash(session, availableChallenges);
+
+  @override
+  String toString() => 'CONTINUE_SIGN_IN_WITH_FIRST_FACTOR_SELECTIONContinueSignInCognitoSignInResultNextStep(session: $session, availableChallenges: $availableChallenges)';
+}
+
+class CONFIRM_SIGN_IN_WITH_PASSWORDContinueSignInCognitoSignInResultNextStep extends ContinueSignInCognitoSignInResultNextStep {
+  final String session;
+
+  const CONFIRM_SIGN_IN_WITH_PASSWORDContinueSignInCognitoSignInResultNextStep({
+    required this.session,
+  });
+
+  factory CONFIRM_SIGN_IN_WITH_PASSWORDContinueSignInCognitoSignInResultNextStep.fromJson(Map<String, dynamic> json) {
+    return CONFIRM_SIGN_IN_WITH_PASSWORDContinueSignInCognitoSignInResultNextStep(
+      session: json['session'] as String,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      'name': 'CONFIRM_SIGN_IN_WITH_PASSWORD',
+      'session': session,
+    };
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is CONFIRM_SIGN_IN_WITH_PASSWORDContinueSignInCognitoSignInResultNextStep &&
+          session == other.session;
+
+  @override
+  int get hashCode => session.hashCode;
+
+  @override
+  String toString() => 'CONFIRM_SIGN_IN_WITH_PASSWORDContinueSignInCognitoSignInResultNextStep(session: $session)';
+}
+
+class CONFIRM_SIGN_IN_WITH_FIRST_FACTOR_EMAIL_OTPContinueSignInCognitoSignInResultNextStep extends ContinueSignInCognitoSignInResultNextStep {
+  final String session;
+  final CodeDeliveryDetails codeDeliveryDetails;
+
+  const CONFIRM_SIGN_IN_WITH_FIRST_FACTOR_EMAIL_OTPContinueSignInCognitoSignInResultNextStep({
+    required this.session,
+    required this.codeDeliveryDetails,
+  });
+
+  factory CONFIRM_SIGN_IN_WITH_FIRST_FACTOR_EMAIL_OTPContinueSignInCognitoSignInResultNextStep.fromJson(Map<String, dynamic> json) {
+    return CONFIRM_SIGN_IN_WITH_FIRST_FACTOR_EMAIL_OTPContinueSignInCognitoSignInResultNextStep(
+      session: json['session'] as String,
+      codeDeliveryDetails: CodeDeliveryDetails.fromJson(json['codeDeliveryDetails'] as Map<String, dynamic>),
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      'name': 'CONFIRM_SIGN_IN_WITH_FIRST_FACTOR_EMAIL_OTP',
+      'session': session,
+      'codeDeliveryDetails': codeDeliveryDetails.toJson(),
+    };
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is CONFIRM_SIGN_IN_WITH_FIRST_FACTOR_EMAIL_OTPContinueSignInCognitoSignInResultNextStep &&
+          session == other.session &&
+          codeDeliveryDetails == other.codeDeliveryDetails;
+
+  @override
+  int get hashCode => Object.hash(session, codeDeliveryDetails);
+
+  @override
+  String toString() => 'CONFIRM_SIGN_IN_WITH_FIRST_FACTOR_EMAIL_OTPContinueSignInCognitoSignInResultNextStep(session: $session, codeDeliveryDetails: $codeDeliveryDetails)';
+}
+
+class CONFIRM_SIGN_IN_WITH_FIRST_FACTOR_SMS_OTPContinueSignInCognitoSignInResultNextStep extends ContinueSignInCognitoSignInResultNextStep {
+  final String session;
+  final CodeDeliveryDetails codeDeliveryDetails;
+
+  const CONFIRM_SIGN_IN_WITH_FIRST_FACTOR_SMS_OTPContinueSignInCognitoSignInResultNextStep({
+    required this.session,
+    required this.codeDeliveryDetails,
+  });
+
+  factory CONFIRM_SIGN_IN_WITH_FIRST_FACTOR_SMS_OTPContinueSignInCognitoSignInResultNextStep.fromJson(Map<String, dynamic> json) {
+    return CONFIRM_SIGN_IN_WITH_FIRST_FACTOR_SMS_OTPContinueSignInCognitoSignInResultNextStep(
+      session: json['session'] as String,
+      codeDeliveryDetails: CodeDeliveryDetails.fromJson(json['codeDeliveryDetails'] as Map<String, dynamic>),
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      'name': 'CONFIRM_SIGN_IN_WITH_FIRST_FACTOR_SMS_OTP',
+      'session': session,
+      'codeDeliveryDetails': codeDeliveryDetails.toJson(),
+    };
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is CONFIRM_SIGN_IN_WITH_FIRST_FACTOR_SMS_OTPContinueSignInCognitoSignInResultNextStep &&
+          session == other.session &&
+          codeDeliveryDetails == other.codeDeliveryDetails;
+
+  @override
+  int get hashCode => Object.hash(session, codeDeliveryDetails);
+
+  @override
+  String toString() => 'CONFIRM_SIGN_IN_WITH_FIRST_FACTOR_SMS_OTPContinueSignInCognitoSignInResultNextStep(session: $session, codeDeliveryDetails: $codeDeliveryDetails)';
+}
+
+class CONFIRM_SIGN_IN_WITH_WEB_AUTHNContinueSignInCognitoSignInResultNextStep extends ContinueSignInCognitoSignInResultNextStep {
+  final String session;
+  final String credentialRequestOptions;
+
+  const CONFIRM_SIGN_IN_WITH_WEB_AUTHNContinueSignInCognitoSignInResultNextStep({
+    required this.session,
+    required this.credentialRequestOptions,
+  });
+
+  factory CONFIRM_SIGN_IN_WITH_WEB_AUTHNContinueSignInCognitoSignInResultNextStep.fromJson(Map<String, dynamic> json) {
+    return CONFIRM_SIGN_IN_WITH_WEB_AUTHNContinueSignInCognitoSignInResultNextStep(
+      session: json['session'] as String,
+      credentialRequestOptions: json['credentialRequestOptions'] as String,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      'name': 'CONFIRM_SIGN_IN_WITH_WEB_AUTHN',
+      'session': session,
+      'credentialRequestOptions': credentialRequestOptions,
+    };
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is CONFIRM_SIGN_IN_WITH_WEB_AUTHNContinueSignInCognitoSignInResultNextStep &&
+          session == other.session &&
+          credentialRequestOptions == other.credentialRequestOptions;
+
+  @override
+  int get hashCode => Object.hash(session, credentialRequestOptions);
+
+  @override
+  String toString() => 'CONFIRM_SIGN_IN_WITH_WEB_AUTHNContinueSignInCognitoSignInResultNextStep(session: $session, credentialRequestOptions: $credentialRequestOptions)';
+}
+
+class RESET_PASSWORDContinueSignInCognitoSignInResultNextStep extends ContinueSignInCognitoSignInResultNextStep {
+
+  const RESET_PASSWORDContinueSignInCognitoSignInResultNextStep();
+
+  factory RESET_PASSWORDContinueSignInCognitoSignInResultNextStep.fromJson(Map<String, dynamic> json) {
+    return RESET_PASSWORDContinueSignInCognitoSignInResultNextStep(
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      'name': 'RESET_PASSWORD',
+    };
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is RESET_PASSWORDContinueSignInCognitoSignInResultNextStep;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  String toString() => 'RESET_PASSWORDContinueSignInCognitoSignInResultNextStep()';
+}
+
+class CONFIRM_SIGN_UPContinueSignInCognitoSignInResultNextStep extends ContinueSignInCognitoSignInResultNextStep {
+  final CodeDeliveryDetails? codeDeliveryDetails;
+
+  const CONFIRM_SIGN_UPContinueSignInCognitoSignInResultNextStep({
+    this.codeDeliveryDetails,
+  });
+
+  factory CONFIRM_SIGN_UPContinueSignInCognitoSignInResultNextStep.fromJson(Map<String, dynamic> json) {
+    return CONFIRM_SIGN_UPContinueSignInCognitoSignInResultNextStep(
+      codeDeliveryDetails: json['codeDeliveryDetails'] != null ? CodeDeliveryDetails.fromJson(json['codeDeliveryDetails'] as Map<String, dynamic>) : null,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      'name': 'CONFIRM_SIGN_UP',
+      if (codeDeliveryDetails != null) 'codeDeliveryDetails': codeDeliveryDetails?.toJson(),
+    };
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is CONFIRM_SIGN_UPContinueSignInCognitoSignInResultNextStep &&
+          codeDeliveryDetails == other.codeDeliveryDetails;
+
+  @override
+  int get hashCode => codeDeliveryDetails.hashCode;
+
+  @override
+  String toString() => 'CONFIRM_SIGN_UPContinueSignInCognitoSignInResultNextStep(codeDeliveryDetails: $codeDeliveryDetails)';
+}
+
+
+
 // --- API Namespaces ---
+
+sealed class CognitoConfirmSignInResult {
+  const CognitoConfirmSignInResult();
+  Map<String, dynamic> toJson();
+  static CognitoConfirmSignInResult fromJson(Map<String, dynamic> json) {
+    switch (json['status'] as String) {
+      case 'continueSignIn': return ContinueSignInCognitoConfirmSignInResult.fromJson(json);
+      case 'signedIn': return SignedInCognitoConfirmSignInResult.fromJson(json);
+      default: throw ArgumentError('Unknown status: ${json['status']}');
+    }
+  }
+}
+
+class ContinueSignInCognitoConfirmSignInResult extends CognitoConfirmSignInResult {
+  final ContinueSignInCognitoConfirmSignInResultNextStep nextStep;
+
+  const ContinueSignInCognitoConfirmSignInResult({
+    required this.nextStep,
+  });
+
+  factory ContinueSignInCognitoConfirmSignInResult.fromJson(Map<String, dynamic> json) {
+    return ContinueSignInCognitoConfirmSignInResult(
+      nextStep: ContinueSignInCognitoConfirmSignInResultNextStep.fromJson(json['nextStep'] as Map<String, dynamic>),
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      'status': 'continueSignIn',
+      'nextStep': nextStep.toJson(),
+    };
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ContinueSignInCognitoConfirmSignInResult &&
+          nextStep == other.nextStep;
+
+  @override
+  int get hashCode => nextStep.hashCode;
+
+  @override
+  String toString() => 'ContinueSignInCognitoConfirmSignInResult(nextStep: $nextStep)';
+}
+
+class SignedInCognitoConfirmSignInResult extends CognitoConfirmSignInResult {
+  final CognitoUser user;
+
+  const SignedInCognitoConfirmSignInResult({
+    required this.user,
+  });
+
+  factory SignedInCognitoConfirmSignInResult.fromJson(Map<String, dynamic> json) {
+    return SignedInCognitoConfirmSignInResult(
+      user: CognitoUser.fromJson(json['user'] as Map<String, dynamic>),
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      'status': 'signedIn',
+      'user': user.toJson(),
+    };
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is SignedInCognitoConfirmSignInResult &&
+          user == other.user;
+
+  @override
+  int get hashCode => user.hashCode;
+
+  @override
+  String toString() => 'SignedInCognitoConfirmSignInResult(user: $user)';
+}
+
+
+
+sealed class CognitoSignInResult {
+  const CognitoSignInResult();
+  Map<String, dynamic> toJson();
+  static CognitoSignInResult fromJson(Map<String, dynamic> json) {
+    switch (json['status'] as String) {
+      case 'continueSignIn': return ContinueSignInCognitoSignInResult.fromJson(json);
+      case 'signedIn': return SignedInCognitoSignInResult.fromJson(json);
+      default: throw ArgumentError('Unknown status: ${json['status']}');
+    }
+  }
+}
+
+class ContinueSignInCognitoSignInResult extends CognitoSignInResult {
+  final ContinueSignInCognitoSignInResultNextStep nextStep;
+
+  const ContinueSignInCognitoSignInResult({
+    required this.nextStep,
+  });
+
+  factory ContinueSignInCognitoSignInResult.fromJson(Map<String, dynamic> json) {
+    return ContinueSignInCognitoSignInResult(
+      nextStep: ContinueSignInCognitoSignInResultNextStep.fromJson(json['nextStep'] as Map<String, dynamic>),
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      'status': 'continueSignIn',
+      'nextStep': nextStep.toJson(),
+    };
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ContinueSignInCognitoSignInResult &&
+          nextStep == other.nextStep;
+
+  @override
+  int get hashCode => nextStep.hashCode;
+
+  @override
+  String toString() => 'ContinueSignInCognitoSignInResult(nextStep: $nextStep)';
+}
+
+class SignedInCognitoSignInResult extends CognitoSignInResult {
+  final CognitoUser user;
+
+  const SignedInCognitoSignInResult({
+    required this.user,
+  });
+
+  factory SignedInCognitoSignInResult.fromJson(Map<String, dynamic> json) {
+    return SignedInCognitoSignInResult(
+      user: CognitoUser.fromJson(json['user'] as Map<String, dynamic>),
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      'status': 'signedIn',
+      'user': user.toJson(),
+    };
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is SignedInCognitoSignInResult &&
+          user == other.user;
+
+  @override
+  int get hashCode => user.hashCode;
+
+  @override
+  String toString() => 'SignedInCognitoSignInResult(user: $user)';
+}
+
+
 
 class ApiApi {
   final BlocksClient _client;
   ApiApi(this._client);
 
-  Future<dynamic> cognitoConfirmSignIn({required String session, required String challengeResponse}) async {
+  Future<CognitoConfirmSignInResult> cognitoConfirmSignIn({required String session, required String challengeResponse}) async {
     final params = <String, dynamic>{
       'session': session,
       'challengeResponse': challengeResponse,
     };
     final result = await _client.call('api.cognitoConfirmSignIn', params);
-    return result as dynamic;
+    return CognitoConfirmSignInResult.fromJson(result as Map<String, dynamic>);
   }
 
-  Future<dynamic> cognitoSignIn({required String username, required String password}) async {
+  Future<CognitoSignInResult> cognitoSignIn({required String username, required String password}) async {
     final params = <String, dynamic>{
       'username': username,
       'password': password,
     };
     final result = await _client.call('api.cognitoSignIn', params);
-    return result as dynamic;
+    return CognitoSignInResult.fromJson(result as Map<String, dynamic>);
   }
 }
 

--- a/native/codegen-fixtures/23-cognito-nested-unions/kotlin/Api.kt
+++ b/native/codegen-fixtures/23-cognito-nested-unions/kotlin/Api.kt
@@ -9,18 +9,12 @@ import com.aws.blocks.kotlin.json.BlocksJson
 import kotlin.OptIn
 import kotlin.String
 import kotlin.collections.List
-import kotlinx.serialization.DeserializationStrategy
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonClassDiscriminator
-import kotlinx.serialization.json.JsonContentPolymorphicSerializer
-import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonPrimitive
-import kotlinx.serialization.json.boolean
 import kotlinx.serialization.json.decodeFromJsonElement
-import kotlinx.serialization.json.jsonObject
-import kotlinx.serialization.json.jsonPrimitive
 
 public class Api(
   private val server: BlocksServer = Servers.local,
@@ -40,23 +34,13 @@ public class Api(
   }
 
   public object CognitoConfirmSignIn {
-    @Serializable(with = ResultSerializer::class)
+    @Serializable
+    @JsonClassDiscriminator("status")
     public sealed class Result {
-      public object ResultSerializer : JsonContentPolymorphicSerializer<Result>(Result::class) {
-        override fun selectDeserializer(element: JsonElement): DeserializationStrategy<Result> {
-          val disc = element.jsonObject["isSignedIn"]?.jsonPrimitive?.boolean
-          return when (disc) {
-            false -> Result.IsSignedInFalse.serializer()
-            true -> Result.IsSignedInTrue.serializer()
-            else -> error("Unknown isSignedIn value: ${'$'}disc")
-          }
-        }
-      }
-
       @Serializable
-      @SerialName("false")
-      public data class IsSignedInFalse(
-        public val nextStep: IsSignedInFalse.NextStep,
+      @SerialName("continueSignIn")
+      public data class ContinueSignIn(
+        public val nextStep: ContinueSignIn.NextStep,
       ) : Result() {
         @Serializable
         @JsonClassDiscriminator("name")
@@ -193,31 +177,21 @@ public class Api(
       }
 
       @Serializable
-      @SerialName("true")
-      public data class IsSignedInTrue(
+      @SerialName("signedIn")
+      public data class SignedIn(
         public val user: CognitoUser,
       ) : Result()
     }
   }
 
   public object CognitoSignIn {
-    @Serializable(with = ResultSerializer::class)
+    @Serializable
+    @JsonClassDiscriminator("status")
     public sealed class Result {
-      public object ResultSerializer : JsonContentPolymorphicSerializer<Result>(Result::class) {
-        override fun selectDeserializer(element: JsonElement): DeserializationStrategy<Result> {
-          val disc = element.jsonObject["isSignedIn"]?.jsonPrimitive?.boolean
-          return when (disc) {
-            false -> Result.IsSignedInFalse.serializer()
-            true -> Result.IsSignedInTrue.serializer()
-            else -> error("Unknown isSignedIn value: ${'$'}disc")
-          }
-        }
-      }
-
       @Serializable
-      @SerialName("false")
-      public data class IsSignedInFalse(
-        public val nextStep: IsSignedInFalse.NextStep,
+      @SerialName("continueSignIn")
+      public data class ContinueSignIn(
+        public val nextStep: ContinueSignIn.NextStep,
       ) : Result() {
         @Serializable
         @JsonClassDiscriminator("name")
@@ -354,8 +328,8 @@ public class Api(
       }
 
       @Serializable
-      @SerialName("true")
-      public data class IsSignedInTrue(
+      @SerialName("signedIn")
+      public data class SignedIn(
         public val user: CognitoUser,
       ) : Result()
     }

--- a/native/codegen-fixtures/23-cognito-nested-unions/spec.json
+++ b/native/codegen-fixtures/23-cognito-nested-unions/spec.json
@@ -30,10 +30,10 @@
             {
               "type": "object",
               "properties": {
-                "isSignedIn": {
-                  "type": "boolean",
+                "status": {
+                  "type": "string",
                   "enum": [
-                    false
+                    "continueSignIn"
                   ]
                 },
                 "nextStep": {
@@ -387,17 +387,17 @@
                 }
               },
               "required": [
-                "isSignedIn",
+                "status",
                 "nextStep"
               ]
             },
             {
               "type": "object",
               "properties": {
-                "isSignedIn": {
-                  "type": "boolean",
+                "status": {
+                  "type": "string",
                   "enum": [
-                    true
+                    "signedIn"
                   ]
                 },
                 "user": {
@@ -405,7 +405,7 @@
                 }
               },
               "required": [
-                "isSignedIn",
+                "status",
                 "user"
               ]
             }
@@ -438,10 +438,10 @@
             {
               "type": "object",
               "properties": {
-                "isSignedIn": {
-                  "type": "boolean",
+                "status": {
+                  "type": "string",
                   "enum": [
-                    false
+                    "continueSignIn"
                   ]
                 },
                 "nextStep": {
@@ -795,17 +795,17 @@
                 }
               },
               "required": [
-                "isSignedIn",
+                "status",
                 "nextStep"
               ]
             },
             {
               "type": "object",
               "properties": {
-                "isSignedIn": {
-                  "type": "boolean",
+                "status": {
+                  "type": "string",
                   "enum": [
-                    true
+                    "signedIn"
                   ]
                 },
                 "user": {
@@ -813,7 +813,7 @@
                 }
               },
               "required": [
-                "isSignedIn",
+                "status",
                 "user"
               ]
             }

--- a/native/codegen-fixtures/23-cognito-nested-unions/swift/Api.swift
+++ b/native/codegen-fixtures/23-cognito-nested-unions/swift/Api.swift
@@ -26,7 +26,7 @@ public class Api {
 
     public enum CognitoConfirmSignIn {
 
-        public struct IsSignedInFalse: Codable {
+        public struct ContinueSignIn: Codable {
             public let nextStep: NextStep
 
             public struct ConfirmSignInWithSmsCode: Codable {
@@ -230,38 +230,38 @@ public class Api {
             }
         }
 
-        public struct IsSignedInTrue: Codable {
+        public struct SignedIn: Codable {
             public let user: CognitoUser
         }
 
         public enum Result: Codable {
-            case isSignedInFalse(IsSignedInFalse)
-            case isSignedInTrue(IsSignedInTrue)
+            case continueSignIn(ContinueSignIn)
+            case signedIn(SignedIn)
 
             enum CodingKeys: String, CodingKey {
-                case isSignedIn
+                case status
             }
 
             public func encode(to encoder: Encoder) throws {
                 var container = encoder.container(keyedBy: CodingKeys.self)
                 switch self {
-                case .isSignedInFalse(let params):
-                    try container.encode("false", forKey: .isSignedIn)
+                case .continueSignIn(let params):
+                    try container.encode("continueSignIn", forKey: .status)
                     try params.encode(to: encoder)
-                case .isSignedInTrue(let params):
-                    try container.encode("true", forKey: .isSignedIn)
+                case .signedIn(let params):
+                    try container.encode("signedIn", forKey: .status)
                     try params.encode(to: encoder)
                 }
             }
 
             public init(from decoder: Decoder) throws {
                 let container = try decoder.container(keyedBy: CodingKeys.self)
-                let disc = try container.decode(String.self, forKey: .isSignedIn)
+                let disc = try container.decode(String.self, forKey: .status)
                 switch disc {
-                case "false": self = .isSignedInFalse(try IsSignedInFalse(from: decoder))
-                case "true": self = .isSignedInTrue(try IsSignedInTrue(from: decoder))
+                case "continueSignIn": self = .continueSignIn(try ContinueSignIn(from: decoder))
+                case "signedIn": self = .signedIn(try SignedIn(from: decoder))
                 default:
-                    throw DecodingError.dataCorruptedError(forKey: .isSignedIn, in: container, debugDescription: "Unknown value: \(disc)")
+                    throw DecodingError.dataCorruptedError(forKey: .status, in: container, debugDescription: "Unknown value: \(disc)")
                 }
             }
         }
@@ -269,7 +269,7 @@ public class Api {
 
     public enum CognitoSignIn {
 
-        public struct IsSignedInFalse: Codable {
+        public struct ContinueSignIn: Codable {
             public let nextStep: NextStep
 
             public struct ConfirmSignInWithSmsCode: Codable {
@@ -473,38 +473,38 @@ public class Api {
             }
         }
 
-        public struct IsSignedInTrue: Codable {
+        public struct SignedIn: Codable {
             public let user: CognitoUser
         }
 
         public enum Result: Codable {
-            case isSignedInFalse(IsSignedInFalse)
-            case isSignedInTrue(IsSignedInTrue)
+            case continueSignIn(ContinueSignIn)
+            case signedIn(SignedIn)
 
             enum CodingKeys: String, CodingKey {
-                case isSignedIn
+                case status
             }
 
             public func encode(to encoder: Encoder) throws {
                 var container = encoder.container(keyedBy: CodingKeys.self)
                 switch self {
-                case .isSignedInFalse(let params):
-                    try container.encode("false", forKey: .isSignedIn)
+                case .continueSignIn(let params):
+                    try container.encode("continueSignIn", forKey: .status)
                     try params.encode(to: encoder)
-                case .isSignedInTrue(let params):
-                    try container.encode("true", forKey: .isSignedIn)
+                case .signedIn(let params):
+                    try container.encode("signedIn", forKey: .status)
                     try params.encode(to: encoder)
                 }
             }
 
             public init(from decoder: Decoder) throws {
                 let container = try decoder.container(keyedBy: CodingKeys.self)
-                let disc = try container.decode(String.self, forKey: .isSignedIn)
+                let disc = try container.decode(String.self, forKey: .status)
                 switch disc {
-                case "false": self = .isSignedInFalse(try IsSignedInFalse(from: decoder))
-                case "true": self = .isSignedInTrue(try IsSignedInTrue(from: decoder))
+                case "continueSignIn": self = .continueSignIn(try ContinueSignIn(from: decoder))
+                case "signedIn": self = .signedIn(try SignedIn(from: decoder))
                 default:
-                    throw DecodingError.dataCorruptedError(forKey: .isSignedIn, in: container, debugDescription: "Unknown value: \(disc)")
+                    throw DecodingError.dataCorruptedError(forKey: .status, in: container, debugDescription: "Unknown value: \(disc)")
                 }
             }
         }

--- a/native/dart/packages/blocks_codegen/lib/src/parser.dart
+++ b/native/dart/packages/blocks_codegen/lib/src/parser.dart
@@ -111,12 +111,20 @@ class OpenRpcParser {
       return _parseOneOf(oneOf);
     }
 
-    // Check for enum
-    if (schema.containsKey('enum')) {
+    final type = schema['type'] as String?;
+
+    // Check for enum. Only a *string* enum becomes a Dart enum
+    // (`UnionLiteralRef`). An `enum` constraint on a non-string primitive —
+    // most commonly a boolean discriminator arm like
+    // `{"type":"boolean","enum":[true]}` — is just a value restriction on that
+    // primitive, NOT a distinct type. Turning it into a Dart enum would emit
+    // `enum Foo { true }` / `enum Foo { false }`, and `true`/`false` are
+    // reserved words that don't compile. Fall through to the primitive mapping
+    // instead (a plain `bool`), matching the Swift and Kotlin generators which
+    // both ignore the enum constraint on non-string primitives.
+    if (schema.containsKey('enum') && (type == null || type == 'string')) {
       return UnionLiteralRef((schema['enum'] as List<dynamic>).map((v) => v.toString()).toList());
     }
-
-    final type = schema['type'] as String?;
 
     // Array (check before primitives since arrays have a 'type')
     if (type == 'array') {

--- a/native/dart/packages/blocks_codegen/test/parser_test.dart
+++ b/native/dart/packages/blocks_codegen/test/parser_test.dart
@@ -120,6 +120,37 @@ void main() {
       expect(param.values, ['a', 'b', 'c']);
     });
 
+    test('boolean enum maps to bool, not a Dart enum', () {
+      // A boolean discriminator arm (`{"type":"boolean","enum":[true]}`) must
+      // stay a `bool`. Treating it as a UnionLiteralRef would emit
+      // `enum Foo { true }` — and `true`/`false` are Dart keywords that don't
+      // compile. Regression test for the boolean-discriminator codegen bug.
+      final model = parser.parse(_spec([
+        {'name': 'fn', 'params': [
+          {'name': 't', 'required': true, 'schema': {'type': 'boolean', 'enum': [true]}},
+          {'name': 'f', 'required': true, 'schema': {'type': 'boolean', 'enum': [false]}},
+        ], 'result': {'name': 'R', 'schema': {'type': 'null'}}},
+      ]));
+      final params = model.methods[0].params;
+      expect(params[0].schema, isA<PrimitiveRef>());
+      expect((params[0].schema as PrimitiveRef).dartType, 'bool');
+      expect((params[1].schema as PrimitiveRef).dartType, 'bool');
+    });
+
+    test('numeric enum maps to its primitive, not a Dart enum', () {
+      // Same rule for integer/number: an `enum` value-restriction on a numeric
+      // primitive is not a distinct type. Keep it as int/num.
+      final model = parser.parse(_spec([
+        {'name': 'fn', 'params': [
+          {'name': 'i', 'required': true, 'schema': {'type': 'integer', 'enum': [1, 2]}},
+          {'name': 'n', 'required': true, 'schema': {'type': 'number', 'enum': [1.5]}},
+        ], 'result': {'name': 'R', 'schema': {'type': 'null'}}},
+      ]));
+      final params = model.methods[0].params;
+      expect((params[0].schema as PrimitiveRef).dartType, 'int');
+      expect((params[1].schema as PrimitiveRef).dartType, 'num');
+    });
+
     test('parses array with missing items as dynamic list', () {
       final model = parser.parse(_spec([
         {'name': 'list', 'params': [], 'result': {'name': 'R', 'schema': {'type': 'array'}}},

--- a/native/kotlin/runtime/src/commonTest/kotlin/com/aws/blocks/kotlin/json/StatusDiscriminatorDecodeTest.kt
+++ b/native/kotlin/runtime/src/commonTest/kotlin/com/aws/blocks/kotlin/json/StatusDiscriminatorDecodeTest.kt
@@ -1,0 +1,121 @@
+@file:OptIn(ExperimentalSerializationApi::class)
+
+package com.aws.blocks.kotlin.json
+
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonClassDiscriminator
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+
+/**
+ * Runtime decode coverage for a status-discriminated result union with a nested
+ * discriminated union in an arm — the shape the Cognito `signIn` /
+ * `confirmSignIn` RPC methods produce.
+ *
+ * The sealed classes below mirror a representative slice of the generated
+ * golden `native/codegen-fixtures/23-cognito-nested-unions/kotlin/Api.kt`
+ * (`Result` + a couple of its nested `NextStep` arms). The golden-file test
+ * (`CodegenFixturesTest`) guards that the generator *emits* that code; this
+ * test guards that it *behaves* correctly at runtime — `@JsonClassDiscriminator`
+ * routing at BOTH the outer (`status`) and nested (`name`) levels, a nested
+ * enum field, round-trip, and a clear error on an unknown discriminant. If the
+ * generator output changes, regenerate the golden and update this mirror.
+ */
+class StatusDiscriminatorDecodeTest {
+
+    @Serializable
+    data class CognitoUser(val userSub: String, val groups: List<String>)
+
+    @Serializable
+    @JsonClassDiscriminator("status")
+    sealed class Result {
+        @Serializable
+        @SerialName("signedIn")
+        data class SignedIn(val user: CognitoUser) : Result()
+
+        @Serializable
+        @SerialName("continueSignIn")
+        data class ContinueSignIn(val nextStep: NextStep) : Result() {
+            @Serializable
+            @JsonClassDiscriminator("name")
+            sealed class NextStep {
+                @Serializable
+                @SerialName("CONFIRM_SIGN_IN_WITH_TOTP_CODE")
+                data class ConfirmSignInWithTotpCode(val session: String) : NextStep()
+
+                @Serializable
+                @SerialName("CONTINUE_SIGN_IN_WITH_MFA_SELECTION")
+                data class ContinueSignInWithMfaSelection(
+                    val session: String,
+                    val allowedMFATypes: List<AllowedMFATypes>,
+                ) : NextStep() {
+                    @Serializable
+                    enum class AllowedMFATypes {
+                        @SerialName("SMS") Sms,
+                        @SerialName("TOTP") Totp,
+                        @SerialName("EMAIL") Email,
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun decodesSignedInArm() {
+        val json = """{"status":"signedIn","user":{"userSub":"s","groups":["admins"]}}"""
+        val result = BlocksJson.decodeFromString<Result>(json)
+        val signedIn = result.shouldBeInstanceOf<Result.SignedIn>()
+        signedIn.user.userSub shouldBe "s"
+        signedIn.user.groups shouldBe listOf("admins")
+    }
+
+    @Test
+    fun decodesNestedNextStepArm() {
+        val json = """{"status":"continueSignIn","nextStep":{"name":"CONFIRM_SIGN_IN_WITH_TOTP_CODE","session":"sess-1"}}"""
+        val result = BlocksJson.decodeFromString<Result>(json)
+        val outer = result.shouldBeInstanceOf<Result.ContinueSignIn>()
+        val inner = outer.nextStep.shouldBeInstanceOf<Result.ContinueSignIn.NextStep.ConfirmSignInWithTotpCode>()
+        inner.session shouldBe "sess-1"
+    }
+
+    @Test
+    fun decodesNestedArmWithEnumList() {
+        val json =
+            """{"status":"continueSignIn","nextStep":{"name":"CONTINUE_SIGN_IN_WITH_MFA_SELECTION","session":"s","allowedMFATypes":["SMS","TOTP"]}}"""
+        val result = BlocksJson.decodeFromString<Result>(json)
+        val outer = result.shouldBeInstanceOf<Result.ContinueSignIn>()
+        val inner = outer.nextStep.shouldBeInstanceOf<Result.ContinueSignIn.NextStep.ContinueSignInWithMfaSelection>()
+        inner.allowedMFATypes shouldBe listOf(
+            Result.ContinueSignIn.NextStep.ContinueSignInWithMfaSelection.AllowedMFATypes.Sms,
+            Result.ContinueSignIn.NextStep.ContinueSignInWithMfaSelection.AllowedMFATypes.Totp,
+        )
+    }
+
+    @Test
+    fun nestedRoundTrips() {
+        val original: Result = Result.ContinueSignIn(
+            Result.ContinueSignIn.NextStep.ConfirmSignInWithTotpCode(session = "sess-2"))
+        val encoded = BlocksJson.encodeToString(original)
+        (encoded.contains("\"status\":\"continueSignIn\"")) shouldBe true
+        (encoded.contains("\"name\":\"CONFIRM_SIGN_IN_WITH_TOTP_CODE\"")) shouldBe true
+        BlocksJson.decodeFromString<Result>(encoded) shouldBe original
+    }
+
+    @Test
+    fun unknownOuterStatusThrows() {
+        assertFailsWith<Exception> {
+            BlocksJson.decodeFromString<Result>("""{"status":"bogus"}""")
+        }
+    }
+
+    @Test
+    fun unknownNestedNameThrows() {
+        assertFailsWith<Exception> {
+            BlocksJson.decodeFromString<Result>("""{"status":"continueSignIn","nextStep":{"name":"NOPE"}}""")
+        }
+    }
+}

--- a/native/swift/Tests/BlocksRuntimeTests/StatusDiscriminatorDecodeTests.swift
+++ b/native/swift/Tests/BlocksRuntimeTests/StatusDiscriminatorDecodeTests.swift
@@ -1,0 +1,170 @@
+import XCTest
+
+/// Runtime decode coverage for status-discriminated result unions, including a
+/// nested discriminated union in an arm — the shape the Cognito `signIn` /
+/// `confirmSignIn` RPC methods produce.
+///
+/// The types below mirror a representative slice of the generated golden
+/// `native/codegen-fixtures/23-cognito-nested-unions/swift/Api.swift`
+/// (`CognitoSignIn.Result` + a couple of its nested `NextStep` arms). The
+/// golden-file test (`GoldenFileTests`) guards that the generator *emits*
+/// exactly that code; this test guards that the emitted shape *behaves*
+/// correctly at runtime — discriminator routing at BOTH the outer (`status`)
+/// and nested (`name`) levels, a nested enum field, round-trip, and a clear
+/// error on an unknown discriminant. If the generator output changes,
+/// regenerate the golden and update this mirror.
+final class StatusDiscriminatorDecodeTests: XCTestCase {
+
+    struct CognitoUser: Codable {
+        let userId: String
+        let username: String
+        let userSub: String
+        let groups: [String]
+    }
+
+    enum CognitoSignIn {
+        struct SignedIn: Codable {
+            let user: CognitoUser
+        }
+
+        struct ContinueSignIn: Codable {
+            let nextStep: NextStep
+
+            struct Confirm_Sign_In_With_Totp_Code: Codable {
+                let session: String
+            }
+
+            struct Continue_Sign_In_With_Mfa_Selection: Codable {
+                let allowedMFATypes: [AllowedMFAType]
+                let session: String
+
+                enum AllowedMFAType: String, Codable {
+                    case sMS = "SMS"
+                    case tOTP = "TOTP"
+                    case eMAIL = "EMAIL"
+                }
+            }
+
+            // Nested discriminated union on `name` (representative 2-arm slice).
+            enum NextStep: Codable {
+                case confirm_Sign_In_With_Totp_Code(Confirm_Sign_In_With_Totp_Code)
+                case continue_Sign_In_With_Mfa_Selection(Continue_Sign_In_With_Mfa_Selection)
+
+                enum CodingKeys: String, CodingKey { case name }
+
+                func encode(to encoder: Encoder) throws {
+                    var container = encoder.container(keyedBy: CodingKeys.self)
+                    switch self {
+                    case .confirm_Sign_In_With_Totp_Code(let p):
+                        try container.encode("CONFIRM_SIGN_IN_WITH_TOTP_CODE", forKey: .name)
+                        try p.encode(to: encoder)
+                    case .continue_Sign_In_With_Mfa_Selection(let p):
+                        try container.encode("CONTINUE_SIGN_IN_WITH_MFA_SELECTION", forKey: .name)
+                        try p.encode(to: encoder)
+                    }
+                }
+
+                init(from decoder: Decoder) throws {
+                    let container = try decoder.container(keyedBy: CodingKeys.self)
+                    switch try container.decode(String.self, forKey: .name) {
+                    case "CONFIRM_SIGN_IN_WITH_TOTP_CODE":
+                        self = .confirm_Sign_In_With_Totp_Code(try Confirm_Sign_In_With_Totp_Code(from: decoder))
+                    case "CONTINUE_SIGN_IN_WITH_MFA_SELECTION":
+                        self = .continue_Sign_In_With_Mfa_Selection(try Continue_Sign_In_With_Mfa_Selection(from: decoder))
+                    case let other:
+                        throw DecodingError.dataCorruptedError(forKey: .name, in: container, debugDescription: "Unknown value: \(other)")
+                    }
+                }
+            }
+        }
+
+        enum Result: Codable {
+            case continueSignIn(ContinueSignIn)
+            case signedIn(SignedIn)
+
+            enum CodingKeys: String, CodingKey { case status }
+
+            func encode(to encoder: Encoder) throws {
+                var container = encoder.container(keyedBy: CodingKeys.self)
+                switch self {
+                case .continueSignIn(let p):
+                    try container.encode("continueSignIn", forKey: .status)
+                    try p.encode(to: encoder)
+                case .signedIn(let p):
+                    try container.encode("signedIn", forKey: .status)
+                    try p.encode(to: encoder)
+                }
+            }
+
+            init(from decoder: Decoder) throws {
+                let container = try decoder.container(keyedBy: CodingKeys.self)
+                switch try container.decode(String.self, forKey: .status) {
+                case "continueSignIn": self = .continueSignIn(try ContinueSignIn(from: decoder))
+                case "signedIn": self = .signedIn(try SignedIn(from: decoder))
+                case let other:
+                    throw DecodingError.dataCorruptedError(forKey: .status, in: container, debugDescription: "Unknown value: \(other)")
+                }
+            }
+        }
+    }
+
+    // MARK: - Outer discriminator (status)
+
+    func testDecodesSignedInArm() throws {
+        let json = #"{"status":"signedIn","user":{"userId":"u","username":"u","userSub":"s","groups":["admins"]}}"#.data(using: .utf8)!
+        let result = try JSONDecoder().decode(CognitoSignIn.Result.self, from: json)
+        guard case .signedIn(let payload) = result else { return XCTFail("expected .signedIn") }
+        XCTAssertEqual(payload.user.userSub, "s")
+        XCTAssertEqual(payload.user.groups, ["admins"])
+    }
+
+    // MARK: - Nested discriminator (name) inside the continueSignIn arm
+
+    func testDecodesNestedNextStepArm() throws {
+        let json = #"{"status":"continueSignIn","nextStep":{"name":"CONFIRM_SIGN_IN_WITH_TOTP_CODE","session":"sess-1"}}"#.data(using: .utf8)!
+        let result = try JSONDecoder().decode(CognitoSignIn.Result.self, from: json)
+        guard case .continueSignIn(let outer) = result else { return XCTFail("expected .continueSignIn") }
+        guard case .confirm_Sign_In_With_Totp_Code(let inner) = outer.nextStep else {
+            return XCTFail("expected nested TOTP arm")
+        }
+        XCTAssertEqual(inner.session, "sess-1")
+    }
+
+    func testDecodesNestedArmWithEnumArray() throws {
+        let json = #"{"status":"continueSignIn","nextStep":{"name":"CONTINUE_SIGN_IN_WITH_MFA_SELECTION","session":"s","allowedMFATypes":["SMS","TOTP"]}}"#.data(using: .utf8)!
+        let result = try JSONDecoder().decode(CognitoSignIn.Result.self, from: json)
+        guard case .continueSignIn(let outer) = result,
+              case .continue_Sign_In_With_Mfa_Selection(let inner) = outer.nextStep else {
+            return XCTFail("expected nested MFA-selection arm")
+        }
+        XCTAssertEqual(inner.allowedMFATypes, [.sMS, .tOTP])
+    }
+
+    // MARK: - Round-trip + unknown discriminant
+
+    func testNestedRoundTrip() throws {
+        let original = CognitoSignIn.Result.continueSignIn(
+            .init(nextStep: .confirm_Sign_In_With_Totp_Code(.init(session: "sess-2"))))
+        let encoded = try JSONEncoder().encode(original)
+        let asString = String(data: encoded, encoding: .utf8)!
+        XCTAssertTrue(asString.contains("\"status\":\"continueSignIn\""))
+        XCTAssertTrue(asString.contains("\"name\":\"CONFIRM_SIGN_IN_WITH_TOTP_CODE\""))
+
+        let decoded = try JSONDecoder().decode(CognitoSignIn.Result.self, from: encoded)
+        guard case .continueSignIn(let outer) = decoded,
+              case .confirm_Sign_In_With_Totp_Code(let inner) = outer.nextStep else {
+            return XCTFail("round-trip lost the nested arm")
+        }
+        XCTAssertEqual(inner.session, "sess-2")
+    }
+
+    func testUnknownOuterStatusThrows() {
+        let json = #"{"status":"bogus"}"#.data(using: .utf8)!
+        XCTAssertThrowsError(try JSONDecoder().decode(CognitoSignIn.Result.self, from: json))
+    }
+
+    func testUnknownNestedNameThrows() {
+        let json = #"{"status":"continueSignIn","nextStep":{"name":"NOPE"}}"#.data(using: .utf8)!
+        XCTAssertThrowsError(try JSONDecoder().decode(CognitoSignIn.Result.self, from: json))
+    }
+}

--- a/packages/bb-auth-cognito/API.md
+++ b/packages/bb-auth-cognito/API.md
@@ -460,10 +460,10 @@ export interface SignInOptions {
 
 // @public
 export type SignInResult<O extends AuthCognitoOptions = AuthCognitoOptions> = {
-    isSignedIn: true;
+    status: 'signedIn';
     user: CognitoUser<O>;
 } | {
-    isSignedIn: false;
+    status: 'continueSignIn';
     nextStep: SignInNextStep;
 };
 

--- a/packages/bb-auth-cognito/README.md
+++ b/packages/bb-auth-cognito/README.md
@@ -87,7 +87,7 @@ Every method takes `context: BlocksContext` (for cookie I/O) or operates on the 
 
 | Method | Signature | Notes |
 |---|---|---|
-| `signIn(username, password, context, options?)` | `Promise<SignInResult>` | Returns `{isSignedIn: true, user}` or `{isSignedIn: false, nextStep}`. On success, sets the session cookie. |
+| `signIn(username, password, context, options?)` | `Promise<SignInResult>` | Returns `{status: 'signedIn', user}` or `{status: 'continueSignIn', nextStep}` (narrow with `if (result.status === 'signedIn')`). On success, sets the session cookie. |
 | `confirmSignIn(session, response, context, options?)` | `Promise<SignInResult>` | Advance any challenge. `response` is discriminated: `{ code }` (SMS/TOTP/Email/TOTP-setup), `{ newPassword }` (NEW_PASSWORD_REQUIRED), `{ mfaType }` (MFA selection / setup selection), `{ email }` (EMAIL_SETUP address submit), `{ password }` (USER_AUTH password leg), `{ firstFactor }` (USER_AUTH first-factor pick), `{ credential }` (USER_AUTH passkey assertion — the JSON-encoded `PublicKeyCredential` from `navigator.credentials.get(...)`). Legacy `string` is still accepted and routed to the code branch. |
 | `signOut(context, options?)` | `Promise<void>` | `{global: true}` calls `GlobalSignOutCommand` (revokes the refresh token at Cognito). |
 
@@ -394,11 +394,14 @@ export const api = new ApiNamespace(scope, 'api', (context) => ({
   },
   async sessionInfo() {
     const session = await auth.fetchAuthSession(context);
-    if (!session.tokens) return { signedIn: false };
+    // Discriminate on a string `status` (not a boolean): native-client codegen
+    // (Swift/Kotlin/Dart) only builds a proper discriminated union from a
+    // single-value string const/enum per arm.
+    if (!session.tokens) return { status: 'signedOut' as const };
     // Claims are `unknown` — narrow before using.
     const payload = session.tokens.idToken.payload;
     const sub = typeof payload.sub === 'string' ? payload.sub : null;
-    return { signedIn: true, sub };
+    return { status: 'signedIn' as const, sub };
   },
 }));
 

--- a/packages/bb-auth-cognito/src/fetchAuthSession.types-test.ts
+++ b/packages/bb-auth-cognito/src/fetchAuthSession.types-test.ts
@@ -39,4 +39,55 @@ function createApiReturnsAuthStateApi() {
 	void api;
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// SignInResult — `status` string discriminator (added for native codegen)
+// ─────────────────────────────────────────────────────────────────────────────
+//
+// `status` is a string-literal union, so it stays fully type-safe end to end:
+// narrowing on it works and bogus values are rejected. These are compile-time
+// assertions — the `@ts-expect-error` lines must stay errors. See
+// {@link SignInResult}.
+
+async function signInStatusNarrows() {
+	const r = await auth.signIn('user', 'pass', ctx);
+
+	// Narrowing on the string discriminator reaches the signed-in payload.
+	if (r.status === 'signedIn') {
+		const user = r.user;
+		void user;
+	}
+	// Narrowing on the other arm reaches `nextStep`.
+	if (r.status === 'continueSignIn') {
+		const next = r.nextStep;
+		void next;
+	}
+}
+
+async function confirmSignInStatusNarrows() {
+	// `confirmSignIn` shares the same `SignInResult` shape.
+	const r = await auth.confirmSignIn('session', '123456', ctx);
+	if (r.status === 'continueSignIn') {
+		void r.nextStep;
+	}
+}
+
+async function signInStatusNegative() {
+	const r = await auth.signIn('user', 'pass', ctx);
+	// @ts-expect-error — 'loggedIn' is not a valid status value (proves it's a
+	// literal union, not wide `string`).
+	if (r.status === 'loggedIn') { /* unreachable */ }
+	// @ts-expect-error — the old boolean discriminator is gone; only `status`
+	// distinguishes the arms now.
+	void r.isSignedIn;
+	if (r.status === 'continueSignIn') {
+		// @ts-expect-error — `user` only exists on the signedIn arm.
+		void r.user;
+	}
+	if (r.status === 'signedIn') {
+		// @ts-expect-error — `nextStep` only exists on the nextStep arm.
+		void r.nextStep;
+	}
+}
+
 void payloadIsUnknown; void forgetDeviceRequiresKey; void createApiReturnsAuthStateApi;
+void signInStatusNarrows; void confirmSignInStatusNarrows; void signInStatusNegative;

--- a/packages/bb-auth-cognito/src/index.aws.ts
+++ b/packages/bb-auth-cognito/src/index.aws.ts
@@ -902,7 +902,7 @@ export class AuthCognito<O extends AuthCognitoOptions = AuthCognitoOptions>
 			if (resp.ChallengeName) {
 				const secret = await this.getSessionSecret();
 				return {
-					isSignedIn: false,
+					status: 'continueSignIn',
 					nextStep: await this.buildNextStep(
 						secret,
 						resp.ChallengeName,
@@ -915,7 +915,7 @@ export class AuthCognito<O extends AuthCognitoOptions = AuthCognitoOptions>
 			}
 
 			const user = await this.issueSession(context, resp.AuthenticationResult);
-			return { isSignedIn: true, user };
+			return { status: 'signedIn', user };
 		} catch (e) {
 			throw asApiError(e);
 		}
@@ -1013,10 +1013,10 @@ export class AuthCognito<O extends AuthCognitoOptions = AuthCognitoOptions>
 			const mfaSetupResp = await this.dispatchMfaSetup(envelope, challengeResponse, secret, options);
 			if (mfaSetupResp) {
 				if (mfaSetupResp.nextStep) {
-					return { isSignedIn: false, nextStep: mfaSetupResp.nextStep };
+					return { status: 'continueSignIn', nextStep: mfaSetupResp.nextStep };
 				}
 				const user = await this.issueSession(context, mfaSetupResp.authResult);
-				return { isSignedIn: true, user };
+				return { status: 'signedIn', user };
 			}
 
 			// USER_AUTH SELECT_CHALLENGE → PASSWORD is a two-step flow on our
@@ -1039,7 +1039,7 @@ export class AuthCognito<O extends AuthCognitoOptions = AuthCognitoOptions>
 					awaitingPassword: true,
 				});
 				return {
-					isSignedIn: false,
+					status: 'continueSignIn',
 					nextStep: { name: 'CONFIRM_SIGN_IN_WITH_PASSWORD', session: nextEnvelope },
 				};
 			}
@@ -1063,7 +1063,7 @@ export class AuthCognito<O extends AuthCognitoOptions = AuthCognitoOptions>
 
 			if (resp.ChallengeName) {
 				return {
-					isSignedIn: false,
+					status: 'continueSignIn',
 					nextStep: await this.buildNextStep(
 						secret,
 						resp.ChallengeName,
@@ -1076,7 +1076,7 @@ export class AuthCognito<O extends AuthCognitoOptions = AuthCognitoOptions>
 			}
 
 			const user = await this.issueSession(context, resp.AuthenticationResult);
-			return { isSignedIn: true, user };
+			return { status: 'signedIn', user };
 		} catch (e) {
 			throw asApiError(e);
 		}
@@ -1793,7 +1793,7 @@ export class AuthCognito<O extends AuthCognitoOptions = AuthCognitoOptions>
 					switch (input.action) {
 						case 'signIn': {
 							const r = await this.signIn(input.username, input.password, context);
-							if (r.isSignedIn) return baseSignedIn(r.user);
+							if (r.status === 'signedIn') return baseSignedIn(r.user);
 							return confirmingSignIn(r.nextStep);
 						}
 						case 'signInWithPasskey': {
@@ -1806,7 +1806,7 @@ export class AuthCognito<O extends AuthCognitoOptions = AuthCognitoOptions>
 								context,
 								{ preferredChallenge: 'WEB_AUTHN' },
 							);
-							if (r.isSignedIn) return baseSignedIn(r.user);
+							if (r.status === 'signedIn') return baseSignedIn(r.user);
 							return confirmingSignIn(r.nextStep);
 						}
 						case 'signUp': {
@@ -1851,7 +1851,7 @@ export class AuthCognito<O extends AuthCognitoOptions = AuthCognitoOptions>
 						}
 						case 'autoSignIn': {
 							const r = await this.autoSignIn(context);
-							if (r.isSignedIn) return baseSignedIn(r.user);
+							if (r.status === 'signedIn') return baseSignedIn(r.user);
 							return confirmingSignIn(r.nextStep);
 						}
 						case 'resendSignUpCode': {
@@ -1877,7 +1877,7 @@ export class AuthCognito<O extends AuthCognitoOptions = AuthCognitoOptions>
 								default: response = '';
 							}
 							const r = await this.confirmSignIn(input.session, response, context);
-							if (r.isSignedIn) return baseSignedIn(r.user);
+							if (r.status === 'signedIn') return baseSignedIn(r.user);
 							return confirmingSignIn(r.nextStep);
 						}
 						case 'startPasskeyRegistration': {

--- a/packages/bb-auth-cognito/src/index.test.ts
+++ b/packages/bb-auth-cognito/src/index.test.ts
@@ -129,6 +129,68 @@ describe('signUp / confirmSignUp / resendSignUpCode', () => {
 	});
 });
 
+// ─── `status` discriminator on SignInResult ─────────────────────────────────
+//
+// `SignInResult` is a discriminated union on the string `status` field
+// ('signedIn' | 'continueSignIn') — the discriminator native-client codegen keys off.
+// These tests assert the right `status` (and the matching payload field) is
+// returned on both the direct-sign-in and the challenge paths, for `signIn`
+// and `confirmSignIn`.
+
+describe('status discriminator on SignInResult', () => {
+	async function signUpAndConfirm(auth: AuthCognito, username: string) {
+		let code = '';
+		(auth as any).options.codeDelivery = async (_u: string, c: string) => { code = c; };
+		await auth.signUp(username, 'Password!1', { attributes: { email: `${username}@x.com` } });
+		await auth.confirmSignUp(username, code);
+	}
+
+	test("signIn returns status 'signedIn' (+ user) on the direct happy path", async () => {
+		const auth = new AuthCognito(ROOT, unique('status-1'), { passwordPolicy: { minLength: 8 } });
+		await signUpAndConfirm(auth, 'sigrid');
+		const { ctx } = freshContext();
+		const r = await auth.signIn('sigrid', 'Password!1', ctx);
+		assert.strictEqual(r.status, 'signedIn');
+		// The signedIn arm carries `user` and no `nextStep`.
+		if (r.status !== 'signedIn') throw new Error('unreachable');
+		assert.strictEqual(r.user.username, 'sigrid');
+		assert.ok(!('nextStep' in r));
+	});
+
+	test("signIn returns status 'continueSignIn' (+ nextStep) when a challenge is required", async () => {
+		const auth = new AuthCognito(ROOT, unique('status-2'), {
+			passwordPolicy: { minLength: 8 },
+			mfa: 'required',
+			mfaTypes: ['TOTP'],
+		});
+		await signUpAndConfirm(auth, 'nadia');
+		const { ctx } = freshContext();
+		const r = await auth.signIn('nadia', 'Password!1', ctx);
+		assert.strictEqual(r.status, 'continueSignIn');
+		// The nextStep arm carries `nextStep` and no `user`.
+		if (r.status !== 'continueSignIn') throw new Error('unreachable');
+		assert.ok(r.nextStep.name.length > 0);
+		assert.ok(!('user' in r));
+	});
+
+	test('confirmSignIn carries status through to the final signed-in result', async () => {
+		const auth = new AuthCognito(ROOT, unique('status-3'), {
+			passwordPolicy: { minLength: 8 },
+			mfa: 'required',
+			mfaTypes: ['TOTP'],
+		});
+		await signUpAndConfirm(auth, 'omar');
+		const { ctx } = freshContext();
+		const challenge = await auth.signIn('omar', 'Password!1', ctx);
+		assert.strictEqual(challenge.status, 'continueSignIn');
+		if (challenge.status !== 'continueSignIn') return;
+		if (challenge.nextStep.name !== 'CONTINUE_SIGN_IN_WITH_TOTP_SETUP') return;
+		// Mock accepts any 6-digit code.
+		const done = await auth.confirmSignIn(challenge.nextStep.session, { code: '123456' }, ctx);
+		assert.strictEqual(done.status, 'signedIn');
+	});
+});
+
 // ─── Sign-in happy path + error cases ───────────────────────────────────────
 
 describe('signIn / signOut / getCurrentUser / requireAuth / checkAuth', () => {
@@ -144,7 +206,7 @@ describe('signIn / signOut / getCurrentUser / requireAuth / checkAuth', () => {
 		await signUpAndConfirm(auth, 'alice');
 		const { ctx } = freshContext();
 		const r = await auth.signIn('alice', 'Password!1', ctx);
-		assert.ok(r.isSignedIn);
+		assert.strictEqual(r.status, 'signedIn');
 		const current = await auth.getCurrentUser(ctx);
 		assert.ok(current);
 		assert.strictEqual(current!.username, 'alice');
@@ -296,8 +358,8 @@ describe('MFA challenge + confirmSignIn', () => {
 		await setupUserWithTotp(auth, 'grace');
 		const { ctx } = freshContext();
 		const r = await auth.signIn('grace', 'Password!1', ctx);
-		assert.strictEqual(r.isSignedIn, false);
-		if (!r.isSignedIn) {
+		assert.strictEqual(r.status, 'continueSignIn');
+		if (r.status === 'continueSignIn') {
 			assert.strictEqual(r.nextStep.name, 'CONFIRM_SIGN_IN_WITH_TOTP_CODE');
 			assert.ok(r.nextStep.session);
 		}
@@ -312,10 +374,10 @@ describe('MFA challenge + confirmSignIn', () => {
 		await setupUserWithTotp(auth, 'hugo');
 		const { ctx } = freshContext();
 		const challenge = await auth.signIn('hugo', 'Password!1', ctx);
-		if (challenge.isSignedIn) throw new Error('expected challenge');
+		if (challenge.status === 'signedIn') throw new Error('expected challenge');
 		const session = (challenge.nextStep as { session: string }).session;
 		const r = await auth.confirmSignIn(session, '123456', ctx);
-		assert.ok(r.isSignedIn);
+		assert.strictEqual(r.status, 'signedIn');
 		assert.strictEqual(await auth.checkAuth(ctx), true);
 	});
 
@@ -328,7 +390,7 @@ describe('MFA challenge + confirmSignIn', () => {
 		await setupUserWithTotp(auth, 'ivy');
 		const { ctx } = freshContext();
 		const challenge = await auth.signIn('ivy', 'Password!1', ctx);
-		if (challenge.isSignedIn) throw new Error('expected challenge');
+		if (challenge.status === 'signedIn') throw new Error('expected challenge');
 		const session = (challenge.nextStep as { session: string }).session;
 		await assert.rejects(
 			() => auth.confirmSignIn(session, 'abc', ctx),
@@ -345,7 +407,7 @@ describe('MFA challenge + confirmSignIn', () => {
 		await setupUserWithTotp(auth, 'jay');
 		const { ctx } = freshContext();
 		const challenge = await auth.signIn('jay', 'Password!1', ctx);
-		if (challenge.isSignedIn) throw new Error('expected challenge');
+		if (challenge.status === 'signedIn') throw new Error('expected challenge');
 		const session = (challenge.nextStep as { session: string }).session;
 		// Force expiry.
 		const entry = (auth as any).challenges.get(session);
@@ -368,8 +430,8 @@ describe('MFA challenge + confirmSignIn', () => {
 		await auth.confirmSignUp('kim', code);
 		const { ctx } = freshContext();
 		const r = await auth.signIn('kim', 'Password!1', ctx);
-		assert.strictEqual(r.isSignedIn, false);
-		if (!r.isSignedIn) {
+		assert.strictEqual(r.status, 'continueSignIn');
+		if (r.status === 'continueSignIn') {
 			assert.strictEqual(r.nextStep.name, 'CONTINUE_SIGN_IN_WITH_TOTP_SETUP');
 		}
 	});
@@ -386,13 +448,13 @@ describe('MFA challenge + confirmSignIn', () => {
 		await auth.confirmSignUp('lee', code);
 		const { ctx } = freshContext();
 		const r = await auth.signIn('lee', 'Password!1', ctx);
-		if (r.isSignedIn) throw new Error('expected TOTP setup challenge');
+		if (r.status === 'signedIn') throw new Error('expected TOTP setup challenge');
 		assert.strictEqual(r.nextStep.name, 'CONTINUE_SIGN_IN_WITH_TOTP_SETUP');
 		if (r.nextStep.name !== 'CONTINUE_SIGN_IN_WITH_TOTP_SETUP') return;
 		assert.ok(r.nextStep.sharedSecret.length > 0, 'shared secret emitted');
 		// Mock accepts any 6-digit code (see DESIGN.md "Mock vs AWS Parity Gaps").
 		const done = await auth.confirmSignIn(r.nextStep.session, { code: '123456' }, ctx);
-		assert.strictEqual(done.isSignedIn, true);
+		assert.strictEqual(done.status, 'signedIn');
 	});
 
 	test('MFA EMAIL setup: address submit → code round-trip signs in', async () => {
@@ -416,23 +478,23 @@ describe('MFA challenge + confirmSignIn', () => {
 		const { ctx } = freshContext();
 		// First login → setup selection (only TOTP + EMAIL can be enrolled).
 		const r1 = await auth.signIn('morgan', 'Password!1', ctx);
-		if (r1.isSignedIn) throw new Error('expected setup selection');
+		if (r1.status === 'signedIn') throw new Error('expected setup selection');
 		assert.strictEqual(r1.nextStep.name, 'CONTINUE_SIGN_IN_WITH_MFA_SETUP_SELECTION');
 		if (r1.nextStep.name !== 'CONTINUE_SIGN_IN_WITH_MFA_SETUP_SELECTION') return;
 		// Pick EMAIL → asks for an address.
 		const r2 = await auth.confirmSignIn(r1.nextStep.session, { mfaType: 'EMAIL' as 'EMAIL' }, ctx);
-		if (r2.isSignedIn) throw new Error('expected email-setup step');
+		if (r2.status === 'signedIn') throw new Error('expected email-setup step');
 		assert.strictEqual(r2.nextStep.name, 'CONTINUE_SIGN_IN_WITH_EMAIL_SETUP');
 		if (r2.nextStep.name !== 'CONTINUE_SIGN_IN_WITH_EMAIL_SETUP') return;
 		// Submit address → code is delivered + EMAIL_CODE challenge follows.
 		lastCode = '';
 		const r3 = await auth.confirmSignIn(r2.nextStep.session, { email: 'morgan-new@x.com' }, ctx);
-		if (r3.isSignedIn) throw new Error('expected follow-up code challenge');
+		if (r3.status === 'signedIn') throw new Error('expected follow-up code challenge');
 		assert.strictEqual(r3.nextStep.name, 'CONFIRM_SIGN_IN_WITH_EMAIL_CODE');
 		if (r3.nextStep.name !== 'CONFIRM_SIGN_IN_WITH_EMAIL_CODE') return;
 		assert.ok(lastCode.length > 0, 'code generated after address submission');
 		const r4 = await auth.confirmSignIn(r3.nextStep.session, { code: lastCode }, ctx);
-		assert.strictEqual(r4.isSignedIn, true);
+		assert.strictEqual(r4.status, 'signedIn');
 	});
 });
 
@@ -774,8 +836,8 @@ describe('USER_AUTH flow', () => {
 		const { auth } = await confirmedUser('ua-1');
 		const { ctx } = freshContext();
 		const r = await auth.signIn('ursula', '', ctx);
-		assert.strictEqual(r.isSignedIn, false);
-		if (!r.isSignedIn) {
+		assert.strictEqual(r.status, 'continueSignIn');
+		if (r.status === 'continueSignIn') {
 			assert.strictEqual(r.nextStep.name, 'CONTINUE_SIGN_IN_WITH_FIRST_FACTOR_SELECTION');
 			if (r.nextStep.name === 'CONTINUE_SIGN_IN_WITH_FIRST_FACTOR_SELECTION') {
 				assert.deepStrictEqual(
@@ -790,39 +852,39 @@ describe('USER_AUTH flow', () => {
 		const { auth } = await confirmedUser('ua-2', { preferredChallenge: 'PASSWORD' });
 		const { ctx } = freshContext();
 		const r = await auth.signIn('ursula', '', ctx);
-		if (r.isSignedIn) throw new Error('expected challenge');
+		if (r.status === 'signedIn') throw new Error('expected challenge');
 		assert.strictEqual(r.nextStep.name, 'CONFIRM_SIGN_IN_WITH_PASSWORD');
 		if (r.nextStep.name !== 'CONFIRM_SIGN_IN_WITH_PASSWORD') return;
 		// Completing the password leg signs the user in.
 		const confirmed = await auth.confirmSignIn(r.nextStep.session, { password: 'Password!1' }, ctx);
-		assert.strictEqual(confirmed.isSignedIn, true);
+		assert.strictEqual(confirmed.status, 'signedIn');
 	});
 
 	test('preferredChallenge=EMAIL_OTP → passwordless sign-in via code', async () => {
 		const { auth, codeHolder } = await confirmedUser('ua-3', { preferredChallenge: 'EMAIL_OTP' });
 		const { ctx } = freshContext();
 		const r = await auth.signIn('ursula', '', ctx);
-		if (r.isSignedIn) throw new Error('expected challenge');
+		if (r.status === 'signedIn') throw new Error('expected challenge');
 		assert.strictEqual(r.nextStep.name, 'CONFIRM_SIGN_IN_WITH_FIRST_FACTOR_EMAIL_OTP');
 		if (r.nextStep.name !== 'CONFIRM_SIGN_IN_WITH_FIRST_FACTOR_EMAIL_OTP') return;
 		const confirmed = await auth.confirmSignIn(r.nextStep.session, { code: codeHolder() }, ctx);
-		assert.strictEqual(confirmed.isSignedIn, true);
+		assert.strictEqual(confirmed.status, 'signedIn');
 	});
 
 	test('SELECT_CHALLENGE → pick EMAIL_OTP → passwordless sign-in', async () => {
 		const { auth, codeHolder } = await confirmedUser('ua-4');
 		const { ctx } = freshContext();
 		const r = await auth.signIn('ursula', '', ctx);
-		if (r.isSignedIn) throw new Error('expected challenge');
+		if (r.status === 'signedIn') throw new Error('expected challenge');
 		if (r.nextStep.name !== 'CONTINUE_SIGN_IN_WITH_FIRST_FACTOR_SELECTION') {
 			throw new Error(`unexpected step: ${r.nextStep.name}`);
 		}
 		const picked = await auth.confirmSignIn(r.nextStep.session, { firstFactor: 'EMAIL_OTP' }, ctx);
-		if (picked.isSignedIn) throw new Error('expected follow-up challenge');
+		if (picked.status === 'signedIn') throw new Error('expected follow-up challenge');
 		assert.strictEqual(picked.nextStep.name, 'CONFIRM_SIGN_IN_WITH_FIRST_FACTOR_EMAIL_OTP');
 		if (picked.nextStep.name !== 'CONFIRM_SIGN_IN_WITH_FIRST_FACTOR_EMAIL_OTP') return;
 		const confirmed = await auth.confirmSignIn(picked.nextStep.session, { code: codeHolder() }, ctx);
-		assert.strictEqual(confirmed.isSignedIn, true);
+		assert.strictEqual(confirmed.status, 'signedIn');
 	});
 
 	test('state-machine dispatch: SELECT_CHALLENGE → PASSWORD → signed in', async () => {
@@ -864,12 +926,12 @@ describe('Passkeys', () => {
 		// Sign the user in via PASSWORD first factor so the access token
 		// cookie is on `ctx`. Subsequent passkey calls use that session.
 		const r = await auth.signIn('paula', '', ctx, { preferredChallenge: 'PASSWORD' });
-		if (r.isSignedIn) throw new Error('expected PASSWORD challenge');
+		if (r.status === 'signedIn') throw new Error('expected PASSWORD challenge');
 		if (r.nextStep.name !== 'CONFIRM_SIGN_IN_WITH_PASSWORD') {
 			throw new Error(`unexpected step: ${r.nextStep.name}`);
 		}
 		const final = await auth.confirmSignIn(r.nextStep.session, { password: 'Password!1' }, ctx);
-		assert.strictEqual(final.isSignedIn, true);
+		assert.strictEqual(final.status, 'signedIn');
 		return { auth, ctx };
 	}
 
@@ -935,7 +997,7 @@ describe('Passkeys', () => {
 		await auth.signOut(ctx);
 		const { ctx: ctx2 } = freshContext();
 		const r = await auth.signIn('paula', '', ctx2, { preferredChallenge: 'WEB_AUTHN' });
-		if (r.isSignedIn) throw new Error('expected WebAuthn challenge');
+		if (r.status === 'signedIn') throw new Error('expected WebAuthn challenge');
 		assert.strictEqual(r.nextStep.name, 'CONFIRM_SIGN_IN_WITH_WEB_AUTHN');
 		if (r.nextStep.name !== 'CONFIRM_SIGN_IN_WITH_WEB_AUTHN') return;
 		const opts = JSON.parse(r.nextStep.credentialRequestOptions);
@@ -946,7 +1008,7 @@ describe('Passkeys', () => {
 			{ credential: JSON.stringify({ id: 'cred-known', response: {} }) },
 			ctx2,
 		);
-		assert.strictEqual(confirmed.isSignedIn, true);
+		assert.strictEqual(confirmed.status, 'signedIn');
 	});
 
 	test('passkey sign-in rejects unknown credential id', async () => {
@@ -958,7 +1020,7 @@ describe('Passkeys', () => {
 		await auth.signOut(ctx);
 		const { ctx: ctx2 } = freshContext();
 		const r = await auth.signIn('paula', '', ctx2, { preferredChallenge: 'WEB_AUTHN' });
-		if (r.isSignedIn) throw new Error('expected WebAuthn challenge');
+		if (r.status === 'signedIn') throw new Error('expected WebAuthn challenge');
 		if (r.nextStep.name !== 'CONFIRM_SIGN_IN_WITH_WEB_AUTHN') throw new Error('unexpected');
 		const session = r.nextStep.session;
 		await assert.rejects(
@@ -980,7 +1042,7 @@ describe('Passkeys', () => {
 		await auth.signOut(ctx);
 		const { ctx: ctx2 } = freshContext();
 		const r = await auth.signIn('paula', '', ctx2);
-		if (r.isSignedIn) throw new Error('expected challenge');
+		if (r.status === 'signedIn') throw new Error('expected challenge');
 		if (r.nextStep.name !== 'CONTINUE_SIGN_IN_WITH_FIRST_FACTOR_SELECTION') {
 			throw new Error(`unexpected step: ${r.nextStep.name}`);
 		}

--- a/packages/bb-auth-cognito/src/index.ts
+++ b/packages/bb-auth-cognito/src/index.ts
@@ -454,8 +454,8 @@ export class AuthCognito<O extends AuthCognitoMockOptions = AuthCognitoMockOptio
 	// ─────────────────────────────────────────────────────────────────────
 
 	/**
-	 * Authenticate a user. Returns `{ isSignedIn: true, user }` on success
-	 * (also sets the session cookie), or `{ isSignedIn: false, nextStep }`
+	 * Authenticate a user. Returns `{ status: 'signedIn', user }` on success
+	 * (also sets the session cookie), or `{ status: 'continueSignIn', nextStep }`
 	 * when a challenge is required (MFA, NEW_PASSWORD_REQUIRED, etc.).
 	 *
 	 * @throws {AuthCognitoErrors.NotAuthorized} Wrong password.
@@ -503,13 +503,13 @@ export class AuthCognito<O extends AuthCognitoMockOptions = AuthCognitoMockOptio
 			// signed-up user's sub-prefix (`mock-signup-session-<sub>`).
 			if (options?.cognitoSession === `mock-signup-session-${user.userSub}`) {
 				await this.issueSession(context, username, user);
-				return { isSignedIn: true, user: this.toCognitoUser(username, user) };
+				return { status: 'signedIn', user: this.toCognitoUser(username, user) };
 			}
 			const next = this.firstFactorChallenge(
 				username,
 				options?.preferredChallenge ?? this.options.preferredChallenge,
 			);
-			return { isSignedIn: false, nextStep: next };
+			return { status: 'continueSignIn', nextStep: next };
 		}
 
 		// USER_PASSWORD_AUTH (classic).
@@ -526,7 +526,7 @@ export class AuthCognito<O extends AuthCognitoMockOptions = AuthCognitoMockOptio
 		// when simulating an `AdminCreateUser({ Permanent: false })` user.
 		if ((user as MockUserRecord & { forcePasswordChange?: boolean }).forcePasswordChange) {
 			return {
-				isSignedIn: false,
+				status: 'continueSignIn',
 				nextStep: this.issueChallenge(username, {
 					name: 'CONFIRM_SIGN_IN_WITH_NEW_PASSWORD_REQUIRED',
 					session: '',
@@ -536,10 +536,10 @@ export class AuthCognito<O extends AuthCognitoMockOptions = AuthCognitoMockOptio
 
 		// Challenge selection (mock — matches Cognito's logic at a high level)
 		const challenge = await this.selectSignInChallenge(username, user);
-		if (challenge) return { isSignedIn: false, nextStep: challenge };
+		if (challenge) return { status: 'continueSignIn', nextStep: challenge };
 
 		await this.issueSession(context, username, user);
-		return { isSignedIn: true, user: this.toCognitoUser(username, user) };
+		return { status: 'signedIn', user: this.toCognitoUser(username, user) };
 	}
 
 	/**
@@ -782,7 +782,7 @@ export class AuthCognito<O extends AuthCognitoMockOptions = AuthCognitoMockOptio
 					challengeResponse as 'SMS' | 'TOTP' | 'EMAIL',
 				);
 				this.challenges.delete(session);
-				return { isSignedIn: false, nextStep: next };
+				return { status: 'continueSignIn', nextStep: next };
 			}
 			case 'CONTINUE_SIGN_IN_WITH_MFA_SETUP_SELECTION': {
 				const next = await this.challengeForMfaSetup(
@@ -790,7 +790,7 @@ export class AuthCognito<O extends AuthCognitoMockOptions = AuthCognitoMockOptio
 					challengeResponse as 'TOTP' | 'EMAIL',
 				);
 				this.challenges.delete(session);
-				return { isSignedIn: false, nextStep: next };
+				return { status: 'continueSignIn', nextStep: next };
 			}
 			case 'CONTINUE_SIGN_IN_WITH_TOTP_SETUP': {
 				if (!/^\d{6}$/.test(challengeResponse)) {
@@ -832,7 +832,7 @@ export class AuthCognito<O extends AuthCognitoMockOptions = AuthCognitoMockOptio
 					},
 				};
 				const issued = this.issueChallenge(challenge.username, next, { isEmailSetup: true });
-				return { isSignedIn: false, nextStep: issued };
+				return { status: 'continueSignIn', nextStep: issued };
 			}
 			case 'CONFIRM_SIGN_IN_WITH_NEW_PASSWORD_REQUIRED': {
 				this.enforcePasswordPolicy(challengeResponse);
@@ -863,7 +863,7 @@ export class AuthCognito<O extends AuthCognitoMockOptions = AuthCognitoMockOptio
 				}
 				this.challenges.delete(session);
 				const next = this.firstFactorChallenge(challenge.username, pick);
-				return { isSignedIn: false, nextStep: next };
+				return { status: 'continueSignIn', nextStep: next };
 			}
 			case 'CONFIRM_SIGN_IN_WITH_PASSWORD': {
 				// USER_AUTH password leg. Validate the password the way the
@@ -918,7 +918,7 @@ export class AuthCognito<O extends AuthCognitoMockOptions = AuthCognitoMockOptio
 		}
 
 		await this.issueSession(context, challenge.username, user);
-		return { isSignedIn: true, user: this.toCognitoUser(challenge.username, user) };
+		return { status: 'signedIn', user: this.toCognitoUser(challenge.username, user) };
 	}
 
 	/**
@@ -1531,7 +1531,7 @@ export class AuthCognito<O extends AuthCognitoMockOptions = AuthCognitoMockOptio
 					switch (input.action) {
 						case 'signIn': {
 							const r = await this.signIn(input.username, input.password, context);
-							if (r.isSignedIn) return baseSignedIn(r.user);
+							if (r.status === 'signedIn') return baseSignedIn(r.user);
 							return confirmingSignIn(r.nextStep);
 						}
 						case 'signInWithPasskey': {
@@ -1541,7 +1541,7 @@ export class AuthCognito<O extends AuthCognitoMockOptions = AuthCognitoMockOptio
 								context,
 								{ preferredChallenge: 'WEB_AUTHN' },
 							);
-							if (r.isSignedIn) return baseSignedIn(r.user);
+							if (r.status === 'signedIn') return baseSignedIn(r.user);
 							return confirmingSignIn(r.nextStep);
 						}
 						case 'signUp': {
@@ -1581,7 +1581,7 @@ export class AuthCognito<O extends AuthCognitoMockOptions = AuthCognitoMockOptio
 						}
 						case 'autoSignIn': {
 							const r = await this.autoSignIn(context);
-							if (r.isSignedIn) return baseSignedIn(r.user);
+							if (r.status === 'signedIn') return baseSignedIn(r.user);
 							return confirmingSignIn(r.nextStep);
 						}
 						case 'resendSignUpCode': {
@@ -1607,7 +1607,7 @@ export class AuthCognito<O extends AuthCognitoMockOptions = AuthCognitoMockOptio
 								default: response = '';
 							}
 							const r = await this.confirmSignIn(input.session, response, context);
-							if (r.isSignedIn) return baseSignedIn(r.user);
+							if (r.status === 'signedIn') return baseSignedIn(r.user);
 							return confirmingSignIn(r.nextStep);
 						}
 						case 'startPasskeyRegistration': {

--- a/packages/bb-auth-cognito/src/scenarios.mock.test.ts
+++ b/packages/bb-auth-cognito/src/scenarios.mock.test.ts
@@ -68,7 +68,7 @@ describe('scenarios.mock', () => {
 		await auth.signUp('u1@test.example', 'Password!1', { attributes: { email: 'u1@test.example' } });
 		await auth.confirmSignUp('u1@test.example', lastCode());
 		const r = await auth.signIn('u1@test.example', 'Password!1', ctx());
-		assert.strictEqual(r.isSignedIn, true);
+		assert.strictEqual(r.status, 'signedIn');
 	});
 
 	test('2: mfa:optional — self sign-up → confirm → direct sign-in (no factors enrolled)', async () => {
@@ -80,7 +80,7 @@ describe('scenarios.mock', () => {
 		await auth.signUp('u2@test.example', 'Password!1', { attributes: { email: 'u2@test.example' } });
 		await auth.confirmSignUp('u2@test.example', lastCode());
 		const r = await auth.signIn('u2@test.example', 'Password!1', ctx());
-		assert.strictEqual(r.isSignedIn, true);
+		assert.strictEqual(r.status, 'signedIn');
 	});
 
 	test('3: mfa:required + [TOTP] — MFA_SETUP TOTP → enrolled, then re-sign-in challenges TOTP', async () => {
@@ -92,19 +92,19 @@ describe('scenarios.mock', () => {
 		await auth.signUp('u3@test.example', 'Password!1', { attributes: { email: 'u3@test.example' } });
 		await auth.confirmSignUp('u3@test.example', lastCode());
 		const r1 = await auth.signIn('u3@test.example', 'Password!1', ctx());
-		if (r1.isSignedIn) throw new Error('expected TOTP setup');
+		if (r1.status === 'signedIn') throw new Error('expected TOTP setup');
 		assert.strictEqual(r1.nextStep.name, 'CONTINUE_SIGN_IN_WITH_TOTP_SETUP');
 		if (r1.nextStep.name !== 'CONTINUE_SIGN_IN_WITH_TOTP_SETUP') return;
 		const setup = await auth.confirmSignIn(r1.nextStep.session, { code: '123456' }, ctx());
-		assert.strictEqual(setup.isSignedIn, true);
+		assert.strictEqual(setup.status, 'signedIn');
 
 		// Second sign-in hits the TOTP challenge path (not setup).
 		const r2 = await auth.signIn('u3@test.example', 'Password!1', ctx());
-		if (r2.isSignedIn) throw new Error('expected TOTP challenge');
+		if (r2.status === 'signedIn') throw new Error('expected TOTP challenge');
 		assert.strictEqual(r2.nextStep.name, 'CONFIRM_SIGN_IN_WITH_TOTP_CODE');
 		if (r2.nextStep.name !== 'CONFIRM_SIGN_IN_WITH_TOTP_CODE') return;
 		const done = await auth.confirmSignIn(r2.nextStep.session, { code: '654321' }, ctx());
-		assert.strictEqual(done.isSignedIn, true);
+		assert.strictEqual(done.status, 'signedIn');
 	});
 
 	test('4: mfa:required + [EMAIL] — address-first setup → code → signed in', async () => {
@@ -123,15 +123,15 @@ describe('scenarios.mock', () => {
 		(auth as any).flushToDisk();
 
 		const r1 = await auth.signIn('u4@test.example', 'Password!1', ctx());
-		if (r1.isSignedIn) throw new Error('expected email setup');
+		if (r1.status === 'signedIn') throw new Error('expected email setup');
 		assert.strictEqual(r1.nextStep.name, 'CONTINUE_SIGN_IN_WITH_EMAIL_SETUP');
 		if (r1.nextStep.name !== 'CONTINUE_SIGN_IN_WITH_EMAIL_SETUP') return;
 		const r2 = await auth.confirmSignIn(r1.nextStep.session, { email: 'u4-new@test.example' }, ctx());
-		if (r2.isSignedIn) throw new Error('expected code challenge');
+		if (r2.status === 'signedIn') throw new Error('expected code challenge');
 		assert.strictEqual(r2.nextStep.name, 'CONFIRM_SIGN_IN_WITH_EMAIL_CODE');
 		if (r2.nextStep.name !== 'CONFIRM_SIGN_IN_WITH_EMAIL_CODE') return;
 		const done = await auth.confirmSignIn(r2.nextStep.session, { code: lastCode() }, ctx());
-		assert.strictEqual(done.isSignedIn, true);
+		assert.strictEqual(done.status, 'signedIn');
 	});
 
 	test('5: mfa:required + [TOTP,EMAIL] — setup selection → pick TOTP', async () => {
@@ -148,15 +148,15 @@ describe('scenarios.mock', () => {
 		(auth as any).flushToDisk();
 
 		const r1 = await auth.signIn('u5@test.example', 'Password!1', ctx());
-		if (r1.isSignedIn) throw new Error('expected setup selection');
+		if (r1.status === 'signedIn') throw new Error('expected setup selection');
 		assert.strictEqual(r1.nextStep.name, 'CONTINUE_SIGN_IN_WITH_MFA_SETUP_SELECTION');
 		if (r1.nextStep.name !== 'CONTINUE_SIGN_IN_WITH_MFA_SETUP_SELECTION') return;
 		const r2 = await auth.confirmSignIn(r1.nextStep.session, { mfaType: 'TOTP' as 'TOTP' }, ctx());
-		if (r2.isSignedIn) throw new Error('expected TOTP setup step');
+		if (r2.status === 'signedIn') throw new Error('expected TOTP setup step');
 		assert.strictEqual(r2.nextStep.name, 'CONTINUE_SIGN_IN_WITH_TOTP_SETUP');
 		if (r2.nextStep.name !== 'CONTINUE_SIGN_IN_WITH_TOTP_SETUP') return;
 		const done = await auth.confirmSignIn(r2.nextStep.session, { code: '123456' }, ctx());
-		assert.strictEqual(done.isSignedIn, true);
+		assert.strictEqual(done.status, 'signedIn');
 	});
 
 	test('6: mfa:required + [TOTP,EMAIL] — setup selection → pick EMAIL', async () => {
@@ -172,13 +172,13 @@ describe('scenarios.mock', () => {
 		(auth as any).flushToDisk();
 
 		const r1 = await auth.signIn('u6@test.example', 'Password!1', ctx());
-		if (r1.isSignedIn || r1.nextStep.name !== 'CONTINUE_SIGN_IN_WITH_MFA_SETUP_SELECTION') return;
+		if (r1.status !== 'continueSignIn' || r1.nextStep.name !== 'CONTINUE_SIGN_IN_WITH_MFA_SETUP_SELECTION') return;
 		const r2 = await auth.confirmSignIn(r1.nextStep.session, { mfaType: 'EMAIL' as 'EMAIL' }, ctx());
-		if (r2.isSignedIn || r2.nextStep.name !== 'CONTINUE_SIGN_IN_WITH_EMAIL_SETUP') return;
+		if (r2.status !== 'continueSignIn' || r2.nextStep.name !== 'CONTINUE_SIGN_IN_WITH_EMAIL_SETUP') return;
 		const r3 = await auth.confirmSignIn(r2.nextStep.session, { email: 'u6-new@test.example' }, ctx());
-		if (r3.isSignedIn || r3.nextStep.name !== 'CONFIRM_SIGN_IN_WITH_EMAIL_CODE') return;
+		if (r3.status !== 'continueSignIn' || r3.nextStep.name !== 'CONFIRM_SIGN_IN_WITH_EMAIL_CODE') return;
 		const done = await auth.confirmSignIn(r3.nextStep.session, { code: lastCode() }, ctx());
-		assert.strictEqual(done.isSignedIn, true);
+		assert.strictEqual(done.status, 'signedIn');
 	});
 
 	test('7: mfa:optional, user with verified phone → SMS challenge → code → signed in', async () => {
@@ -193,11 +193,11 @@ describe('scenarios.mock', () => {
 		await auth.confirmSignUp('u7@test.example', lastCode());
 		// confirmSignUp auto-verifies phone_number when present.
 		const r1 = await auth.signIn('u7@test.example', 'Password!1', ctx());
-		if (r1.isSignedIn) throw new Error('expected SMS challenge');
+		if (r1.status === 'signedIn') throw new Error('expected SMS challenge');
 		assert.strictEqual(r1.nextStep.name, 'CONFIRM_SIGN_IN_WITH_SMS_CODE');
 		if (r1.nextStep.name !== 'CONFIRM_SIGN_IN_WITH_SMS_CODE') return;
 		const done = await auth.confirmSignIn(r1.nextStep.session, { code: lastCode() }, ctx());
-		assert.strictEqual(done.isSignedIn, true);
+		assert.strictEqual(done.status, 'signedIn');
 	});
 
 	test('8: enrolled TOTP + verified-SMS user → SELECT_MFA_TYPE → pick TOTP', async () => {
@@ -217,15 +217,15 @@ describe('scenarios.mock', () => {
 		(auth as any).flushToDisk();
 
 		const r1 = await auth.signIn('u8@test.example', 'Password!1', ctx());
-		if (r1.isSignedIn) throw new Error('expected SELECT_MFA_TYPE');
+		if (r1.status === 'signedIn') throw new Error('expected SELECT_MFA_TYPE');
 		assert.strictEqual(r1.nextStep.name, 'CONTINUE_SIGN_IN_WITH_MFA_SELECTION');
 		if (r1.nextStep.name !== 'CONTINUE_SIGN_IN_WITH_MFA_SELECTION') return;
 		assert.ok(r1.nextStep.allowedMFATypes.includes('TOTP'));
 		assert.ok(r1.nextStep.allowedMFATypes.includes('SMS'));
 		const r2 = await auth.confirmSignIn(r1.nextStep.session, { mfaType: 'TOTP' as 'TOTP' }, ctx());
-		if (r2.isSignedIn || r2.nextStep.name !== 'CONFIRM_SIGN_IN_WITH_TOTP_CODE') return;
+		if (r2.status !== 'continueSignIn' || r2.nextStep.name !== 'CONFIRM_SIGN_IN_WITH_TOTP_CODE') return;
 		const done = await auth.confirmSignIn(r2.nextStep.session, { code: '111222' }, ctx());
-		assert.strictEqual(done.isSignedIn, true);
+		assert.strictEqual(done.status, 'signedIn');
 	});
 
 	test('9: NEW_PASSWORD_REQUIRED — admin-created user with temp password → new password', async () => {
@@ -246,11 +246,11 @@ describe('scenarios.mock', () => {
 		(auth as any).flushToDisk();
 
 		const r1 = await auth.signIn('u9@test.example', 'TempPw!1', ctx());
-		if (r1.isSignedIn) throw new Error('expected NEW_PASSWORD_REQUIRED');
+		if (r1.status === 'signedIn') throw new Error('expected NEW_PASSWORD_REQUIRED');
 		assert.strictEqual(r1.nextStep.name, 'CONFIRM_SIGN_IN_WITH_NEW_PASSWORD_REQUIRED');
 		if (r1.nextStep.name !== 'CONFIRM_SIGN_IN_WITH_NEW_PASSWORD_REQUIRED') return;
 		const done = await auth.confirmSignIn(r1.nextStep.session, { newPassword: 'Permanent!1' }, ctx());
-		assert.strictEqual(done.isSignedIn, true);
+		assert.strictEqual(done.status, 'signedIn');
 	});
 
 	test('10: forgot password → code → new password → sign in', async () => {
@@ -265,7 +265,7 @@ describe('scenarios.mock', () => {
 		const resetCode = lastCode();
 		await auth.confirmResetPassword('u10@test.example', resetCode, 'NewPass!1');
 		const done = await auth.signIn('u10@test.example', 'NewPass!1', ctx());
-		assert.strictEqual(done.isSignedIn, true);
+		assert.strictEqual(done.status, 'signedIn');
 	});
 
 	// ─── USER_AUTH ────────────────────────────────────────────────────
@@ -285,11 +285,11 @@ describe('scenarios.mock', () => {
 		// the follow-up call because the mock doesn't support the combined
 		// InitiateAuth shape — matches the state-machine flow users see).
 		const r1 = await auth.signIn('u11@test.example', '', ctx());
-		if (r1.isSignedIn) throw new Error('expected password step');
+		if (r1.status === 'signedIn') throw new Error('expected password step');
 		assert.strictEqual(r1.nextStep.name, 'CONFIRM_SIGN_IN_WITH_PASSWORD');
 		if (r1.nextStep.name !== 'CONFIRM_SIGN_IN_WITH_PASSWORD') return;
 		const done = await auth.confirmSignIn(r1.nextStep.session, { password: 'Password!1' }, ctx());
-		assert.strictEqual(done.isSignedIn, true);
+		assert.strictEqual(done.status, 'signedIn');
 	});
 
 	test('12: USER_AUTH preferredChallenge=EMAIL_OTP → passwordless sign-in', async () => {
@@ -303,11 +303,11 @@ describe('scenarios.mock', () => {
 		await auth.confirmSignUp('u12@test.example', lastCode());
 
 		const r1 = await auth.signIn('u12@test.example', '', ctx());
-		if (r1.isSignedIn) throw new Error('expected email-OTP step');
+		if (r1.status === 'signedIn') throw new Error('expected email-OTP step');
 		assert.strictEqual(r1.nextStep.name, 'CONFIRM_SIGN_IN_WITH_FIRST_FACTOR_EMAIL_OTP');
 		if (r1.nextStep.name !== 'CONFIRM_SIGN_IN_WITH_FIRST_FACTOR_EMAIL_OTP') return;
 		const done = await auth.confirmSignIn(r1.nextStep.session, { code: lastCode() }, ctx());
-		assert.strictEqual(done.isSignedIn, true);
+		assert.strictEqual(done.status, 'signedIn');
 	});
 
 	test('13: USER_AUTH preferredChallenge=SMS_OTP → passwordless sign-in', async () => {
@@ -323,11 +323,11 @@ describe('scenarios.mock', () => {
 		await auth.confirmSignUp('u13@test.example', lastCode());
 
 		const r1 = await auth.signIn('u13@test.example', '', ctx());
-		if (r1.isSignedIn) throw new Error('expected SMS-OTP step');
+		if (r1.status === 'signedIn') throw new Error('expected SMS-OTP step');
 		assert.strictEqual(r1.nextStep.name, 'CONFIRM_SIGN_IN_WITH_FIRST_FACTOR_SMS_OTP');
 		if (r1.nextStep.name !== 'CONFIRM_SIGN_IN_WITH_FIRST_FACTOR_SMS_OTP') return;
 		const done = await auth.confirmSignIn(r1.nextStep.session, { code: lastCode() }, ctx());
-		assert.strictEqual(done.isSignedIn, true);
+		assert.strictEqual(done.status, 'signedIn');
 	});
 
 	test('14: USER_AUTH no preference → SELECT_CHALLENGE → pick PASSWORD → signed in', async () => {
@@ -340,13 +340,13 @@ describe('scenarios.mock', () => {
 		await auth.confirmSignUp('u14@test.example', lastCode());
 
 		const r1 = await auth.signIn('u14@test.example', '', ctx());
-		if (r1.isSignedIn) throw new Error('expected picker');
+		if (r1.status === 'signedIn') throw new Error('expected picker');
 		assert.strictEqual(r1.nextStep.name, 'CONTINUE_SIGN_IN_WITH_FIRST_FACTOR_SELECTION');
 		if (r1.nextStep.name !== 'CONTINUE_SIGN_IN_WITH_FIRST_FACTOR_SELECTION') return;
 		const r2 = await auth.confirmSignIn(r1.nextStep.session, { firstFactor: 'PASSWORD' }, ctx());
-		if (r2.isSignedIn || r2.nextStep.name !== 'CONFIRM_SIGN_IN_WITH_PASSWORD') return;
+		if (r2.status !== 'continueSignIn' || r2.nextStep.name !== 'CONFIRM_SIGN_IN_WITH_PASSWORD') return;
 		const done = await auth.confirmSignIn(r2.nextStep.session, { password: 'Password!1' }, ctx());
-		assert.strictEqual(done.isSignedIn, true);
+		assert.strictEqual(done.status, 'signedIn');
 	});
 
 	test('15: USER_AUTH no preference → pick EMAIL_OTP → code → signed in', async () => {
@@ -359,11 +359,11 @@ describe('scenarios.mock', () => {
 		await auth.confirmSignUp('u15@test.example', lastCode());
 
 		const r1 = await auth.signIn('u15@test.example', '', ctx());
-		if (r1.isSignedIn || r1.nextStep.name !== 'CONTINUE_SIGN_IN_WITH_FIRST_FACTOR_SELECTION') return;
+		if (r1.status !== 'continueSignIn' || r1.nextStep.name !== 'CONTINUE_SIGN_IN_WITH_FIRST_FACTOR_SELECTION') return;
 		const r2 = await auth.confirmSignIn(r1.nextStep.session, { firstFactor: 'EMAIL_OTP' }, ctx());
-		if (r2.isSignedIn || r2.nextStep.name !== 'CONFIRM_SIGN_IN_WITH_FIRST_FACTOR_EMAIL_OTP') return;
+		if (r2.status !== 'continueSignIn' || r2.nextStep.name !== 'CONFIRM_SIGN_IN_WITH_FIRST_FACTOR_EMAIL_OTP') return;
 		const done = await auth.confirmSignIn(r2.nextStep.session, { code: lastCode() }, ctx());
-		assert.strictEqual(done.isSignedIn, true);
+		assert.strictEqual(done.status, 'signedIn');
 	});
 
 	test('16: USER_AUTH no preference → pick SMS_OTP → code → signed in', async () => {
@@ -378,11 +378,11 @@ describe('scenarios.mock', () => {
 		await auth.confirmSignUp('u16@test.example', lastCode());
 
 		const r1 = await auth.signIn('u16@test.example', '', ctx());
-		if (r1.isSignedIn || r1.nextStep.name !== 'CONTINUE_SIGN_IN_WITH_FIRST_FACTOR_SELECTION') return;
+		if (r1.status !== 'continueSignIn' || r1.nextStep.name !== 'CONTINUE_SIGN_IN_WITH_FIRST_FACTOR_SELECTION') return;
 		const r2 = await auth.confirmSignIn(r1.nextStep.session, { firstFactor: 'SMS_OTP' }, ctx());
-		if (r2.isSignedIn || r2.nextStep.name !== 'CONFIRM_SIGN_IN_WITH_FIRST_FACTOR_SMS_OTP') return;
+		if (r2.status !== 'continueSignIn' || r2.nextStep.name !== 'CONFIRM_SIGN_IN_WITH_FIRST_FACTOR_SMS_OTP') return;
 		const done = await auth.confirmSignIn(r2.nextStep.session, { code: lastCode() }, ctx());
-		assert.strictEqual(done.isSignedIn, true);
+		assert.strictEqual(done.status, 'signedIn');
 	});
 });
 

--- a/packages/bb-auth-cognito/src/scenarios.passwordless-demo.sandbox.test.ts
+++ b/packages/bb-auth-cognito/src/scenarios.passwordless-demo.sandbox.test.ts
@@ -178,7 +178,7 @@ describe('passwordless-demo.sandbox · matches the template config', { skip: !EN
 
 			const autoCtx = roll(confirmCtx);
 			const done = await auth.autoSignIn(autoCtx);
-			assert.strictEqual(done.isSignedIn, true);
+			assert.strictEqual(done.status, 'signedIn');
 		} finally {
 			await deleteUser(pool, username);
 		}
@@ -196,13 +196,13 @@ describe('passwordless-demo.sandbox · matches the template config', { skip: !EN
 			await auth.confirmSignUp(username, signUpCode);
 
 			const r1 = await auth.signIn(username, '', ctx());
-			if (r1.isSignedIn) throw new Error('expected EMAIL_OTP challenge');
+			if (r1.status === 'signedIn') throw new Error('expected EMAIL_OTP challenge');
 			assert.strictEqual(r1.nextStep.name, 'CONFIRM_SIGN_IN_WITH_FIRST_FACTOR_EMAIL_OTP');
 			if (r1.nextStep.name !== 'CONFIRM_SIGN_IN_WITH_FIRST_FACTOR_EMAIL_OTP') return;
 
 			const otp = await pool.captureCode!(username, 'mfa');
 			const done = await auth.confirmSignIn(r1.nextStep.session, { code: otp }, ctx());
-			assert.strictEqual(done.isSignedIn, true);
+			assert.strictEqual(done.status, 'signedIn');
 		} finally {
 			await deleteUser(pool, username);
 		}

--- a/packages/bb-auth-cognito/src/scenarios.sandbox.test.ts
+++ b/packages/bb-auth-cognito/src/scenarios.sandbox.test.ts
@@ -90,7 +90,7 @@ describe('scenarios.sandbox · Pool A (mfa:off)', { skip: !ENABLED }, () => {
 			const code = await pool.captureCode!(username, 'signup');
 			await auth.confirmSignUp(username, code);
 			const r = await auth.signIn(username, password, ctx());
-			assert.strictEqual(r.isSignedIn, true);
+			assert.strictEqual(r.status, 'signedIn');
 		} finally {
 			await deleteUser(pool, username);
 		}
@@ -106,7 +106,7 @@ describe('scenarios.sandbox · Pool A (mfa:off)', { skip: !ENABLED }, () => {
 			const code = await pool.captureCode!(username, 'forgot');
 			await auth.confirmResetPassword(username, code, 'NewPass!1');
 			const r = await auth.signIn(username, 'NewPass!1', ctx());
-			assert.strictEqual(r.isSignedIn, true);
+			assert.strictEqual(r.status, 'signedIn');
 		} finally {
 			await deleteUser(pool, username);
 		}
@@ -130,7 +130,7 @@ describe('scenarios.sandbox · Pool B (mfa:optional)', { skip: !ENABLED }, () =>
 		try {
 			const auth = authFor(pool, `s2-${Math.random().toString(36).slice(2, 6)}`);
 			const r = await auth.signIn(username, password, ctx());
-			assert.strictEqual(r.isSignedIn, true);
+			assert.strictEqual(r.status, 'signedIn');
 		} finally {
 			await deleteUser(pool, username);
 		}
@@ -150,11 +150,11 @@ describe('scenarios.sandbox · Pool B (mfa:optional)', { skip: !ENABLED }, () =>
 		try {
 			const auth = authFor(pool, `s9-${Math.random().toString(36).slice(2, 6)}`);
 			const r1 = await auth.signIn(username, tempPassword, ctx());
-			if (r1.isSignedIn) throw new Error('expected NEW_PASSWORD_REQUIRED');
+			if (r1.status === 'signedIn') throw new Error('expected NEW_PASSWORD_REQUIRED');
 			assert.strictEqual(r1.nextStep.name, 'CONFIRM_SIGN_IN_WITH_NEW_PASSWORD_REQUIRED');
 			if (r1.nextStep.name !== 'CONFIRM_SIGN_IN_WITH_NEW_PASSWORD_REQUIRED') return;
 			const r2 = await auth.confirmSignIn(r1.nextStep.session, { newPassword: 'FinalPass!1' }, ctx());
-			assert.strictEqual(r2.isSignedIn, true);
+			assert.strictEqual(r2.status, 'signedIn');
 		} finally {
 			await deleteUser(pool, username);
 		}
@@ -178,23 +178,23 @@ describe('scenarios.sandbox · Pool C (required, TOTP only)', { skip: !ENABLED }
 		try {
 			const auth = authFor(pool, `s3-${Math.random().toString(36).slice(2, 6)}`);
 			const r1 = await auth.signIn(username, password, ctx());
-			if (r1.isSignedIn) throw new Error('expected TOTP setup');
+			if (r1.status === 'signedIn') throw new Error('expected TOTP setup');
 			assert.strictEqual(r1.nextStep.name, 'CONTINUE_SIGN_IN_WITH_TOTP_SETUP');
 			if (r1.nextStep.name !== 'CONTINUE_SIGN_IN_WITH_TOTP_SETUP') return;
 			const sharedSecret = r1.nextStep.sharedSecret;
 			const setup = await auth.confirmSignIn(r1.nextStep.session, { code: totpNow(sharedSecret) }, ctx());
-			assert.strictEqual(setup.isSignedIn, true, 'setup completes');
+			assert.strictEqual(setup.status, 'signedIn', 'setup completes');
 
 			// Wait past current TOTP window (code reuse rejected).
 			const wait = 30 - (Math.floor(Date.now() / 1000) % 30) + 2;
 			await new Promise((r) => setTimeout(r, wait * 1000));
 
 			const r2 = await auth.signIn(username, password, ctx());
-			if (r2.isSignedIn) throw new Error('expected TOTP challenge');
+			if (r2.status === 'signedIn') throw new Error('expected TOTP challenge');
 			assert.strictEqual(r2.nextStep.name, 'CONFIRM_SIGN_IN_WITH_TOTP_CODE');
 			if (r2.nextStep.name !== 'CONFIRM_SIGN_IN_WITH_TOTP_CODE') return;
 			const done = await auth.confirmSignIn(r2.nextStep.session, { code: totpNow(sharedSecret) }, ctx());
-			assert.strictEqual(done.isSignedIn, true);
+			assert.strictEqual(done.status, 'signedIn');
 		} finally {
 			await deleteUser(pool, username);
 		}
@@ -241,12 +241,12 @@ describe('scenarios.sandbox · Pool D (required, EMAIL only)', { skip: !ENABLED 
 		try {
 			const auth = authFor(pool, `s4-${Math.random().toString(36).slice(2, 6)}`);
 			const r1 = await auth.signIn(username, password, ctx());
-			if (r1.isSignedIn) throw new Error('expected EMAIL challenge');
+			if (r1.status === 'signedIn') throw new Error('expected EMAIL challenge');
 			assert.strictEqual(r1.nextStep.name, 'CONFIRM_SIGN_IN_WITH_EMAIL_CODE');
 			if (r1.nextStep.name !== 'CONFIRM_SIGN_IN_WITH_EMAIL_CODE') return;
 			const code = await pool.captureCode!(username, 'mfa');
 			const done = await auth.confirmSignIn(r1.nextStep.session, { code }, ctx());
-			assert.strictEqual(done.isSignedIn, true);
+			assert.strictEqual(done.status, 'signedIn');
 		} finally {
 			await deleteUser(pool, username);
 		}
@@ -297,12 +297,12 @@ describe('scenarios.sandbox · Pool E (required, TOTP+EMAIL)', { skip: !ENABLED 
 		try {
 			const auth = authFor(pool, `s5-${Math.random().toString(36).slice(2, 6)}`);
 			const r1 = await auth.signIn(username, password, ctx());
-			if (r1.isSignedIn) throw new Error('expected EMAIL challenge');
+			if (r1.status === 'signedIn') throw new Error('expected EMAIL challenge');
 			assert.strictEqual(r1.nextStep.name, 'CONFIRM_SIGN_IN_WITH_EMAIL_CODE');
 			if (r1.nextStep.name !== 'CONFIRM_SIGN_IN_WITH_EMAIL_CODE') return;
 			const code = await pool.captureCode!(username, 'mfa');
 			const done = await auth.confirmSignIn(r1.nextStep.session, { code }, ctx());
-			assert.strictEqual(done.isSignedIn, true);
+			assert.strictEqual(done.status, 'signedIn');
 		} finally {
 			await deleteUser(pool, username);
 		}
@@ -335,15 +335,15 @@ describe('scenarios.sandbox · Pool E (required, TOTP+EMAIL)', { skip: !ENABLED 
 		try {
 			const auth = authFor(pool, `s6-${Math.random().toString(36).slice(2, 6)}`);
 			const r1 = await auth.signIn(username, password, ctx());
-			if (r1.isSignedIn || r1.nextStep.name !== 'CONTINUE_SIGN_IN_WITH_MFA_SETUP_SELECTION') return;
+			if (r1.status !== 'continueSignIn' || r1.nextStep.name !== 'CONTINUE_SIGN_IN_WITH_MFA_SETUP_SELECTION') return;
 			const r2 = await auth.confirmSignIn(r1.nextStep.session, { mfaType: 'EMAIL' as 'EMAIL' }, ctx());
-			if (r2.isSignedIn || r2.nextStep.name !== 'CONTINUE_SIGN_IN_WITH_EMAIL_SETUP') return;
+			if (r2.status !== 'continueSignIn' || r2.nextStep.name !== 'CONTINUE_SIGN_IN_WITH_EMAIL_SETUP') return;
 			const newEmail = uniqueUser('s6-new');
 			const r3 = await auth.confirmSignIn(r2.nextStep.session, { email: newEmail }, ctx());
-			if (r3.isSignedIn || r3.nextStep.name !== 'CONFIRM_SIGN_IN_WITH_EMAIL_CODE') return;
+			if (r3.status !== 'continueSignIn' || r3.nextStep.name !== 'CONFIRM_SIGN_IN_WITH_EMAIL_CODE') return;
 			const code = await pool.captureCode!(newEmail, 'mfa');
 			const done = await auth.confirmSignIn(r3.nextStep.session, { code }, ctx());
-			assert.strictEqual(done.isSignedIn, true);
+			assert.strictEqual(done.status, 'signedIn');
 		} finally {
 			await deleteUser(pool, username);
 		}
@@ -376,12 +376,12 @@ describe('scenarios.sandbox · Pool F (optional, SMS+TOTP)', { skip: !ENABLED },
 			await setMfaPreference(pool, username, { sms: { enabled: true, preferred: true } });
 			const auth = authFor(pool, `s7-${Math.random().toString(36).slice(2, 6)}`);
 			const r1 = await auth.signIn(username, password, ctx());
-			if (r1.isSignedIn) throw new Error('expected SMS challenge');
+			if (r1.status === 'signedIn') throw new Error('expected SMS challenge');
 			assert.strictEqual(r1.nextStep.name, 'CONFIRM_SIGN_IN_WITH_SMS_CODE');
 			if (r1.nextStep.name !== 'CONFIRM_SIGN_IN_WITH_SMS_CODE') return;
 			const code = await pool.captureCode!(username, 'mfa');
 			const done = await auth.confirmSignIn(r1.nextStep.session, { code }, ctx());
-			assert.strictEqual(done.isSignedIn, true);
+			assert.strictEqual(done.status, 'signedIn');
 		} finally {
 			await deleteUser(pool, username);
 		}
@@ -398,14 +398,14 @@ describe('scenarios.sandbox · Pool F (optional, SMS+TOTP)', { skip: !ENABLED },
 			// Sign in (no challenge, OPTIONAL + nothing enrolled).
 			const auth = authFor(pool, `s8-${Math.random().toString(36).slice(2, 6)}`);
 			const signIn = await auth.signIn(username, password, ctx());
-			if (!signIn.isSignedIn) throw new Error('expected direct signIn');
+			if (signIn.status === 'continueSignIn') throw new Error('expected direct signIn');
 
 			// Associate TOTP via access token.
 			const tokens = await auth.fetchAuthSession(roll(ctx()));
 			// Hack: previous ctx is gone; use a fresh signIn to get usable access token.
 			const signInCtx = ctx();
 			const fresh = await auth.signIn(username, password, signInCtx);
-			if (!fresh.isSignedIn) return;
+			if (fresh.status === 'continueSignIn') return;
 			const fetchCtx = roll(signInCtx);
 			const session = await auth.fetchAuthSession(fetchCtx);
 			const accessToken = session.tokens?.accessToken?.toString();
@@ -433,15 +433,15 @@ describe('scenarios.sandbox · Pool F (optional, SMS+TOTP)', { skip: !ENABLED },
 
 			// New sign-in hits SELECT_MFA_TYPE.
 			const r1 = await auth.signIn(username, password, ctx());
-			if (r1.isSignedIn) throw new Error('expected SELECT_MFA_TYPE');
+			if (r1.status === 'signedIn') throw new Error('expected SELECT_MFA_TYPE');
 			assert.strictEqual(r1.nextStep.name, 'CONTINUE_SIGN_IN_WITH_MFA_SELECTION');
 			if (r1.nextStep.name !== 'CONTINUE_SIGN_IN_WITH_MFA_SELECTION') return;
 			assert.ok(r1.nextStep.allowedMFATypes.includes('TOTP'));
 			assert.ok(r1.nextStep.allowedMFATypes.includes('SMS'));
 			const r2 = await auth.confirmSignIn(r1.nextStep.session, { mfaType: 'TOTP' as 'TOTP' }, ctx());
-			if (r2.isSignedIn || r2.nextStep.name !== 'CONFIRM_SIGN_IN_WITH_TOTP_CODE') return;
+			if (r2.status !== 'continueSignIn' || r2.nextStep.name !== 'CONFIRM_SIGN_IN_WITH_TOTP_CODE') return;
 			const done = await auth.confirmSignIn(r2.nextStep.session, { code: totpNow(sharedSecret) }, ctx());
-			assert.strictEqual(done.isSignedIn, true);
+			assert.strictEqual(done.status, 'signedIn');
 		} finally {
 			await deleteUser(pool, username);
 		}
@@ -481,7 +481,7 @@ describe('scenarios.sandbox · Pool G (USER_AUTH)', { skip: !ENABLED }, () => {
 				preferredChallenge: 'PASSWORD',
 			});
 			const r = await auth.signIn(username, password, ctx());
-			assert.strictEqual(r.isSignedIn, true);
+			assert.strictEqual(r.status, 'signedIn');
 		} finally {
 			await deleteUser(pool, username);
 		}
@@ -497,12 +497,12 @@ describe('scenarios.sandbox · Pool G (USER_AUTH)', { skip: !ENABLED }, () => {
 				preferredChallenge: 'EMAIL_OTP',
 			});
 			const r1 = await auth.signIn(username, '', ctx());
-			if (r1.isSignedIn) throw new Error('expected email OTP');
+			if (r1.status === 'signedIn') throw new Error('expected email OTP');
 			assert.strictEqual(r1.nextStep.name, 'CONFIRM_SIGN_IN_WITH_FIRST_FACTOR_EMAIL_OTP');
 			if (r1.nextStep.name !== 'CONFIRM_SIGN_IN_WITH_FIRST_FACTOR_EMAIL_OTP') return;
 			const code = await pool.captureCode!(username, 'mfa');
 			const done = await auth.confirmSignIn(r1.nextStep.session, { code }, ctx());
-			assert.strictEqual(done.isSignedIn, true);
+			assert.strictEqual(done.status, 'signedIn');
 		} finally {
 			await deleteUser(pool, username);
 		}
@@ -521,12 +521,12 @@ describe('scenarios.sandbox · Pool G (USER_AUTH)', { skip: !ENABLED }, () => {
 				preferredChallenge: 'SMS_OTP',
 			});
 			const r1 = await auth.signIn(username, '', ctx());
-			if (r1.isSignedIn) throw new Error('expected SMS OTP');
+			if (r1.status === 'signedIn') throw new Error('expected SMS OTP');
 			assert.strictEqual(r1.nextStep.name, 'CONFIRM_SIGN_IN_WITH_FIRST_FACTOR_SMS_OTP');
 			if (r1.nextStep.name !== 'CONFIRM_SIGN_IN_WITH_FIRST_FACTOR_SMS_OTP') return;
 			const code = await pool.captureCode!(username, 'mfa');
 			const done = await auth.confirmSignIn(r1.nextStep.session, { code }, ctx());
-			assert.strictEqual(done.isSignedIn, true);
+			assert.strictEqual(done.status, 'signedIn');
 		} finally {
 			await deleteUser(pool, username);
 		}
@@ -539,13 +539,13 @@ describe('scenarios.sandbox · Pool G (USER_AUTH)', { skip: !ENABLED }, () => {
 		try {
 			const auth = authFor(pool, `s14-${Math.random().toString(36).slice(2, 6)}`, { authFlowType: 'USER_AUTH' });
 			const r1 = await auth.signIn(username, '', ctx());
-			if (r1.isSignedIn) throw new Error('expected SELECT_CHALLENGE');
+			if (r1.status === 'signedIn') throw new Error('expected SELECT_CHALLENGE');
 			assert.strictEqual(r1.nextStep.name, 'CONTINUE_SIGN_IN_WITH_FIRST_FACTOR_SELECTION');
 			if (r1.nextStep.name !== 'CONTINUE_SIGN_IN_WITH_FIRST_FACTOR_SELECTION') return;
 			const r2 = await auth.confirmSignIn(r1.nextStep.session, { firstFactor: 'PASSWORD' }, ctx());
-			if (r2.isSignedIn || r2.nextStep.name !== 'CONFIRM_SIGN_IN_WITH_PASSWORD') return;
+			if (r2.status !== 'continueSignIn' || r2.nextStep.name !== 'CONFIRM_SIGN_IN_WITH_PASSWORD') return;
 			const done = await auth.confirmSignIn(r2.nextStep.session, { password }, ctx());
-			assert.strictEqual(done.isSignedIn, true);
+			assert.strictEqual(done.status, 'signedIn');
 		} finally {
 			await deleteUser(pool, username);
 		}
@@ -558,12 +558,12 @@ describe('scenarios.sandbox · Pool G (USER_AUTH)', { skip: !ENABLED }, () => {
 		try {
 			const auth = authFor(pool, `s15-${Math.random().toString(36).slice(2, 6)}`, { authFlowType: 'USER_AUTH' });
 			const r1 = await auth.signIn(username, '', ctx());
-			if (r1.isSignedIn || r1.nextStep.name !== 'CONTINUE_SIGN_IN_WITH_FIRST_FACTOR_SELECTION') return;
+			if (r1.status !== 'continueSignIn' || r1.nextStep.name !== 'CONTINUE_SIGN_IN_WITH_FIRST_FACTOR_SELECTION') return;
 			const r2 = await auth.confirmSignIn(r1.nextStep.session, { firstFactor: 'EMAIL_OTP' }, ctx());
-			if (r2.isSignedIn || r2.nextStep.name !== 'CONFIRM_SIGN_IN_WITH_FIRST_FACTOR_EMAIL_OTP') return;
+			if (r2.status !== 'continueSignIn' || r2.nextStep.name !== 'CONFIRM_SIGN_IN_WITH_FIRST_FACTOR_EMAIL_OTP') return;
 			const code = await pool.captureCode!(username, 'mfa');
 			const done = await auth.confirmSignIn(r2.nextStep.session, { code }, ctx());
-			assert.strictEqual(done.isSignedIn, true);
+			assert.strictEqual(done.status, 'signedIn');
 		} finally {
 			await deleteUser(pool, username);
 		}
@@ -579,12 +579,12 @@ describe('scenarios.sandbox · Pool G (USER_AUTH)', { skip: !ENABLED }, () => {
 		try {
 			const auth = authFor(pool, `s16-${Math.random().toString(36).slice(2, 6)}`, { authFlowType: 'USER_AUTH' });
 			const r1 = await auth.signIn(username, '', ctx());
-			if (r1.isSignedIn || r1.nextStep.name !== 'CONTINUE_SIGN_IN_WITH_FIRST_FACTOR_SELECTION') return;
+			if (r1.status !== 'continueSignIn' || r1.nextStep.name !== 'CONTINUE_SIGN_IN_WITH_FIRST_FACTOR_SELECTION') return;
 			const r2 = await auth.confirmSignIn(r1.nextStep.session, { firstFactor: 'SMS_OTP' }, ctx());
-			if (r2.isSignedIn || r2.nextStep.name !== 'CONFIRM_SIGN_IN_WITH_FIRST_FACTOR_SMS_OTP') return;
+			if (r2.status !== 'continueSignIn' || r2.nextStep.name !== 'CONFIRM_SIGN_IN_WITH_FIRST_FACTOR_SMS_OTP') return;
 			const code = await pool.captureCode!(username, 'mfa');
 			const done = await auth.confirmSignIn(r2.nextStep.session, { code }, ctx());
-			assert.strictEqual(done.isSignedIn, true);
+			assert.strictEqual(done.status, 'signedIn');
 		} finally {
 			await deleteUser(pool, username);
 		}

--- a/packages/bb-auth-cognito/src/types.ts
+++ b/packages/bb-auth-cognito/src/types.ts
@@ -635,12 +635,23 @@ export type ConfirmSignInResponse<O extends AuthCognitoOptions = AuthCognitoOpti
 	| { credential: string };
 
 /**
- * Tagged union on `isSignedIn`. TypeScript narrows the branch automatically
- * inside an `if (result.isSignedIn)` check.
+ * Tagged union on the string `status` field. TypeScript narrows the branch
+ * automatically inside an `if (result.status === 'signedIn')` check, and the
+ * `status` value is the discriminator native clients (Swift / Kotlin / Dart)
+ * key off when generating their result types.
+ *
+ * `status` is a string literal rather than a boolean on purpose: the native
+ * generators detect a discriminated union only when each arm carries a
+ * single-value **string** `const`/`enum` field. A boolean discriminator
+ * (`isSignedIn: true | false`) is invisible to them — they fall back to numeric
+ * `_Variant0/1` structs and try-each-variant decoding that fails to compile —
+ * and a boolean value can't name a variant (`true`/`false` are reserved words
+ * in all three languages). A string discriminator emits clean, named,
+ * switch-decoded variants on every platform.
  */
 export type SignInResult<O extends AuthCognitoOptions = AuthCognitoOptions> =
-	| { isSignedIn: true; user: CognitoUser<O> }
-	| { isSignedIn: false; nextStep: SignInNextStep };
+	| { status: 'signedIn'; user: CognitoUser<O> }
+	| { status: 'continueSignIn'; nextStep: SignInNextStep };
 
 /**
  * Every challenge / continuation state `signIn` and `confirmSignIn` can

--- a/packages/bb-auth-cognito/src/user-auth-integration.test.ts
+++ b/packages/bb-auth-cognito/src/user-auth-integration.test.ts
@@ -117,14 +117,14 @@ describe('MFA_SETUP TOTP (real Cognito)', { skip: !ENABLED }, () => {
 			const ctx = freshCtx();
 
 			const r1 = await auth.signIn(username, password, ctx);
-			if (r1.isSignedIn) throw new Error('expected MFA_SETUP challenge on first login');
+			if (r1.status === 'signedIn') throw new Error('expected MFA_SETUP challenge on first login');
 			assert.strictEqual(r1.nextStep.name, 'CONTINUE_SIGN_IN_WITH_TOTP_SETUP');
 			if (r1.nextStep.name !== 'CONTINUE_SIGN_IN_WITH_TOTP_SETUP') return;
 			assert.ok(r1.nextStep.sharedSecret.length > 0, 'secret from AssociateSoftwareToken');
 
 			const code = totpNow(r1.nextStep.sharedSecret);
 			const r2 = await auth.confirmSignIn(r1.nextStep.session, { code }, ctx);
-			assert.strictEqual(r2.isSignedIn, true, 'VerifySoftwareToken + RespondToAuthChallenge succeed');
+			assert.strictEqual(r2.status, 'signedIn', 'VerifySoftwareToken + RespondToAuthChallenge succeed');
 		} finally {
 			await deleteUser(pool, username);
 		}
@@ -159,7 +159,7 @@ describe('enrolled TOTP MFA (real Cognito)', { skip: !ENABLED }, () => {
 			// with TOTP enabled), completing the ceremony, then signing back
 			// out and signing in again to test the enrolled path.
 			const r1 = await auth.signIn(username, password, ctx);
-			if (r1.isSignedIn) throw new Error('expected MFA_SETUP on first login');
+			if (r1.status === 'signedIn') throw new Error('expected MFA_SETUP on first login');
 			if (r1.nextStep.name !== 'CONTINUE_SIGN_IN_WITH_TOTP_SETUP') {
 				throw new Error(`unexpected step: ${r1.nextStep.name}`);
 			}
@@ -178,11 +178,11 @@ describe('enrolled TOTP MFA (real Cognito)', { skip: !ENABLED }, () => {
 			// Second sign-in: TOTP challenge this time (not setup).
 			const ctx2 = freshCtx();
 			const r2 = await auth.signIn(username, password, ctx2);
-			if (r2.isSignedIn) throw new Error('expected TOTP challenge');
+			if (r2.status === 'signedIn') throw new Error('expected TOTP challenge');
 			assert.strictEqual(r2.nextStep.name, 'CONFIRM_SIGN_IN_WITH_TOTP_CODE');
 			if (r2.nextStep.name !== 'CONFIRM_SIGN_IN_WITH_TOTP_CODE') return;
 			const r3 = await auth.confirmSignIn(r2.nextStep.session, { code: totpNow(sharedSecret) }, ctx2);
-			assert.strictEqual(r3.isSignedIn, true);
+			assert.strictEqual(r3.status, 'signedIn');
 		} finally {
 			await deleteUser(pool, username);
 		}
@@ -221,7 +221,7 @@ describe('enrolled SMS MFA (real Cognito, capture sender)', { skip: !ENABLED }, 
 			const ctx = freshCtx();
 
 			const r1 = await auth.signIn(username, password, ctx);
-			if (r1.isSignedIn) throw new Error('expected SMS_MFA challenge');
+			if (r1.status === 'signedIn') throw new Error('expected SMS_MFA challenge');
 			assert.strictEqual(r1.nextStep.name, 'CONFIRM_SIGN_IN_WITH_SMS_CODE');
 			if (r1.nextStep.name !== 'CONFIRM_SIGN_IN_WITH_SMS_CODE') return;
 			const smsStep = r1.nextStep;
@@ -231,7 +231,7 @@ describe('enrolled SMS MFA (real Cognito, capture sender)', { skip: !ENABLED }, 
 			assert.match(code, /^\d{6}$/, 'Cognito delivered a 6-digit SMS code');
 
 			const r2 = await auth.confirmSignIn(smsStep.session, { code }, ctx);
-			assert.strictEqual(r2.isSignedIn, true);
+			assert.strictEqual(r2.status, 'signedIn');
 		} finally {
 			await deleteUser(pool, username);
 		}
@@ -268,7 +268,7 @@ describe('enrolled EMAIL MFA (real Cognito, capture sender)', { skip: !ENABLED }
 			const ctx = freshCtx();
 
 			const r1 = await auth.signIn(username, password, ctx);
-			if (r1.isSignedIn) throw new Error('expected EMAIL_OTP challenge');
+			if (r1.status === 'signedIn') throw new Error('expected EMAIL_OTP challenge');
 			assert.strictEqual(r1.nextStep.name, 'CONFIRM_SIGN_IN_WITH_EMAIL_CODE');
 			if (r1.nextStep.name !== 'CONFIRM_SIGN_IN_WITH_EMAIL_CODE') return;
 			const emailStep = r1.nextStep;
@@ -278,7 +278,7 @@ describe('enrolled EMAIL MFA (real Cognito, capture sender)', { skip: !ENABLED }
 			assert.match(code, /^\d{6}$/, 'Cognito delivered a 6-digit email code');
 
 			const r2 = await auth.confirmSignIn(emailStep.session, { code }, ctx);
-			assert.strictEqual(r2.isSignedIn, true);
+			assert.strictEqual(r2.status, 'signedIn');
 		} finally {
 			await deleteUser(pool, username);
 		}
@@ -320,7 +320,7 @@ describe('SELECT_MFA_TYPE (real Cognito)', { skip: !ENABLED }, () => {
 			const auth = authFor(pool, `select-${Math.random().toString(36).slice(2, 6)}`);
 			const ctxEnroll = freshCtx();
 			const signIn = await auth.signIn(username, password, ctxEnroll);
-			if (!signIn.isSignedIn) {
+			if (signIn.status === 'continueSignIn') {
 				throw new Error(`expected signed-in; got ${signIn.nextStep.name}`);
 			}
 
@@ -356,18 +356,18 @@ describe('SELECT_MFA_TYPE (real Cognito)', { skip: !ENABLED }, () => {
 
 			const ctx = freshCtx();
 			const r1 = await auth.signIn(username, password, ctx);
-			if (r1.isSignedIn) throw new Error('expected SELECT_MFA_TYPE');
+			if (r1.status === 'signedIn') throw new Error('expected SELECT_MFA_TYPE');
 			assert.strictEqual(r1.nextStep.name, 'CONTINUE_SIGN_IN_WITH_MFA_SELECTION');
 			if (r1.nextStep.name !== 'CONTINUE_SIGN_IN_WITH_MFA_SELECTION') return;
 			assert.ok(r1.nextStep.allowedMFATypes.includes('TOTP'));
 			assert.ok(r1.nextStep.allowedMFATypes.includes('SMS'));
 
 			const r2 = await auth.confirmSignIn(r1.nextStep.session, { mfaType: 'TOTP' as 'TOTP' }, ctx);
-			if (r2.isSignedIn) throw new Error('expected TOTP challenge after pick');
+			if (r2.status === 'signedIn') throw new Error('expected TOTP challenge after pick');
 			assert.strictEqual(r2.nextStep.name, 'CONFIRM_SIGN_IN_WITH_TOTP_CODE');
 			if (r2.nextStep.name !== 'CONFIRM_SIGN_IN_WITH_TOTP_CODE') return;
 			const r3 = await auth.confirmSignIn(r2.nextStep.session, { code: totpNow(sharedSecret) }, ctx);
-			assert.strictEqual(r3.isSignedIn, true);
+			assert.strictEqual(r3.status, 'signedIn');
 		} finally {
 			await deleteUser(pool, username);
 		}
@@ -399,11 +399,11 @@ describe('NEW_PASSWORD_REQUIRED (real Cognito)', { skip: !ENABLED }, () => {
 			const auth = authFor(pool, `newpw-${Math.random().toString(36).slice(2, 6)}`);
 			const ctx = freshCtx();
 			const r1 = await auth.signIn(username, tempPassword, ctx);
-			if (r1.isSignedIn) throw new Error('expected NEW_PASSWORD_REQUIRED');
+			if (r1.status === 'signedIn') throw new Error('expected NEW_PASSWORD_REQUIRED');
 			assert.strictEqual(r1.nextStep.name, 'CONFIRM_SIGN_IN_WITH_NEW_PASSWORD_REQUIRED');
 			if (r1.nextStep.name !== 'CONFIRM_SIGN_IN_WITH_NEW_PASSWORD_REQUIRED') return;
 			const r2 = await auth.confirmSignIn(r1.nextStep.session, { newPassword: 'FinalPass!1234' }, ctx);
-			assert.strictEqual(r2.isSignedIn, true);
+			assert.strictEqual(r2.status, 'signedIn');
 		} finally {
 			await deleteUser(pool, username);
 		}
@@ -435,7 +435,7 @@ describe('USER_AUTH flow (real Cognito)', { skip: !ENABLED }, () => {
 			// intermediate CONFIRM_SIGN_IN_WITH_PASSWORD step. This matches
 			// Amplify-JS v6's bundled wire shape.
 			const r1 = await auth.signIn(username, password, ctx);
-			assert.strictEqual(r1.isSignedIn, true);
+			assert.strictEqual(r1.status, 'signedIn');
 		} finally {
 			await deleteUser(pool, username);
 		}
@@ -450,15 +450,15 @@ describe('USER_AUTH flow (real Cognito)', { skip: !ENABLED }, () => {
 			const ctx = freshCtx();
 
 			const r1 = await auth.signIn(username, '', ctx);
-			if (r1.isSignedIn) throw new Error('expected SELECT_CHALLENGE');
+			if (r1.status === 'signedIn') throw new Error('expected SELECT_CHALLENGE');
 			assert.strictEqual(r1.nextStep.name, 'CONTINUE_SIGN_IN_WITH_FIRST_FACTOR_SELECTION');
 			if (r1.nextStep.name !== 'CONTINUE_SIGN_IN_WITH_FIRST_FACTOR_SELECTION') return;
 			const r2 = await auth.confirmSignIn(r1.nextStep.session, { firstFactor: 'PASSWORD' }, ctx);
-			if (r2.isSignedIn) throw new Error('expected password challenge');
+			if (r2.status === 'signedIn') throw new Error('expected password challenge');
 			assert.strictEqual(r2.nextStep.name, 'CONFIRM_SIGN_IN_WITH_PASSWORD');
 			if (r2.nextStep.name !== 'CONFIRM_SIGN_IN_WITH_PASSWORD') return;
 			const r3 = await auth.confirmSignIn(r2.nextStep.session, { password }, ctx);
-			assert.strictEqual(r3.isSignedIn, true);
+			assert.strictEqual(r3.status, 'signedIn');
 		} finally {
 			await deleteUser(pool, username);
 		}
@@ -509,7 +509,7 @@ describe('customer-SES regression (shape-only)', { skip: !CUSTOMER_SES_ENABLED }
 			const ctx = freshCtx();
 
 			const r1 = await auth.signIn(username, password, ctx);
-			if (r1.isSignedIn) throw new Error('expected EMAIL_OTP challenge');
+			if (r1.status === 'signedIn') throw new Error('expected EMAIL_OTP challenge');
 			assert.strictEqual(r1.nextStep.name, 'CONFIRM_SIGN_IN_WITH_EMAIL_CODE');
 			if (r1.nextStep.name !== 'CONFIRM_SIGN_IN_WITH_EMAIL_CODE') return;
 			const emailStep = r1.nextStep;

--- a/test-apps/comprehensive/aws-blocks/index.ts
+++ b/test-apps/comprehensive/aws-blocks/index.ts
@@ -1005,11 +1005,11 @@ export const api = new ApiNamespace(scope, 'api', (context) => ({
   // project to strings + narrowed claims for the RPC boundary.
   async authCFetchAuthSession() {
     const session = await authC.fetchAuthSession(context);
-    if (!session.tokens) return { signedIn: false as const };
+    if (!session.tokens) return { status: 'signedOut' as const };
     const payload = session.tokens.idToken.payload;
     const sub = typeof payload.sub === 'string' ? payload.sub : null;
     return {
-      signedIn: true as const,
+      status: 'signedIn' as const,
       userSub: session.userSub ?? null,
       idToken: session.tokens.idToken.toString(),
       accessToken: session.tokens.accessToken.toString(),
@@ -1021,11 +1021,11 @@ export const api = new ApiNamespace(scope, 'api', (context) => ({
 
   async authCFetchAuthSessionForceRefresh() {
     const session = await authC.fetchAuthSession(context, { forceRefresh: true });
-    if (!session.tokens) return { signedIn: false as const };
+    if (!session.tokens) return { status: 'signedOut' as const };
     const payload = session.tokens.idToken.payload;
     const sub = typeof payload.sub === 'string' ? payload.sub : null;
     return {
-      signedIn: true as const,
+      status: 'signedIn' as const,
       userSub: session.userSub ?? null,
       idToken: session.tokens.idToken.toString(),
       accessToken: session.tokens.accessToken.toString(),

--- a/test-apps/comprehensive/test/auth-cognito-sandbox.test.ts
+++ b/test-apps/comprehensive/test/auth-cognito-sandbox.test.ts
@@ -118,8 +118,8 @@ export function authCognitoSandboxTests(getApi: () => typeof apiType) {
 
 				try {
 					const r = await api.authCSignIn(username, password);
-					assert.ok(r.isSignedIn);
-					if (r.isSignedIn) {
+					assert.strictEqual(r.status, 'signedIn');
+					if (r.status === 'signedIn') {
 						assert.strictEqual(r.user.username, username);
 					}
 					await api.authCSignOut();
@@ -217,8 +217,8 @@ export function authCognitoSandboxTests(getApi: () => typeof apiType) {
 				try {
 					await api.authCSignIn(username, password);
 					const s = await api.authCFetchAuthSession();
-					assert.strictEqual(s.signedIn, true);
-					if (!s.signedIn) throw new Error('unreachable');
+					assert.strictEqual(s.status, 'signedIn');
+					if (s.status !== 'signedIn') throw new Error('unreachable');
 					assert.ok(s.idToken.length > 0);
 					assert.ok(s.accessToken.length > 0);
 					assert.ok(s.userSub);

--- a/test-apps/comprehensive/test/auth-cognito.test.ts
+++ b/test-apps/comprehensive/test/auth-cognito.test.ts
@@ -65,8 +65,8 @@ export function authCognitoTests(getApi: () => typeof apiType) {
 				await createConfirmedUser(api, username, 'Password1!', `${username}@example.com`);
 
 				const r = await api.authCSignIn(username, 'Password1!');
-				assert.ok(r.isSignedIn);
-				if (r.isSignedIn) {
+				assert.strictEqual(r.status, 'signedIn');
+				if (r.status === 'signedIn') {
 					assert.strictEqual(r.user.username, username);
 				}
 				await api.authCSignOut();
@@ -237,7 +237,7 @@ export function authCognitoTests(getApi: () => typeof apiType) {
 
 				// New password works.
 				const r = await api.authCSignIn(username, 'New!Password2');
-				assert.ok(r.isSignedIn);
+				assert.strictEqual(r.status, 'signedIn');
 				await api.authCSignOut();
 			});
 		});
@@ -316,7 +316,7 @@ export function authCognitoTests(getApi: () => typeof apiType) {
 
 				// New password works; old does not.
 				const r = await api.authCSignIn(username, 'Reset!Pass9');
-				assert.ok(r.isSignedIn);
+				assert.strictEqual(r.status, 'signedIn');
 				await api.authCSignOut();
 
 				try {
@@ -336,7 +336,7 @@ export function authCognitoTests(getApi: () => typeof apiType) {
 				const api = getApi();
 				await api.authCSignOut();
 				const s = await api.authCFetchAuthSession();
-				assert.strictEqual(s.signedIn, false);
+				assert.strictEqual(s.status, 'signedOut');
 			});
 
 			// A9 — signed-in session returns real tokens + userSub + narrowed sub claim.
@@ -347,8 +347,8 @@ export function authCognitoTests(getApi: () => typeof apiType) {
 				await api.authCSignIn(username, 'Password1!');
 
 				const s = await api.authCFetchAuthSession();
-				assert.strictEqual(s.signedIn, true);
-				if (!s.signedIn) throw new Error('unreachable');
+				assert.strictEqual(s.status, 'signedIn');
+				if (s.status !== 'signedIn') throw new Error('unreachable');
 				assert.ok(s.idToken.length > 0, 'idToken must be a non-empty JWT string');
 				assert.ok(s.accessToken.length > 0, 'accessToken must be a non-empty JWT string');
 				assert.ok(s.userSub, 'userSub should be populated');
@@ -480,7 +480,7 @@ export function authCognitoTests(getApi: () => typeof apiType) {
 
 				// First sign-in skips the challenge (no factor enrolled yet).
 				const r = await api.authCMfaSignIn(username, 'Password1!');
-				if (!r.isSignedIn) throw new Error('expected direct sign-in (no factor enrolled)');
+				if (r.status !== 'signedIn') throw new Error('expected direct sign-in (no factor enrolled)');
 
 				// Enroll TOTP so updateMFAPreference tests that touch TOTP
 				// don't trip the "not associated" guard.
@@ -612,12 +612,12 @@ export function authCognitoTests(getApi: () => typeof apiType) {
 
 				// Second sign-in now issues a TOTP challenge.
 				const r = await api.authCMfaSignIn(username, 'Password1!');
-				if (r.isSignedIn) throw new Error('expected TOTP challenge');
+				if (r.status === 'signedIn') throw new Error('expected TOTP challenge');
 				const step = r.nextStep as { session: string; name: string };
 				assert.strictEqual(step.name, 'CONFIRM_SIGN_IN_WITH_TOTP_CODE');
 				// Mock accepts any 6-digit code; real Cognito validates RFC-6238.
 				const final = await api.authCMfaConfirmSignIn(step.session, '123456');
-				assert.ok(final.isSignedIn);
+				assert.strictEqual(final.status, 'signedIn');
 				await api.authCMfaSignOut();
 			});
 		});

--- a/test-apps/comprehensive/test/sandbox-admin-e2e.ts
+++ b/test-apps/comprehensive/test/sandbox-admin-e2e.ts
@@ -295,7 +295,7 @@ async function main() {
 		await runTest('signIn with valid creds issues a session', async () => {
 			const s = new ApiSession(stack.apiUrl);
 			const r = await s.call('authCSignIn', [username, 'Password1!']);
-			if (!r.isSignedIn) throw new Error(`expected isSignedIn=true, got ${JSON.stringify(r)}`);
+			if (r.status !== 'signedIn') throw new Error(`expected status=signedIn, got ${JSON.stringify(r)}`);
 			if (r.user.username !== username) throw new Error(`username mismatch: ${r.user.username}`);
 			await s.call('authCSignOut');
 		});
@@ -365,7 +365,7 @@ async function main() {
 			const s = new ApiSession(stack.apiUrl);
 			await s.call('authCSignIn', [username, 'Password1!']);
 			const sess = await s.call('authCFetchAuthSession');
-			if (!sess.signedIn) throw new Error('expected signedIn');
+			if (sess.status !== 'signedIn') throw new Error('expected signedIn');
 			if (!sess.idToken || sess.idToken.length < 20) throw new Error('bad idToken');
 			if (!sess.accessToken || sess.accessToken.length < 20) throw new Error('bad accessToken');
 			if (!/^[0-9a-f-]{36}$/.test(sess.userSub)) throw new Error(`userSub not a UUID: ${sess.userSub}`);
@@ -392,7 +392,7 @@ async function main() {
 		await runTest('fetchAuthSession signed-out → signedIn=false', async () => {
 			const s = new ApiSession(stack.apiUrl);
 			const sess = await s.call('authCFetchAuthSession');
-			if (sess.signedIn !== false) throw new Error(`expected false, got ${JSON.stringify(sess)}`);
+			if (sess.status !== 'signedOut') throw new Error(`expected false, got ${JSON.stringify(sess)}`);
 		});
 	}
 
@@ -430,7 +430,7 @@ async function main() {
 				if (!isBlocksErrName(e, 'NotAuthorizedException')) throw e;
 			}
 			const r = await s.call('authCSignIn', [username, 'Rotated!Pw9']);
-			if (!r.isSignedIn) throw new Error('new password rejected');
+			if (r.status !== 'signedIn') throw new Error('new password rejected');
 			await s.call('authCSignOut');
 			await cog.send(new AdminSetUserPasswordCommand({
 				UserPoolId: stack.authCPoolId, Username: username, Password: 'Password1!', Permanent: true,
@@ -540,7 +540,7 @@ async function main() {
 		await runTest('setUpTOTP returns a base32 shared secret', async () => {
 			const s = new ApiSession(stack.apiUrl);
 			const r1 = await s.call('authCMfaSignIn', [username, 'Password1!']);
-			if (!r1.isSignedIn) throw new Error(`unexpected challenge on first sign-in: ${JSON.stringify(r1)}`);
+			if (r1.status !== 'signedIn') throw new Error(`unexpected challenge on first sign-in: ${JSON.stringify(r1)}`);
 			const r = await s.call('authCMfaSetUpTOTP');
 			if (!r.sharedSecret || !/^[A-Z2-7]+=*$/.test(r.sharedSecret)) {
 				throw new Error(`bad sharedSecret: ${r.sharedSecret}`);
@@ -587,25 +587,25 @@ async function main() {
 		await runTest('end-to-end: signIn → CONFIRM_SIGN_IN_WITH_TOTP_CODE → complete with RFC-6238 code', async () => {
 			const s = new ApiSession(stack.apiUrl);
 			const r1 = await s.call('authCMfaSignIn', [username, 'Password1!']);
-			if (r1.isSignedIn) throw new Error(`expected TOTP challenge, got isSignedIn=true`);
+			if (r1.status === 'signedIn') throw new Error(`expected TOTP challenge, got status=signedIn`);
 			if (r1.nextStep?.name !== 'CONFIRM_SIGN_IN_WITH_TOTP_CODE') {
 				throw new Error(`unexpected nextStep: ${JSON.stringify(r1.nextStep)}`);
 			}
 			await waitNextTotpStep();
 			const code = totp(sharedSecret);
 			const r2 = await s.call('authCMfaConfirmSignIn', [r1.nextStep.session, code]);
-			if (!r2.isSignedIn) throw new Error(`confirmSignIn failed: ${JSON.stringify(r2)}`);
+			if (r2.status !== 'signedIn') throw new Error(`confirmSignIn failed: ${JSON.stringify(r2)}`);
 			await s.call('authCMfaSignOut');
 		});
 
 		await runTest('updateMFAPreference({totp: DISABLED}) removes TOTP', async () => {
 			const s = new ApiSession(stack.apiUrl);
 			const r1 = await s.call('authCMfaSignIn', [username, 'Password1!']);
-			if (!r1.isSignedIn) {
+			if (r1.status !== 'signedIn') {
 				await waitNextTotpStep();
 				const code = totp(sharedSecret);
 				const r2 = await s.call('authCMfaConfirmSignIn', [r1.nextStep.session, code]);
-				if (!r2.isSignedIn) throw new Error(`confirmSignIn failed: ${JSON.stringify(r2)}`);
+				if (r2.status !== 'signedIn') throw new Error(`confirmSignIn failed: ${JSON.stringify(r2)}`);
 			}
 			await s.call('authCMfaUpdateMFAPreference', [{ totp: 'DISABLED' }]);
 			const pref = await s.call('authCMfaFetchMFAPreference');
@@ -619,7 +619,7 @@ async function main() {
 		await runTest('updateMFAPreference({totp: PREFERRED}) on un-enrolled user throws', async () => {
 			const s = new ApiSession(stack.apiUrl);
 			const r1 = await s.call('authCMfaSignIn', [neverEnrolled, 'Password1!']);
-			if (!r1.isSignedIn) throw new Error(`unexpected challenge: ${JSON.stringify(r1)}`);
+			if (r1.status !== 'signedIn') throw new Error(`unexpected challenge: ${JSON.stringify(r1)}`);
 			try {
 				await s.call('authCMfaUpdateMFAPreference', [{ totp: 'PREFERRED' }]);
 				throw new Error('expected failure');

--- a/test-apps/native-bindings/aws-blocks/index.ts
+++ b/test-apps/native-bindings/aws-blocks/index.ts
@@ -268,11 +268,26 @@ export const api = new ApiNamespace(scope, 'api', (context) => ({
     return { success: true };
   },
 
-  async cognitoFetchAuthSession() {
+  // The `status` string field is the discriminator native clients (Swift /
+  // Kotlin / Dart) key off when generating the result union. The generators
+  // detect a discriminated union only from a single-value *string* const/enum
+  // per arm; without it they emit numeric `Result_Variant0/1` structs and
+  // try-each-variant decoding that fails to compile. The explicit return type
+  // also keeps the signed-out arm minimal — no phantom `null`-typed token
+  // fields (which became invalid `Void?` in Swift).
+  async cognitoFetchAuthSession(): Promise<
+    | { status: 'signedOut' }
+    | {
+        status: 'signedIn';
+        userSub: string | null;
+        idToken: string;
+        accessToken: string;
+      }
+  > {
     const session = await authCognito.fetchAuthSession(context);
-    if (!session.tokens) return { signedIn: false as const };
+    if (!session.tokens) return { status: 'signedOut' };
     return {
-      signedIn: true as const,
+      status: 'signedIn',
       userSub: session.userSub ?? null,
       idToken: session.tokens.idToken.toString(),
       accessToken: session.tokens.accessToken.toString(),


### PR DESCRIPTION
## Problem

The Cognito result unions sent to native clients were **discriminated on a boolean** — `fetchAuthSession` on `signedIn`, `SignInResult` (`signIn`/`confirmSignIn`) on `isSignedIn`. Native codegen detects a discriminated union only from a single-value **string** `const`/`enum` per arm, so a boolean discriminator produced broken/awkward output.

## The change

```ts
export type SignInResult<O> =
  | { status: 'signedIn'; user: CognitoUser<O> }
  | { status: 'nextStep'; nextStep: SignInNextStep };
```

- `status` is a string-literal union → TS narrowing / exhaustiveness / typo-rejection all hold.
- `isSignedIn` (and `fetchAuthSession`'s `signedIn`) **removed** — pre-release, no back-compat alias.
- All internal call sites + tests migrated to `status`.
- **No generator files modified** — the only codegen artifacts that change are the `23-cognito-nested-unions` fixture spec + its regenerated Swift/Kotlin/Dart goldens.

### Generated output

- **Swift / Kotlin / Dart** `23-cognito-nested-unions` goldens regenerated to the status shape; all compile and pass golden-file tests.
- Kotlin: `@JsonClassDiscriminator("status")` sealed class with `SignedIn`/`NextStep` variants (nested `NextStep` union on `name`).
- Swift: `enum Result { case signedIn(SignedIn); case nextStep(NextStep) }`, switch on `status`.
- Dart: `sealed class … switch (json['status'])`.

### Bonus: latent Dart-parser fix

A boolean field with an `enum` constraint became a Dart `enum { true }` / `{ false }` (reserved words, won't compile). The Dart parser now only treats **string** enums as enum types; boolean/numeric enums map to their primitive. Guarded by new `parser_test.dart` cases.

## Migration notes (adjustments for this repo)

- The new Kotlin runtime decode test was placed under this repo's `com.aws.blocks.kotlin.json` namespace (the source repo used `com.amazonaws.blocks`).
- `packages/bb-auth-cognito/README.md` was merged so the `status` wording and this repo's existing `{ credential }` passkey entry both survive.
