### PR TITLE
chore(swift): update codegen for nullable discriminated unions

### DIFF
--- a/native/codegen-fixtures/24-nullable-discriminated-union/swift/Api.swift
+++ b/native/codegen-fixtures/24-nullable-discriminated-union/swift/Api.swift
@@ -9,18 +9,18 @@ public class Api {
     }
 
     /// Calls `api.updateAttributes`.
-    public func updateAttributes(attributes: [String: String]) async throws -> [String: UpdateAttributes.ResultValue] {
+    public func updateAttributes(attributes: [String: String]) async throws -> [String: UpdateAttributes.ResultValue?] {
         let request = BlocksRequest(method: "api.updateAttributes", params: [attributes], id: BlocksRequest.nextId())
         let result = try await client.execute(request)
         guard let result else { throw RPCError(message: "Unexpected null result for api.updateAttributes") }
-        return try JSONDecoder().decode([String: UpdateAttributes.ResultValue].self, from: result)
+        return try JSONDecoder().decode([String: UpdateAttributes.ResultValue?].self, from: result)
     }
 
     /// Calls `api.getNotification`.
-    public func getNotification(id: String) async throws -> GetNotification.Result {
+    public func getNotification(id: String) async throws -> GetNotification.Result? {
         let request = BlocksRequest(method: "api.getNotification", params: [id], id: BlocksRequest.nextId())
         let result = try await client.execute(request)
-        guard let result else { throw RPCError(message: "Unexpected null result for api.getNotification") }
+        guard let result else { return nil }
         return try JSONDecoder().decode(GetNotification.Result.self, from: result)
     }
 

--- a/native/swift/.changeset/red-guests-fry.md
+++ b/native/swift/.changeset/red-guests-fry.md
@@ -1,0 +1,5 @@
+---
+"aws-blocks-swift": patch
+---
+
+chore(swift): update codegen for nullable discriminated unions

--- a/native/swift/Sources/BlocksCodegen/CodegenModelBuilder.swift
+++ b/native/swift/Sources/BlocksCodegen/CodegenModelBuilder.swift
@@ -327,6 +327,7 @@ public struct CodegenModelBuilder {
         case .union(let members):
             let unionName = pascalCase(name)
             let myId = "\(currentParentId ?? "root").\(unionName)"
+            let hasNullMember = members.contains { if case .primitive(kind: .void, _) = $0 { return true }; return false }
             let resolved = resolveUnion(
                 members: members,
                 unionName: unionName,
@@ -344,7 +345,8 @@ public struct CodegenModelBuilder {
                     for existing in typeDefinitions {
                         if case .union(_, let ev, let ed) = existing.type,
                            structuralKeyOfUnion(variants: ev, discriminator: ed) == key {
-                            return .typeReference(name: existing.name)
+                            let ref: ResolvedType = .typeReference(name: existing.name)
+                            return hasNullMember ? .nullable(inner: ref) : ref
                         }
                     }
                     // Also check inline types for structural dedup
@@ -352,7 +354,8 @@ public struct CodegenModelBuilder {
                         if case .union(_, let ev, let ed) = existing.type,
                            structuralKeyOfUnion(variants: ev, discriminator: ed) == key,
                            existing.shortName != unionName {
-                            return .typeReference(name: existing.shortName)
+                            let ref: ResolvedType = .typeReference(name: existing.shortName)
+                            return hasNullMember ? .nullable(inner: ref) : ref
                         }
                     }
                 }
@@ -367,7 +370,7 @@ public struct CodegenModelBuilder {
                     ))
                 }
             }
-            return resolved
+            return hasNullMember ? .nullable(inner: resolved) : resolved
 
         case .schemaRef(let refName, _):
             if componentSchemas[refName] != nil {

--- a/native/swift/Tests/BlocksCodegenTests/CodegenModelBuilderTests.swift
+++ b/native/swift/Tests/BlocksCodegenTests/CodegenModelBuilderTests.swift
@@ -192,4 +192,81 @@ final class CodegenModelBuilderTests: XCTestCase {
             XCTFail("Expected union type")
         }
     }
+
+    // MARK: - Nullable Discriminated Unions
+
+    func testNullableDiscriminatedUnionWrapsInNullable() throws {
+        let model = try buildModel(from: """
+        {
+            "openrpc": "1.3.2",
+            "info": { "title": "test", "version": "1.0.0" },
+            "methods": [{
+                "name": "api.getNotification",
+                "params": [{ "name": "id", "required": true, "schema": { "type": "string" } }],
+                "result": { "name": "GetNotificationResult", "schema": {
+                    "oneOf": [
+                        { "type": "object", "properties": { "type": { "type": "string", "enum": ["email"] }, "subject": { "type": "string" }, "body": { "type": "string" } }, "required": ["type", "subject", "body"] },
+                        { "type": "object", "properties": { "type": { "type": "string", "enum": ["sms"] }, "message": { "type": "string" } }, "required": ["type", "message"] },
+                        { "type": "null" }
+                    ]
+                }}
+            }]
+        }
+        """)
+
+        let op = model.apiNamespaces[0].operations[0]
+        if case .nullable(let inner) = op.result.type {
+            if case .union(_, let variants, let discriminator) = inner {
+                XCTAssertNotNil(discriminator)
+                XCTAssertEqual(discriminator?.fieldName, "type")
+                XCTAssertEqual(variants.count, 2)
+                XCTAssertEqual(variants[0].discriminatorValue, "email")
+                XCTAssertEqual(variants[1].discriminatorValue, "sms")
+            } else {
+                XCTFail("Expected union inside nullable")
+            }
+        } else {
+            XCTFail("Expected nullable type, got \(op.result.type)")
+        }
+    }
+
+    func testNullableDiscriminatedUnionWithBooleanDiscriminator() throws {
+        let model = try buildModel(from: """
+        {
+            "openrpc": "1.3.2",
+            "info": { "title": "test", "version": "1.0.0" },
+            "methods": [{
+                "name": "api.updateAttributes",
+                "params": [{ "name": "attributes", "required": true, "schema": { "type": "object", "additionalProperties": { "type": "string" } } }],
+                "result": { "name": "UpdateAttributesResult", "schema": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "oneOf": [
+                            { "type": "object", "properties": { "isUpdated": { "type": "boolean", "enum": [true] } }, "required": ["isUpdated"] },
+                            { "type": "object", "properties": { "isUpdated": { "type": "boolean", "enum": [false] }, "nextStep": { "type": "object", "properties": { "name": { "type": "string" }, "destination": { "type": "string" } }, "required": ["name", "destination"] } }, "required": ["isUpdated", "nextStep"] },
+                            { "type": "null" }
+                        ]
+                    }
+                }}
+            }]
+        }
+        """)
+
+        let op = model.apiNamespaces[0].operations[0]
+        if case .map(let valueType) = op.result.type {
+            if case .nullable(let inner) = valueType {
+                if case .union(_, let variants, let discriminator) = inner {
+                    XCTAssertNotNil(discriminator)
+                    XCTAssertEqual(discriminator?.fieldName, "isUpdated")
+                    XCTAssertEqual(variants.count, 2)
+                } else {
+                    XCTFail("Expected union inside nullable, got \(inner)")
+                }
+            } else {
+                XCTFail("Expected nullable map value type, got \(valueType)")
+            }
+        } else {
+            XCTFail("Expected map type, got \(op.result.type)")
+        }
+    }
 }

