### PR TITLE
chore(swift): fix readme and agents.md

### DIFF
--- a/native/swift/AGENTS.md
+++ b/native/swift/AGENTS.md
@@ -56,7 +56,7 @@ A Swift Package that generates type-safe Swift client code from an OpenRPC speci
 | Constraints / formats / defaults / const / tuple | `Tests/BlocksCodegenTests/ConstraintsAndDefaultsTests.swift` |
 | Helpers / naming | `Tests/BlocksCodegenTests/HelpersTests.swift` |
 | Generator output | `Tests/BlocksCodegenTests/SwiftCodeGeneratorTests.swift` |
-| Hybrid-arm fixture spec | `Tests/BlocksCodegenTests/Resources/hybrid-arm-spec.json` |
+| Hybrid-arm fixture spec | `../codegen-fixtures/18-hybrid-arm/spec.json` |
 | Runtime tests | `Tests/BlocksRuntimeTests/*` |
 
 ## Build and Test Commands
@@ -67,7 +67,7 @@ A Swift Package that generates type-safe Swift client code from an OpenRPC speci
 # Build everything (codegen, runtime, plugins, CLI)
 swift build
 
-# Run all tests (114 tests)
+# Run all tests
 swift test
 
 # Filter to one suite

--- a/native/swift/README.md
+++ b/native/swift/README.md
@@ -10,7 +10,7 @@ In your `Package.swift`:
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/aws-amplify/aws-blocks-swift.git", from: "0.1.0"),
+    .package(url: "https://github.com/aws-devtools-labs/aws-blocks-swift.git", from: "0.1.0"),
 ],
 targets: [
     .target(
@@ -40,22 +40,18 @@ The build plugin generates `Models.swift` and `API.swift` into the target's deri
 ```swift
 import BlocksRuntime
 
-let client = BlocksClient(url: URL(string: "https://api.example.com")!)
+// Each API namespace becomes its own class with a built-in BlocksClient.
+// Pass a custom server or use the default from the spec.
+let auth = AuthApi(server: BlocksServer(name: "prod", url: "https://api.example.com"))
 
 // Sign in
-let state = try await client.setAuthState(input: .signIn(SignIn(
+let state = try await auth.setAuthState(input: .signIn(SetAuthState.SignIn(
     username: "alice",
     password: "P@ss1"
 )))
 
-// Confirm a Cognito challenge — discriminated, type-safe per challenge shape
-let confirmed = try await client.setAuthState(input: .confirmSignIn(ConfirmSignIn(
-    session: state.actions[0].fields.first { $0.name == "session" }!.defaultValue!,
-    challenge: .code(Code(code: "123456"))
-)))
-
 // Open-shape Cognito sign-up with custom attributes
-_ = try await client.setAuthState(input: .signUp(SignUp(
+_ = try await auth.setAuthState(input: .signUp(SetAuthState.SignUp(
     username: "alice",
     password: "P@ss1",
     attributes: ["email": "alice@example.com", "custom:department": "platform"]
@@ -81,7 +77,7 @@ The build plugin discovers `blocks.spec.json` automatically next to your target.
 swift run swift-code-generator path/to/blocks.spec.json path/to/output-dir
 ```
 
-This emits two files into the output directory: `Models.swift` (types) and `API.swift` (the `extension BlocksClient { … }` with the typed methods).
+This emits two files into the output directory: `Models.swift` (shared types) and `API.swift` (one class per API namespace with typed `async throws` methods).
 
 ## Targets
 
@@ -106,10 +102,6 @@ Linux / watchOS / tvOS are not currently targeted — the runtime relies on Foun
 
 - Swift 5.9+
 - Xcode 15+ (for iOS / macOS app builds)
-
-## Status
-
-See [`ROADMAP.md`](ROADMAP.md) for planned features.
 
 ## License
 


### PR DESCRIPTION
## Problem

<!--
Describe the issue this PR is solving. For trivial changes, a short one-liner is fine.
-->

**Issue #, if available:**
NA

<!--
Summarize the changes introduced in this PR. Call out critical or potentially problematic parts of the change.
-->
## Summary

- Fix dead links, incorrect URLs, and outdated information in `native/swift/README.md` and `native/swift/AGENTS.md`

## Changes

**README.md:**
- Fix package URL from `aws-amplify/aws-blocks-swift` → `aws-devtools-labs/aws-blocks-swift`
- Fix code example to match actual generated API shape (namespace classes with `BlocksServer` init, not `BlocksClient(url: URL(...))`)
- Fix CLI output description: generated code uses one class per namespace, not a `BlocksClient` extension
- Remove dead `ROADMAP.md` link (file does not exist)

**AGENTS.md:**
- Fix dead path for hybrid-arm spec: `Tests/BlocksCodegenTests/Resources/hybrid-arm-spec.json` → `../codegen-fixtures/18-hybrid-arm/spec.json`
- Remove hardcoded test count "(114 tests)" which was stale

## Test plan

- [x] Documentation-only change — no code affected
- [x] Verified all referenced file paths exist on disk
- [x] Verified package URL matches the actual GitHub repo

## Checklist

- [x] PR description included
- [x] Tests are changed or added
- [x] Relevant documentation is changed or added (and PR referenced)

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
