### PR TITLE
fix(kotlin): Fix realtime channel for local dev

### DIFF
--- a/native/kotlin/.changeset/smooth-balloons-admire.md
+++ b/native/kotlin/.changeset/smooth-balloons-admire.md
@@ -1,0 +1,5 @@
+---
+"aws-blocks-kotlin": patch
+---
+
+Fix RealtimeChannel throwing exception when running against a local server

--- a/native/kotlin/runtime/src/commonMain/kotlin/com/aws/blocks/kotlin/realtime/RealtimeChannel.kt
+++ b/native/kotlin/runtime/src/commonMain/kotlin/com/aws/blocks/kotlin/realtime/RealtimeChannel.kt
@@ -29,9 +29,9 @@ class RealtimeChannel<T>(
             val obj = element.jsonObject
             val ch = obj["channel"]!!.jsonPrimitive.content
             val baseWsUrl = obj["wsUrl"]!!.jsonPrimitive.content
-            val connectToken = obj["connectToken"]!!.jsonPrimitive.content
+            val connectToken = obj["connectToken"]?.jsonPrimitive?.content
             val token = obj["token"]!!.jsonPrimitive.content
-            val wsUrl = "$baseWsUrl?token=${connectToken}"
+            val wsUrl = if (connectToken != null) "$baseWsUrl?token=$connectToken" else baseWsUrl
             return RealtimeChannel(channel = ch, wsUrl = wsUrl, token = token, deserializer = deserializer)
         }
     }


### PR DESCRIPTION
## Problem

`RealtimeChannel` would throw an exception when hydrating from a local server because of a missing `connectToken`. This token is not returned by the local server, only by prod/sandbox.

**Issue #, if available:**

## Changes

If `connectToken` is returned then append it to the `wsUrl`, otherwise do not throw if it is not returned.

## Validation

Validated RealtimeChannel connects to both local and sandbox servers.

## Checklist

- [x] PR description included
- [ ] Tests are changed or added
- [ ] Relevant documentation is changed or added (and PR referenced)

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
