### PR TITLE
fix(bb-auth-oidc) 1/3: signIn() surfaces errors instead of swallowing them

### DIFF
--- a/.changeset/bb-auth-oidc-signin-errors.md
+++ b/.changeset/bb-auth-oidc-signin-errors.md
@@ -1,0 +1,9 @@
+---
+"@aws-blocks/bb-auth-oidc": patch
+---
+
+fix(bb-auth-oidc): `signIn()` surfaces errors instead of swallowing them
+
+`signIn()` was fire-and-forget (`void this._signInPKCE(...)` with no `.catch`), so a failed cross-origin authorize-params fetch became a silent unhandled rejection and the caller never knew sign-in hadn't started. It now returns `Promise<void>`, so callers can `await auth.signIn(...)` / `.catch(...)`, while fire-and-forget callers (`onClick={() => auth.signIn('google')}`) get the failure logged to `console.error` instead of losing it. The public `OIDCClient` interface and the server-side stub are updated to match.
+
+Part 1 of a 3-PR stack splitting the bb-auth-oidc SPA fixes (errors → idempotency → broadcast bridge).

--- a/packages/bb-auth-oidc/src/auth-oidc.ts
+++ b/packages/bb-auth-oidc/src/auth-oidc.ts
@@ -464,7 +464,7 @@ export class AuthOIDC<
 					authorizeParamsBasePath: `${basePath}/authorize-params`,
 				};
 				return {
-					signIn(_provider: ProviderName<P>, _opts?: { state?: string; redirectPath?: string }) { /* server-side no-op */ },
+					async signIn(_provider: ProviderName<P>, _opts?: { state?: string; redirectPath?: string }) { /* server-side no-op */ },
 					async handleRedirectCallback() { return null; },
 					async signOut() {},
 					onAuthStateChange(_handler: (user: OIDCUser | null, meta: { state?: string } | null) => void) { return () => {}; },

--- a/packages/bb-auth-oidc/src/index.browser.test.ts
+++ b/packages/bb-auth-oidc/src/index.browser.test.ts
@@ -224,3 +224,55 @@ describe('AuthOIDCClient.handleRedirectCallback — return shape', () => {
 		assert.strictEqual('iss' in lastExchangeBody, false, 'iss should be omitted, not sent as undefined');
 	});
 });
+
+/**
+ * Fix (a): `signIn()` was fire-and-forget (`void this._signInPKCE(...)`), so a
+ * failed authorize-params fetch was swallowed and callers couldn't react. It now
+ * returns the in-flight promise (awaitable / `.catch`-able) while still logging
+ * failures for fire-and-forget callers.
+ */
+describe('AuthOIDCClient.signIn — surfaces errors instead of swallowing them', () => {
+	let originalFetch: typeof globalThis.fetch;
+
+	beforeEach(() => {
+		installBrowserGlobals(CURRENT_PAGE);
+		// Resolve _getBaseUrl() deterministically so the authorize-params fetch is
+		// the only network call under test.
+		process.env.BLOCKS_API_URL = 'http://localhost:3000/aws-blocks/api';
+		originalFetch = globalThis.fetch;
+	});
+
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+		delete process.env.BLOCKS_API_URL;
+		clearBrowserGlobals();
+	});
+
+	/** Client WITHOUT inlined providerConfigs → signIn hits the authorize-params fetch path. */
+	function makeNetworkClient() {
+		return new AuthOIDCClient({ providers: ['google'] });
+	}
+
+	test('returns a Promise that REJECTS when the authorize-params fetch fails', async () => {
+		globalThis.fetch = (async () => ({ ok: false, status: 500, json: async () => ({}) })) as unknown as typeof globalThis.fetch;
+		const client = makeNetworkClient();
+		// signIn logs the failure for fire-and-forget callers; silence it for clean test output.
+		const origError = console.error;
+		console.error = () => {};
+		try {
+			await assert.rejects(
+				client.signIn('google'),
+				/failed to fetch authorize params for 'google': 500/,
+			);
+		} finally {
+			console.error = origError;
+		}
+	});
+
+	test('the returned Promise is awaitable and resolves once it navigates to the IdP', async () => {
+		// providerConfigs path → no fetch; just computes PKCE and navigates.
+		const client = makeClient();
+		await client.signIn('google');
+		assert.ok(navigatedTo.startsWith(AUTHORIZE_URL), 'should have navigated to the IdP authorize URL');
+	});
+});

--- a/packages/bb-auth-oidc/src/index.browser.ts
+++ b/packages/bb-auth-oidc/src/index.browser.ts
@@ -228,14 +228,35 @@ export class AuthOIDCClient<
 	 * Initiate sign-in using client-initiated PKCE. Navigates the
 	 * browser to the IdP. Call `handleRedirectCallback()` on return.
 	 *
