### PR TITLE
docs: fix bug report issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yaml
@@ -11,7 +11,7 @@ body:
     attributes:
       label: Before opening, please confirm
       options:
-        - label: I have [searched for duplicate or closed issues](https://github.com/aws-amplify/aws-blocks/issues?q=is%3Aissue).
+        - label: I have [searched for duplicate or closed issues](https://github.com/aws-devtools-labs/aws-blocks/issues?q=is%3Aissue).
           required: true
         - label: I have done my best to include a minimal, self-contained set of instructions for consistently reproducing the issue.
           required: true
@@ -42,6 +42,7 @@ body:
         - "Building Block: tracer"
         - "Native Client: Kotlin"
         - "Native Client: Swift"
+        - "Native Client: Dart/Flutter"
         - Other
     validations:
       required: true


### PR DESCRIPTION
## Problem

The bug report template asks reporters to search for duplicates in `aws-amplify/aws-blocks`, which is not this repository. The bug package dropdown also omits the Dart/Flutter native client option even though the feature request template already includes it.

**Issue #, if available:** N/A

## Changes

- Point the duplicate issue search link at `aws-devtools-labs/aws-blocks`.
- Add `Native Client: Dart/Flutter` to the bug report package options.

## Validation

- Parsed `.github/ISSUE_TEMPLATE/bug-report.yaml` with the repository `yaml` package.
- `git diff --check`
- `./node_modules/.bin/changeset status --since=origin/main`
- `./node_modules/.bin/tsx scripts/verify-changeset-coverage.ts`

No automated tests were added because this is a GitHub issue-template-only change.

## Checklist

- [x] PR description included
- [x] Tests are changed or added, or not applicable with validation noted above
- [x] Relevant documentation is changed or added (and PR referenced)

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._