### PR TITLE
fix: run nextjs template dev with webpack

### DIFF
--- a/.changeset/nextjs-template-webpack-dev.md
+++ b/.changeset/nextjs-template-webpack-dev.md
@@ -1,0 +1,5 @@
+---
+"@aws-blocks/create-blocks-app": patch
+---
+
+Make the Next.js template run its local frontend with webpack so `npm run dev` renders the scaffolded app correctly with local Blocks workspace packages, and make the template e2e test start the dev server itself.

--- a/packages/create-blocks-app/templates/nextjs/aws-blocks/scripts/server.ts
+++ b/packages/create-blocks-app/templates/nextjs/aws-blocks/scripts/server.ts
@@ -6,6 +6,6 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 
 startDevServer({
   backendPath: join(__dirname, '..', 'index.ts'),
-  frontendCommand: 'npx next dev --port 3100',
+  frontendCommand: 'npx next dev --webpack --port 3100',
   frontendPort: 3100,
 });

--- a/packages/create-blocks-app/templates/nextjs/test/e2e.test.ts
+++ b/packages/create-blocks-app/templates/nextjs/test/e2e.test.ts
@@ -1,24 +1,57 @@
+import { test } from 'node:test';
 import assert from 'node:assert';
+import { spawn, type ChildProcess } from 'node:child_process';
+import { setTimeout } from 'node:timers/promises';
 
 // Basic e2e test for the Next.js template
 // Run with: npm run test:e2e
 
-async function test() {
-  const baseUrl = process.env.TEST_URL || 'http://localhost:3000';
-  
-  console.log(`Testing ${baseUrl}...`);
-  
-  // Test home page loads
-  const res = await fetch(baseUrl);
-  assert.strictEqual(res.status, 200, 'Home page should return 200');
-  
-  const html = await res.text();
-  assert.ok(html.includes('AWS Blocks + Next.js'), 'Page should contain title');
-  
-  console.log('✓ All tests passed');
+const baseUrl = process.env.TEST_URL || 'http://localhost:3000';
+let server: ChildProcess | null = null;
+
+async function isServerReady() {
+  try {
+    const res = await fetch(baseUrl);
+    return res.status === 200;
+  } catch {
+    return false;
+  }
 }
 
-test().catch((err) => {
-  console.error('✗ Test failed:', err.message);
-  process.exit(1);
+async function waitForServer() {
+  for (let i = 0; i < 60; i++) {
+    if (await isServerReady()) return;
+    await setTimeout(1000);
+  }
+  throw new Error(`Next.js dev server did not become ready at ${baseUrl}`);
+}
+
+test.before(async () => {
+  console.log(`Testing ${baseUrl}...`);
+
+  if (!process.env.TEST_URL && !await isServerReady()) {
+    server = spawn('npm', ['run', 'dev'], {
+      cwd: process.cwd(),
+      stdio: ['ignore', 'pipe', 'pipe'],
+      detached: true,
+      env: { ...process.env, NODE_OPTIONS: '' },
+    });
+    server.unref();
+  }
+
+  await waitForServer();
+});
+
+test.after(() => {
+  if (server?.pid) {
+    try { process.kill(-server.pid, 'SIGTERM'); } catch {}
+  }
+});
+
+test('home page loads', async () => {
+  const res = await fetch(baseUrl);
+  assert.strictEqual(res.status, 200, 'Home page should return 200');
+
+  const html = await res.text();
+  assert.ok(html.includes('Blocks + Next.js'), 'Page should contain title');
 });


### PR DESCRIPTION
## Problem

**Issue #, if available:** N/A

The Next.js template currently starts its frontend with `npx next dev --port 3100`.
With the template's `next: ^16.0.0` dependency, `next dev` uses Turbopack by default.

When validating a freshly scaffolded Next.js app from the local monorepo path, the app starts but the page returns HTTP 500:

```text
./aws-blocks/client.js:8:1
Module not found: Can't resolve '@aws-blocks/blocks/client'
```

I also found that the Next.js template e2e test did not catch this because it assumed a server was already running at `http://localhost:3000`. Once it actually reaches the page, it was also asserting the old `AWS Blocks + Next.js` text while the template renders `Blocks + Next.js`.

## Changes

- Run the Next.js template frontend with `next dev --webpack --port 3100`.
- Make the Next.js template e2e test start `npm run dev` when `TEST_URL` is not provided.
- Keep `TEST_URL` support for externally managed dev servers.
- Update the e2e title assertion to match the current template UI.
- Add a changeset for `@aws-blocks/create-blocks-app`.

## Validation

Reproduced before the fix with a freshly scaffolded Next.js app:

```text
curl -i http://localhost:3000
HTTP/1.1 500 Internal Server Error
Module not found: Can't resolve '@aws-blocks/blocks/client'
```

Validated after the fix:

```text
node packages/create-blocks-app/dist/index.js /private/tmp/.../nextjs-app --template nextjs -y
cd /private/tmp/.../nextjs-app
npm run test:e2e
```

Result:

```text
✔ home page loads
ℹ pass 1
ℹ fail 0
```

Additional checks:

```text
npm run build -w packages/create-blocks-app
npm run test -w packages/create-blocks-app
./node_modules/.bin/changeset status --since=origin/main
./node_modules/.bin/tsx scripts/verify-changeset-coverage.ts
git diff --check
git diff --cached --check
```

Note: this is independent from the other open `create-blocks-app` PRs. I know the branch may need a quick rebase depending on merge order and can handle that if needed.

## Checklist

- [x] PR description included
- [x] Tests are changed or added
- [ ] Relevant documentation is changed or added (not applicable; release-note changeset added)

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
