### PR TITLE
fix(release): bump @aws-blocks/blocks in changeset

### DIFF
--- a/.changeset/add-design-docs.md
+++ b/.changeset/add-design-docs.md
@@ -19,6 +19,7 @@
 "@aws-blocks/bb-metrics": patch
 "@aws-blocks/bb-realtime": patch
 "@aws-blocks/bb-tracer": patch
+"@aws-blocks/blocks": patch
 ---
 
 docs: add per-package DESIGN.md documents
@@ -28,3 +29,4 @@ Adds a `DESIGN.md` to each building-block package describing its architecture, A
 - Each document is cross-checked against the current source so identifiers, environment variables, error names, and described behavior match the implementation.
 - Each `DESIGN.md` is listed in its package's `files` array so it ships on npm alongside `README.md`.
 - For consistency, `bb-auth-cognito`'s document lives at the package root like every other package.
+- Bumps the umbrella `@aws-blocks/blocks` package so its bundled `docs/` — assembled from these block READMEs at build time — republishes with a fresh version. Its packed content changes whenever the READMEs change, but the version was previously left untouched, which tripped the publish integrity guard.


### PR DESCRIPTION
## Problem

`publish-packages.yml` fails on merge to `main` at the **Publish to S3** step:

```
@aws-blocks/blocks@0.1.4 already exists with different content.
Did you forget to include it in your changeset?
```

## Root cause

The umbrella package `@aws-blocks/blocks` bundles **every `bb-*` README** into its own `docs/` directory at build time (via `scripts/sync-block-docs.mjs`, shipped through `files: ["docs"]`) and caret-pins all `bb-*` packages as dependencies.

When `changeset version` bumps the `bb-*` packages, the umbrella's **packed content changes** (its `docs/` are refreshed from the updated READMEs) — but its **version is not bumped**, because no changeset named `@aws-blocks/blocks`. Changesets' default `updateInternalDependents: "out-of-range"` leaves it alone since the `^` ranges still satisfy the new versions.

The publish script's integrity guard (`scripts/publish/publish.ts`) then correctly refuses the changed-but-same-version `0.1.4` tarball.

## Fix

Add `'@aws-blocks/blocks': patch` to the pending `.changeset/add-design-docs.md` changeset so the umbrella package is version-bumped (`0.1.4 → 0.1.5`) alongside the `bb-*` packages whose READMEs it bundles. It now republishes cleanly with fresh content under a fresh version.

The publish integrity guard in `scripts/publish/publish.ts` is **left untouched** — it is working as intended.

## Verification

Ran `changeset version` locally against the pending changesets:

- `@aws-blocks/blocks`: **`0.1.4 → 0.1.5`** ✅
- Its `bb-*` dependency ranges were rewritten (e.g. `bb-auth-cognito ^0.1.3 → ^0.1.4`, `bb-logger ^0.1.1 → ^0.1.2`)
- A fresh `CHANGELOG.md` entry was generated for `@aws-blocks/blocks@0.1.5`
- No errors

## Scope

- **Only** `.changeset/add-design-docs.md` is changed (2 insertions).
- No source/code changes; the publish guard is untouched.
