### PR TITLE
feat(kotlin): Make FileHandle url public

### DIFF
--- a/native/kotlin/.changeset/pink-eels-thank.md
+++ b/native/kotlin/.changeset/pink-eels-thank.md
@@ -1,0 +1,5 @@
+---
+"aws-blocks-kotlin": minor
+---
+
+Make the URL publicly accessible from a File\*Handle

--- a/native/kotlin/runtime/src/commonMain/kotlin/com/aws/blocks/kotlin/filebucket/FileDownloadHandle.kt
+++ b/native/kotlin/runtime/src/commonMain/kotlin/com/aws/blocks/kotlin/filebucket/FileDownloadHandle.kt
@@ -16,7 +16,7 @@ import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 
 class FileDownloadHandle(
-    private val url: String,
+    val url: String,
     private val httpClient: HttpClient = defaultHttpClient()
 ) {
 
@@ -27,8 +27,6 @@ class FileDownloadHandle(
             return FileDownloadHandle(url)
         }
     }
-
-    fun getUrl(): String = url
 
     suspend fun download(): ByteArray = try {
         val response = httpClient.get(url)

--- a/native/kotlin/runtime/src/commonMain/kotlin/com/aws/blocks/kotlin/filebucket/FileUploadHandle.kt
+++ b/native/kotlin/runtime/src/commonMain/kotlin/com/aws/blocks/kotlin/filebucket/FileUploadHandle.kt
@@ -17,7 +17,7 @@ import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 
 class FileUploadHandle(
-    private val url: String,
+    val url: String,
     private val fileContentType: String? = null,
     private val httpClient: HttpClient = defaultHttpClient()
 ) {
@@ -30,8 +30,6 @@ class FileUploadHandle(
             return FileUploadHandle(url, contentType)
         }
     }
-
-    fun getUrl(): String = url
 
     suspend fun upload(body: ByteArray) {
         try {


### PR DESCRIPTION
## Problem

The pre-signed URL was previously private in FileHandle, accessible only through a separate `getUrl()` function. Idiomatic Kotlin is to use a read-only property, instead.

**Issue #, if available:**

## Changes

Instead of `handle.getUrl()`, use `handle.url`

## Validation

n/a

## Checklist

- [x] PR description included
- [ ] Tests are changed or added
- [ ] Relevant documentation is changed or added (and PR referenced)

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
