### PR TITLE
fix(bb-auth-oidc) 3/3: bridge OIDC sign-in to onAuthChange + SPA README

### DIFF
--- a/.changeset/bb-auth-oidc-broadcast-bridge.md
+++ b/.changeset/bb-auth-oidc-broadcast-bridge.md
@@ -1,0 +1,9 @@
+---
+"@aws-blocks/bb-auth-oidc": patch
+---
+
+fix(bb-auth-oidc): bridge OIDC sign-in to the shared auth bus and document the SPA flow
+
+`handleRedirectCallback()` called only the package-local `notify()` (its own `onAuthStateChange` subscribers) and `index.browser.ts` never imported `@aws-blocks/auth-common`, so `onAuthChange` listeners and the shared `<Authenticator>` / `<AuthenticatedContent>` components never updated on OIDC sign-in. A successful exchange now also calls `broadcastAuthChange(user)`, and `signOut()` broadcasts `null`, so those consumers update automatically (same window and across tabs). The README gains a React SPA example wiring `handleRedirectCallback()` and showing `onAuthChange` updating with no manual wiring.
+
+Part 3 of a 3-PR stack splitting the bb-auth-oidc SPA fixes (errors → idempotency → broadcast bridge).

--- a/packages/bb-auth-oidc/README.md
+++ b/packages/bb-auth-oidc/README.md
@@ -63,6 +63,67 @@ auth.signIn('google', { redirectPath: '/auth-return' });
 
 `redirectPath` becomes the OAuth `redirect_uri`, so it must be a page your frontend serves **and** a redirect URI registered with the provider (the stub IdP accepts any HTTPS or localhost URL, so local/sandbox needs no registration).
 
+### React SPA: handle the callback and react to auth state
+
+In a SPA the IdP redirects back to a route you own, and that route must call `handleRedirectCallback()` to finish the PKCE exchange. The method is **idempotent**, so React 18 StrictMode's double-mount (effects run twice in dev) is safe — the second call reuses the in-flight exchange and resolves to the same user instead of replaying the single-use `code`:
+
+```tsx
+import { useEffect, useState } from 'react';
+import { authApi } from 'aws-blocks';
+
+// Route mounted at the `redirectPath` you passed to signIn() (e.g. /auth-return)
+function AuthReturn() {
+	const [error, setError] = useState<Error | null>(null);
+
+	useEffect(() => {
+		let cancelled = false;
+		(async () => {
+			try {
+				const auth = await authApi.getClient();
+				const user = await auth.handleRedirectCallback();
+				if (!cancelled && user) {
+					window.history.replaceState({}, '', '/'); // drop ?code=…&state=… and route home
+				}
+			} catch (err) {
+				if (!cancelled) setError(err as Error);
+			}
+		})();
+		return () => {
+			cancelled = true;
+		};
+	}, []);
+
+	if (error) return <p>Sign-in failed: {error.message}</p>;
+	return <p>Completing sign-in…</p>;
+}
+```
+
+`signIn()` returns a `Promise<void>`, so callers can surface failures (e.g. a cross-origin authorize-params fetch that fails) instead of losing them to a swallowed rejection:
+
+```tsx
+<button
+	onClick={() =>
+		auth.signIn('google', { redirectPath: '/auth-return' }).catch((err) => {
+			showToast(`Could not start sign-in: ${err.message}`);
+		})
+	}
+>
+	Sign in with Google
+</button>
+```
+
+A successful `handleRedirectCallback()` (and `signOut()`) broadcasts the new auth state on the shared bus, so `onAuthChange` listeners — and the `<Authenticator>` / `<AuthenticatedContent>` components from `@aws-blocks/auth-common/ui` — update automatically, including across tabs. No manual wiring needed:
+
+```tsx
+import { onAuthChange } from '@aws-blocks/blocks/ui';
+import { authApi } from 'aws-blocks';
+
+// Fires immediately with the current user, then on every sign-in / sign-out
+const unsubscribe = onAuthChange(authApi, (user) => {
+	setCurrentUser(user); // user is null when signed out
+});
+```
+
 ### Which flow to use
 
 - **Server-initiated** (`GET /aws-blocks/auth/signin/<provider>` — a link or the `<Authenticator>` button): the backend owns the callback and sets the session cookie. This is the default for **same-origin** apps (frontend and API on one origin: local dev, single deployed origin, or the sandbox front door).

