### PR TITLE
fix(bb-auth-oidc) 2/3: idempotent handleRedirectCallback() (React StrictMode safe)

### DIFF
--- a/.changeset/bb-auth-oidc-idempotent-callback.md
+++ b/.changeset/bb-auth-oidc-idempotent-callback.md
@@ -1,0 +1,9 @@
+---
+"@aws-blocks/bb-auth-oidc": patch
+---
+
+fix(bb-auth-oidc): make `handleRedirectCallback()` idempotent under React StrictMode
+
+`handleRedirectCallback()` removed the single-use PKCE state from `sessionStorage` only AFTER the exchange `await`, so a second invocation (React 18 StrictMode's double-mount, a double-click, or a re-render) read the same pending state and replayed the single-use authorization `code` — which the IdP/exchange rejects — throwing on the second call and stranding the app. It now consumes the pending state synchronously before the await and caches the in-flight exchange per `code`, so concurrent or sequential re-invocations reuse the same exchange and both resolve to the same user. The first successful flow always completes and renders.
+
+Part 2 of a 3-PR stack splitting the bb-auth-oidc SPA fixes (errors → idempotency → broadcast bridge).

--- a/packages/bb-auth-oidc/src/index.browser.test.ts
+++ b/packages/bb-auth-oidc/src/index.browser.test.ts
@@ -276,3 +276,73 @@ describe('AuthOIDCClient.signIn — surfaces errors instead of swallowing them',
 		assert.ok(navigatedTo.startsWith(AUTHORIZE_URL), 'should have navigated to the IdP authorize URL');
 	});
 });
+
+/**
+ * Fix (b): `handleRedirectCallback()` consumed the single-use PKCE state only
+ * AFTER the exchange await, so a React StrictMode double-mount replayed the
+ * single-use `code` and the second exchange threw — stranding the app. It is now
+ * idempotent: the in-flight (or settled) exchange is reused per `code`.
+ */
+describe('AuthOIDCClient.handleRedirectCallback — idempotent under double invocation (StrictMode)', () => {
+	const STATE = 'state-idem';
+	const BARE_USER = { userId: 'iss:sub', username: 'bob', email: 'bob@example.invalid', provider: 'google' };
+	let originalFetch: typeof globalThis.fetch;
+	let exchangeCalls: number;
+
+	beforeEach(() => {
+		installBrowserGlobals(`http://localhost:3000/spa-callback?code=auth-code-idem&state=${STATE}`);
+		process.env.BLOCKS_API_URL = 'http://localhost:3000/aws-blocks/api';
+		store.set('__blocks_oidc_pending', JSON.stringify({
+			provider: 'google', verifier: 'v', state: STATE, nonce: 'n',
+			callbackUrl: 'http://localhost:3000/spa-callback', appState: 'app-state',
+		}));
+		originalFetch = globalThis.fetch;
+		exchangeCalls = 0;
+	});
+
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+		delete process.env.BLOCKS_API_URL;
+		clearBrowserGlobals();
+	});
+
+	/** Stub the exchange and count how many times the single-use code is sent. */
+	function stubCountingExchange(user: unknown): void {
+		globalThis.fetch = (async () => {
+			exchangeCalls += 1;
+			return { ok: true, json: async () => ({ user }) };
+		}) as unknown as typeof globalThis.fetch;
+	}
+
+	test('concurrent double-invoke exchanges ONCE and both callers get the same user', async () => {
+		stubCountingExchange(BARE_USER);
+		const client = makeClient();
+		const [a, b] = await Promise.all([
+			client.handleRedirectCallback(),
+			client.handleRedirectCallback(),
+		]);
+		assert.strictEqual(exchangeCalls, 1, 'the single-use authorization code must not be replayed');
+		assert.ok(a && b, 'both invocations resolve a user (the first flow completes and renders)');
+		assert.strictEqual(a!.userId, 'iss:sub');
+		assert.strictEqual(a, b, 'both callers observe the identical resolved value');
+		assert.strictEqual(store.get('__blocks_oidc_pending'), undefined, 'pending PKCE state is consumed');
+	});
+
+	test('sequential re-invoke after resolution returns the same user without a second exchange', async () => {
+		stubCountingExchange(BARE_USER);
+		const client = makeClient();
+		const first = await client.handleRedirectCallback();
+		const second = await client.handleRedirectCallback();
+		assert.strictEqual(exchangeCalls, 1, 'the settled exchange is reused, not replayed');
+		assert.ok(first && second);
+		assert.strictEqual(first!.userId, second!.userId);
+	});
+
+	test('the second invocation never throws (StrictMode safety)', async () => {
+		stubCountingExchange(BARE_USER);
+		const client = makeClient();
+		const p1 = client.handleRedirectCallback();
+		const p2 = client.handleRedirectCallback();
+		await assert.doesNotReject(Promise.all([p1, p2]));
+	});
+});

--- a/packages/bb-auth-oidc/src/index.browser.ts
+++ b/packages/bb-auth-oidc/src/index.browser.ts
@@ -202,6 +202,14 @@ export class AuthOIDCClient<
 
 	private readonly providerConfigs?: Record<string, { authorizeUrl: string; clientId: string; scopes: string[]; kind: string }>;
 
