### PR TITLE
fix(bb-auth-oidc): surface client signIn() failures instead of swallowing them

### DIFF
--- a/.changeset/issue-79-signin-error-handling.md
+++ b/.changeset/issue-79-signin-error-handling.md
@@ -1,0 +1,20 @@
+---
+"@aws-blocks/bb-auth-oidc": patch
+---
+
+fix(bb-auth-oidc): surface client `signIn()` failures instead of swallowing them
+
+The browser client's `signIn()` kicked off the PKCE flow with
+`void this._signInPKCE(...)`, discarding the promise. Any failure during
+sign-in setup — most commonly the `authorize-params` discovery fetch
+returning a non-2xx — became a silent unhandled rejection that callers
+could neither `await` nor `.catch()`, so a broken sign-in looked like a
+no-op to the app.
+
+`signIn()` now returns `Promise<void>`, propagating the underlying
+`_signInPKCE` promise. Callers can `await auth.signIn(provider)` (or attach
+`.catch()`) to detect and handle failures. The return type is widened
+consistently across the `OIDCClient` interface and the server-side no-op
+stub returned by `getClient()`, so SSR/mock parity is preserved. Existing
+fire-and-forget callers (e.g. `onClick={() => auth.signIn('google')}`)
+are unaffected.

--- a/packages/bb-auth-oidc/src/auth-oidc.ts
+++ b/packages/bb-auth-oidc/src/auth-oidc.ts
@@ -464,7 +464,7 @@ export class AuthOIDC<
 					authorizeParamsBasePath: `${basePath}/authorize-params`,
 				};
 				return {
-					signIn(_provider: ProviderName<P>, _opts?: { state?: string; redirectPath?: string }) { /* server-side no-op */ },
+					async signIn(_provider: ProviderName<P>, _opts?: { state?: string; redirectPath?: string }) { /* server-side no-op */ },
 					async handleRedirectCallback() { return null; },
 					async signOut() {},
 					onAuthStateChange(_handler: (user: OIDCUser | null, meta: { state?: string } | null) => void) { return () => {}; },

--- a/packages/bb-auth-oidc/src/index.browser.test.ts
+++ b/packages/bb-auth-oidc/src/index.browser.test.ts
@@ -130,6 +130,45 @@ describe('AuthOIDCClient.signIn — redirect_uri construction', () => {
 	});
 });
 
