### PR TITLE
fix(create-blocks-app): bump aws-cdk-lib to ^2.257.0 in react template

### DIFF
--- a/.changeset/fix-react-template-cdk-version.md
+++ b/.changeset/fix-react-template-cdk-version.md
@@ -1,0 +1,7 @@
+---
+"@aws-blocks/create-blocks-app": patch
+---
+
+fix(create-blocks-app): bump `aws-cdk-lib` to `^2.257.0` in the react template
+
+The react template pinned `aws-cdk-lib` to `2.245.0`, while every block (e.g. `@aws-blocks/bb-realtime`) declares a peer dependency of `aws-cdk-lib@^2.257.0`. The unmet peer caused npm to nest `@aws-blocks/bb-realtime` under `@aws-blocks/blocks/node_modules` instead of hoisting it to the top level. Because the generated `aws-blocks/client.js` imports `@aws-blocks/bb-realtime/mock-middleware` directly from the workspace, Vite failed to resolve it (`Failed to resolve import "@aws-blocks/bb-realtime/mock-middleware"`) and `npm run dev` broke. Aligning the version with the other templates (`^2.257.0`) satisfies the peer dependency so the block hoists correctly.

--- a/packages/create-blocks-app/templates/react/package.json
+++ b/packages/create-blocks-app/templates/react/package.json
@@ -39,7 +39,7 @@
     "tsx": "^4.7.0",
     "concurrently": "^8.2.0",
     "esbuild": "^0.27.1",
-    "aws-cdk-lib": "2.245.0",
+    "aws-cdk-lib": "^2.257.0",
     "constructs": "^10.6.0"
   }
 }


### PR DESCRIPTION
## Problem

The `react` template pins `aws-cdk-lib` to `2.245.0`, while every block (e.g. `@aws-blocks/bb-realtime`) declares a peer dependency of `aws-cdk-lib@^2.257.0`. Only the `react` template is out of sync — `default`, `nextjs`, `bare`, `demo`, `auth-cognito`, and `backend` already use `^2.257.0`.

The unmet peer dependency causes npm to nest `@aws-blocks/bb-realtime` under `node_modules/@aws-blocks/blocks/node_modules/` instead of hoisting it to the top level. Because the generated `aws-blocks/client.js` imports `@aws-blocks/bb-realtime/mock-middleware` directly from the workspace, Vite cannot resolve it and `npm run dev` fails:

```
[vite] Internal server error: Failed to resolve import "@aws-blocks/bb-realtime/mock-middleware" from "aws-blocks/client.js". Does the file exist?
```

**Issue #, if available:** #76

## Changes

- `packages/create-blocks-app/templates/react/package.json`: bump `aws-cdk-lib` from `2.245.0` to `^2.257.0` to match the other templates and satisfy the blocks' peer dependency, so `@aws-blocks/bb-realtime` hoists to the top level and the `mock-middleware` import resolves.
- Added a changeset (`@aws-blocks/create-blocks-app`, patch).

## Validation

Manual verification: reproduced the original `npm run dev` failure in a project generated from the `react` template, applied the version bump, reinstalled, and confirmed `@aws-blocks/bb-realtime` is installed at the top level (`node_modules/@aws-blocks/bb-realtime`) and that `@aws-blocks/bb-realtime/mock-middleware` resolves, clearing the Vite error.

No automated tests were added — this is a template dependency-version change with no application logic to unit-test.

## Checklist

- [x] PR description included
- [ ] Tests are changed or added
- [x] Relevant documentation is changed or added (and PR referenced)

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._