### PR TITLE
ci: skip templates without package metadata

### DIFF
--- a/.github/workflows/dependency-update.yml
+++ b/.github/workflows/dependency-update.yml
@@ -32,6 +32,10 @@ jobs:
       - name: Bump templates
         run: |
           for dir in packages/create-blocks-app/templates/*/; do
+            if [ ! -f "$dir/package.json" ]; then
+              echo "Skipping $dir (no package.json)"
+              continue
+            fi
             echo "Updating $dir"
             ncu -u --cwd "$dir"
           done


### PR DESCRIPTION
## Problem

The weekly dependency update workflow runs `ncu -u --cwd "$dir"` for every directory under `packages/create-blocks-app/templates/*/`. The `amplify` integration template does not have a root `package.json`, so the workflow can attempt to run dependency updates in a directory without package metadata.

**Issue #, if available:** N/A

## Changes

- Skip template directories that do not contain a root `package.json`.
- Log skipped directories so the workflow output remains clear.

## Validation

- Parsed `.github/workflows/dependency-update.yml` with the repo's `yaml` package.
- Ran a local dry-run of the template loop and confirmed `templates/amplify/` is skipped while package-backed templates are still selected for update.
- `git diff --check`
- `git diff --cached --check`

## Checklist

- [x] PR description included
- [ ] Tests are changed or added
- [ ] Relevant documentation is changed or added (and PR referenced)

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
