### PR TITLE
fix: validate create app template option

### DIFF
--- a/.changeset/friendly-template-validation.md
+++ b/.changeset/friendly-template-validation.md
@@ -1,0 +1,5 @@
+---
+"@aws-blocks/create-blocks-app": patch
+---
+
+Validate unknown `--template` values before reading template metadata so the CLI reports the intended `Unknown template` message instead of a file-system error.

--- a/packages/create-blocks-app/src/cli.test.ts
+++ b/packages/create-blocks-app/src/cli.test.ts
@@ -54,6 +54,14 @@ describe('create-blocks-app CLI argument parsing', () => {
     assert.match(result.stderr, /Unknown option: -z/);
   });
 
+  it('unknown template exits 1 with a friendly error message', () => {
+    const result = run(['--template', 'does-not-exist']);
+    assert.strictEqual(result.exitCode, 1);
+    assert.match(result.stderr, /Unknown template "does-not-exist"/);
+    assert.match(result.stderr, /Available templates:/);
+    assert.doesNotMatch(result.stderr, /ENOENT/);
+  });
+
   it('multiple positional args exits 1 with error message', () => {
     const result = run(['my-app', 'extra-arg']);
     assert.strictEqual(result.exitCode, 1);

--- a/packages/create-blocks-app/src/index.ts
+++ b/packages/create-blocks-app/src/index.ts
@@ -175,14 +175,18 @@ async function addBlocksWorkspace(targetDir: string, options: {
 
 const AVAILABLE_TEMPLATES = ['default', 'bare', 'react', 'backend', 'nextjs', 'auth-cognito', 'amplify', 'demo'];
 
-// ─── Fresh project creation ──────────────────────────────────────────────────
-
-async function createFreshProject(targetDir: string, templateName: string) {
+function validateTemplateName(templateName: string): void {
   if (!AVAILABLE_TEMPLATES.includes(templateName)) {
     console.error(`Error: Unknown template "${templateName}".`);
     console.error(`Available templates: ${AVAILABLE_TEMPLATES.join(', ')}`);
     process.exit(1);
   }
+}
+
+// ─── Fresh project creation ──────────────────────────────────────────────────
+
+async function createFreshProject(targetDir: string, templateName: string) {
+  validateTemplateName(templateName);
 
   // Read template package.json to get template name
   const templateDir = join(__dirname, '../templates', templateName);
@@ -608,6 +612,8 @@ async function create() {
       process.exit(1);
     }
   }
+
+  validateTemplateName(templateName);
 
   const templatePkgVersion: string = JSON.parse(
     await readFile(join(__dirname, '../templates', templateName, 'package.json'), 'utf-8'),


### PR DESCRIPTION
## Problem

Unknown `--template` values are used to read `../templates/<name>/package.json` before template validation runs. That produces a low-level `ENOENT` error instead of the CLI's intended friendly `Unknown template` message.

**Issue #, if available:** N/A

## Changes

- Move template-name validation into a shared helper.
- Validate the selected template before reading template metadata.
- Add a CLI regression test for unknown `--template` values.
- Add a patch changeset for `@aws-blocks/create-blocks-app`.

## Validation

- `npm run build -w packages/create-blocks-app`
- `npm run test -w packages/create-blocks-app`
- `git diff --check`
- `git diff --cached --check`
- `./node_modules/.bin/changeset status --since=origin/main`
- `./node_modules/.bin/tsx scripts/verify-changeset-coverage.ts`

## Checklist

- [x] PR description included
- [x] Tests are changed or added
- [x] Relevant documentation is changed or added (and PR referenced)

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
