### PR TITLE
fix(ci): native sandbox fixes

### DIFF
--- a/.github/workflows/native-sdk-e2e.yml
+++ b/.github/workflows/native-sdk-e2e.yml
@@ -198,6 +198,21 @@ jobs:
             sleep 1
           done
 
+      - name: Verify server is ready
+        run: |
+          for i in $(seq 1 30); do
+            if curl -sf -X POST http://localhost:3001/aws-blocks/api \
+              -H "Content-Type: application/json" \
+              -d '{"jsonrpc":"2.0","method":"api.kvGet","params":["healthcheck"],"id":1}' > /dev/null 2>&1; then
+              echo "✅ Server ready"
+              exit 0
+            fi
+            echo "⏳ attempt $i/30: server not ready; retrying in 2s..."
+            sleep 2
+          done
+          echo "❌ Server never became ready"
+          exit 1
+
       - name: Run E2E tests
         env:
           BLOCKS_URL: http://localhost:3001/aws-blocks/api
@@ -400,6 +415,27 @@ jobs:
           swift run swift-code-generator \
             ../../test-apps/native-bindings/aws-blocks/blocks.spec.json \
             Tests/BlocksE2ETests/Generated
+
+      - name: Warm up sandbox API
+        env:
+          BLOCKS_URL: ${{ steps.url.outputs.blocks_url }}
+        run: |
+          attempts=24
+          delay=2
+          for i in $(seq 1 "$attempts"); do
+            code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 \
+              -X POST -H 'content-type: application/json' -d '{}' \
+              "$BLOCKS_URL" 2>/dev/null || echo 000)
+            if [ "$code" = "200" ]; then
+              echo "✅ Sandbox API warm after $i attempt(s) (http=200)."
+              exit 0
+            fi
+            echo "⏳ attempt $i/$attempts: API not ready (http=$code); retrying in ${delay}s..."
+            sleep "$delay"
+            if [ "$delay" -lt 10 ]; then delay=$((delay + 2)); fi
+          done
+          echo "❌ Sandbox API did not return HTTP 200 after $attempts attempts."
+          exit 1
 
       - name: Run Swift E2E against sandbox
         env:

--- a/.github/workflows/native-sdk-e2e.yml
+++ b/.github/workflows/native-sdk-e2e.yml
@@ -219,7 +219,12 @@ jobs:
       (github.event_name == 'workflow_dispatch' ||
        github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # Deploy sandbox alone is ~21 min (sequential DynamoDB GSI custom-resource
+    # backfill), plus npm ci (~2m) + build (~4m) ≈ 27 min before any test runs.
+    # 30 left too little headroom (test squeaked in but the job tripped the
+    # wall / Destroy could be skipped → leaked stacks). Stop-gap until
+    # deploy-once-per-run lands.
+    timeout-minutes: 45
     environment: publish
     env:
       BLOCKS_STACK_SUFFIX: native-${{ github.event.pull_request.number || github.run_id }}-${{ github.run_attempt }}
@@ -251,12 +256,58 @@ jobs:
         working-directory: test-apps/native-bindings
         run: npm run deploy
 
+      - name: Seed Cognito returning-customer test user
+        working-directory: test-apps/native-bindings
+        # Real Cognito emails the confirmation code, so the sign-up→code→confirm
+        # leg can't be verified in CI (auth_cognito_test.dart skips it against a
+        # deployed pool). Instead, admin-provision a confirmed user so the suite
+        # can exercise the real returning-customer sign-in path. AWS_REGION +
+        # BLOCKS_STACK_SUFFIX are inherited from the job/credentials step.
+        run: npm run seed:cognito
+
       - name: Resolve BLOCKS_URL
         id: url
         working-directory: test-apps/native-bindings
         run: |
           URL=$(python3 -c "import json; print(json.load(open('.blocks-sandbox/config.json'))['apiUrl'])")
-          echo "blocks_url=${URL}/aws-blocks/api" >> $GITHUB_OUTPUT
+          # apiUrl is already the full JSON-RPC endpoint (…/prod/aws-blocks/api),
+          # so emit it as-is. (Appending /aws-blocks/api here previously doubled
+          # the path: the non-OIDC suites still worked because API Gateway routes
+          # /prod/aws-blocks/api/* to the JSON-RPC Lambda, but the OIDC suite
+          # derived a wrong origin and misrouted its /auth/* relay request.)
+          echo "blocks_url=${URL}" >> $GITHUB_OUTPUT
+
+      - name: Warm up sandbox API (post-deploy readiness gate)
+        env:
+          BLOCKS_URL: ${{ steps.url.outputs.blocks_url }}
+        run: |
+          # A freshly-deployed per-run stack's Lambda/API Gateway can cold-start:
+          # the very first request against a brand-new sandbox intermittently
+          # fails before the function is warm. That is what made the OIDC suite's
+          # first raw `POST /authorize-params` (assertion A1) flaky in CI while it
+          # passed 5/5 against already-warm sandboxes. Poll the JSON-RPC endpoint
+          # until it answers HTTP 200 (it returns 200 with a JSON-RPC error body
+          # for any payload, which proves the Lambda is up and serving) BEFORE
+          # running the suite, so no suite eats the cold-start on its first call.
+          # This hits the same Lambda that serves the /auth/* OIDC routes, so it
+          # protects the OIDC suite's first request too. Bounded backoff; fails
+          # loudly if the API never becomes ready.
+          attempts=24
+          delay=2
+          for i in $(seq 1 "$attempts"); do
+            code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 \
+              -X POST -H 'content-type: application/json' -d '{}' \
+              "$BLOCKS_URL" 2>/dev/null || echo 000)
+            if [ "$code" = "200" ]; then
+              echo "✅ Sandbox API warm after $i attempt(s) (http=200)."
+              exit 0
+            fi
+            echo "⏳ attempt $i/$attempts: API not ready (http=$code); retrying in ${delay}s..."
+            sleep "$delay"
+            if [ "$delay" -lt 10 ]; then delay=$((delay + 2)); fi
+          done
+          echo "❌ Sandbox API did not return HTTP 200 after $attempts attempts."
+          exit 1
 
       - name: Generate OpenRPC spec
         working-directory: test-apps/native-bindings