+describe('AuthOIDCClient.signIn — error propagation', () => {
+	let originalFetch: typeof globalThis.fetch;
+
+	beforeEach(() => {
+		installBrowserGlobals(CURRENT_PAGE);
+		// Resolve the API base URL deterministically (skip the config.json fetch).
+		process.env.BLOCKS_API_URL = 'http://localhost:3000/aws-blocks/api';
+		originalFetch = globalThis.fetch;
+	});
+
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+		delete process.env.BLOCKS_API_URL;
+		clearBrowserGlobals();
+	});
+
+	test('returns a promise that rejects when authorize-params discovery fails', async () => {
+		// No inlined providerConfig → the client fetches authorize params; make
+		// that fetch fail so the PKCE setup throws. Before the fix `signIn` did
+		// `void this._signInPKCE(...)`, swallowing this into a silent unhandled
+		// rejection that callers could neither await nor catch.
+		globalThis.fetch = (async () => ({ ok: false, status: 500, json: async () => ({}) })) as unknown as typeof globalThis.fetch;
+		const client = new AuthOIDCClient({ providers: ['google'] });
+		await assert.rejects(
+			client.signIn('google'),
+			/failed to fetch authorize params for 'google': 500/,
+			'signIn() must surface the discovery failure to the caller',
+		);
+		// A failed setup must not have navigated the browser anywhere.
+		assert.strictEqual(navigatedTo, '', 'must not navigate to the IdP on failure');
+	});
+
+	test('returns a promise that resolves once navigation to the IdP is scheduled', async () => {
+		const client = makeClient();
+		await assert.doesNotReject(client.signIn('google'), 'happy-path signIn() should resolve');
+		assert.ok(navigatedTo.startsWith(AUTHORIZE_URL), 'should have navigated to the IdP');
+	});
+});
+
 describe('AuthOIDCClient.handleRedirectCallback — return shape', () => {
 	const STATE = 'state-123';
 	const BARE_USER = { userId: 'iss:sub', username: 'alice', email: 'alice@example.invalid', provider: 'google' };

--- a/packages/bb-auth-oidc/src/index.browser.ts
+++ b/packages/bb-auth-oidc/src/index.browser.ts
@@ -233,9 +233,13 @@ export class AuthOIDCClient<
 	 *   and that runs `handleRedirectCallback()`. Becomes the OAuth `redirect_uri`,
 	 *   so it must be a frontend-served page registered with the provider.
 	 *   Defaults to the current page.
+	 * @returns A promise that resolves once the browser has been navigated to the
+	 *   IdP. It **rejects** if the PKCE setup fails (e.g. the authorize-params
+	 *   fetch errors) — `await` it or attach a `.catch()` to surface the failure
+	 *   instead of letting it become a silent unhandled rejection.
 	 */
-	signIn(provider: Provider, opts?: { state?: string; redirectPath?: string }): void {
-		void this._signInPKCE(provider, opts?.state, opts?.redirectPath);
+	signIn(provider: Provider, opts?: { state?: string; redirectPath?: string }): Promise<void> {
+		return this._signInPKCE(provider, opts?.state, opts?.redirectPath);
 	}
 
 	/**

--- a/packages/bb-auth-oidc/src/types.ts
+++ b/packages/bb-auth-oidc/src/types.ts
@@ -373,8 +373,12 @@ export interface OIDCClient<Provider extends string = string> {
 	 *   registered with the provider. Defaults to the current page. Use this for
 	 *   SPAs that handle the callback on a dedicated route rather than the
 	 *   backend's `/aws-blocks/auth/callback`.
+	 *
+	 * @returns A promise that resolves once the browser navigates to the IdP and
+	 *   **rejects** if PKCE setup fails. `await` it (or `.catch()`) to surface
+	 *   sign-in failures instead of leaving them as unhandled rejections.
 	 */
-	signIn(provider: Provider, opts?: { state?: string; redirectPath?: string }): void;
+	signIn(provider: Provider, opts?: { state?: string; redirectPath?: string }): Promise<void>;
 	handleRedirectCallback(): Promise<{ userId: string; username: string } | null>;
 	signOut(): Promise<void>;
 	onAuthStateChange(handler: (user: OIDCUser | null, meta: { state?: string } | null) => void): () => void;


### PR DESCRIPTION
## Problem

The `@aws-blocks/bb-auth-oidc` browser client swallowed sign-in failures. `AuthOIDCClient.signIn()` started the client-initiated PKCE flow with `void this._signInPKCE(...)`, discarding the returned promise. Any rejection during sign-in setup — most commonly the `/aws-blocks/auth/authorize-params/<provider>` discovery `fetch` returning a non-2xx — surfaced only as a silent **unhandled promise rejection**. Callers had no way to `await` or `.catch()` the failure, so a broken sign-in looked like a no-op to the application.

Closes https://github.com/aws-devtools-labs/aws-blocks/issues/79

## Changes

- `signIn()` now returns `Promise<void>`, propagating the underlying `_signInPKCE` promise instead of dropping it with `void`. Callers can `await auth.signIn(provider)` or attach `.catch()` to detect and handle failures.
- Widened the return type consistently so SSR/mock parity is preserved:
  - `OIDCClient.signIn` in `src/types.ts` now declares `Promise<void>`.
  - the server-side no-op stub returned by `getClient()` in `src/auth-oidc.ts` is now `async` (returns a resolved `Promise<void>`).
- Updated the JSDoc on both `signIn` declarations to document that the promise rejects on PKCE-setup failure.

Existing fire-and-forget callers (e.g. `onClick={() => auth.signIn('google')}`) are unaffected — the extra returned promise is simply ignored.

Added a changeset (`patch` for `@aws-blocks/bb-auth-oidc`).

## Validation

Added unit tests in `src/index.browser.test.ts` (new `AuthOIDCClient.signIn — error propagation` suite):

- **rejection is observable** — with no inlined provider config and a stubbed `fetch` returning `{ ok: false, status: 500 }`, `await assert.rejects(client.signIn('google'), /failed to fetch authorize params for 'google': 500/)` passes, and the client does not navigate to the IdP.
- **resolves on the happy path** — `assert.doesNotReject(client.signIn('google'))` with an inlined provider config, and the browser navigates to the authorize URL.

Build + full package test suite pass (Node 22):

```
npm run build -w packages/bb-auth-oidc   # tsc --build, clean
npm run test  -w packages/bb-auth-oidc   # tests 102 | pass 102 | fail 0
```

(100 pre-existing tests + 2 new.)

## Checklist

- [x] PR description included
- [x] Tests are changed or added
- [x] Relevant documentation is changed or added (and PR referenced)

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
