### PR TITLE
fix(bb-auth-oidc): surface signIn errors, idempotent redirect callback, broadcastAuthChange bridge

### DIFF
--- a/.changeset/bb-auth-oidc-spa-fixes.md
+++ b/.changeset/bb-auth-oidc-spa-fixes.md
@@ -1,0 +1,11 @@
+---
+"@aws-blocks/bb-auth-oidc": patch
+---
+
+fix(bb-auth-oidc): surface `signIn` errors, make the redirect callback idempotent, and bridge to the shared auth bus
+
+Three browser/SPA developer-experience fixes:
+
+- **`signIn()` no longer swallows errors.** It now returns `Promise<void>`, so `await auth.signIn(...)` and `.catch(...)` observe failures (e.g. an unreachable `authorize-params` endpoint). Fire-and-forget callers (`onClick={() => auth.signIn('google')}`) still work and now log the failure to `console.error` instead of producing a silent unhandled rejection.
+- **`handleRedirectCallback()` is idempotent.** It consumes the single-use PKCE state from `sessionStorage` synchronously *before* the exchange await, and caches the in-flight exchange per authorization `code`. A React StrictMode double-mount, double-click, or re-render reuses the same exchange and resolves to the same user instead of replaying the single-use `code` (which the IdP rejects). The first successful flow always completes and renders; a genuinely-already-consumed second call returns `null` harmlessly.
+- **Auth state is bridged to the shared bus.** A successful exchange and `signOut()` now call `broadcastAuthChange(...)` from `@aws-blocks/auth-common`, so `onAuthChange` listeners and the `<Authenticator>` / `<AuthenticatedContent>` components update automatically (same window and across tabs) — previously only the package-local `onAuthStateChange` subscribers were notified. The README gains a React SPA example wiring the callback and `onAuthChange`.

--- a/packages/bb-auth-oidc/README.md
+++ b/packages/bb-auth-oidc/README.md
@@ -63,6 +63,67 @@ auth.signIn('google', { redirectPath: '/auth-return' });
 
 `redirectPath` becomes the OAuth `redirect_uri`, so it must be a page your frontend serves **and** a redirect URI registered with the provider (the stub IdP accepts any HTTPS or localhost URL, so local/sandbox needs no registration).
 
+### React SPA: handle the callback and react to auth state
+
+In a SPA the IdP redirects back to a route you own, and that route must call `handleRedirectCallback()` to finish the PKCE exchange. The method is **idempotent**, so React 18 StrictMode's double-mount (effects run twice in dev) is safe — the second call reuses the in-flight exchange and resolves to the same user instead of replaying the single-use `code`:
+
+```tsx
+import { useEffect, useState } from 'react';
+import { authApi } from 'aws-blocks';
+
+// Route mounted at the `redirectPath` you passed to signIn() (e.g. /auth-return)
+function AuthReturn() {
+	const [error, setError] = useState<Error | null>(null);
+
+	useEffect(() => {
+		let cancelled = false;
+		(async () => {
+			try {
+				const auth = await authApi.getClient();
+				const user = await auth.handleRedirectCallback();
+				if (!cancelled && user) {
+					window.history.replaceState({}, '', '/'); // drop ?code=…&state=… and route home
+				}
+			} catch (err) {
+				if (!cancelled) setError(err as Error);
+			}
+		})();
+		return () => {
+			cancelled = true;
+		};
+	}, []);
+
+	if (error) return <p>Sign-in failed: {error.message}</p>;
+	return <p>Completing sign-in…</p>;
+}
+```
+
+`signIn()` returns a `Promise<void>`, so callers can surface failures (e.g. a cross-origin authorize-params fetch that fails) instead of losing them to a swallowed rejection:
+
+```tsx
+<button
+	onClick={() =>
+		auth.signIn('google', { redirectPath: '/auth-return' }).catch((err) => {
+			showToast(`Could not start sign-in: ${err.message}`);
+		})
+	}
+>
+	Sign in with Google
+</button>
+```
+
+A successful `handleRedirectCallback()` (and `signOut()`) broadcasts the new auth state on the shared bus, so `onAuthChange` listeners — and the `<Authenticator>` / `<AuthenticatedContent>` components from `@aws-blocks/auth-common/ui` — update automatically, including across tabs. No manual wiring needed:
+
+```tsx
+import { onAuthChange } from '@aws-blocks/blocks/ui';
+import { authApi } from 'aws-blocks';
+
+// Fires immediately with the current user, then on every sign-in / sign-out
+const unsubscribe = onAuthChange(authApi, (user) => {
+	setCurrentUser(user); // user is null when signed out
+});
+```
+
 ### Which flow to use
 
 - **Server-initiated** (`GET /aws-blocks/auth/signin/<provider>` — a link or the `<Authenticator>` button): the backend owns the callback and sets the session cookie. This is the default for **same-origin** apps (frontend and API on one origin: local dev, single deployed origin, or the sandbox front door).

