### PR TITLE
fix: clarify amplify create app template

### DIFF
--- a/.changeset/amplify-template-guidance.md
+++ b/.changeset/amplify-template-guidance.md
@@ -1,0 +1,5 @@
+---
+"@aws-blocks/create-blocks-app": patch
+---
+
+Treat Amplify Gen 2 integration as an auto-detected existing-project flow instead of advertising it as a fresh project template, and report clear guidance for `--template amplify`.

--- a/packages/create-blocks-app/README.md
+++ b/packages/create-blocks-app/README.md
@@ -27,7 +27,6 @@ Available templates:
 - **backend** - Backend-only (no frontend)
 - **nextjs** - Next.js integration
 - **auth-cognito** - Cognito authentication example
-- **amplify** - Amplify Gen 2 integration
 - **demo** - Demo application
 
 ### Add to Existing Project
@@ -45,6 +44,8 @@ npx @aws-blocks/create-blocks-app .
 ```
 
 The CLI detects your Amplify project (`amplify/backend.ts`) and integrates Blocks alongside it — adding a `aws-blocks/` workspace, wiring auth via bearer tokens, and scaffolding npm scripts for deployment. Your existing Amplify auth, data, and hosting stay untouched.
+
+Amplify Gen 2 integration is auto-detected from an existing project and is not selected with `--template`.
 
 ## What Gets Created
 

--- a/packages/create-blocks-app/src/cli.test.ts
+++ b/packages/create-blocks-app/src/cli.test.ts
@@ -33,7 +33,7 @@ describe('create-blocks-app CLI argument parsing', () => {
     assert.strictEqual(result.exitCode, 0);
     assert.match(result.stdout, /Usage: create-blocks-app/);
     assert.match(result.stdout, /--template/);
-    assert.match(result.stdout, /Available templates: default, bare, react, backend, nextjs, auth-cognito, amplify, demo/);
+    assert.match(result.stdout, /Available templates: default, bare, react, backend, nextjs, auth-cognito, demo/);
     assert.match(result.stdout, /--skip-install/);
     assert.match(result.stdout, /--help/);
     assert.match(result.stdout, /auto-detected/);
@@ -77,6 +77,14 @@ describe('create-blocks-app CLI argument parsing', () => {
     assert.strictEqual(result.exitCode, 1);
     assert.match(result.stderr, /Unknown template "does-not-exist"/);
     assert.match(result.stderr, /Available templates:/);
+    assert.doesNotMatch(result.stderr, /ENOENT/);
+  });
+
+  it('--template amplify exits 1 with existing-project guidance', () => {
+    const result = run(['my-app', '--template', 'amplify']);
+    assert.strictEqual(result.exitCode, 1);
+    assert.match(result.stderr, /Amplify integration is auto-detected/);
+    assert.match(result.stderr, /npx @aws-blocks\/create-blocks-app \./);
     assert.doesNotMatch(result.stderr, /ENOENT/);
   });
 

--- a/packages/create-blocks-app/src/index.ts
+++ b/packages/create-blocks-app/src/index.ts
@@ -185,12 +185,13 @@ async function addBlocksWorkspace(targetDir: string, options: {
   }
 }
 
-const AVAILABLE_TEMPLATES = ['default', 'bare', 'react', 'backend', 'nextjs', 'auth-cognito', 'amplify', 'demo'];
+const FRESH_PROJECT_TEMPLATES = ['default', 'bare', 'react', 'backend', 'nextjs', 'auth-cognito', 'demo'];
+const AMPLIFY_INTEGRATION_TEMPLATE = 'amplify';
 
 function validateTemplateName(templateName: string): void {
-  if (!AVAILABLE_TEMPLATES.includes(templateName)) {
+  if (!FRESH_PROJECT_TEMPLATES.includes(templateName)) {
     console.error(`Error: Unknown template "${templateName}".`);
-    console.error(`Available templates: ${AVAILABLE_TEMPLATES.join(', ')}`);
+    console.error(`Available templates: ${FRESH_PROJECT_TEMPLATES.join(', ')}`);
     process.exit(1);
   }
 }
@@ -307,7 +308,7 @@ async function integrateWithAmplify(targetDir: string, skipConfirm = false, skip
   console.log('\n📦 Scaffolding Blocks...\n');
 
   // 1. Copy aws-blocks/ template
-  const templateDir = join(__dirname, '../templates/amplify');
+  const templateDir = join(__dirname, '../templates', AMPLIFY_INTEGRATION_TEMPLATE);
   const awsBlocksSrc = join(templateDir, 'aws-blocks');
   const awsBlocksDest = join(targetDir, 'aws-blocks');
   await cp(awsBlocksSrc, awsBlocksDest, { recursive: true });
@@ -581,7 +582,7 @@ Options:
                          starter app; when adding to an existing project it
                          selects which aws-blocks/ workspace to copy, e.g.
                          "nextjs" for a Next.js dev server (default: "default")
-                         Available templates: ${AVAILABLE_TEMPLATES.join(', ')}
+                         Available templates: ${FRESH_PROJECT_TEMPLATES.join(', ')}
   --skip-install         Skip installing dependencies
   -y, --yes              Skip confirmation prompts
   -h, --help             Show this help message
@@ -631,6 +632,13 @@ async function create() {
       console.error(`Run with --help for usage information.`);
       process.exit(1);
     }
+  }
+
+  if (templateName === AMPLIFY_INTEGRATION_TEMPLATE) {
+    console.error('Error: The Amplify integration is auto-detected and is not a fresh project template.');
+    console.error('Run from your Amplify Gen 2 project root without --template:');
+    console.error('  npx @aws-blocks/create-blocks-app .');
+    process.exit(1);
   }
 
   validateTemplateName(templateName);


### PR DESCRIPTION
## Problem

The `amplify` integration assets live under `packages/create-blocks-app/templates/amplify/`, but that directory is not a fresh project template: it has no root `package.json` or root `gitignore`, and is used by the existing Amplify Gen 2 project integration path.

Because `amplify` is currently listed as an available fresh template, `create-blocks-app my-app --template amplify` tries to read `templates/amplify/package.json` and fails with a low-level file-system error.

**Issue #, if available:** N/A

## Changes

- Treat `amplify` as the existing-project integration template, not a fresh project template.
- Remove `amplify` from the documented fresh project template list.
- Add explicit `--template amplify` guidance that points users to running from an existing Amplify Gen 2 project root.
- Add a CLI regression test and a patch changeset for `@aws-blocks/create-blocks-app`.

## Validation

- `npm run build -w packages/create-blocks-app`
- `npm run test -w packages/create-blocks-app`
- `git diff --check`
- `git diff --cached --check`
- `./node_modules/.bin/changeset status --since=origin/main`
- `./node_modules/.bin/tsx scripts/verify-changeset-coverage.ts`

## Note

This is independent from the other `create-blocks-app` PRs, but it touches nearby CLI template handling and may need a quick rebase depending on merge order. I’ll handle that if needed.

## Checklist

- [x] PR description included
- [x] Tests are changed or added
- [x] Relevant documentation is changed or added (and PR referenced)

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
