### PR TITLE
docs: list create app templates in help

### DIFF
--- a/.changeset/create-app-help-templates.md
+++ b/.changeset/create-app-help-templates.md
@@ -1,0 +1,5 @@
+---
+"@aws-blocks/create-blocks-app": patch
+---
+
+List the available starter templates in `create-blocks-app --help` so users can discover valid `--template` values directly from the CLI.

--- a/packages/create-blocks-app/src/cli.test.ts
+++ b/packages/create-blocks-app/src/cli.test.ts
@@ -31,6 +31,7 @@ describe('create-blocks-app CLI argument parsing', () => {
     assert.strictEqual(result.exitCode, 0);
     assert.match(result.stdout, /Usage: create-blocks-app/);
     assert.match(result.stdout, /--template/);
+    assert.match(result.stdout, /Available templates: default, bare, react, backend, nextjs, auth-cognito, amplify, demo/);
     assert.match(result.stdout, /--help/);
     assert.match(result.stdout, /auto-detected/);
   });

--- a/packages/create-blocks-app/src/index.ts
+++ b/packages/create-blocks-app/src/index.ts
@@ -565,6 +565,7 @@ Arguments:
 
 Options:
   --template <name>      Template to use for fresh projects (default: "default")
+                         Available templates: ${AVAILABLE_TEMPLATES.join(', ')}
   -y, --yes              Skip confirmation prompts
   -h, --help             Show this help message
 


### PR DESCRIPTION
## Problem

`create-blocks-app --help` documents the `--template <name>` option but does not show which template names are accepted. Users have to consult the README or guess valid values from examples.

**Issue #, if available:** N/A

## Changes

- List the available starter templates in the CLI help text.
- Source the list from the existing `AVAILABLE_TEMPLATES` constant.
- Add a CLI regression assertion for the help output.
- Add a patch changeset for `@aws-blocks/create-blocks-app`.

## Validation

- `npm run build -w packages/create-blocks-app`
- `npm run test -w packages/create-blocks-app`
- `git diff --check`
- `git diff --cached --check`
- `./node_modules/.bin/changeset status --since=origin/main`
- `./node_modules/.bin/tsx scripts/verify-changeset-coverage.ts`

## Checklist

- [x] PR description included
- [x] Tests are changed or added
- [x] Relevant documentation is changed or added (and PR referenced)

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
