### PR TITLE
feat(kotlin): Add NetworkException for transport-level and use ApiException for application-level errors

### DIFF
--- a/native/kotlin/.changeset/olive-cooks-fold.md
+++ b/native/kotlin/.changeset/olive-cooks-fold.md
@@ -1,0 +1,5 @@
+---
+"aws-blocks-kotlin": minor
+---
+
+Add NetworkException for transport-level exceptions

--- a/native/kotlin/runtime/src/commonMain/kotlin/com/aws/blocks/kotlin/BlocksClient.kt
+++ b/native/kotlin/runtime/src/commonMain/kotlin/com/aws/blocks/kotlin/BlocksClient.kt
@@ -2,6 +2,7 @@ package com.aws.blocks.kotlin
 
 import com.aws.blocks.kotlin.exceptions.ApiException
 import com.aws.blocks.kotlin.exceptions.BlocksException
+import com.aws.blocks.kotlin.exceptions.NetworkException
 import io.ktor.client.HttpClient
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
@@ -13,6 +14,8 @@ import io.ktor.http.isSuccess
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.int
+import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 
 /** JSON-RPC client that executes requests against an AWS Blocks backend endpoint. */
@@ -38,9 +41,17 @@ class BlocksClient(
         }
 
         if (!response.status.isSuccess()) {
-            val message = responseJson?.get("error")?.jsonPrimitive?.content ?: "HTTP Error: ${response.status.value}"
-            val name = responseJson?.get("name")?.jsonPrimitive?.content
-            throw ApiException(message, response.status.value, name)
+            val message = responseJson?.get("error")?.jsonPrimitive?.content ?: "HTTP ${response.status.value}"
+            throw NetworkException(message, response.status.value)
+        }
+
+        val errorObj = responseJson?.get("error")
+        if (errorObj != null) {
+            val error = errorObj.jsonObject
+            val message = error["message"]?.jsonPrimitive?.content ?: "Unknown error"
+            val code = error["code"]?.jsonPrimitive?.int ?: -1
+            val data = error["data"] as? JsonObject
+            throw ApiException(message, code, data)
         }
 
         val resultElement = responseJson?.get("result")

--- a/native/kotlin/runtime/src/commonMain/kotlin/com/aws/blocks/kotlin/exceptions/ApiException.kt
+++ b/native/kotlin/runtime/src/commonMain/kotlin/com/aws/blocks/kotlin/exceptions/ApiException.kt
@@ -2,13 +2,29 @@ package com.aws.blocks.kotlin.exceptions
 
 import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.contract
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonPrimitive
 
+/**
+ * Thrown when the server returns a JSON-RPC error response (HTTP 200 with an `error` field).
+ *
+ * This represents an application-level failure — the request reached the server and was
+ * rejected (e.g. authentication required, validation failed, method not found).
+ *
+ * @property code The JSON-RPC error code returned by the server.
+ * @property data The optional arbitrary JSON object from the `error.data` field.
+ * @property name Convenience accessor for `data["name"]` — the server's error name
+ *   (e.g. "NotAuthenticatedError"), or null if not present.
+ */
 class ApiException(
     message: String,
-    val status: Int,
-    val name: String? = null,
+    val code: Int,
+    val data: JsonObject? = null,
     cause: Throwable? = null
-) : BlocksException(message, cause)
+) : BlocksException(message, cause) {
+    val name: String?
+        get() = data?.get("name")?.jsonPrimitive?.content
+}
 
 @OptIn(ExperimentalContracts::class)
 fun Throwable.isBlocksError(name: String): Boolean {

--- a/native/kotlin/runtime/src/commonMain/kotlin/com/aws/blocks/kotlin/exceptions/BlocksException.kt
+++ b/native/kotlin/runtime/src/commonMain/kotlin/com/aws/blocks/kotlin/exceptions/BlocksException.kt
@@ -1,3 +1,10 @@
 package com.aws.blocks.kotlin.exceptions
 
+/**
+ * Base exception for all errors originating from the Blocks SDK.
+ *
+ * Catch this to handle any Blocks error generically. For finer-grained handling,
+ * catch [ApiException] (server returned a JSON-RPC error) or [NetworkException]
+ * (HTTP transport failure) directly.
+ */
 open class BlocksException(message: String, cause: Throwable? = null) : RuntimeException(message, cause)

--- a/native/kotlin/runtime/src/commonMain/kotlin/com/aws/blocks/kotlin/exceptions/NetworkException.kt
+++ b/native/kotlin/runtime/src/commonMain/kotlin/com/aws/blocks/kotlin/exceptions/NetworkException.kt
@@ -1,0 +1,15 @@
+package com.aws.blocks.kotlin.exceptions
+
+/**
+ * Thrown when the HTTP request to the server fails at the transport level (non-2xx status).
+ *
+ * This represents an infrastructure-level failure — the request did not reach the
+ * application layer (e.g. server unavailable, proxy error, gateway timeout).
+ *
+ * @property statusCode The HTTP status code from the response.
+ */
+class NetworkException(
+    message: String,
+    val statusCode: Int,
+    cause: Throwable? = null
+) : BlocksException(message, cause)

--- a/native/kotlin/runtime/src/commonMain/kotlin/com/aws/blocks/kotlin/exceptions/TransferableException.kt
+++ b/native/kotlin/runtime/src/commonMain/kotlin/com/aws/blocks/kotlin/exceptions/TransferableException.kt
@@ -1,13 +1,29 @@
 package com.aws.blocks.kotlin.exceptions
 
+/**
+ * Base exception for errors that occur when hydrating a transferable descriptor
+ * (e.g. RealtimeChannel, FileDownloadHandle) from its JSON wire representation.
+ */
 open class TransferableException(message: String, cause: Throwable? = null) :
     BlocksException(message, cause)
 
+/**
+ * Thrown when the server returns a transferable descriptor with a `__blocks` type
+ * that the SDK does not recognize (no hydrator registered).
+ */
 class UnknownTransferableTypeException(val blocksType: String) :
     TransferableException("No hydrator registered for transferable type: $blocksType")
 
+/**
+ * Thrown when a transferable descriptor is missing a required field needed
+ * to construct the client-side handle (e.g. a channel descriptor without a `wsUrl`).
+ */
 class InvalidDescriptorException(val blocksType: String, val missingField: String) :
     TransferableException("Descriptor '$blocksType' is missing required field: $missingField")
 
+/**
+ * Thrown when an I/O operation on a transferable handle fails (e.g. a file upload
+ * or download encounters a network error after the handle was successfully created).
+ */
 class TransferableIOException(message: String, cause: Throwable? = null) :
     TransferableException(message, cause)


### PR DESCRIPTION
## Problem

ApiException was being used for non-200 HTTP responses, which isn't correct for JSON RPC.

**Issue #, if available:**

## Changes

- Add a `NetworkException` for non-200 responses
- Make `ApiException` specifically for errors returned by the API via JSON RPC
- Add KDoc to all exception types

## Validation

n/a

## Checklist

- [x] PR description included
- [ ] Tests are changed or added
- [ ] Relevant documentation is changed or added (and PR referenced)

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
