### PR TITLE
fix(auth-common): emit synchronous first frame in onAuthChange & Authenticator

### DIFF
--- a/.changeset/sync-onauthchange-first-frame.md
+++ b/.changeset/sync-onauthchange-first-frame.md
@@ -1,0 +1,15 @@
+---
+"@aws-blocks/auth-common": patch
+---
+
+Fix `onAuthChange` and `Authenticator` to paint a synchronous first frame.
+
+Both previously deferred their initial emit/render behind the async
+`ensureState().then(...)`, so a signed-out UI never painted synchronously on
+subscribe — leaving a blank first frame and causing non-deterministic timeouts
+in CI harnesses (and contradicting `onAuthChange`'s documented "calls callback
+immediately" contract). `onAuthChange` now emits the last-known user from the
+shared cache synchronously, then refreshes from the async hydration — with a
+dedupe to avoid a spurious `null → user` flash and a `.catch` so a rejected
+`getAuthState()` never strands the UI. `Authenticator` does the same synchronous
+first paint from the cache and gains the same `.catch` hardening.

--- a/packages/auth-common/src/ui.test.ts
+++ b/packages/auth-common/src/ui.test.ts
@@ -544,6 +544,59 @@ describe('onAuthChange', () => {
 		unsub();
 	});
 
+	// Regression guard: the FIRST emit must be synchronous (no await). Before
+	// the fix the only emit was deferred behind `ensureState().then(...)`, so a
+	// signed-out UI never painted a first frame and CI harnesses timed out.
+	test('emits synchronously on subscribe (signed out)', () => {
+		const api = mockApi(signedOutState());
+		let called = false;
+		let received: any = 'sentinel';
+		onAuthChange(api, (user) => { called = true; received = user; });
+		// No `await flush()` here — synchronous emission is the whole point.
+		assert.strictEqual(called, true, 'callback must fire synchronously on subscribe');
+		assert.strictEqual(received, null, 'cold signed-out load emits null synchronously');
+	});
+
+	test('emits the signed-in user synchronously from a warm cache', async () => {
+		const api = mockApi(signedInState());
+		// Warm the shared cache (async hydration triggered by the first subscribe).
+		const unsubWarm = onAuthChange(api, () => {});
+		await flush();
+
+		// A subsequent subscribe must emit the known user synchronously, and must
+		// NOT flash null → user — the dedupe suppresses the redundant refresh.
+		const seen: any[] = [];
+		const unsub = onAuthChange(api, (user) => { seen.push(user); });
+		assert.strictEqual(seen.length, 1, 'warm-cache subscribe emits exactly once, synchronously');
+		assert.deepStrictEqual(seen[0], { userId: 'alice', username: 'alice' });
+
+		await flush();
+		assert.strictEqual(seen.length, 1, 'no redundant repaint after async refresh (no null → user flash)');
+
+		unsub();
+		unsubWarm();
+	});
+
+	test('does not throw or strand the UI when getAuthState rejects', async () => {
+		const api = mockApi(signedOutState());
+		api.getAuthState = async () => { throw new Error('network down'); };
+
+		const seen: any[] = [];
+		// Subscribing must not throw even though hydration will reject.
+		const unsub = onAuthChange(api, (user) => { seen.push(user); });
+
+		// Synchronous first frame still painted from the (cold) cache.
+		assert.strictEqual(seen.length, 1, 'sync first frame emitted before the rejection');
+		assert.strictEqual(seen[0], null);
+
+		// Let the rejected hydration settle: no unhandled rejection, no throw,
+		// and the last-known frame is preserved (no extra emit).
+		await flush();
+		assert.strictEqual(seen.length, 1, 'rejection does not strand or re-emit');
+
+		unsub();
+	});
+
 	test('reacts to broadcastAuthChange', async () => {
 		const api = mockApi(signedOutState());
 		const events: any[] = [];

--- a/packages/auth-common/src/ui.test.ts
+++ b/packages/auth-common/src/ui.test.ts
@@ -493,6 +493,53 @@ describe('Authenticator', () => {
 		const inputs = el.querySelectorAll('input');
 		assert.ok(inputs.length >= 2);
 	});
+
+	// ---------------------------------------------------------------------
+	// Synchronous first paint (regression guards)
+	// ---------------------------------------------------------------------
+
+	test('paints the sign-in form synchronously from a warm cache (signed out)', async () => {
+		const api = mockApi(signedOutState());
+		// Warm the shared cache for this api (async hydration on first mount).
+		const warm = Authenticator(api);
+		await flush();
+		assert.ok(warm.querySelectorAll('input').length >= 2, 'warm element hydrated');
+
+		// A fresh Authenticator on the now-warm api must paint synchronously —
+		// no `await flush()` before these assertions.
+		const el = Authenticator(api);
+		const inputs = el.querySelectorAll('input');
+		assert.ok(inputs.length >= 2, 'sign-in inputs present synchronously on return');
+		const labels = Array.from(el.querySelectorAll('button')).map((b) => b.textContent);
+		assert.ok(labels.includes('Sign In'), 'Sign In button present synchronously');
+	});
+
+	test('paints the signed-in view synchronously from a warm cache', async () => {
+		const api = mockApi(signedInState());
+		const warm = Authenticator(api);
+		await flush();
+		assert.ok(warm.textContent?.includes('alice'), 'warm element hydrated');
+
+		const el = Authenticator(api);
+		// No `await flush()` — synchronous paint is the point.
+		assert.ok(el.textContent?.includes('alice'), 'signed-in view painted synchronously');
+	});
+
+	test('does not re-render on a warm-cache load (no double paint)', async () => {
+		const api = mockApi(signedInState());
+		const warm = Authenticator(api);
+		await flush();
+		assert.ok(warm.textContent?.includes('alice'));
+
+		const el = Authenticator(api);
+		const firstChild = el.firstElementChild;
+		assert.ok(firstChild, 'painted synchronously on return');
+
+		await flush();
+		// `rerender` replaces children with a fresh subtree, so if the async
+		// hydrate repainted, firstElementChild would be a different node.
+		assert.strictEqual(el.firstElementChild, firstChild, 'async hydrate must not repaint a warm load');
+	});
 });
 
 describe('AuthenticatedContent', () => {
@@ -551,10 +598,11 @@ describe('onAuthChange', () => {
 		const api = mockApi(signedOutState());
 		let called = false;
 		let received: any = 'sentinel';
-		onAuthChange(api, (user) => { called = true; received = user; });
+		const unsub = onAuthChange(api, (user) => { called = true; received = user; });
 		// No `await flush()` here — synchronous emission is the whole point.
 		assert.strictEqual(called, true, 'callback must fire synchronously on subscribe');
 		assert.strictEqual(received, null, 'cold signed-out load emits null synchronously');
+		unsub();
 	});
 
 	test('emits the signed-in user synchronously from a warm cache', async () => {
@@ -595,6 +643,37 @@ describe('onAuthChange', () => {
 		assert.strictEqual(seen.length, 1, 'rejection does not strand or re-emit');
 
 		unsub();
+	});
+
+	test('retries hydration after a rejected getAuthState (hydrating not stranded)', async () => {
+		const api = mockApi(signedOutState());
+		let calls = 0;
+		api.getAuthState = async () => {
+			calls += 1;
+			if (calls === 1) throw new Error('network down');
+			return signedInState();
+		};
+
+		// First subscribe: sync null frame, then the hydration rejects.
+		const seen1: any[] = [];
+		const unsub1 = onAuthChange(api, (user) => { seen1.push(user); });
+		await flush();
+		assert.strictEqual(calls, 1, 'first hydration attempted');
+
+		// Second subscribe must RETRY hydration — the rejected attempt cleared
+		// cache.hydrating instead of stranding a rejected promise — and resolve
+		// to the now-available signed-in user.
+		const seen2: any[] = [];
+		const unsub2 = onAuthChange(api, (user) => { seen2.push(user); });
+		await flush();
+		assert.strictEqual(calls, 2, 'rejected hydration is retried, not replayed');
+		assert.ok(
+			seen2.some((u) => u && u.userId === 'alice'),
+			'retry resolves to the signed-in user',
+		);
+
+		unsub1();
+		unsub2();
 	});
 
 	test('reacts to broadcastAuthChange', async () => {

--- a/packages/auth-common/src/ui.ts
+++ b/packages/auth-common/src/ui.ts
@@ -148,11 +148,19 @@ async function ensureState(api: AuthStateApi): Promise<AuthState> {
 	const cache = getCache(api);
 	if (cache.state) return cache.state;
 	if (cache.hydrating) return cache.hydrating;
-	cache.hydrating = api.getAuthState().then((s) => {
-		cache.state = s;
-		cache.hydrating = null;
-		return s;
-	});
+	cache.hydrating = api.getAuthState()
+		.then((s) => {
+			cache.state = s;
+			cache.hydrating = null;
+			return s;
+		})
+		.catch((e) => {
+			// Clear the in-flight marker on failure so the next ensureState()
+			// retries the network instead of replaying a stale rejected
+			// promise forever. Re-throw so callers' .catch() still fires.
+			cache.hydrating = null;
+			throw e;
+		});
 	return cache.hydrating;
 }
 
@@ -508,12 +516,20 @@ export function Authenticator(api: AuthStateApi, options?: AuthenticatorOptions)
 	const cached = getCache(api).state;
 	if (cached) rerender(cached);
 
-	// Refresh from the (async) hydrated state. .catch() so a rejected
-	// getAuthState() doesn't surface as an unhandled rejection or leave the
-	// component stranded.
-	ensureState(api).then(rerender).catch(() => {
-		// keep the last-known frame
-	});
+	// Refresh from the (async) hydrated state. Skip the repaint when the
+	// resolved state is the very object we already painted synchronously
+	// (warm-cache fast path — `ensureState` returns the cached object), so a
+	// warm load renders exactly once. .catch() so a rejected getAuthState()
+	// doesn't surface as an unhandled rejection or leave the component
+	// stranded.
+	ensureState(api)
+		.then((s) => {
+			if (s === cached) return;
+			rerender(s);
+		})
+		.catch(() => {
+			// keep the last-known frame
+		});
 
 	// Re-render when state is updated (by setAuthState or external changes)
 	subscribe(api, rerender);

--- a/packages/auth-common/src/ui.ts
+++ b/packages/auth-common/src/ui.ts
@@ -189,10 +189,34 @@ export function broadcastAuthChange(user: AuthUser | null): void {
 }
 
 /**
+ * Shallow structural equality for cached auth users. Used to suppress a
+ * redundant repaint when the async hydration resolves to the same user that
+ * was already emitted synchronously. Returns true for two `null`s and for the
+ * same object reference (the warm-cache fast path).
+ */
+function sameAuthUser(a: AuthUser | null, b: AuthUser | null): boolean {
+	if (a === b) return true;
+	if (a === null || b === null) return false;
+	const ra = a as unknown as Record<string, unknown>;
+	const rb = b as unknown as Record<string, unknown>;
+	const aKeys = Object.keys(ra);
+	const bKeys = Object.keys(rb);
+	if (aKeys.length !== bKeys.length) return false;
+	return aKeys.every((k) => ra[k] === rb[k]);
+}
+
+/**
  * Subscribe to auth state changes from any source (same window + other tabs).
  *
- * Calls `callback` immediately with the current user, then again whenever
- * auth state changes anywhere. Uses the shared state cache — only one
+ * Invokes `callback` **synchronously** with the last-known user from the
+ * shared cache so the UI can paint a first frame without waiting on the
+ * network, then again once the async hydration settles and on every later
+ * change. A warm cache emits the cached user immediately (and skips the
+ * redundant refresh); a cold cache emits `null` synchronously and refreshes
+ * when `getAuthState()` resolves — unless a hydration is already in flight,
+ * in which case the synchronous `null` is skipped to avoid a signed-out
+ * flash. A rejected `getAuthState()` keeps the synchronous first frame
+ * rather than stranding the UI. Uses the shared state cache — only one
  * network call is made regardless of how many subscribers exist.
  *
  * @returns An unsubscribe function.
@@ -213,8 +237,27 @@ export function onAuthChange(
 	};
 	window.addEventListener(AUTH_LOCAL_EVENT, localHandler);
 
-	// Initial state from shared cache (single network call)
-	ensureState(api).then((s) => callback(s.user ?? null));
+	// Synchronous first frame from the shared cache, then an async refresh.
+	// Skip the sync emit only when the cache is cold AND a hydration is
+	// already in flight — the pending promise will deliver the real value,
+	// so emitting a throwaway `null` now would just flash signed-out.
+	const cache = getCache(api);
+	let emitted: AuthUser | null | undefined;
+	if (cache.state || !cache.hydrating) {
+		emitted = cache.state?.user ?? null;
+		callback(emitted);
+	}
+	ensureState(api)
+		.then((s) => {
+			const user = s.user ?? null;
+			// Don't repaint if the hydrated value matches the sync emit.
+			if (emitted !== undefined && sameAuthUser(user, emitted)) return;
+			callback(user);
+		})
+		.catch(() => {
+			// getAuthState() rejected — keep the last-known frame; never
+			// strand the UI on an unresolved subscribe.
+		});
 
 	return () => {
 		getChannel().removeEventListener('message', channelHandler);
@@ -457,8 +500,20 @@ export function Authenticator(api: AuthStateApi, options?: AuthenticatorOptions)
 		}
 	}
 
-	// Initial render from shared cache
-	ensureState(api).then(rerender);
+	// Paint a synchronous first frame from the last-known cache so the
+	// component isn't a blank <div> until the network round-trip lands. A
+	// cold cache has no actions to render yet (they arrive with the async
+	// state), so the sync paint only fires once a prior hydration populated
+	// the cache; the async refresh below covers the cold first load.
+	const cached = getCache(api).state;
+	if (cached) rerender(cached);
+
+	// Refresh from the (async) hydrated state. .catch() so a rejected
+	// getAuthState() doesn't surface as an unhandled rejection or leave the
+	// component stranded.
+	ensureState(api).then(rerender).catch(() => {
+		// keep the last-known frame
+	});
 
 	// Re-render when state is updated (by setAuthState or external changes)
 	subscribe(api, rerender);


### PR DESCRIPTION
## Problem

`onAuthChange(api, cb)` and `Authenticator(api)` in `packages/auth-common/src/ui.ts` deferred their **first** emit/paint behind the async `ensureState(api).then(...)`, so a signed-out UI never produced a synchronous first frame on subscribe/return:

- **`onAuthChange`** emitted *only* via `ensureState(api).then((s) => callback(s.user ?? null))` — there was no synchronous emit, so its documented contract *"Calls callback immediately with the current user"* was false.
- **`Authenticator`** returned an empty `<div>` and filled it only via `ensureState(api).then(rerender)`.

This left a blank first frame until the network round-trip resolved and caused **non-deterministic timeouts** in CI harnesses that assert on the first frame without awaiting a tick.

A review of the initial fix surfaced three latent issues that are also addressed here:
- `ensureState` only cleared `cache.hydrating` on success, so a rejected `getAuthState()` left a stranded rejected promise that blocked all future retries.
- `Authenticator` repainted twice on a warm cache (synchronous paint followed by a redundant async `rerender` with the same state).
- A test subscribed via `onAuthChange` without ever calling its returned `unsub()` (leaked listener).

**Issue #, if available:** N/A

## Changes

**`onAuthChange`**
- Emit the last-known user from the shared cache **synchronously** (`getCache(api).state?.user ?? null`), then refresh from the async hydration.
- **Dedupe** via a small `sameAuthUser()` helper so an already-signed-in warm load doesn't flash `null → user`, and so the callback isn't re-invoked when the hydrated value matches the synchronous emit.
- **No signed-out flash:** skip the synchronous `null` only when the cache is cold *and* a hydration is already in flight (the pending promise delivers the real value).
- **`.catch()`** so a rejected `getAuthState()` keeps the last-known frame instead of stranding the UI.
- Broadcast / local listeners are untouched.

**`Authenticator`**
- Synchronous initial `rerender(getCache(api).state)` when the cache is warm, independent of the async hydrate, so the sign-in form paints on return.
- Skip the redundant async `rerender` when `ensureState` resolves the **same** cached object already painted (`s === cached`), so a warm load renders exactly once.
- `.catch()` on the async hydrate so a rejection doesn't surface as an unhandled rejection or leave the component stranded.

**`ensureState`**
- Clear `cache.hydrating` on rejection (and re-throw) so a failed `getAuthState()` is retried on the next call instead of replaying a stranded rejected promise forever. The re-throw preserves the `.catch()` handlers in `onAuthChange` / `Authenticator`.

**Docs**
- JSDoc on `onAuthChange` updated to accurately describe the synchronous-first-frame + async-refresh + dedupe behavior (the previous text claimed an unconditional immediate call).

Commits: `e7f1a05` (initial sync first-frame fix) and `0791148` (review findings — `ensureState` retry, `Authenticator` warm-cache dedupe, test cleanup + new guards).

## Validation

Tests run against the compiled `dist/` output on Node 22:

```bash
npm run build -w packages/hosting -w packages/pipeline -w packages/core -w packages/auth-common
npm run test -w packages/auth-common
# tests 50 / pass 50 / fail 0
```

Added **7** regression guards in `packages/auth-common/src/ui.test.ts` (suite 43 → 50):

`onAuthChange`
- `emits synchronously on subscribe (signed out)` — callback fires **without** `await flush()`.
- `emits the signed-in user synchronously from a warm cache` — cached user emitted synchronously, no `null → user` flash (dedupe).
- `does not throw or strand the UI when getAuthState rejects` — a rejected hydration neither throws nor strands, and the synchronous first frame is preserved.
- `retries hydration after a rejected getAuthState (hydrating not stranded)` — a second subscribe re-attempts `getAuthState()` and resolves to the signed-in user.

`Authenticator`
- `paints the sign-in form synchronously from a warm cache (signed out)` — inputs and the "Sign In" button are present on return, **without** `await flush()`.
- `paints the signed-in view synchronously from a warm cache` — signed-in content is present on return.
- `does not re-render on a warm-cache load (no double paint)` — `firstElementChild` identity is stable across the async tick.

The existing `await flush()` tests are unchanged. Each new guard was confirmed to **fail when its corresponding fix is reverted** (3/3 for the sync-emit fix, 4/4 for the review-finding fixes) and to **pass** with the fix in place (**50/50**).

A patch changeset for `@aws-blocks/auth-common` is included (`.changeset/sync-onauthchange-first-frame.md`); the **Require changeset** CI gate passes.

## Checklist

- [x] PR description included
- [x] Tests are changed or added
- [ ] Relevant documentation is changed or added (and PR referenced) — only inline JSDoc on `onAuthChange` was updated (covered above); no separate documentation deliverable references this PR.

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
