### PR TITLE
fix(core): serve `/.blocks-sandbox/config.json` from the dev server

### DIFF
--- a/.changeset/dev-server-serve-blocks-config.md
+++ b/.changeset/dev-server-serve-blocks-config.md
@@ -1,0 +1,7 @@
+---
+"@aws-blocks/core": patch
+---
+
+Serve `/.blocks-sandbox/config.json` from the dev server itself instead of proxying it to the framework dev server.
+
+The browser auth client resolves its API URL by fetching `/.blocks-sandbox/config.json`. The dev server proxied that request to the framework dev server (Next.js/Nuxt/Astro), which only serves its own static dir and returned 404 — so the client failed with "Blocks API URL not configured" in local `dev`. The dev server now answers this reserved path directly, mirroring production where CloudFront serves `/.blocks-sandbox/*` as static assets. Framework-agnostic and requires no per-app workaround.

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -29,3 +29,16 @@ export const BLOCKS_RPC_PREFIX = '/aws-blocks/api';
  * prefix; CloudFront forwards the subtree and the Lambda dispatches by path.
  */
 export const BLOCKS_AUTH_PREFIX = '/aws-blocks/auth';
+
+/**
+ * Reserved path for the client runtime config (`config.json`).
+ *
+ * In production CloudFront serves `${BLOCKS_SANDBOX_PREFIX}/*` from S3 as
+ * static assets (see hosting.ts) so the browser client can resolve its API
+ * URL. The local dev server mirrors this by serving the config from the front
+ * door itself, instead of proxying the request to the framework dev server —
+ * which only serves its own static dir (Next.js `public/`, etc.) and would 404
+ * on a project-root file. Keeping this symmetric with production is what makes
+ * the browser client work the same in `dev`, `sandbox`, and deployed.
+ */
+export const BLOCKS_SANDBOX_PREFIX = '/.blocks-sandbox';

--- a/packages/core/src/scripts/dev-server-config.test.ts
+++ b/packages/core/src/scripts/dev-server-config.test.ts
@@ -1,0 +1,43 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { buildBlocksConfig, isBlocksConfigRequest } from './dev-server.js';
+
+describe('buildBlocksConfig — client runtime config', () => {
+  it('points the browser at the localhost front door RPC endpoint', () => {
+    assert.deepStrictEqual(buildBlocksConfig(3000, false), {
+      apiUrl: 'http://localhost:3000/aws-blocks/api',
+      environment: 'local',
+    });
+  });
+
+  it('honors a custom port', () => {
+    assert.strictEqual(buildBlocksConfig(4000, false).apiUrl, 'http://localhost:4000/aws-blocks/api');
+  });
+
+  it('marks the environment as sandbox but keeps the localhost front door', () => {
+    assert.deepStrictEqual(buildBlocksConfig(3000, true), {
+      apiUrl: 'http://localhost:3000/aws-blocks/api',
+      environment: 'sandbox',
+    });
+  });
+});
+
+describe('isBlocksConfigRequest — reserved runtime-config path', () => {
+  it('matches GET /.blocks-sandbox/config.json', () => {
+    assert.strictEqual(isBlocksConfigRequest('GET', '/.blocks-sandbox/config.json'), true);
+  });
+
+  it('ignores non-GET methods (only the static-style read is reserved)', () => {
+    assert.strictEqual(isBlocksConfigRequest('POST', '/.blocks-sandbox/config.json'), false);
+    assert.strictEqual(isBlocksConfigRequest('HEAD', '/.blocks-sandbox/config.json'), false);
+  });
+
+  it('does not match other paths (frontend/app routes pass through to the proxy)', () => {
+    assert.strictEqual(isBlocksConfigRequest('GET', '/'), false);
+    assert.strictEqual(isBlocksConfigRequest('GET', '/api/chat'), false);
+    assert.strictEqual(isBlocksConfigRequest('GET', '/.blocks-sandbox/other.json'), false);
+    assert.strictEqual(isBlocksConfigRequest('GET', '/aws-blocks/api'), false);
+  });
+});