--- a/packages/bb-auth-oidc/src/auth-oidc.ts
+++ b/packages/bb-auth-oidc/src/auth-oidc.ts
@@ -464,7 +464,7 @@ export class AuthOIDC<
 					authorizeParamsBasePath: `${basePath}/authorize-params`,
 				};
 				return {
-					signIn(_provider: ProviderName<P>, _opts?: { state?: string; redirectPath?: string }) { /* server-side no-op */ },
+					async signIn(_provider: ProviderName<P>, _opts?: { state?: string; redirectPath?: string }) { /* server-side no-op */ },
 					async handleRedirectCallback() { return null; },
 					async signOut() {},
 					onAuthStateChange(_handler: (user: OIDCUser | null, meta: { state?: string } | null) => void) { return () => {}; },

--- a/packages/bb-auth-oidc/src/index.browser.test.ts
+++ b/packages/bb-auth-oidc/src/index.browser.test.ts
@@ -4,6 +4,37 @@
 import { describe, test, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert';
 import { AuthOIDCClient, resolveApiBaseOrigin } from './index.browser.js';
+import { onAuthChange, type AuthStateApi } from '@aws-blocks/auth-common/ui';
+
+// auth-common's broadcast bus lazily creates a module-level `BroadcastChannel`
+// singleton (via getChannel()). Node's real BroadcastChannel keeps the event
+// loop alive, which would stop `node --test` from exiting. Swap in a no-op,
+// in-process shim (same approach as auth-common/ui.test.ts) before any broadcast
+// runs. The same-window delivery we assert on uses window.dispatchEvent, not the
+// channel, so an inert channel is sufficient.
+class BroadcastChannelShim {
+	name: string;
+	private listeners: ((event: MessageEvent) => void)[] = [];
+	private static channels = new Map<string, BroadcastChannelShim[]>();
+	constructor(name: string) {
+		this.name = name;
+		const group = BroadcastChannelShim.channels.get(name) ?? [];
+		group.push(this);
+		BroadcastChannelShim.channels.set(name, group);
+	}
+	postMessage(data: unknown) {
+		// BroadcastChannel delivers to OTHER instances with the same name, not self.
+		for (const ch of BroadcastChannelShim.channels.get(this.name) ?? []) {
+			if (ch !== this) for (const fn of ch.listeners) fn({ data } as MessageEvent);
+		}
+	}
+	addEventListener(_type: string, fn: (event: MessageEvent) => void) { this.listeners.push(fn); }
+	removeEventListener(_type: string, fn: (event: MessageEvent) => void) {
+		this.listeners = this.listeners.filter((f) => f !== fn);
+	}
+	close() { /* no-op */ }
+}
+(globalThis as any).BroadcastChannel = BroadcastChannelShim;
 
 /**
  * Browser-client tests for `AuthOIDCClient.signIn()` redirect-target
@@ -28,10 +59,17 @@ function installBrowserGlobals(currentHref: string): void {
 		set href(v: string) { navigatedTo = v; },
 		origin: url.origin,
 		pathname: url.pathname,
+		reload() { /* no-op for tests (signOut() calls this) */ },
 	};
 	store = new Map<string, string>();
 
