### PR TITLE
fix: honor fresh project skip install

### DIFF
--- a/.changeset/fresh-skip-install.md
+++ b/.changeset/fresh-skip-install.md
@@ -1,0 +1,5 @@
+---
+"@aws-blocks/create-blocks-app": patch
+---
+
+Honor `--skip-install` when creating a fresh project so scaffolding can complete without running `npm install`.

--- a/packages/create-blocks-app/src/cli.test.ts
+++ b/packages/create-blocks-app/src/cli.test.ts
@@ -2,18 +2,20 @@ import { describe, it } from 'node:test';
 import { execFileSync } from 'node:child_process';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { mkdirSync, writeFileSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { existsSync, mkdirSync, mkdtempSync, writeFileSync, readFileSync, rmSync } from 'node:fs';
 import assert from 'node:assert';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const CLI_PATH = join(__dirname, '../dist/index.js');
 
-function run(args: string[], cwd?: string): { stdout: string; stderr: string; exitCode: number } {
+function run(args: string[], cwd?: string, env?: Record<string, string>): { stdout: string; stderr: string; exitCode: number } {
   try {
     const stdout = execFileSync('node', [CLI_PATH, ...args], {
       encoding: 'utf-8',
       timeout: 30000,
       cwd,
+      env: env ? { ...process.env, ...env } : undefined,
     });
     return { stdout, stderr: '', exitCode: 0 };
   } catch (err: any) {
@@ -32,6 +34,7 @@ describe('create-blocks-app CLI argument parsing', () => {
     assert.match(result.stdout, /Usage: create-blocks-app/);
     assert.match(result.stdout, /--template/);
     assert.match(result.stdout, /Available templates: default, bare, react, backend, nextjs, auth-cognito, amplify, demo/);
+    assert.match(result.stdout, /--skip-install/);
     assert.match(result.stdout, /--help/);
     assert.match(result.stdout, /auto-detected/);
   });
@@ -260,6 +263,23 @@ describe('create-blocks-app auto-detection', () => {
       assert.strictEqual(result.exitCode, 0);
       const serverContent = readFileSync(join(tmpDir, 'aws-blocks', 'scripts', 'server.ts'), 'utf-8');
       assert.match(serverContent, /vite/, 'default template should start the Vite dev server');
+    } finally {
+      rmSync(tmpDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+    }
+  });
+
+  it('skips npm install when creating a fresh project with --skip-install', () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), 'create-blocks-app-fresh-skip-install-'));
+    const targetDir = join(tmpDir, 'fresh-app');
+    try {
+      const result = run([targetDir, '-y', '--skip-install'], undefined, {
+        NPM_CONFIG_REGISTRY: 'http://127.0.0.1:9',
+      });
+      assert.strictEqual(result.exitCode, 0);
+      assert.match(result.stdout, /Blocks app created/);
+      assert.doesNotMatch(result.stdout, /Installing dependencies/);
+      assert.match(result.stdout, /\n  npm install\n/);
+      assert.strictEqual(existsSync(join(targetDir, 'node_modules')), false);
     } finally {
       rmSync(tmpDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
     }

--- a/packages/create-blocks-app/src/index.ts
+++ b/packages/create-blocks-app/src/index.ts
@@ -185,7 +185,7 @@ function validateTemplateName(templateName: string): void {
 
 // ─── Fresh project creation ──────────────────────────────────────────────────
 
-async function createFreshProject(targetDir: string, templateName: string) {
+async function createFreshProject(targetDir: string, templateName: string, skipInstall = false) {
   validateTemplateName(templateName);
 
   // Read template package.json to get template name
@@ -259,12 +259,17 @@ async function createFreshProject(targetDir: string, templateName: string) {
   cdkContent = cdkContent.replace(/my-blocks-stack/g, `${sanitizedName}-stack`);
   await writeFile(cdkPath, cdkContent);
   
-  console.log('Installing dependencies...');
-  execSync('npm install', { cwd: targetDir, stdio: 'inherit' });
+  if (!skipInstall) {
+    console.log('Installing dependencies...');
+    execSync('npm install', { cwd: targetDir, stdio: 'inherit' });
+  }
   
   console.log('\n✓ Blocks app created!');
   console.log(`\nNext steps:`);
   console.log(`  cd ${targetDir}`);
+  if (skipInstall) {
+    console.log(`  npm install`);
+  }
   console.log(`  npm run dev`);
   console.log(`\nThen open http://localhost:3000`);
   console.log(`\nSee README.md for an overview and AGENTS.md for AI agent instructions.`);
@@ -575,6 +580,7 @@ Options:
                          selects which aws-blocks/ workspace to copy, e.g.
                          "nextjs" for a Next.js dev server (default: "default")
                          Available templates: ${AVAILABLE_TEMPLATES.join(', ')}
+  --skip-install         Skip installing dependencies
   -y, --yes              Skip confirmation prompts
   -h, --help             Show this help message
 
@@ -655,7 +661,7 @@ async function create() {
         const templateDisplayName = tplPkg.blocksTemplate || templateName;
         targetDir = join('blocks-demo-apps', `template-${templateDisplayName}`);
       }
-      await createFreshProject(resolve(targetDir), templateName);
+      await createFreshProject(resolve(targetDir), templateName, skipInstall);
       return;
     }
 


### PR DESCRIPTION
## Problem

**Issue #, if available:** N/A

`create-blocks-app` parses `--skip-install`, and the flag is honored for existing-project and Amplify integration paths. However, the fresh-project path did not pass that parsed flag into `createFreshProject()`, so fresh app scaffolding always ran `npm install`.

I reproduced this by pointing npm at a closed registry and creating a fresh app with `--skip-install`:

```text
NPM_CONFIG_REGISTRY=http://127.0.0.1:9 node packages/create-blocks-app/dist/index.js /private/tmp/.../my-app --skip-install -y
Creating Blocks app in /private/tmp/.../my-app...
Installing dependencies...
```

That `Installing dependencies...` line should not appear when `--skip-install` is set.

## Changes

- Pass `skipInstall` into the fresh-project creation path.
- Skip `npm install` in `createFreshProject()` when the flag is set.
- Show `npm install` in the printed next steps when install was skipped.
- List `--skip-install` in `--help`.
- Add a CLI regression test that uses a closed registry URL and asserts fresh scaffolding completes without creating `node_modules`.
- Add a changeset for `@aws-blocks/create-blocks-app`.

## Validation

Re-ran the same closed-registry command after the fix:

```text
NPM_CONFIG_REGISTRY=http://127.0.0.1:9 node packages/create-blocks-app/dist/index.js /private/tmp/.../my-app --skip-install -y
Creating Blocks app in /private/tmp/.../my-app...

✓ Blocks app created!

Next steps:
  cd /private/tmp/.../my-app
  npm install
  npm run dev
```

Also verified `node_modules` is not created in the scaffolded app.

Additional checks:

```text
npm run build -w packages/create-blocks-app
npm run test -w packages/create-blocks-app
./node_modules/.bin/changeset status --since=origin/main
./node_modules/.bin/tsx scripts/verify-changeset-coverage.ts
git diff --check
git diff --cached --check
```

Note: this is independent from the other open `create-blocks-app` PRs. I know the branch may need a quick rebase depending on merge order and can handle that if needed.

## Checklist

- [x] PR description included
- [x] Tests are changed or added
- [x] Relevant documentation is changed or added (help output and changeset)

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