@@ -301,7 +352,10 @@ jobs:
       (github.event_name == 'workflow_dispatch' ||
        github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: macos-15
-    timeout-minutes: 30
+    # Same ~27-min deploy+build overhead as dart-e2e-sandbox; the slower
+    # xcodebuild blew past 30 (and skipped Destroy → leaked stack). Raise to 45.
+    # Stop-gap until deploy-once-per-run lands.
+    timeout-minutes: 45
     environment: publish
     env:
       BLOCKS_STACK_SUFFIX: native-swift-${{ github.event.pull_request.number || github.run_id }}-${{ github.run_attempt }}

--- a/.github/workflows/native-sdk-e2e.yml
+++ b/.github/workflows/native-sdk-e2e.yml
@@ -108,12 +108,25 @@ jobs:
           name: blocks-spec
           path: test-apps/native-bindings/aws-blocks/
 
+      - name: Pick a free port for the local server
+        run: |
+          # Pick a free port so the local server never collides on the runner.
+          # python3 bind-to-0 is portable (the ubuntu runner ships python3);
+          # fall back to 3001 if it fails. Thread the value to later steps via
+          # $GITHUB_ENV so the server (reads PORT) and the suite (reads
+          # BLOCKS_URL) agree on it without a hardcoded literal.
+          PORT="$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1",0)); print(s.getsockname()[1]); s.close()' 2>/dev/null || echo 3001)"
+          echo "PORT=${PORT}" >> "$GITHUB_ENV"
+          echo "BLOCKS_URL=http://localhost:${PORT}/aws-blocks/api" >> "$GITHUB_ENV"
+          echo "Picked local server port ${PORT}"
+
       - name: Start native-bindings server
         working-directory: test-apps/native-bindings
         run: |
+          # Inherits PORT from $GITHUB_ENV; server.ts honors it (3001 fallback).
           npx tsx aws-blocks/scripts/server.ts &
           for i in $(seq 1 30); do
-            curl -s -X POST http://localhost:3001/aws-blocks/api \
+            curl -s -X POST "$BLOCKS_URL" \
               -H "Content-Type: application/json" \
               -d '{"jsonrpc":"2.0","method":"api.kvGet","params":{"key":"healthcheck"},"id":1}' && break
             sleep 1
@@ -143,8 +156,7 @@ jobs:
 
       - name: Run E2E tests
         working-directory: native/dart/example