-	(globalThis as any).window = { location: locationStub };
+	// Back `window` with a real EventTarget so auth-common's broadcastAuthChange()
+	// (window.dispatchEvent(new CustomEvent(...))) and onAuthChange()
+	// (window.addEventListener(...)) exercise the real same-window event path — no
+	// mocks. CustomEvent + BroadcastChannel are Node 22 globals.
+	const win = new EventTarget() as EventTarget & { location: typeof locationStub };
+	win.location = locationStub;
+	(globalThis as any).window = win;
 	(globalThis as any).sessionStorage = {
 		getItem: (k: string) => store.get(k) ?? null,
 		setItem: (k: string, v: string) => { store.set(k, v); },
@@ -222,5 +260,190 @@ describe('AuthOIDCClient.handleRedirectCallback — return shape', () => {
 		await client.handleRedirectCallback();
 		assert.ok(lastExchangeBody, 'exchange should have been called');
 		assert.strictEqual('iss' in lastExchangeBody, false, 'iss should be omitted, not sent as undefined');
+	});
+});
+
+/**
+ * Fix (a): `signIn()` was fire-and-forget (`void this._signInPKCE(...)`), so a
+ * failed authorize-params fetch was swallowed and callers couldn't react. It now
+ * returns the in-flight promise (awaitable / `.catch`-able) while still logging
+ * failures for fire-and-forget callers.
+ */
+describe('AuthOIDCClient.signIn — surfaces errors instead of swallowing them', () => {
+	let originalFetch: typeof globalThis.fetch;
+
+	beforeEach(() => {
+		installBrowserGlobals(CURRENT_PAGE);
+		// Resolve _getBaseUrl() deterministically so the authorize-params fetch is
+		// the only network call under test.
+		process.env.BLOCKS_API_URL = 'http://localhost:3000/aws-blocks/api';
+		originalFetch = globalThis.fetch;
+	});
+
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+		delete process.env.BLOCKS_API_URL;
+		clearBrowserGlobals();
+	});
+
+	/** Client WITHOUT inlined providerConfigs → signIn hits the authorize-params fetch path. */
+	function makeNetworkClient() {
+		return new AuthOIDCClient({ providers: ['google'] });
+	}
+
+	test('returns a Promise that REJECTS when the authorize-params fetch fails', async () => {
+		globalThis.fetch = (async () => ({ ok: false, status: 500, json: async () => ({}) })) as unknown as typeof globalThis.fetch;
+		const client = makeNetworkClient();
+		// signIn logs the failure for fire-and-forget callers; silence it for clean test output.
+		const origError = console.error;
+		console.error = () => {};
+		try {
+			await assert.rejects(
+				client.signIn('google'),
+				/failed to fetch authorize params for 'google': 500/,
+			);
+		} finally {
+			console.error = origError;
+		}
+	});
+
+	test('the returned Promise is awaitable and resolves once it navigates to the IdP', async () => {
+		// providerConfigs path → no fetch; just computes PKCE and navigates.
+		const client = makeClient();
+		await client.signIn('google');
+		assert.ok(navigatedTo.startsWith(AUTHORIZE_URL), 'should have navigated to the IdP authorize URL');
+	});
+});
+
+/**
+ * Fix (b): `handleRedirectCallback()` consumed the single-use PKCE state only
+ * AFTER the exchange await, so a React StrictMode double-mount replayed the
+ * single-use `code` and the second exchange threw — stranding the app. It is now
+ * idempotent: the in-flight (or settled) exchange is reused per `code`.
+ */
+describe('AuthOIDCClient.handleRedirectCallback — idempotent under double invocation (StrictMode)', () => {
+	const STATE = 'state-idem';
+	const BARE_USER = { userId: 'iss:sub', username: 'bob', email: 'bob@example.invalid', provider: 'google' };
+	let originalFetch: typeof globalThis.fetch;
+	let exchangeCalls: number;
+
+	beforeEach(() => {
+		installBrowserGlobals(`http://localhost:3000/spa-callback?code=auth-code-idem&state=${STATE}`);
+		process.env.BLOCKS_API_URL = 'http://localhost:3000/aws-blocks/api';
+		store.set('__blocks_oidc_pending', JSON.stringify({
+			provider: 'google', verifier: 'v', state: STATE, nonce: 'n',
+			callbackUrl: 'http://localhost:3000/spa-callback', appState: 'app-state',
+		}));
+		originalFetch = globalThis.fetch;
+		exchangeCalls = 0;
+	});
+
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+		delete process.env.BLOCKS_API_URL;
+		clearBrowserGlobals();
+	});
+
+	/** Stub the exchange and count how many times the single-use code is sent. */
+	function stubCountingExchange(user: unknown): void {
+		globalThis.fetch = (async () => {
+			exchangeCalls += 1;
+			return { ok: true, json: async () => ({ user }) };
+		}) as unknown as typeof globalThis.fetch;
+	}
+
+	test('concurrent double-invoke exchanges ONCE and both callers get the same user', async () => {
+		stubCountingExchange(BARE_USER);
+		const client = makeClient();
+		const [a, b] = await Promise.all([
+			client.handleRedirectCallback(),
+			client.handleRedirectCallback(),
+		]);
+		assert.strictEqual(exchangeCalls, 1, 'the single-use authorization code must not be replayed');
+		assert.ok(a && b, 'both invocations resolve a user (the first flow completes and renders)');
+		assert.strictEqual(a!.userId, 'iss:sub');
+		assert.strictEqual(a, b, 'both callers observe the identical resolved value');
+		assert.strictEqual(store.get('__blocks_oidc_pending'), undefined, 'pending PKCE state is consumed');
+	});
+
+	test('sequential re-invoke after resolution returns the same user without a second exchange', async () => {
+		stubCountingExchange(BARE_USER);
+		const client = makeClient();
+		const first = await client.handleRedirectCallback();
+		const second = await client.handleRedirectCallback();
+		assert.strictEqual(exchangeCalls, 1, 'the settled exchange is reused, not replayed');
+		assert.ok(first && second);
+		assert.strictEqual(first!.userId, second!.userId);
+	});
+
+	test('the second invocation never throws (StrictMode safety)', async () => {
+		stubCountingExchange(BARE_USER);
+		const client = makeClient();
+		const p1 = client.handleRedirectCallback();
+		const p2 = client.handleRedirectCallback();
+		await assert.doesNotReject(Promise.all([p1, p2]));
+	});
+});
+
+/**
+ * Fix (c): the bridge to `@aws-blocks/auth-common`'s `onAuthChange` was unwired —
+ * a successful exchange only called the module-local `notify()`. It now also calls
+ * `broadcastAuthChange(user)`, so `onAuthChange` / `AuthenticatedContent` /
+ * `<Authenticator>` consumers update automatically.
+ */
+describe('AuthOIDCClient.handleRedirectCallback — bridges to auth-common onAuthChange', () => {
+	const STATE = 'state-bcast';
+	const BARE_USER = { userId: 'iss:carol', username: 'carol' };
+	let originalFetch: typeof globalThis.fetch;
+
+	beforeEach(() => {
+		installBrowserGlobals(`http://localhost:3000/spa-callback?code=auth-code-bcast&state=${STATE}`);
+		process.env.BLOCKS_API_URL = 'http://localhost:3000/aws-blocks/api';
+		store.set('__blocks_oidc_pending', JSON.stringify({
+			provider: 'google', verifier: 'v', state: STATE, nonce: 'n',
+			callbackUrl: 'http://localhost:3000/spa-callback',
+		}));
+		originalFetch = globalThis.fetch;
+		globalThis.fetch = (async () => ({ ok: true, json: async () => ({ user: BARE_USER }) })) as unknown as typeof globalThis.fetch;
+	});
+
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+		delete process.env.BLOCKS_API_URL;
+		clearBrowserGlobals();
+	});
+
+	test('a successful exchange notifies real onAuthChange consumers via broadcastAuthChange', async () => {
+		// Minimal AuthStateApi for onAuthChange's shared-cache hydration (cold → signedOut).
+		const api: AuthStateApi = {
+			async getAuthState() { return { state: 'signedOut', actions: [] }; },
+			async setAuthState() { return { state: 'signedOut', actions: [] }; },
+		};
+		const received: Array<{ userId: string } | null> = [];
+		const unsub = onAuthChange(api, (user) => { received.push(user as { userId: string } | null); });
+
+		const client = makeClient();
+		const user = await client.handleRedirectCallback();
+		// Let the broadcast CustomEvent + onAuthChange microtasks flush.
+		await new Promise((r) => setTimeout(r, 5));
+
+		assert.ok(user, 'the exchange resolved a user');
+		const last = received[received.length - 1];
+		assert.ok(last, 'onAuthChange consumer should have been notified via the broadcast');
+		assert.strictEqual(last!.userId, 'iss:carol');
+		unsub();
+	});
+
+	test('dispatches a same-window blocks-auth-change event carrying the exchanged user', async () => {
+		// `any` (like `lastExchangeBody` above): the value is only ever assigned
+		// inside the listener closure, which TS control-flow can't see.
+		let detailUser: any = null;
+		const handler = (e: Event) => { detailUser = (e as CustomEvent).detail?.user ?? null; };
+		(window as unknown as EventTarget).addEventListener('blocks-auth-change', handler);
+		const client = makeClient();
+		await client.handleRedirectCallback();
+		assert.ok(detailUser, 'broadcastAuthChange should dispatch a same-window CustomEvent');
+		assert.strictEqual(detailUser.userId, 'iss:carol');
+		(window as unknown as EventTarget).removeEventListener('blocks-auth-change', handler);
 	});
 });