+	 * Returns the in-flight promise so callers can observe failures
+	 * (e.g. an unreachable `authorize-params` endpoint) by awaiting or
+	 * attaching `.catch(...)`:
+	 *
+	 * ```tsx
+	 * // Fire-and-forget — failures are logged to console.error.
+	 * <button onClick={() => auth.signIn('google')}>Sign in</button>
+	 *
+	 * // Or handle the error explicitly.
+	 * try { await auth.signIn('google'); } catch (e) { showError(e); }
+	 * ```
+	 *
 	 * @param opts.state - Opaque app state, round-tripped to `onAuthStateChange`.
 	 * @param opts.redirectPath - Path (or absolute URL) the IdP redirects back to
 	 *   and that runs `handleRedirectCallback()`. Becomes the OAuth `redirect_uri`,
 	 *   so it must be a frontend-served page registered with the provider.
 	 *   Defaults to the current page.
+	 * @returns A promise that resolves once the browser is navigating to the IdP,
+	 *   or rejects if sign-in could not be initiated.
 	 */
-	signIn(provider: Provider, opts?: { state?: string; redirectPath?: string }): void {
-		void this._signInPKCE(provider, opts?.state, opts?.redirectPath);
+	signIn(provider: Provider, opts?: { state?: string; redirectPath?: string }): Promise<void> {
+		const pending = this._signInPKCE(provider, opts?.state, opts?.redirectPath);
+		// Surface failures for fire-and-forget callers (`onClick={() => auth.signIn(...)}`)
+		// instead of swallowing the rejection, while still returning the promise so
+		// `await auth.signIn(...)` / `.catch(...)` observe the same error.
+		pending.catch((err) => {
+			if (typeof console !== 'undefined') console.error('[AuthOIDC] signIn failed:', err);
+		});
+		return pending;
 	}
 
 	/**

--- a/packages/bb-auth-oidc/src/types.ts
+++ b/packages/bb-auth-oidc/src/types.ts
@@ -366,6 +366,11 @@ export interface OIDCClient<Provider extends string = string> {
 	 * Initiate client-initiated PKCE sign-in. Navigates the browser to the IdP;
 	 * call `handleRedirectCallback()` on the page the IdP returns to.
 	 *
+	 * Returns the in-flight promise so callers can surface failures (e.g. an
+	 * unreachable `authorize-params` endpoint) via `await` or `.catch(...)`.
+	 * Fire-and-forget callers (`onClick={() => auth.signIn('google')}`) still
+	 * work — failures are logged to `console.error` instead of being swallowed.
+	 *
 	 * @param opts.state - Opaque app state, round-tripped to `onAuthStateChange`.
 	 * @param opts.redirectPath - Path (or absolute URL) the IdP redirects back to
 	 *   and that runs `handleRedirectCallback()`. This becomes the OAuth
@@ -374,7 +379,7 @@ export interface OIDCClient<Provider extends string = string> {
 	 *   SPAs that handle the callback on a dedicated route rather than the
 	 *   backend's `/aws-blocks/auth/callback`.
 	 */
-	signIn(provider: Provider, opts?: { state?: string; redirectPath?: string }): void;
+	signIn(provider: Provider, opts?: { state?: string; redirectPath?: string }): Promise<void>;
 	handleRedirectCallback(): Promise<{ userId: string; username: string } | null>;
 	signOut(): Promise<void>;
 	onAuthStateChange(handler: (user: OIDCUser | null, meta: { state?: string } | null) => void): () => void;


### PR DESCRIPTION
## Part 1 of 3 — stacked PR &nbsp;·&nbsp; base: `main`

Splits #82 into one PR per fix for easier review. Stacked — review/merge **bottom-up**:

| # | Fix | PR | Base |
|---|-----|----|------|
| **1 (this PR)** | `signIn()` error surfacing | **#83** | `main` |
| 2 | `handleRedirectCallback()` idempotency | #84 | #83 |
| 3 | `broadcastAuthChange` bridge + README | #85 | #84 |

The cumulative tip of the stack (#85) is byte-identical (package source) to the original single PR #82. Replaces #82.

---

## Issue fixed — (a) `signIn()` swallowed errors

### Root cause
`signIn()` returned `void` and ran `void this._signInPKCE(...)` with no `.catch`. When the cross-origin `authorize-params` fetch failed (`!paramsResp.ok → throw`), the rejection became an unobservable **unhandled promise rejection**. A caller writing `onClick={() => auth.signIn('google')}` got no signal that sign-in never started, and `await auth.signIn(...)` was impossible because the method returned `void`.

### Fix
- `signIn()` now returns **`Promise<void>`**, so `await auth.signIn(...)` and `.catch(...)` observe failures.
- A `.catch` is attached internally so fire-and-forget callers log to `console.error` instead of producing a silent unhandled rejection — backward compatible (statement-position `auth.signIn(...)` calls still work).
- Public `OIDCClient` interface (`types.ts`) updated to `Promise<void>`; the server-side stub (`auth-oidc.ts`) is now `async`.

### Tests
- `signIn()` rejects when the `authorize-params` fetch fails (500).
- The returned promise is awaitable and resolves once it navigates to the IdP.

### Verification (Node 22 + WebCrypto)
```
# tests 102
# pass  102
# fail  0      (clean exit, RC=0)
build RC=0
```

Refs bench cell `oidc-dsql-notes · react` (PR #31, run 27988095874).