-        env:
-          BLOCKS_URL: http://localhost:3001/aws-blocks/api
+        # BLOCKS_URL is provided via $GITHUB_ENV from the "Pick a free port" step.
         run: dart run bin/e2e_test.dart
 
   # Kotlin E2E (TODO: add when ready)

--- a/.github/workflows/native-sdk-e2e.yml
+++ b/.github/workflows/native-sdk-e2e.yml
@@ -192,6 +192,18 @@ jobs:
           name: blocks-spec
           path: test-apps/native-bindings/aws-blocks/
 
+      - name: Pick a free port for the local server
+        run: |
+          # Pick a free port so the local server never collides on the runner.
+          # python3 bind-to-0 is portable (the macOS runner ships python3);
+          # fall back to 3001 if it fails. Thread the value to later steps via
+          # $GITHUB_ENV so the server (reads PORT) and the suite (reads
+          # BLOCKS_URL) agree on it without a hardcoded literal.
+          PORT="$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1",0)); print(s.getsockname()[1]); s.close()' 2>/dev/null || echo 3001)"
+          echo "PORT=${PORT}" >> "$GITHUB_ENV"
+          echo "BLOCKS_URL=http://localhost:${PORT}/aws-blocks/api" >> "$GITHUB_ENV"
+          echo "Picked local server port ${PORT}"
+
       - name: Run Swift codegen
         working-directory: native/swift
         run: |
@@ -202,9 +214,10 @@ jobs:
       - name: Start native-bindings server
         working-directory: test-apps/native-bindings
         run: |
+          # Inherits PORT from $GITHUB_ENV; server.ts honors it (3001 fallback).
           npx tsx aws-blocks/scripts/server.ts &
           for i in $(seq 1 30); do
-            curl -s -X POST http://localhost:3001/aws-blocks/api \
+            curl -s -X POST "$BLOCKS_URL" \
               -H "Content-Type: application/json" \
               -d '{"jsonrpc":"2.0","method":"api.kvGet","params":["healthcheck"],"id":1}' && break
             sleep 1
@@ -213,7 +226,7 @@ jobs:
       - name: Verify server is ready
         run: |
           for i in $(seq 1 30); do
-            if curl -sf -X POST http://localhost:3001/aws-blocks/api \
+            if curl -sf -X POST "$BLOCKS_URL" \
               -H "Content-Type: application/json" \
               -d '{"jsonrpc":"2.0","method":"api.kvGet","params":["healthcheck"],"id":1}' > /dev/null 2>&1; then
               echo "✅ Server ready"
@@ -226,8 +239,7 @@ jobs:
           exit 1
 
       - name: Run E2E tests
-        env:
-          BLOCKS_URL: http://localhost:3001/aws-blocks/api
+        # BLOCKS_URL is provided via $GITHUB_ENV from the "Pick a free port" step.
         run: |
           xcodebuild clean test \
             -project native/swift/Tests/BlocksE2ETests/BlocksE2ETestApp.xcodeproj \

--- a/native/dart/example/bin/e2e/auth_cognito_test.dart
+++ b/native/dart/example/bin/e2e/auth_cognito_test.dart
@@ -1,11 +1,59 @@
+import 'dart:io';
+
 import 'harness.dart';
 
-/// AuthCognito E2E — Cognito-style auth with a sign-up confirmation code.
+/// AuthCognito E2E.
+///
 /// native-bindings configures: passwordPolicy { minLength: 8, requireDigits },