--- a/packages/core/src/scripts/dev-server.ts
+++ b/packages/core/src/scripts/dev-server.ts
@@ -10,7 +10,7 @@ import { createConnection } from 'node:net';
 import httpProxy from 'http-proxy';
 import { writeClientCode } from './generate-client.js';
 import { ApiError } from '../errors.js';
-import { BLOCKS_RPC_PREFIX } from '../constants.js';
+import { BLOCKS_RPC_PREFIX, BLOCKS_SANDBOX_PREFIX } from '../constants.js';
 import { matchRoute, lockRouteRegistry } from '../raw-route.js';
 import { registerBuiltinRoutes } from '../builtin-routes.js';
 import {
@@ -41,6 +41,35 @@ export const LOCALHOST_PATTERN = /^https?:\/\/(localhost|127\.0\.0\.1)(:\d+)?$/;
  */
 export function resolveDevCorsOrigin(origin: string): string {
   return LOCALHOST_PATTERN.test(origin) ? origin : 'http://localhost:3000';
+}
+
+/** Shape of the client runtime config the browser fetches to discover the API URL. */
+export interface BlocksRuntimeConfig {
+  apiUrl: string;
+  environment: 'local' | 'sandbox';
+}
+
+/**
+ * Build the runtime config the browser fetches at `${BLOCKS_SANDBOX_PREFIX}/config.json`.
+ * In sandbox mode the browser still targets the localhost front door (the dev
+ * server proxies `/aws-blocks/api` to the deployed API), so the shape is the
+ * same in both modes — only `environment` differs.
+ */
+export function buildBlocksConfig(port: number, isSandbox: boolean): BlocksRuntimeConfig {
+  return {
+    apiUrl: `http://localhost:${port}${BLOCKS_RPC_PREFIX}`,
+    environment: isSandbox ? 'sandbox' : 'local',
+  };
+}
+
+/**
+ * True for the reserved runtime-config request the dev server answers itself
+ * (mirroring production, where CloudFront serves `${BLOCKS_SANDBOX_PREFIX}/*`
+ * statically) instead of proxying it to the framework dev server — which only
+ * serves its own static dir (Next.js `public/`, etc.) and would 404.
+ */
+export function isBlocksConfigRequest(method: string, pathname: string): boolean {
+  return method === 'GET' && pathname === `${BLOCKS_SANDBOX_PREFIX}/config.json`;
 }
 
 export interface DevServerOptions {
@@ -125,11 +154,9 @@ export async function startDevServer(options: DevServerOptions) {
   // BLOCKS_API_URL server-side, so the request still reaches the deployed Lambda.
   // This makes sandbox single-origin, matching `npm run dev` and the prod
   // CloudFront proxy; `crossDomain` stays unnecessary.
+  const blocksConfig = buildBlocksConfig(port, isSandbox);
   mkdirSync('.blocks-sandbox', { recursive: true });
-  writeFileSync('.blocks-sandbox/config.json', JSON.stringify({
-    apiUrl: `http://localhost:${port}${BLOCKS_RPC_PREFIX}`,
-    environment: isSandbox ? 'sandbox' : 'local',
-  }, null, 2));
+  writeFileSync('.blocks-sandbox/config.json', JSON.stringify(blocksConfig, null, 2));
 
   // 1. Set up global collectors for plugin discovery
   (globalThis as any).__BLOCKS_CLIENT_MIDDLEWARE__ = [];
@@ -218,6 +245,18 @@ export async function startDevServer(options: DevServerOptions) {
     if (method === 'OPTIONS') {
       res.writeHead(200);
       res.end();
+      return;
+    }
+
+    // ── Blocks runtime config ──────────────────────────────────────────
+    // Reserved path: serve it from the front door so it works for every
+    // framework (Next/Nuxt/Astro/SPA all proxy through this :3000 server),
+    // mirroring production where CloudFront serves `${BLOCKS_SANDBOX_PREFIX}/*`
+    // statically. Otherwise the request is proxied to the framework dev
+    // server, which can't serve this project-root file and 404s.
+    if (isBlocksConfigRequest(method, url.pathname)) {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(blocksConfig));
       return;
     }
 

--- a/packages/core/src/scripts/dev-server.ts
+++ b/packages/core/src/scripts/dev-server.ts
@@ -4,7 +4,7 @@
 import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
 import { pathToFileURL, URL } from 'node:url';
 import { resolve, dirname, join } from 'node:path';
-import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { writeFileSync, mkdirSync } from 'node:fs';
 import { spawn, type ChildProcess } from 'node:child_process';
 import { createConnection } from 'node:net';
 import httpProxy from 'http-proxy';
@@ -255,7 +255,10 @@ export async function startDevServer(options: DevServerOptions) {
     // statically. Otherwise the request is proxied to the framework dev
     // server, which can't serve this project-root file and 404s.
     if (isBlocksConfigRequest(method, url.pathname)) {
-      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.writeHead(200, {
+        'Content-Type': 'application/json',
+        'Cache-Control': 'no-store',
+      });
       res.end(JSON.stringify(blocksConfig));
       return;
     }


### PR DESCRIPTION
## Problem

In local development the browser cannot resolve its Blocks API URL. The client fetches `/.blocks-sandbox/config.json`, but the dev server proxies that request to the framework dev server (Next.js/Nuxt/Astro), which only serves its own static directory and returns 404. The client then throws "Blocks API URL not configured", and any browser-side call — notably the `Authenticator` / `onAuthChange` auth UI — fails.

The dev server already writes this file and serves the RPC endpoint at `/aws-blocks/api`; it just doesn't serve the config path. Production has no such gap: the `Hosting` construct serves `/.blocks-sandbox/*` as static assets via CloudFront (`packages/core/src/hosting.ts`). This change makes `dev` symmetric with production.

**Issue #, if available:** #66 (aws-devtools-labs/aws-blocks#66)

## Changes

`packages/core/src/scripts/dev-server.ts`
- The dev server now answers the reserved path `GET /.blocks-sandbox/config.json` directly, from the config it already builds in memory, before falling through to the frontend proxy. Framework-agnostic — every framework proxies through the same `:3000` front door — so no per-app workaround is needed.
- Extracted two pure helpers (mirroring the existing `resolveDevCorsOrigin` pattern) for testability:
  - `buildBlocksConfig(port, isSandbox): BlocksRuntimeConfig`
  - `isBlocksConfigRequest(method, pathname): boolean`

`packages/core/src/constants.ts`
- Added `BLOCKS_SANDBOX_PREFIX = '/.blocks-sandbox'`. Internal only (not re-exported from the package entry), so there is no public API surface change.

`.changeset/dev-server-serve-blocks-config.md`
- `@aws-blocks/core: patch`.

No dependency changes; `package-lock.json` is untouched.

## Validation

- **Unit tests** (`packages/core/src/scripts/dev-server-config.test.ts`): cover `buildBlocksConfig` (local / sandbox / custom port) and `isBlocksConfigRequest` (method + path matching, including near-miss paths). All 11 dev-server unit tests pass.
- **Build**: `npm run build -w @aws-blocks/core` → exit 0.
- **Manual** (Next.js 16 app, `npm run dev:server`): `GET /.blocks-sandbox/config.json` returns `200 {"apiUrl":"http://localhost:3000/aws-blocks/api","environment":"local"}` served by the dev server (no app-side route or rewrite); the auth UI resolves and sign-in works end to end.
- Cross-framework E2E (`test-apps/hosting-ssr`, `-nuxt`, `-astro`) require an AWS sandbox and run in CI; not run locally.

## Checklist

- [x] PR description included
- [x] Tests are changed or added
- [ ] Relevant documentation is changed or added — n/a; behavior now matches the documented production semantics, and the reserved path is documented inline on `BLOCKS_SANDBOX_PREFIX`.

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
