### PR TITLE
docs: fix foundations license

### DIFF
--- a/packages/foundations/README.md
+++ b/packages/foundations/README.md
@@ -191,4 +191,4 @@ See the Building Block Guide (see docs/reference/building-block-structure.md) fo
 
 ## License
 
-ISC
+Apache-2.0


### PR DESCRIPTION
## Problem

`packages/foundations/README.md` lists the package license as `ISC`, but `packages/foundations/package.json` and the package `LICENSE` file use Apache-2.0.

**Issue #, if available:** N/A

## Changes

- Update the `foundations` README license section to `Apache-2.0`.

## Validation

- Confirmed `packages/foundations/package.json` has `"license": "Apache-2.0"`.
- `git diff --check`
- `git diff --cached --check`
- `./node_modules/.bin/changeset status --since=origin/main`
- `./node_modules/.bin/tsx scripts/verify-changeset-coverage.ts`

## Checklist

- [x] PR description included
- [ ] Tests are changed or added
- [x] Relevant documentation is changed or added (and PR referenced)

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