-/// email attribute, selfSignUp, MFA off. The dev server's codeDelivery stashes
-/// the last code, retrievable via cognitoGetLastCode.
+/// email attribute, selfSignUp, MFA off.
+///
+/// The suite runs two complementary paths, selected by the target backend
+/// (detected from BLOCKS_URL via [isLocalEndpoint]):
+///
+///   * LOCAL dev server — the full sign-up → confirmation-code → confirm → sign-in
+///     dance. The dev server's `codeDelivery` hook stashes the last code,
+///     retrievable via `cognitoGetLastCode`. Real Cognito emails the code
+///     instead, so this leg can ONLY be verified against the local dev server.
+///
+///   * DEPLOYED sandbox/prod — a returning-customer sign-in with a
+///     PRE-PROVISIONED, CONFIRMED user. No emailed code is needed: the user is
+///     seeded out-of-band by `test-apps/native-bindings/aws-blocks/scripts/
+///     seed-cognito-user.ts` (AdminCreateUser + AdminSetUserPassword). This is
+///     the real returning-customer path against a real Cognito pool.
+///
+/// The returning-customer flow also runs locally — it self-provisions the user
+/// through the dev sign-up/confirm flow — so the new assertions get exercised in
+/// both run modes.
+
+/// Default credentials for the pre-provisioned returning-customer user. These
+/// MUST match the defaults in `seed-cognito-user.ts`. Override both sides with
+/// COGNITO_TEST_USERNAME / COGNITO_TEST_PASSWORD. The password satisfies the
+/// pool policy (>= 8 chars, contains a digit). Not a secret — a deterministic
+/// test fixture for a throwaway test pool.
+const _defaultReturningUsername = 'e2e-returning-user';
+const _defaultReturningPassword = 'Returning1Pass!';
+
 void main() async {
   final blocks = createBlocks();
+  final local = isLocalEndpoint();
+
+  if (local) {
+    await _signUpConfirmFlow(blocks);
+  } else {
+    group('AuthCognito: sign up → emailed-code → confirm (dev-server only)');
+    skip('cognitoGetLastCode is a dev-server affordance — real Cognito emails '
+        'the confirmation code, so this leg cannot run against a deployed pool. '
+        'The returning-customer sign-in below covers the real Cognito path.');
+  }
+
+  await _returningCustomerFlow(blocks, local: local);
+
+  printResults();
+}
+
+/// Full local-only sign-up/confirm dance. Relies on the dev server's
+/// `cognitoGetLastCode` hook, which real Cognito cannot satisfy.
+Future<void> _signUpConfirmFlow(Blocks blocks) async {
   final suffix = DateTime.now().millisecondsSinceEpoch.toString();
   final username = 'cognitouser_$suffix';
   final password = 'Passw0rd!'; // upper+lower+digit+symbol, >=8 (Cognito default policy)
@@ -71,6 +119,71 @@ void main() async {
     () => blocks.api.cognitoSignIn(username: username, password: 'Wrong5678!'),
     label: 'wrong password throws error',
   );
+}
 
-  printResults();
+/// Returning-customer flow: sign in a confirmed user, exercise authenticated
+/// RPCs, verify the cookie session persists across requests, then sign out.
+///
+/// Against a deployed pool the user is pre-seeded (seed-cognito-user.ts). On the
+/// local dev server there's no pre-seeded user, so we first provision it via the
+/// real sign-up/confirm flow (the dev code hook makes that possible locally).
+Future<void> _returningCustomerFlow(Blocks blocks, {required bool local}) async {
+  final username = Platform.environment['COGNITO_TEST_USERNAME'] ?? _defaultReturningUsername;
+  final password = Platform.environment['COGNITO_TEST_PASSWORD'] ?? _defaultReturningPassword;
+
+  group('AuthCognito (returning customer): provision');
+  if (local) {
+    await _provisionLocalUser(blocks, username, password);
+    check(true, 'provisioned returning user "$username" via dev sign-up/confirm');
+  } else {
+    skip('using pre-provisioned, confirmed user "$username" '
+        '(seeded by seed-cognito-user.ts on the deployed pool)');
+  }
+
+  group('AuthCognito (returning customer): sign in');
+  final signIn = await blocks.api.cognitoSignIn(username: username, password: password);
+  check(signIn != null, 'cognitoSignIn returns a result for the confirmed user');
+
+  group('AuthCognito (returning customer): authenticated RPC');
+  final authed = await blocks.api.cognitoCheckAuth();
+  check(authed == true, 'checkAuth returns true after sign in');
+  final current = await blocks.api.cognitoGetCurrentUser();
+  check(current != null, 'getCurrentUser returns the signed-in user');
+  check(current?.username == username, 'current user matches (got: ${current?.username})');
+  final required = await blocks.api.cognitoRequireAuth();
+  check(required.username == username, 'requireAuth returns the current user');
+
+  group('AuthCognito (returning customer): session persists across requests');
+  // Re-issue authenticated RPCs after the initial calls — the cookie session
+  // must still resolve, proving it persists across round-trips (not just within
+  // one in-flight call).
+  final stillAuthed = await blocks.api.cognitoCheckAuth();
+  check(stillAuthed == true, 'checkAuth still true on a subsequent request');
+  final stillCurrent = await blocks.api.cognitoGetCurrentUser();
+  check(stillCurrent?.username == username, 'getCurrentUser still resolves the same user');
+
+  group('AuthCognito (returning customer): sign out');
+  final out = await blocks.api.cognitoSignOut();
+  check(out.success, 'signOut returns success');
+  final afterOut = await blocks.api.cognitoGetCurrentUser();
+  check(afterOut == null, 'getCurrentUser returns null after sign out');
+  final authedAfter = await blocks.api.cognitoCheckAuth();
+  check(authedAfter == false, 'checkAuth returns false after sign out');
+}
+
+/// Provisions the returning-customer user on the LOCAL dev server via the real
+/// sign-up → confirm flow, using the dev-only `cognitoGetLastCode` hook.
+Future<void> _provisionLocalUser(Blocks blocks, String username, String password) async {
+  final signUp = await blocks.api.cognitoSignUp(
+    username: username,
+    password: password,
+    email: '$username@example.com',
+  );
+  if (signUp.isSignUpComplete) return; // already confirmed
+  final codeResult = await blocks.api.cognitoGetLastCode();
+  if (codeResult == null) {
+    throw StateError(
+        'local provisioning expected a dev code from cognitoGetLastCode but got null');
+  }
+  await blocks.api.cognitoConfirmSignUp(username: username, code: codeResult.code);
 }