--- a/native/swift/Tests/BlocksCodegenTests/SwiftCodeGeneratorTests.swift
+++ b/native/swift/Tests/BlocksCodegenTests/SwiftCodeGeneratorTests.swift
@@ -310,4 +310,56 @@ final class SwiftCodeGeneratorTests: XCTestCase {
 
         XCTAssertFalse(output.api.contains("!"), "Generated API should not contain force unwraps")
     }
+
+    // MARK: - Nullable Discriminated Unions
+
+    func testNullableDiscriminatedUnionGeneratesOptionalReturnType() throws {
+        let output = try generate(from: """
+        {
+            "openrpc": "1.3.2",
+            "info": { "title": "test", "version": "1.0.0" },
+            "methods": [{
+                "name": "api.getNotification",
+                "params": [{ "name": "id", "required": true, "schema": { "type": "string" } }],
+                "result": { "name": "GetNotificationResult", "schema": {
+                    "oneOf": [
+                        { "type": "object", "properties": { "type": { "type": "string", "enum": ["email"] }, "subject": { "type": "string" }, "body": { "type": "string" } }, "required": ["type", "subject", "body"] },
+                        { "type": "object", "properties": { "type": { "type": "string", "enum": ["sms"] }, "message": { "type": "string" } }, "required": ["type", "message"] },
+                        { "type": "null" }
+                    ]
+                }}
+            }]
+        }
+        """)
+
+        XCTAssertTrue(output.api.contains("-> GetNotification.Result?"), "Return type should be optional")
+        XCTAssertTrue(output.api.contains("guard let result else { return nil }"), "Should return nil for null result")
+        XCTAssertTrue(output.api.contains("case email(Email)"), "Should have email variant")
+        XCTAssertTrue(output.api.contains("case sms(Sms)"), "Should have sms variant")
+    }
+
+    func testNullableDiscriminatedUnionInMapValue() throws {
+        let output = try generate(from: """
+        {
+            "openrpc": "1.3.2",
+            "info": { "title": "test", "version": "1.0.0" },
+            "methods": [{
+                "name": "api.updateAttributes",
+                "params": [{ "name": "attributes", "required": true, "schema": { "type": "object", "additionalProperties": { "type": "string" } } }],
+                "result": { "name": "UpdateAttributesResult", "schema": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "oneOf": [
+                            { "type": "object", "properties": { "isUpdated": { "type": "boolean", "enum": [true] } }, "required": ["isUpdated"] },
+                            { "type": "object", "properties": { "isUpdated": { "type": "boolean", "enum": [false] }, "nextStep": { "type": "object", "properties": { "name": { "type": "string" }, "destination": { "type": "string" } }, "required": ["name", "destination"] } }, "required": ["isUpdated", "nextStep"] },
+                            { "type": "null" }
+                        ]
+                    }
+                }}
+            }]
+        }
+        """)
+
+        XCTAssertTrue(output.api.contains("[String: UpdateAttributes.ResultValue?]"), "Map value type should be optional")
+    }
 }