--- a/packages/bb-auth-oidc/src/index.browser.test.ts
+++ b/packages/bb-auth-oidc/src/index.browser.test.ts
@@ -4,6 +4,37 @@
 import { describe, test, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert';
 import { AuthOIDCClient, resolveApiBaseOrigin } from './index.browser.js';
+import { onAuthChange, type AuthStateApi } from '@aws-blocks/auth-common/ui';
+
+// auth-common's broadcast bus lazily creates a module-level `BroadcastChannel`
+// singleton (via getChannel()). Node's real BroadcastChannel keeps the event
+// loop alive, which would stop `node --test` from exiting. Swap in a no-op,
+// in-process shim (same approach as auth-common/ui.test.ts) before any broadcast
+// runs. The same-window delivery we assert on uses window.dispatchEvent, not the
+// channel, so an inert channel is sufficient.
+class BroadcastChannelShim {
+	name: string;
+	private listeners: ((event: MessageEvent) => void)[] = [];
+	private static channels = new Map<string, BroadcastChannelShim[]>();
+	constructor(name: string) {
+		this.name = name;
+		const group = BroadcastChannelShim.channels.get(name) ?? [];
+		group.push(this);
+		BroadcastChannelShim.channels.set(name, group);
+	}
+	postMessage(data: unknown) {
+		// BroadcastChannel delivers to OTHER instances with the same name, not self.
+		for (const ch of BroadcastChannelShim.channels.get(this.name) ?? []) {
+			if (ch !== this) for (const fn of ch.listeners) fn({ data } as MessageEvent);
+		}
+	}
+	addEventListener(_type: string, fn: (event: MessageEvent) => void) { this.listeners.push(fn); }
+	removeEventListener(_type: string, fn: (event: MessageEvent) => void) {
+		this.listeners = this.listeners.filter((f) => f !== fn);
+	}
+	close() { /* no-op */ }
+}
+(globalThis as any).BroadcastChannel = BroadcastChannelShim;
 
 /**
  * Browser-client tests for `AuthOIDCClient.signIn()` redirect-target
@@ -28,10 +59,17 @@ function installBrowserGlobals(currentHref: string): void {
 		set href(v: string) { navigatedTo = v; },
 		origin: url.origin,
 		pathname: url.pathname,
+		reload() { /* no-op for tests (signOut() calls this) */ },
 	};
 	store = new Map<string, string>();
 
-	(globalThis as any).window = { location: locationStub };
+	// Back `window` with a real EventTarget so auth-common's broadcastAuthChange()
+	// (window.dispatchEvent(new CustomEvent(...))) and onAuthChange()
+	// (window.addEventListener(...)) exercise the real same-window event path — no
+	// mocks. CustomEvent + BroadcastChannel are Node 22 globals.
+	const win = new EventTarget() as EventTarget & { location: typeof locationStub };
+	win.location = locationStub;
+	(globalThis as any).window = win;
 	(globalThis as any).sessionStorage = {
 		getItem: (k: string) => store.get(k) ?? null,
 		setItem: (k: string, v: string) => { store.set(k, v); },
@@ -344,5 +382,68 @@ describe('AuthOIDCClient.handleRedirectCallback — idempotent under double invo
 		const p1 = client.handleRedirectCallback();
 		const p2 = client.handleRedirectCallback();
 		await assert.doesNotReject(Promise.all([p1, p2]));
+	});
+});
+
+/**
+ * Fix (c): the bridge to `@aws-blocks/auth-common`'s `onAuthChange` was unwired —
+ * a successful exchange only called the module-local `notify()`. It now also calls
+ * `broadcastAuthChange(user)`, so `onAuthChange` / `AuthenticatedContent` /
+ * `<Authenticator>` consumers update automatically.
+ */
+describe('AuthOIDCClient.handleRedirectCallback — bridges to auth-common onAuthChange', () => {
+	const STATE = 'state-bcast';
+	const BARE_USER = { userId: 'iss:carol', username: 'carol' };
+	let originalFetch: typeof globalThis.fetch;
+
+	beforeEach(() => {
+		installBrowserGlobals(`http://localhost:3000/spa-callback?code=auth-code-bcast&state=${STATE}`);
+		process.env.BLOCKS_API_URL = 'http://localhost:3000/aws-blocks/api';
+		store.set('__blocks_oidc_pending', JSON.stringify({
+			provider: 'google', verifier: 'v', state: STATE, nonce: 'n',
+			callbackUrl: 'http://localhost:3000/spa-callback',
+		}));
+		originalFetch = globalThis.fetch;
+		globalThis.fetch = (async () => ({ ok: true, json: async () => ({ user: BARE_USER }) })) as unknown as typeof globalThis.fetch;
+	});
+
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+		delete process.env.BLOCKS_API_URL;
+		clearBrowserGlobals();
+	});
+
+	test('a successful exchange notifies real onAuthChange consumers via broadcastAuthChange', async () => {
+		// Minimal AuthStateApi for onAuthChange's shared-cache hydration (cold → signedOut).
+		const api: AuthStateApi = {
+			async getAuthState() { return { state: 'signedOut', actions: [] }; },
+			async setAuthState() { return { state: 'signedOut', actions: [] }; },
+		};
+		const received: Array<{ userId: string } | null> = [];
+		const unsub = onAuthChange(api, (user) => { received.push(user as { userId: string } | null); });
+
+		const client = makeClient();
+		const user = await client.handleRedirectCallback();
+		// Let the broadcast CustomEvent + onAuthChange microtasks flush.
+		await new Promise((r) => setTimeout(r, 5));
+
+		assert.ok(user, 'the exchange resolved a user');
+		const last = received[received.length - 1];
+		assert.ok(last, 'onAuthChange consumer should have been notified via the broadcast');
+		assert.strictEqual(last!.userId, 'iss:carol');
+		unsub();
+	});
+
+	test('dispatches a same-window blocks-auth-change event carrying the exchanged user', async () => {
+		// `any` (like `lastExchangeBody` above): the value is only ever assigned
+		// inside the listener closure, which TS control-flow can't see.
+		let detailUser: any = null;
+		const handler = (e: Event) => { detailUser = (e as CustomEvent).detail?.user ?? null; };
+		(window as unknown as EventTarget).addEventListener('blocks-auth-change', handler);
+		const client = makeClient();
+		await client.handleRedirectCallback();
+		assert.ok(detailUser, 'broadcastAuthChange should dispatch a same-window CustomEvent');
+		assert.strictEqual(detailUser.userId, 'iss:carol');
+		(window as unknown as EventTarget).removeEventListener('blocks-auth-change', handler);
 	});
 });