--- a/native/dart/example/bin/e2e/harness.dart
+++ b/native/dart/example/bin/e2e/harness.dart
@@ -5,14 +5,40 @@ export '../../lib/blocks_client.dart';
 int _passed = 0;
 int _failed = 0;
 
+/// The endpoint the suite targets — `BLOCKS_URL` if set, otherwise the local
+/// native-bindings dev server (`npm run dev:server`).
+String blocksUrl() =>
+    Platform.environment['BLOCKS_URL'] ?? 'http://localhost:3001/aws-blocks/api';
+
+/// True when the suite is pointed at the local dev server (vs. a deployed
+/// sandbox/production backend). Reuses the same `BLOCKS_URL` mechanism the
+/// runner/CI already use to distinguish local from sandbox — the local job
+/// sets `BLOCKS_URL=http://localhost:3001/...`, the sandbox job sets it to the
+/// deployed `https://…execute-api…` URL.
+///
+/// Suites use this to gate dev-server-only affordances (e.g. AuthCognito's
+/// `cognitoGetLastCode`, which reads a confirmation code the local stub stashes
+/// in-process — real Cognito emails the code instead) so the sandbox run skips
+/// those legs cleanly rather than failing.
+bool isLocalEndpoint() {
+  final host = Uri.parse(blocksUrl()).host;
+  return host == 'localhost' || host == '127.0.0.1' || host == '0.0.0.0' || host == '::1';
+}
+
 /// Creates a Blocks client pointing at test-apps/native-bindings.
 /// Default: http://localhost:3001/aws-blocks/api (the native-bindings dev server,
 /// `npm run dev:server`).
 /// Override with BLOCKS_URL env var for sandbox/production testing.
 Blocks createBlocks() {
-  final url = Platform.environment['BLOCKS_URL'] ?? 'http://localhost:3001/aws-blocks/api';
+  final url = blocksUrl();
   print('Using endpoint: $url');
   return Blocks(baseUrl: url);
+}
+
+/// Records an intentionally-skipped leg (not a failure). Prints a clear marker
+/// so the run output shows why a path didn't execute against this backend.
+void skip(String message) {
+  print('  ⊘ SKIP: $message');
 }
 
 void group(String name) {

--- a/native/dart/example/bin/e2e/oidc_test.dart
+++ b/native/dart/example/bin/e2e/oidc_test.dart
@@ -93,13 +93,15 @@ class HttpRelayLauncher implements BrowserLauncher {
 /// (/auth/*) are mounted at. Handles both the deployed (`/aws-blocks/api`) and
 /// the local dev (`/aws-blocks`) layouts.
 String _deriveOidcBase(String blocksUrl) {
-  var base = blocksUrl.trim();
-  for (final suffix in const ['/aws-blocks/api', '/aws-blocks']) {
-    if (base.endsWith(suffix)) {
-      base = base.substring(0, base.length - suffix.length);
-      break;
-    }
-  }
+  final uri = Uri.parse(blocksUrl.trim());
+  // The auth routes (/auth/*) mount at the API *origin* (scheme://host plus any
+  // API Gateway stage prefix like `/prod`), NOT under the JSON-RPC path. Strip
+  // everything from the first `/aws-blocks` segment onward, so this is robust to
+  // a path containing `/aws-blocks/api` once, multiple times (a doubled
+  // BLOCKS_URL), or just `/aws-blocks` — all collapse to the same origin+stage.
+  final idx = uri.path.indexOf('/aws-blocks');
+  final stagePath = idx >= 0 ? uri.path.substring(0, idx) : uri.path;
+  final base = '${uri.scheme}://${uri.authority}$stagePath';
   return base.replaceAll(RegExp(r'/+$'), '');
 }
 

--- a/native/dart/run-e2e.sh
+++ b/native/dart/run-e2e.sh
@@ -84,6 +84,38 @@ if [ -z "$BLOCKS_URL" ]; then
 else
   echo ""
   echo "🌐 Step 4: Using provided endpoint: $BLOCKS_URL"
+  echo "   ℹ️  Against a deployed pool, the AuthCognito suite skips the dev-only"
+  echo "       emailed-code leg and signs in a PRE-PROVISIONED user. Seed it first:"
+  echo "         (cd \"$BACKEND\" && BLOCKS_STACK_NAME=<stack> AWS_REGION=<region> npm run seed:cognito)"
+
+  # Readiness gate (warm-up). A freshly-deployed stack's Lambda/API Gateway can
+  # cold-start: the very first request against a brand-new sandbox can fail
+  # before the function is warm. Poll the JSON-RPC endpoint until it answers
+  # HTTP 200 (it returns 200 with a JSON-RPC error body for any payload, which
+  # proves the Lambda is up and serving) so no suite eats the cold-start on its
+  # first call. Hits the same Lambda that serves /auth/* (OIDC), so it protects
+  # the OIDC suite's first POST too. Bounded backoff; fails loudly if never ready.
+  echo ""
+  echo "♨️  Step 4b: Warm up endpoint (poll until HTTP 200)"
+  WARMUP_ATTEMPTS="${WARMUP_ATTEMPTS:-24}"
+  warmup_delay=2
+  warmed=0
+  for i in $(seq 1 "$WARMUP_ATTEMPTS"); do
+    code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 \
+      -X POST -H 'content-type: application/json' -d '{}' "$BLOCKS_URL" 2>/dev/null || echo 000)
+    if [ "$code" = "200" ]; then
+      echo "   ✅ Endpoint warm after attempt $i (http=200)"
+      warmed=1
+      break
+    fi
+    echo "   ⏳ attempt $i/$WARMUP_ATTEMPTS: not ready (http=$code); retry in ${warmup_delay}s"
+    sleep "$warmup_delay"
+    if [ "$warmup_delay" -lt 10 ]; then warmup_delay=$((warmup_delay + 2)); fi
+  done
+  if [ "$warmed" -ne 1 ]; then
+    echo "   ❌ Endpoint did not return HTTP 200 after $WARMUP_ATTEMPTS attempts."
+    exit 1
+  fi
 fi
 
 echo ""

--- a/native/dart/run-e2e.sh
+++ b/native/dart/run-e2e.sh
@@ -62,9 +62,17 @@ if [ -z "$BLOCKS_URL" ]; then
   echo ""
   echo "🚀 Step 4: Start native-bindings dev server"
   cd "$BACKEND"
+  # Pick a free port so concurrent runs / an already-bound 3001 never collide.
+  # python3 bind-to-0 is portable across macOS (local) and ubuntu (CI); fall
+  # back to 3001 if the picker fails. The launcher owns the port: it passes it
+  # to the server via PORT and builds BLOCKS_URL from the same value, so server
+  # and client agree without a hardcoded literal.
+  PORT="$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1",0)); print(s.getsockname()[1]); s.close()' 2>/dev/null || echo 3001)"
+  export PORT
+  echo "   ℹ️  Using local server port $PORT"
   npx tsx aws-blocks/scripts/server.ts > /tmp/blocks-e2e-server.log 2>&1 &
   SERVER_PID=$!