### PR DESCRIPTION
## Problem

<!--
Describe the issue this PR is solving. For trivial changes, a short one-liner is fine.
-->

**Issue #, if available:**
NA

<!--
Summarize the changes introduced in this PR. Call out critical or potentially problematic parts of the change.
-->
## Summary

- Fix Swift code generation for nullable discriminated unions (mirrors Kotlin fix from #35)
- When a `oneOf` contains object variants plus a `"type": "null"` member, the generated Swift code now correctly emits optional types (`Result?`) instead of non-nullable enums
- Previously, the null member was skipped during variant construction but its nullability was never propagated to the resolved type

## Changes

**CodegenModelBuilder.swift** — In the `resolveType` `.union` case, detect whether any member is a void primitive (`"type": "null"`) and wrap the resolved union in `.nullable(inner:)` when present. Also applies nullable wrapping in the structural-dedup early-return paths.

**Golden fixture 24** — Regenerated `Api.swift` now produces:
- `-> GetNotification.Result?` (was `-> GetNotification.Result`)
- `-> [String: UpdateAttributes.ResultValue?]` (was `-> [String: UpdateAttributes.ResultValue]`)
- `guard let result else { return nil }` (was `throw RPCError(...)`)

## Test plan

- [x] 2 new `CodegenModelBuilderTests`: verify `.nullable` wrapping for string-discriminated and boolean-discriminated unions with null members
- [x] 2 new `SwiftCodeGeneratorTests`: verify generated Swift emits optional return types and nil-returning guard
- [x] All 24 golden fixture tests pass
- [x] Full `BlocksCodegenTests` suite passes (77 tests, 0 failures)

## Checklist

- [x] PR description included
- [x] Tests are changed or added
- [x] Relevant documentation is changed or added (and PR referenced)

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
