### PR TITLE
chore(swift): add warm up step before e2e tests

### DIFF
--- a/.github/workflows/native-sdk-e2e.yml
+++ b/.github/workflows/native-sdk-e2e.yml
@@ -198,6 +198,21 @@ jobs:
             sleep 1
           done
 
+      - name: Verify server is ready
+        run: |
+          for i in $(seq 1 30); do
+            if curl -sf -X POST http://localhost:3001/aws-blocks/api \
+              -H "Content-Type: application/json" \
+              -d '{"jsonrpc":"2.0","method":"api.kvGet","params":["healthcheck"],"id":1}' > /dev/null 2>&1; then
+              echo "✅ Server ready"
+              exit 0
+            fi
+            echo "⏳ attempt $i/30: server not ready; retrying in 2s..."
+            sleep 2
+          done
+          echo "❌ Server never became ready"
+          exit 1
+
       - name: Run E2E tests
         env:
           BLOCKS_URL: http://localhost:3001/aws-blocks/api
@@ -400,6 +415,27 @@ jobs:
           swift run swift-code-generator \
             ../../test-apps/native-bindings/aws-blocks/blocks.spec.json \
             Tests/BlocksE2ETests/Generated
+
+      - name: Warm up sandbox API
+        env:
+          BLOCKS_URL: ${{ steps.url.outputs.blocks_url }}
+        run: |
+          attempts=24
+          delay=2
+          for i in $(seq 1 "$attempts"); do
+            code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 \
+              -X POST -H 'content-type: application/json' -d '{}' \
+              "$BLOCKS_URL" 2>/dev/null || echo 000)
+            if [ "$code" = "200" ]; then
+              echo "✅ Sandbox API warm after $i attempt(s) (http=200)."
+              exit 0
+            fi
+            echo "⏳ attempt $i/$attempts: API not ready (http=$code); retrying in ${delay}s..."
+            sleep "$delay"
+            if [ "$delay" -lt 10 ]; then delay=$((delay + 2)); fi
+          done
+          echo "❌ Sandbox API did not return HTTP 200 after $attempts attempts."
+          exit 1
 
       - name: Run Swift E2E against sandbox
         env:


### PR DESCRIPTION
## Problem

<!--
Describe the issue this PR is solving. For trivial changes, a short one-liner is fine.
-->

**Issue #, if available:**
NA

## Summary

- Add server readiness gates to Swift E2E jobs to prevent race-condition test failures
- The `testCheckAuthWhenSignedIn` test was failing in CI because `xcodebuild` launched tests before the dev server was fully ready — the first test hit a 60s timeout on `Connection refused`, while all subsequent tests passed once the server warmed up

## Changes

**`.github/workflows/native-sdk-e2e.yml`:**
- **`swift-e2e` (local):** Add a "Verify server is ready" step with `curl -sf` polling (30 attempts, 2s apart) immediately before `xcodebuild`. The existing warm-up loop in "Start native-bindings server" can pass before the server is fully accepting requests; this second gate runs right before tests and fails loudly if the server is down.
- **`swift-e2e-sandbox` (deployed):** Add a "Warm up sandbox API" step with bounded backoff (24 attempts, 2-10s delay) matching the Dart sandbox pattern. Prevents Lambda cold-start from failing the first Swift test.

## Root cause

The existing server-start step backgrounds the process and polls with `curl -s`, which can break out of the loop on a transient success. Between that point and when `xcodebuild` actually runs the first test, there's significant overhead (Swift compilation, simulator boot). If the server wasn't fully stable, the first test (`testCheckAuthWhenSignedIn`, alphabetically first) would get `Connection refused` → timeout → fail, while later tests pass because the server recovered.

## Test plan

- [x] Matches the warm-up pattern already proven stable in the Dart E2E jobs
- [x] No code changes to Swift source — CI-only fix
- [x] If the server genuinely fails to start, the new step fails fast with a clear error instead of a 60s test timeout

## Checklist

- [x] PR description included
- [ ] Tests are changed or added
- [ ] Relevant documentation is changed or added (and PR referenced)

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