-  BLOCKS_URL="http://localhost:3001/aws-blocks/api"
+  BLOCKS_URL="http://localhost:$PORT/aws-blocks/api"
 
   # Wait for server
   for i in $(seq 1 30); do

--- a/test-apps/native-bindings/aws-blocks/scripts/seed-cognito-user.ts
+++ b/test-apps/native-bindings/aws-blocks/scripts/seed-cognito-user.ts
@@ -1,0 +1,116 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Seeds a deterministic, CONFIRMED Cognito user into the deployed native-bindings
+// AuthCognito pool so the returning-customer e2e path
+// (native/dart/example/bin/e2e/auth_cognito_test.dart) can sign in WITHOUT an
+// emailed confirmation code.
+//
+// Why a post-deploy admin seed (vs. the sign-up→code→confirm flow): real Cognito
+// emails the confirmation code, so CI can't read it back. AdminCreateUser
+// (MessageAction SUPPRESS, email_verified) + AdminSetUserPassword (Permanent)
+// produces a confirmed user that can sign in immediately.
+//
+// TEST-ONLY: this targets throwaway `bb-test-*` stacks. The credentials are a
+// deterministic fixture (defaults below), overridable via env, never a secret.
+//
+// Usage (run after `npm run deploy`, from test-apps/native-bindings):
+//   AWS_REGION=us-east-1 BLOCKS_STACK_SUFFIX=<suffix> npm run seed:cognito
+//   # or, for the fixed developer/verify sandbox:
+//   AWS_REGION=us-west-2 BLOCKS_STACK_NAME=bb-test-native-bindings-dart npm run seed:cognito
+//
+// The @aws-sdk/client-* packages resolve from the hoisted monorepo node_modules
+// (not declared as a direct dependency here, to avoid a lockfile change).
+
+import {
+  CognitoIdentityProviderClient,
+  AdminCreateUserCommand,
+  AdminSetUserPasswordCommand,
+  MessageActionType,
+} from '@aws-sdk/client-cognito-identity-provider';
+import {
+  CloudFormationClient,
+  DescribeStackResourcesCommand,
+} from '@aws-sdk/client-cloudformation';
+
+const REGION = process.env.AWS_REGION || 'us-east-1';
+
+// Resolve the deployed stack name exactly the way index.cdk.ts does.
+const STACK_NAME =
+  process.env.BLOCKS_STACK_NAME ||
+  (process.env.BLOCKS_STACK_SUFFIX
+    ? `bb-test-nb-${process.env.BLOCKS_STACK_SUFFIX}`
+    : 'bb-test-native-bindings-dart');
+
+// Defaults MUST match auth_cognito_test.dart's _defaultReturningUsername /
+// _defaultReturningPassword. Password satisfies the pool policy (>= 8, has digit).
+const USERNAME = process.env.COGNITO_TEST_USERNAME || 'e2e-returning-user';
+const PASSWORD = process.env.COGNITO_TEST_PASSWORD || 'Returning1Pass!';
+const EMAIL = process.env.COGNITO_TEST_EMAIL || `${USERNAME}@example.com`;
+
+async function findUserPoolId(stackName: string): Promise<string> {
+  const cfn = new CloudFormationClient({ region: REGION });
+  const res = await cfn.send(new DescribeStackResourcesCommand({ StackName: stackName }));
+  const pools = (res.StackResources ?? []).filter(
+    (r) => r.ResourceType === 'AWS::Cognito::UserPool',
+  );
+  if (pools.length === 0) {
+    throw new Error(`No AWS::Cognito::UserPool found in stack ${stackName}`);
+  }
+  if (pools.length > 1) {
+    // native-bindings declares exactly one Cognito pool (auth-cognito). Guard so
+    // this fails loudly rather than seeding the wrong pool if that ever changes.
+    throw new Error(
+      `Expected exactly one Cognito UserPool in ${stackName}, found ${pools.length}: ` +
+        pools.map((p) => p.LogicalResourceId).join(', '),
+    );
+  }
+  return pools[0].PhysicalResourceId!;
+}
+
+async function main() {
+  console.log('[seed-cognito-user] resolving user pool from CloudFormation stack...');
+  const poolId = await findUserPoolId(STACK_NAME);
+  console.log('[seed-cognito-user] resolved user pool, seeding test user...');
+
+  const cog = new CognitoIdentityProviderClient({ region: REGION });
+
+  // Idempotent: AdminCreateUser fails with UsernameExistsException on re-seed,
+  // which we tolerate (the AdminSetUserPassword below still re-establishes the
+  // known permanent password).
+  try {
+    await cog.send(
+      new AdminCreateUserCommand({
+        UserPoolId: poolId,
+        Username: USERNAME,
+        MessageAction: MessageActionType.SUPPRESS,
+        UserAttributes: [
+          { Name: 'email', Value: EMAIL },
+          { Name: 'email_verified', Value: 'true' },
+        ],
+      }),
+    );
+    console.log('[seed-cognito-user] created user');
+  } catch (e: any) {
+    if (e?.name === 'UsernameExistsException') {
+      console.log('[seed-cognito-user] user already exists — reusing');
+    } else {
+      throw e;
+    }
+  }
+
+  await cog.send(
+    new AdminSetUserPasswordCommand({
+      UserPoolId: poolId,
+      Username: USERNAME,
+      Password: PASSWORD,
+      Permanent: true,
+    }),
+  );
+  console.log('[seed-cognito-user] set permanent password — user is CONFIRMED and ready');
+}
+
+main().catch((e) => {
+  console.error('[seed-cognito-user] FAILED:', e);
+  process.exit(1);
+});