--- a/packages/bb-auth-oidc/src/index.browser.ts
+++ b/packages/bb-auth-oidc/src/index.browser.ts
@@ -9,6 +9,8 @@
  */
 
 import { ApiError, registerMiddleware } from '@aws-blocks/core/client';
+import { broadcastAuthChange } from '@aws-blocks/auth-common/ui';
+import type { AuthUser } from '@aws-blocks/auth-common';
 
 // Provider helpers are pure config builders — safe to ship to the browser.
 export {
@@ -400,6 +402,9 @@ export class AuthOIDCClient<
 		const user = (body.user ?? body) as User;
 		lastUser = user;
 		notify(user, { state: pending.appState });
+		// Bridge to the shared cross-tab/same-window auth bus so `onAuthChange`,
+		// `AuthenticatedContent`, and `<Authenticator>` consumers update automatically.
+		broadcastAuthChange(user as unknown as AuthUser);
 		return user;
 	}
 
@@ -409,6 +414,9 @@ export class AuthOIDCClient<
 		await fetch(`${baseUrl}${this.signOutPath}`, { method: 'POST', credentials: 'include' });
 		lastUser = null;
 		notify(null, null);
+		// Mirror the sign-out onto the shared auth bus so `onAuthChange` consumers
+		// and other tabs drop to signed-out before this tab reloads.
+		broadcastAuthChange(null);
 		if (typeof window !== 'undefined' && window.location) {
 			window.location.reload();
 		}


### PR DESCRIPTION
## Part 3 of 3 — stacked PR &nbsp;·&nbsp; base: `fix/bb-auth-oidc-2-idempotent-callback` (#84)

Splits #82 into one PR per fix. Stacked, merge **bottom-up**:

| # | Fix | Branch | Base |
|---|-----|--------|------|
| 1 | `signIn()` error surfacing | `fix/bb-auth-oidc-1-signin-errors` | `main` → #83 |
| 2 | `handleRedirectCallback()` idempotency | `fix/bb-auth-oidc-2-idempotent-callback` | #83 → #84 |
| **3 (this PR)** | `broadcastAuthChange` bridge + README | `fix/bb-auth-oidc-3-broadcast-bridge` | #84 |

> ⚠️ Review/merge **#83 then #84 first**. This PR targets the #84 branch, so its diff shows only the broadcast-bridge change. The cumulative tip of this stack is byte-identical (package source) to the original #82.

---

## Issue fixed — (c) auth state never bridged to the shared `auth-common` bus

### Root cause
`index.browser.ts` had no import from `@aws-blocks/auth-common` and never called `broadcastAuthChange()`. A successful exchange called only the package-local `notify()` (its own `onAuthStateChange` subscribers). So `onAuthChange` listeners and the shared `<Authenticator>` / `<AuthenticatedContent>` components — which react to `broadcastAuthChange` — **never updated on OIDC sign-in**. The README had no OIDC + SPA example showing how to wire this.

### Fix
- After a successful exchange, the client now calls `broadcastAuthChange(user)` from `@aws-blocks/auth-common` in addition to the existing local `notify()`. `signOut()` broadcasts `null`. `onAuthChange` listeners and the shared auth UI components now update automatically (same window **and** across tabs).
- `README.md` gains a **React SPA** section: a callback-route component that calls `handleRedirectCallback()` (idempotent under StrictMode), `signIn().catch(...)` error handling, and an `onAuthChange` example that updates automatically — no manual wiring.

### Tests
- A successful exchange notifies real `onAuthChange` consumers via `broadcastAuthChange`.
- A same-window `blocks-auth-change` `CustomEvent` is dispatched carrying the exchanged user.

A `BroadcastChannelShim` (mirroring `auth-common/ui.test.ts`) keeps Node's real `BroadcastChannel` singleton from holding the event loop open; same-window delivery (which the tests assert) uses `window.dispatchEvent`.

### Verification (Node 22 + WebCrypto)
```
# tests 107
# pass  107
# fail  0      (clean exit, RC=0 — no BroadcastChannel hang)
build RC=0
```

Refs bench cell `oidc-dsql-notes · react` (PR #31, run 27988095874).