+	/**
+	 * Per-instance dedup of in-flight (and settled) redirect-callback exchanges,
+	 * keyed by the IdP authorization `code`. Makes `handleRedirectCallback()`
+	 * idempotent under React StrictMode's double-mount (and double-clicks) so the
+	 * single-use `code` is never replayed — both callers observe the same result.
+	 */
+	private readonly _pendingCallbacks = new Map<string, Promise<User | null>>();
+
 	constructor(options: {
 		providers: readonly Provider[];
 		providerConfigs?: Record<string, { authorizeUrl: string; clientId: string; scopes: string[]; kind: string }>;
@@ -313,21 +321,43 @@ export class AuthOIDCClient<
 	/**
 	 * Complete the IdP redirect callback. Reads `code`/`state` from the URL,
 	 * verifies state, and POSTs to `/aws-blocks/auth/exchange`.
+	 *
+	 * Idempotent: a second invocation for the same authorization `code` —
+	 * React StrictMode's double-mount, a double-click, or a re-render — reuses
+	 * the in-flight (or already-settled) exchange on this client instead of
+	 * replaying the single-use `code`, which the IdP would reject. Both callers
+	 * resolve to the same user, so a StrictMode double-mount still renders
+	 * signed-in.
+	 *
 	 * @returns The authenticated user, or `null` if no pending PKCE flow.
 	 */
-	async handleRedirectCallback(): Promise<User | null> {
-		if (typeof window === 'undefined') return null;
+	handleRedirectCallback(): Promise<User | null> {
+		if (typeof window === 'undefined') return Promise.resolve(null);
 		const url = new URL(window.location.href);
 		const code = url.searchParams.get('code');
 		const returnedState = url.searchParams.get('state');
-		if (!code || !returnedState) return null;
+		if (!code || !returnedState) return Promise.resolve(null);
+
+		const existing = this._pendingCallbacks.get(code);
+		if (existing) return existing;
+
+		const flow = this._completeRedirectCallback(url, code, returnedState);
+		this._pendingCallbacks.set(code, flow);
+		return flow;
+	}
+
+	private async _completeRedirectCallback(url: URL, code: string, returnedState: string): Promise<User | null> {
 		// Forward RFC 9207 `iss` when present — the server-side exchange passes it
 		// to openid-client, which fails the exchange if the provider sent it and
 		// we drop it.
 		const iss = url.searchParams.get('iss') ?? undefined;
 
+		// Read AND consume the single-use pending PKCE state synchronously, before
+		// the first await, so a racing invocation (e.g. on a second client instance)
+		// can't read it again and replay the exchange.
 		const raw = sessionStorage.getItem(_PENDING_STORAGE_KEY);
 		if (!raw) return null;
+		sessionStorage.removeItem(_PENDING_STORAGE_KEY);
 
 		const pending = JSON.parse(raw) as {
 			provider: string;
@@ -339,7 +369,6 @@ export class AuthOIDCClient<
 		};
 
 		if (returnedState !== pending.state) {
-			sessionStorage.removeItem(_PENDING_STORAGE_KEY);
 			throw new Error('AuthOIDC: state mismatch in callback');
 		}
 
@@ -358,8 +387,6 @@ export class AuthOIDCClient<
 				...(iss ? { iss } : {}),
 			}),
 		});
-
-		sessionStorage.removeItem(_PENDING_STORAGE_KEY);
 
 		if (!resp.ok) {
 			const err = await resp.json().catch(() => ({ error: 'Exchange failed' }));


### PR DESCRIPTION
## Part 2 of 3 — stacked PR &nbsp;·&nbsp; base: `fix/bb-auth-oidc-1-signin-errors` (#83)

Splits #82 into one PR per fix. Stacked — review/merge **bottom-up**:

| # | Fix | PR | Base |
|---|-----|----|------|
| 1 | `signIn()` error surfacing | #83 | `main` |
| **2 (this PR)** | `handleRedirectCallback()` idempotency | **#84** | #83 |
| 3 | `broadcastAuthChange` bridge + README | #85 | #84 |

> ⚠️ Review/merge **#83 first**. This PR targets the #83 branch, so its diff shows only the idempotency change.

---

## Issue fixed — (b) `handleRedirectCallback()` was not idempotent

### Root cause
The method read the single-use PKCE state from `sessionStorage` but removed it only **after** the `await fetch(exchange)` round-trip. Under React 18 StrictMode (effects run twice in dev), a double-click, or a re-render, a second invocation read the *same* pending state and replayed the single-use authorization `code` — which the IdP/exchange rejects — **throwing on the second call and stranding the app**. There was also no dedup of the in-flight exchange.

### Fix
- The single-use PKCE state is read **and removed from `sessionStorage` synchronously, before the first `await`**, so a racing second client instance can't read it again (it returns `null` harmlessly instead of replaying the `code`).
- The in-flight exchange is cached in a per-instance `Map<code, Promise<User|null>>` (`_pendingCallbacks`). A StrictMode double-mount / double-click / re-render reuses the same promise and **both callers resolve to the same user**. The first successful flow always completes and renders.
- Implemented by splitting the monolithic method into a synchronous guard/cache (`handleRedirectCallback`) + the async exchange (`_completeRedirectCallback`).

### Tests
- Concurrent double-invoke exchanges **once**; both callers get the identical user; pending state is consumed.
- Sequential re-invoke after resolution returns the same user without a second exchange.
- The second invocation never throws (StrictMode safety).

### Verification (Node 22 + WebCrypto)
```
# tests 105
# pass  105
# fail  0      (clean exit, RC=0)
build RC=0
```

Refs bench cell `oidc-dsql-notes · react` (PR #31, run 27988095874).