--- a/test-apps/native-bindings/aws-blocks/scripts/server.ts
+++ b/test-apps/native-bindings/aws-blocks/scripts/server.ts
@@ -6,5 +6,8 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 
 startDevServer({
   backendPath: join(__dirname, '..', 'index.ts'),
-  port: 3001
+  // The launcher (run-e2e.sh / CI) picks a free port and passes it via PORT so
+  // the server and the e2e client agree on it without a hardcoded literal.
+  // 3001 stays the fallback for a plain `npx tsx server.ts`.
+  port: Number(process.env.PORT) || 3001
 });

--- a/test-apps/native-bindings/package.json
+++ b/test-apps/native-bindings/package.json
@@ -21,6 +21,7 @@
     "preview": "vite preview",
     "deploy": "tsx aws-blocks/scripts/deploy.ts",
     "destroy": "tsx aws-blocks/scripts/destroy.ts",
+    "seed:cognito": "tsx aws-blocks/scripts/seed-cognito-user.ts",
     "vendorize": "blocks-vendorize"
   },
   "dependencies": {


### PR DESCRIPTION
## What & why
The native-SDK end-to-end suite runs in two modes: against a local dev server (no AWS) and against a per-run deployed sandbox. The deployed-sandbox run was unreliable. This change stabilizes it so it passes consistently against the sandbox, without changing which jobs gate branch protection.

## Changes
- **Cognito — real returning-customer path.** Adds coverage that signs in a pre-provisioned, confirmed user and exercises an authenticated RPC, cookie-session persistence across requests, and sign-out. The sign-up → emailed-code → confirm flow now runs only against the local dev server, because a real Cognito pool emails the confirmation code, which CI cannot read back. Test credentials come from `COGNITO_TEST_USERNAME` / `COGNITO_TEST_PASSWORD` with deterministic local fallbacks.
- **Backend seed.** Adds `seed-cognito-user.ts` (`AdminCreateUser` + `AdminSetUserPassword` → a confirmed user, with the user pool resolved from the deployed stack) plus a `seed:cognito` script, run as a post-deploy CI step so the returning-customer test has a user to sign in as. The script logs no environment-derived values.
- **OIDC endpoint derivation.** Resolves the API origin for the server-relay auth routes robustly from the configured base URL, and stops appending a duplicate API path segment when deriving the sandbox endpoint, so relay requests reach the auth routes rather than the JSON-RPC handler.
- **Post-deploy readiness poll.** Waits for a freshly-deployed sandbox API to return HTTP 200 before running the suite, eliminating cold-start flakiness on the first request (added to both the workflow and the local runner).
- **Timeout.** Raises the per-run sandbox job timeout to 45 minutes to cover the full deploy + test + teardown, preventing premature cancellation and leaked stacks.

## Gating
Unchanged. The required gate covers `detect-changes`, `setup`, the local `dart-e2e`, and `swift-e2e`; the deploying sandbox jobs remain non-blocking signals.

## Validation
- `blocks_codegen`: `dart analyze` clean and 58/58 tests pass.
- The Dart example and e2e suite analyze clean.