--- a/packages/bb-auth-oidc/src/index.browser.ts
+++ b/packages/bb-auth-oidc/src/index.browser.ts
@@ -9,6 +9,8 @@
  */
 
 import { ApiError, registerMiddleware } from '@aws-blocks/core/client';
+import { broadcastAuthChange } from '@aws-blocks/auth-common/ui';
+import type { AuthUser } from '@aws-blocks/auth-common';
 
 // Provider helpers are pure config builders — safe to ship to the browser.
 export {
@@ -202,6 +204,14 @@ export class AuthOIDCClient<
 
 	private readonly providerConfigs?: Record<string, { authorizeUrl: string; clientId: string; scopes: string[]; kind: string }>;
 
+	/**
+	 * Per-instance dedup of in-flight (and settled) redirect-callback exchanges,
+	 * keyed by the IdP authorization `code`. Makes `handleRedirectCallback()`
+	 * idempotent under React StrictMode's double-mount (and double-clicks) so the
+	 * single-use `code` is never replayed — both callers observe the same result.
+	 */
+	private readonly _pendingCallbacks = new Map<string, Promise<User | null>>();
+
 	constructor(options: {
 		providers: readonly Provider[];
 		providerConfigs?: Record<string, { authorizeUrl: string; clientId: string; scopes: string[]; kind: string }>;
@@ -228,14 +238,35 @@ export class AuthOIDCClient<
 	 * Initiate sign-in using client-initiated PKCE. Navigates the
 	 * browser to the IdP. Call `handleRedirectCallback()` on return.
 	 *
+	 * Returns the in-flight promise so callers can observe failures
+	 * (e.g. an unreachable `authorize-params` endpoint) by awaiting or
+	 * attaching `.catch(...)`:
+	 *
+	 * ```tsx
+	 * // Fire-and-forget — failures are logged to console.error.
+	 * <button onClick={() => auth.signIn('google')}>Sign in</button>
+	 *
+	 * // Or handle the error explicitly.
+	 * try { await auth.signIn('google'); } catch (e) { showError(e); }
+	 * ```
+	 *
 	 * @param opts.state - Opaque app state, round-tripped to `onAuthStateChange`.
 	 * @param opts.redirectPath - Path (or absolute URL) the IdP redirects back to
 	 *   and that runs `handleRedirectCallback()`. Becomes the OAuth `redirect_uri`,
 	 *   so it must be a frontend-served page registered with the provider.
 	 *   Defaults to the current page.
+	 * @returns A promise that resolves once the browser is navigating to the IdP,
+	 *   or rejects if sign-in could not be initiated.
 	 */
-	signIn(provider: Provider, opts?: { state?: string; redirectPath?: string }): void {
-		void this._signInPKCE(provider, opts?.state, opts?.redirectPath);
+	signIn(provider: Provider, opts?: { state?: string; redirectPath?: string }): Promise<void> {
+		const pending = this._signInPKCE(provider, opts?.state, opts?.redirectPath);
+		// Surface failures for fire-and-forget callers (`onClick={() => auth.signIn(...)}`)
+		// instead of swallowing the rejection, while still returning the promise so
+		// `await auth.signIn(...)` / `.catch(...)` observe the same error.
+		pending.catch((err) => {
+			if (typeof console !== 'undefined') console.error('[AuthOIDC] signIn failed:', err);
+		});
+		return pending;
 	}
 
 	/**
@@ -292,21 +323,43 @@ export class AuthOIDCClient<
 	/**
 	 * Complete the IdP redirect callback. Reads `code`/`state` from the URL,
 	 * verifies state, and POSTs to `/aws-blocks/auth/exchange`.
+	 *
+	 * Idempotent: a second invocation for the same authorization `code` —
+	 * React StrictMode's double-mount, a double-click, or a re-render — reuses
+	 * the in-flight (or already-settled) exchange on this client instead of
+	 * replaying the single-use `code`, which the IdP would reject. Both callers
+	 * resolve to the same user, so a StrictMode double-mount still renders
+	 * signed-in.
+	 *
 	 * @returns The authenticated user, or `null` if no pending PKCE flow.
 	 */
-	async handleRedirectCallback(): Promise<User | null> {
-		if (typeof window === 'undefined') return null;
+	handleRedirectCallback(): Promise<User | null> {
+		if (typeof window === 'undefined') return Promise.resolve(null);
 		const url = new URL(window.location.href);
 		const code = url.searchParams.get('code');
 		const returnedState = url.searchParams.get('state');
-		if (!code || !returnedState) return null;
+		if (!code || !returnedState) return Promise.resolve(null);
+
+		const existing = this._pendingCallbacks.get(code);
+		if (existing) return existing;
+
+		const flow = this._completeRedirectCallback(url, code, returnedState);
+		this._pendingCallbacks.set(code, flow);
+		return flow;
+	}
+
+	private async _completeRedirectCallback(url: URL, code: string, returnedState: string): Promise<User | null> {
 		// Forward RFC 9207 `iss` when present — the server-side exchange passes it
 		// to openid-client, which fails the exchange if the provider sent it and
 		// we drop it.
 		const iss = url.searchParams.get('iss') ?? undefined;
 
+		// Read AND consume the single-use pending PKCE state synchronously, before
+		// the first await, so a racing invocation (e.g. on a second client instance)
+		// can't read it again and replay the exchange.
 		const raw = sessionStorage.getItem(_PENDING_STORAGE_KEY);
 		if (!raw) return null;
+		sessionStorage.removeItem(_PENDING_STORAGE_KEY);
 
 		const pending = JSON.parse(raw) as {
 			provider: string;
@@ -318,7 +371,6 @@ export class AuthOIDCClient<
 		};
 
 		if (returnedState !== pending.state) {
-			sessionStorage.removeItem(_PENDING_STORAGE_KEY);
 			throw new Error('AuthOIDC: state mismatch in callback');
 		}
 
@@ -338,8 +390,6 @@ export class AuthOIDCClient<
 			}),
 		});
 
-		sessionStorage.removeItem(_PENDING_STORAGE_KEY);
-
 		if (!resp.ok) {
 			const err = await resp.json().catch(() => ({ error: 'Exchange failed' }));
 			throw new Error(`AuthOIDC exchange failed: ${(err as any).error ?? resp.status}`);
@@ -352,6 +402,9 @@ export class AuthOIDCClient<
 		const user = (body.user ?? body) as User;
 		lastUser = user;
 		notify(user, { state: pending.appState });
+		// Bridge to the shared cross-tab/same-window auth bus so `onAuthChange`,
+		// `AuthenticatedContent`, and `<Authenticator>` consumers update automatically.
+		broadcastAuthChange(user as unknown as AuthUser);
 		return user;
 	}
 
@@ -361,6 +414,9 @@ export class AuthOIDCClient<
 		await fetch(`${baseUrl}${this.signOutPath}`, { method: 'POST', credentials: 'include' });
 		lastUser = null;
 		notify(null, null);
+		// Mirror the sign-out onto the shared auth bus so `onAuthChange` consumers
+		// and other tabs drop to signed-out before this tab reloads.
+		broadcastAuthChange(null);
 		if (typeof window !== 'undefined' && window.location) {
 			window.location.reload();
 		}

--- a/packages/bb-auth-oidc/src/types.ts
+++ b/packages/bb-auth-oidc/src/types.ts
@@ -366,6 +366,11 @@ export interface OIDCClient<Provider extends string = string> {
 	 * Initiate client-initiated PKCE sign-in. Navigates the browser to the IdP;
 	 * call `handleRedirectCallback()` on the page the IdP returns to.
 	 *
+	 * Returns the in-flight promise so callers can surface failures (e.g. an
+	 * unreachable `authorize-params` endpoint) via `await` or `.catch(...)`.
+	 * Fire-and-forget callers (`onClick={() => auth.signIn('google')}`) still
+	 * work — failures are logged to `console.error` instead of being swallowed.
+	 *
 	 * @param opts.state - Opaque app state, round-tripped to `onAuthStateChange`.
 	 * @param opts.redirectPath - Path (or absolute URL) the IdP redirects back to
 	 *   and that runs `handleRedirectCallback()`. This becomes the OAuth
@@ -374,7 +379,7 @@ export interface OIDCClient<Provider extends string = string> {
 	 *   SPAs that handle the callback on a dedicated route rather than the
 	 *   backend's `/aws-blocks/auth/callback`.
 	 */
-	signIn(provider: Provider, opts?: { state?: string; redirectPath?: string }): void;
+	signIn(provider: Provider, opts?: { state?: string; redirectPath?: string }): Promise<void>;
 	handleRedirectCallback(): Promise<{ userId: string; username: string } | null>;
 	signOut(): Promise<void>;
 	onAuthStateChange(handler: (user: OIDCUser | null, meta: { state?: string } | null) => void): () => void;


### PR DESCRIPTION
## Summary

Three related developer-experience bugs in the `@aws-blocks/bb-auth-oidc` **browser** client made client-initiated OIDC sign-in fail silently in a React SPA. All three were confirmed against the source on `main` and fixed with minimal, well-scoped changes plus tests.

Refs bench cell `oidc-dsql-notes · react` (PR #31, run 27988095874, scored 1/5).

## The bugs (all confirmed in `packages/bb-auth-oidc/src/index.browser.ts`)

### (a) `signIn()` was fire-and-forget — errors were swallowed
`signIn()` returned `void` and ran `void this._signInPKCE(...)` with no `.catch`. When the cross-origin `authorize-params` fetch failed (`!paramsResp.ok` → `throw`), the rejection became an unobservable unhandled promise rejection. A caller writing `onClick={() => auth.signIn('google')}` had no way to know sign-in never started, and `await auth.signIn(...)` was impossible because the method returned `void`.

### (b) `handleRedirectCallback()` was not idempotent
The method read the single-use PKCE state from `sessionStorage` but only removed it **after** the `await fetch(exchange)` round-trip. Under React 18 StrictMode (effects run twice in dev), a double-click, or any re-render, a second invocation read the *same* pending state and replayed the single-use authorization `code` — which the IdP/exchange rejects — throwing on the second call and stranding the app. There was also no dedup of the in-flight exchange.

### (c) Auth state was never bridged to the shared `auth-common` bus
`index.browser.ts` had no import from `@aws-blocks/auth-common` and never called `broadcastAuthChange()`. A successful exchange called only the package-local `notify()` (its own `onAuthStateChange` subscribers). So `onAuthChange` listeners and the shared `<Authenticator>` / `<AuthenticatedContent>` components — which react to `broadcastAuthChange` — never updated on OIDC sign-in. The README had no OIDC + SPA example showing how to wire this.

## The fixes

### (a) `signIn()` surfaces errors
- Signature changed to return `Promise<void>`, so `await auth.signIn(...)` and `.catch(...)` both observe failures.
- A `.catch` is attached internally so fire-and-forget callers (`onClick={() => auth.signIn('google')}`) log to `console.error` instead of producing a silent unhandled rejection — backward compatible (statement-position calls still work).
- Public `OIDCClient` interface in `types.ts` updated to `Promise<void>`; the server-side stub in `auth-oidc.ts` is now `async`.

### (b) `handleRedirectCallback()` is idempotent
- The single-use PKCE state is read **and removed from `sessionStorage` synchronously, before the first `await`**, so a racing second client instance can't read it again (it returns `null` harmlessly instead of replaying the `code`).
- The in-flight exchange is cached in a per-instance `Map<code, Promise<User|null>>`. A StrictMode double-mount / double-click / re-render reuses the same promise and **both callers resolve to the same user**. The first successful flow always completes and renders.

### (c) Bridge to the shared auth bus + README
- After a successful exchange, the client now calls `broadcastAuthChange(user)` from `@aws-blocks/auth-common` in addition to the existing local `notify()`. `signOut()` broadcasts `null`. `onAuthChange` listeners and the shared auth UI components now update automatically (same window **and** across tabs).
- `README.md` gains a **React SPA** section: a dedicated callback-route component that calls `handleRedirectCallback()` (idempotent under StrictMode), `signIn().catch(...)` error handling, and an `onAuthChange` example that updates automatically — no manual wiring.

## Tests (`packages/bb-auth-oidc/src/index.browser.test.ts`)

- **signIn surfaces errors**: rejects when the `authorize-params` fetch fails; fire-and-forget callers get `console.error`; returns a `Promise`.
- **handleRedirectCallback idempotent**: concurrent double-invoke exchanges **once** and both callers get the same user; sequential re-invoke returns the same user without a second exchange; the second invocation never throws (StrictMode safety).
- **broadcastAuthChange bridge**: a successful exchange notifies real `onAuthChange` consumers; a same-window `blocks-auth-change` `CustomEvent` is dispatched carrying the exchanged user.

A `BroadcastChannelShim` (mirroring `auth-common/ui.test.ts`) keeps Node's real `BroadcastChannel` singleton from holding the event loop open; same-window delivery (which the tests assert) uses `window.dispatchEvent`.

## Verification (Node 22 + WebCrypto)

```
# bb-auth-oidc full suite
# tests 107
# pass 107
# fail 0          (clean exit, RC=0)

# auth-common (dependency sanity)
# tests 50
# pass 50
# fail 0

# full monorepo build (downstream consumers, incl. @aws-blocks/blocks umbrella)
BUILD_RC=0
```

## Changeset

Adds `.changeset/bb-auth-oidc-spa-fixes.md` — **patch** bump for `@aws-blocks/bb-auth-oidc`. `auth-common` was not modified (only imported), so no changeset is needed for it.

## Scope

Changes are confined to `@aws-blocks/bb-auth-oidc` (`index.browser.ts`, `types.ts`, `auth-oidc.ts`, `index.browser.test.ts`, `README.md`) plus the changeset. No unrelated refactors.
