### PR TITLE
fix(kotlin): Use ClassName for proper references to nested serializers

### DIFF
--- a/native/codegen-fixtures/24-nullable-discriminated-union/kotlin/Api.kt
+++ b/native/codegen-fixtures/24-nullable-discriminated-union/kotlin/Api.kt
@@ -42,7 +42,7 @@ public class Api(
   }
 
   public object UpdateAttributes {
-    @Serializable(with = ResultSerializer::class)
+    @Serializable(with = Result.ResultSerializer::class)
     public sealed class Result {
       public object ResultSerializer : JsonContentPolymorphicSerializer<Result>(Result::class) {
         override fun selectDeserializer(element: JsonElement): DeserializationStrategy<Result> {

--- a/native/kotlin/.changeset/few-camels-draw.md
+++ b/native/kotlin/.changeset/few-camels-draw.md
@@ -1,0 +1,5 @@
+---
+"aws-blocks-kotlin": patch
+---
+
+Fixes code generator for nested serializers in discriminated unions. Previously, such serializers were not properly referenced in the generated code.

--- a/native/kotlin/codegen/src/main/java/com/aws/blocks/kotlin/generator/KotlinCodeGenerator.kt
+++ b/native/kotlin/codegen/src/main/java/com/aws/blocks/kotlin/generator/KotlinCodeGenerator.kt
@@ -538,7 +538,7 @@ class KotlinCodeGenerator(
             val serializerName = "${name}Serializer"
             sealedBuilder.addAnnotation(
                 AnnotationSpec.builder(ClassNames.serializable)
-                    .addMember("with = %L::class", serializerName)
+                    .addMember("with = %T::class", ClassName("", name, serializerName))
                     .build()
             )
             sealedBuilder.addType(generateBooleanDiscriminatorSerializer(name, serializerName, discriminator, union.variants))


### PR DESCRIPTION
## Problem

Kotlin code generator was not outputting valid references for the nested serializers in generated code, causing it to not compile. This affected the serializers used for discriminated unions with a boolean discriminator.

**Issue #, if available:**

## Changes

Use ClassName instead of a bare String to reference the type. KotlinPoet generates the correct reference.

## Validation

Validate that such code now compiles.

Before:

```kotlin
@Serializable(with = ResultSerializer::class) // incorrect, compiler error
public sealed class Result {
      public object ResultSerializer
}
```

After:

```kotlin
@Serializable(with = Result.ResultSerializer::class) // correct
public sealed class Result {
      public object ResultSerializer
}
```

## Checklist

- [x] PR description included
- [x] Tests are changed or added
- [ ] Relevant documentation is changed or added (and PR referenced)

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
