### PR TITLE
feat(bb-agent): toAgentTools(): kv-store

### DIFF
--- a/.changeset/add-to-agent-tools.md
+++ b/.changeset/add-to-agent-tools.md
@@ -8,4 +8,4 @@ Add `toAgentTools()` API for Building Blocks to expose their operations as agent
 
 Building Blocks that can hold per-user data declare `requiresScope` (via the new `BuildAgentToolsConfig`); `buildAgentTools()` then throws at construction unless the caller passes `scope` or `unscoped: true`, so an accidental unscoped spread can't quietly expose every user's data. KVStore opts into this. `MethodOverrides.schema` is now typed as `StandardSchemaV1` (core depends only on the types-only `@standard-schema/spec`, never on a concrete validation library).
 
-Fields injected server-side by `scope` or `fixed` are stripped from the JSON Schema parameters the model sees, so the model never receives a parameter it can't control.
+Fields injected server-side by `scope` or `fixed` are stripped from the JSON Schema parameters the model sees, so the model never receives a parameter it can't control. Registry methods can declare `scopeSafe: false` (e.g. a `scan` that lists the whole store); `buildAgentTools()` throws if such a method is exposed under `scope`, preventing a scoped store from leaking data across users. KVStore marks `scan` accordingly.

--- a/.changeset/add-to-agent-tools.md
+++ b/.changeset/add-to-agent-tools.md
@@ -1,0 +1,6 @@
+---
+"@aws-blocks/core": minor
+"@aws-blocks/bb-kv-store": minor
+---
+
+Add `toAgentTools()` API for Building Blocks to expose their operations as agent tools. Core provides `buildAgentTools()` helper with filtering, overrides, and scope injection. KVStore exposes get, put, delete, and scan as agent tools with approval controls.

--- a/.changeset/add-to-agent-tools.md
+++ b/.changeset/add-to-agent-tools.md
@@ -1,6 +1,7 @@
 ---
 "@aws-blocks/core": minor
 "@aws-blocks/bb-kv-store": minor
+"@aws-blocks/bb-agent": patch
 ---
 
 Add `toAgentTools()` API for Building Blocks to expose their operations as agent tools. Core provides `buildAgentTools()` helper with filtering, overrides, and scope injection. KVStore exposes get, put, delete, and scan as agent tools with approval controls.

--- a/.changeset/add-to-agent-tools.md
+++ b/.changeset/add-to-agent-tools.md
@@ -5,3 +5,7 @@
 ---
 
 Add `toAgentTools()` API for Building Blocks to expose their operations as agent tools. Core provides `buildAgentTools()` helper with filtering, overrides, and scope injection. KVStore exposes get, put, delete, and scan as agent tools with approval controls.
+
+Building Blocks that can hold per-user data declare `requiresScope` (via the new `BuildAgentToolsConfig`); `buildAgentTools()` then throws at construction unless the caller passes `scope` or `unscoped: true`, so an accidental unscoped spread can't quietly expose every user's data. KVStore opts into this. `MethodOverrides.schema` is now typed as `StandardSchemaV1` (core depends only on the types-only `@standard-schema/spec`, never on a concrete validation library).
+
+Fields injected server-side by `scope` or `fixed` are stripped from the JSON Schema parameters the model sees, so the model never receives a parameter it can't control.

--- a/docs/reference/building-block-structure.md
+++ b/docs/reference/building-block-structure.md
@@ -479,6 +479,25 @@ export function myBBToAgentTools(self: Scope & MyBBLike, options?: AgentToolProv
 }
 ```
 
+If your BB can hold **per-user data** (it can be keyed or partitioned by a user id), pass `{ requiresScope: true }`. `buildAgentTools` then throws at construction unless the caller supplies `scope` (to lock operations to the current user) or `unscoped: true` (an explicit opt-out for shared stores) — so an accidental unscoped spread can't silently expose every user's data:
+
+```typescript
+export function myBBToAgentTools(self: Scope & MyBBLike, options?: AgentToolProviderOptions): Record<string, any> {
+  return buildAgentTools(self, MY_BB_TOOL_METHODS, options, { requiresScope: true });
+}
+```
+
+Mark any method whose handler **ignores the scoped fields** (e.g. a `scan` that lists the entire store) with `scopeSafe: false` in the registry. `buildAgentTools` throws if such a method is exposed under `scope`, since it would return data across users despite the scoping:
+
+```typescript
+scan: {
+  description: 'List all entries',
+  parameters: { type: 'object', properties: {} },
+  scopeSafe: false, // can't be scope-isolated — caller must exclude it on a scoped BB
+  handler: (self) => async () => { /* ... */ },
+},
+```
+
 2. Add `toAgentTools()` to both runtime classes (one-liner each):
 
 ```typescript
@@ -503,13 +522,16 @@ export class MyBB extends Scope {
 - **Handlers** should return JSON-serializable values. For `AsyncIterable` results (like `scan`), collect into an array with a default limit.
 - **Tool names** are generated automatically as `{bbId}__{methodName}` by `buildAgentTools`.
 - **The interface** (`MyBBLike`) ensures the tool registry stays in sync with the BB's public API.
+- **Scoping** — decide whether your BB can hold per-user data. If so, pass `{ requiresScope: true }` and mark any list-all method `scopeSafe: false`. Shared BBs (a knowledge base, app-wide config) leave both unset so scoping stays optional.
 
 ### What `buildAgentTools` Handles
 
 The `buildAgentTools` helper from `@aws-blocks/core` handles:
 - `include`/`exclude` filtering
 - `overrides` (description, needsApproval, trustable, schema, fixed)
-- `scope` injection (merges context fields into handler input)
+- `scope` injection (merges context fields into handler input; overwrites model-supplied values)
+- The scoping requirement (`requiresScope`) and the `scopeSafe: false` gate — throwing at construction when a per-user BB isn't scoped or a scope-unsafe method is exposed under `scope`
+- Stripping `scope`/`fixed` fields from the JSON Schema the model sees, so the model can't supply a server-injected parameter
 - Tool naming (`{bbId}__{methodName}`)
 
 You only need to define the tool registry and delegate.

--- a/docs/reference/building-block-structure.md
+++ b/docs/reference/building-block-structure.md
@@ -440,6 +440,80 @@ export class MyBlock {
 }
 ```
 
+## Agent Tool Support (`toAgentTools`)
+
+BBs can expose their operations as agent tools by implementing `toAgentTools()`. This lets users spread BB operations directly into an Agent's `tools` callback without writing manual tool definitions.
+
+### How to Implement
+
+1. Create a shared `agent-tools.ts` file with the tool registry (used by both mock and AWS runtimes):
+
+```typescript
+// my-bb/src/agent-tools.ts
+import { buildAgentTools } from '@aws-blocks/core';
+import type { AgentToolProviderOptions, ToolMethodDef } from '@aws-blocks/core';
+import type { Scope } from '@aws-blocks/core';
+
+interface MyBBLike {
+  get(key: string): Promise<unknown>;
+  put(key: string, value: unknown): Promise<void>;
+}
+
+export const MY_BB_TOOL_METHODS: Record<string, ToolMethodDef<MyBBLike>> = {
+  get: {
+    description: 'Retrieve a value by key',
+    parameters: { type: 'object', properties: { key: { type: 'string', description: 'The key' } }, required: ['key'] },
+    handler: (self) => async ({ input }) => self.get(input.key),
+  },
+  put: {
+    description: 'Store a value',
+    parameters: { type: 'object', properties: { key: { type: 'string' }, value: {} }, required: ['key', 'value'] },
+    needsApproval: true,
+    trustable: true,
+    handler: (self) => async ({ input }) => { await self.put(input.key, input.value); return { success: true }; },
+  },
+};
+
+export function myBBToAgentTools(self: Scope & MyBBLike, options?: AgentToolProviderOptions): Record<string, any> {
+  return buildAgentTools(self, MY_BB_TOOL_METHODS, options);
+}
+```
+
+2. Add `toAgentTools()` to both runtime classes (one-liner each):
+
+```typescript
+// In index.mock.ts and index.aws.ts
+import { myBBToAgentTools } from './agent-tools.js';
+import type { AgentToolProviderOptions } from '@aws-blocks/core';
+
+export class MyBB extends Scope {
+  // ... existing methods ...
+
+  toAgentTools(options?: AgentToolProviderOptions): Record<string, any> {
+    return myBBToAgentTools(this, options);
+  }
+}
+```
+
+### Guidelines
+
+- **Parameters use JSON Schema** — avoids adding zod as a dependency to your BB. Users can override with zod via the `overrides.schema` option.
+- **Read operations** set `needsApproval: false`; **write operations** set `needsApproval: true` (and optionally `trustable: true`); **delete operations** set `needsApproval: true` and `trustable: false` (each deletion requires explicit approval).
+- **Descriptions** should be concise and tell the LLM what the tool does and when to use it.
+- **Handlers** should return JSON-serializable values. For `AsyncIterable` results (like `scan`), collect into an array with a default limit.
+- **Tool names** are generated automatically as `{bbId}__{methodName}` by `buildAgentTools`.
+- **The interface** (`MyBBLike`) ensures the tool registry stays in sync with the BB's public API.
+
+### What `buildAgentTools` Handles
+
+The `buildAgentTools` helper from `@aws-blocks/core` handles:
+- `include`/`exclude` filtering
+- `overrides` (description, needsApproval, trustable, schema, fixed)
+- `scope` injection (merges context fields into handler input)
+- Tool naming (`{bbId}__{methodName}`)
+
+You only need to define the tool registry and delegate.
+
 ## Best Practices
 
 1. **Keep interfaces consistent** - Runtime and mock should export the same interface

--- a/package-lock.json
+++ b/package-lock.json
@@ -55879,6 +55879,7 @@
         "@aws-blocks/pipeline": "*",
         "@aws-sdk/client-s3": "^3.700.0",
         "@aws-sdk/client-ssm": "^3.700.0",
+        "@standard-schema/spec": "^1.1.0",
         "cross-spawn": "^7.0.6",
         "http-proxy": "^1.18.1"
       },

--- a/packages/bb-agent/README.md
+++ b/packages/bb-agent/README.md
@@ -803,7 +803,7 @@ const agent = new Agent(scope, 'assistant', {
 
 // at call time, userId comes from the authenticated session:
 const user = await auth.getCurrentUser(requestContext);
-await agent.stream(message, { conversationId, context: { userId: user.userId } });
+await agent.stream(message, { conversationId, userId: user.userId, context: { userId: user.userId } });
 ```
 
 > Some operations can't be scope-isolated (for example, one that lists an entire store). `toAgentTools()` throws if such a method is exposed under `scope`; exclude it, or use `unscoped: true` only when cross-user results are genuinely intended. See the BB's own README for which of its methods are affected.

--- a/packages/bb-agent/README.md
+++ b/packages/bb-agent/README.md
@@ -711,7 +711,7 @@ Tool names follow the convention `{bbId}__{methodName}` (e.g. `memory__get`, `me
 | `description` | Describes the operation | Yes, via `overrides` |
 | `parameters` | Schema matching the BB method's input | Yes, via `overrides.schema` |
 | `needsApproval` | Read operations: `false`, write/delete: `true` | Yes, via `overrides` |
-| `trustable` | Write/delete: `true` (user can trust after first approval) | Yes, via `overrides` |
+| `trustable` | Write: `true` (agent may write without reasking); delete: `false` (each call needs approval) | Yes, via `overrides` |
 | `handler` | Calls the BB method directly | No (use a manual `tool()` for custom logic) |
 
 ### Filtering

--- a/packages/bb-agent/README.md
+++ b/packages/bb-agent/README.md
@@ -694,7 +694,7 @@ const agent = new Agent(scope, 'assistant', {
   model: { deployed: BedrockModels.BALANCED },
   systemPrompt: 'You are a helpful assistant.',
   tools: (tool) => ({
-    ...store.toAgentTools({ include: ['get', 'put'] }),
+    ...store.toAgentTools({ include: ['get', 'put'], unscoped: true }),
     echo: tool({
       description: 'Echo back the user message',
       parameters: z.object({ message: z.string() }),
@@ -703,6 +703,8 @@ const agent = new Agent(scope, 'assistant', {
   }),
 });
 ```
+
+> A `KVStore` can hold per-user data, so `toAgentTools()` requires you to either pass `scope` (lock operations to the current user) or `unscoped: true` (opt out for a shared store) — otherwise it throws. See [Scoping](#scoping) below. The example above uses `unscoped: true` because it is a shared store.
 
 Tool names follow the convention `{bbId}__{methodName}` (e.g. `memory__get`, `memory__put`). The BB provides defaults for each tool:
 
@@ -719,14 +721,14 @@ Tool names follow the convention `{bbId}__{methodName}` (e.g. `memory__get`, `me
 Control which operations are exposed to the agent:
 
 ```typescript
-// Only read operations
-store.toAgentTools({ include: ['get', 'scan'] })
+// Only read operations (shared store)
+store.toAgentTools({ include: ['get', 'scan'], unscoped: true })
 
-// Everything except destructive operations
-store.toAgentTools({ exclude: ['delete'] })
+// Everything except destructive operations (shared store)
+store.toAgentTools({ exclude: ['delete'], unscoped: true })
 
-// All operations (default)
-store.toAgentTools()
+// All operations, scoped to the current user (scan excluded — see Scoping)
+store.toAgentTools({ scope: (ctx) => ({ key: ctx.userId }), exclude: ['scan'] })
 ```
 
 `include` and `exclude` are mutually exclusive.
@@ -781,6 +783,29 @@ The model's tool has no `key` parameter — it's injected server-side on every c
 > **Precedence:** When the same key appears in multiple sources, `fixed` wins over `scope` which wins over model input.
 
 > **Note:** If a tool requires custom logic or many overrides, a manual `tool()` definition is often simpler and easier to read.
+
+### Scoping
+
+A BB that can hold per-user data will not expose itself to the agent unscoped. `toAgentTools()` throws at construction unless you pass one of:
+
+- **`scope`** — a callback that maps the request context to fields injected into every call, locking operations to the current user. The model never sees or controls a scoped field (it is stripped from the tool's parameters and overwritten server-side).
+- **`unscoped: true`** — an explicit opt-out for stores whose data is genuinely shared (a cache, feature flags, config).
+
+```typescript
+const agent = new Agent(scope, 'assistant', {
+  toolContextSchema: z.object({ userId: z.string() }),
+  tools: (tool) => ({
+    // every operation is locked to the caller's own key
+    ...store.toAgentTools({ scope: (ctx) => ({ key: ctx.userId }) }),
+  }),
+});
+
+// at call time, userId comes from the authenticated session:
+const user = await auth.getCurrentUser(requestContext);
+await agent.stream(message, { conversationId, context: { userId: user.userId } });
+```
+
+> Some operations can't be scope-isolated (for example, one that lists an entire store). `toAgentTools()` throws if such a method is exposed under `scope`; exclude it, or use `unscoped: true` only when cross-user results are genuinely intended. See the BB's own README for which of its methods are affected.
 
 ### Supported BBs
 

--- a/packages/bb-agent/README.md
+++ b/packages/bb-agent/README.md
@@ -398,6 +398,8 @@ tools: (tool) => ({
 
 The callback form lets TypeScript infer each tool's `input` from its `parameters`. The Record key is the tool's name.
 
+> **Tip:** Some Building Blocks (e.g. KVStore) can expose their operations as agent tools automatically via `toAgentTools()` — no manual tool definitions needed. See [BB-Provided Tools](#bb-provided-tools-toagenttools) for details.
+
 ### Tool Context — Scoping Tools to the Caller
 
 Tools often need request-scoped information (e.g. the authenticated `userId`). Pass a `context` object on each `stream()`/`resume()` call; it's forwarded to every tool invocation:
@@ -672,6 +674,128 @@ await chat.respondToInterrupt([{ interruptId: 'x', approved: true }]);
 ```
 
 **Note:** `useChat` is a factory function, not a React hook. Call it **once** (e.g., outside a component or in a ref) — not on every render. It returns a mutable singleton. Message history only includes `user`, `assistant`, and `approval` messages — tool-call/tool-result internals are filtered for UI clarity. Use `getConversation()` directly if you need the full history.
+
+## BB-Provided Tools (`toAgentTools`)
+
+Building Blocks that support agent tools expose a `toAgentTools()` method. Each BB provides sensible defaults for tool descriptions, parameter schemas, and approval settings — you can use them as-is or override any value.
+
+### Basic Usage
+
+Spread `toAgentTools()` into the `tools` callback alongside manual tools:
+
+```typescript
+import { Agent, BedrockModels } from '@aws-blocks/bb-agent';
+import { KVStore } from '@aws-blocks/bb-kv-store';
+import { z } from 'zod';
+
+const store = new KVStore(scope, 'memory');
+
+const agent = new Agent(scope, 'assistant', {
+  model: { deployed: BedrockModels.BALANCED },
+  systemPrompt: 'You are a helpful assistant.',
+  tools: (tool) => ({
+    ...store.toAgentTools({ include: ['get', 'put'] }),
+    echo: tool({
+      description: 'Echo back the user message',
+      parameters: z.object({ message: z.string() }),
+      handler: async ({ input }) => ({ reply: input.message }),
+    }),
+  }),
+});
+```
+
+Tool names follow the convention `{bbId}__{methodName}` (e.g. `memory__get`, `memory__put`). The BB provides defaults for each tool:
+
+| Property | Default provided by BB | Overridable? |
+|---|---|---|
+| `description` | Describes the operation | Yes, via `overrides` |
+| `parameters` | Schema matching the BB method's input | Yes, via `overrides.schema` |
+| `needsApproval` | Read operations: `false`, write/delete: `true` | Yes, via `overrides` |
+| `trustable` | Write/delete: `true` (user can trust after first approval) | Yes, via `overrides` |
+| `handler` | Calls the BB method directly | No (use a manual `tool()` for custom logic) |
+
+### Filtering
+
+Control which operations are exposed to the agent:
+
+```typescript
+// Only read operations
+store.toAgentTools({ include: ['get', 'scan'] })
+
+// Everything except destructive operations
+store.toAgentTools({ exclude: ['delete'] })
+
+// All operations (default)
+store.toAgentTools()
+```
+
+`include` and `exclude` are mutually exclusive.
+
+### Overrides
+
+Override any default per method. Each key in `overrides` is a method name:
+
+```typescript
+store.toAgentTools({
+  overrides: {
+    get: {
+      description: 'Look up a customer record by ID',
+    },
+    put: {
+      needsApproval: false,  // trust the agent to write without asking
+      trustable: false,
+    },
+    scan: {
+      schema: z.object({ limit: z.number() }),
+    },
+  },
+})
+```
+
+Available override fields:
+
+| Field | Effect |
+|---|---|
+| `description` | Replace the tool description the model sees |
+| `needsApproval` | Override whether the agent pauses for user approval |
+| `trustable` | Override whether the user can trust the tool after first approval |
+| `schema` | Replace the parameters schema the model sees |
+| `fixed` | Inject static values into the input (hidden from the model) |
+
+### Fixed Values
+
+Pin a parameter to a constant value — the model never sees it:
+
+```typescript
+store.toAgentTools({
+  overrides: {
+    get: {
+      fixed: { key: 'config:app-settings' },  // always reads this key
+    },
+  },
+})
+```
+
+The model's tool has no `key` parameter — it's injected server-side on every call.
+
+> **Note:** If a tool requires custom logic or many overrides, a manual `tool()` definition is often simpler and easier to read.
+
+### Supported BBs
+
+| BB | Description |
+|---|---|
+| **KVStore** | Simple key-value storage — get, put, delete, and scan operations |
+
+More BBs will be added in future releases. Refer to each BB's README for details on its operations and configuration.
+
+#### KVStore
+
+| Method | Description | Parameters | `needsApproval` | `trustable` |
+|---|---|---|---|---|
+| `get` | Retrieve a value by key | `z.object({ key: z.string() })` | `false` | — |
+| `put` | Store a value at a key | `z.object({ key: z.string(), value: z.unknown() })` | `true` | `true` |
+| `delete` | Delete a key | `z.object({ key: z.string() })` | `true` | `false` |
+| `scan` | List keys and values (default limit: 100) | `z.object({ limit: z.number().optional() })` | `false` | — |
 
 ## Full Examples
 

--- a/packages/bb-agent/README.md
+++ b/packages/bb-agent/README.md
@@ -778,6 +778,8 @@ store.toAgentTools({
 
 The model's tool has no `key` parameter — it's injected server-side on every call.
 
+> **Precedence:** When the same key appears in multiple sources, `fixed` wins over `scope` which wins over model input.
+
 > **Note:** If a tool requires custom logic or many overrides, a manual `tool()` definition is often simpler and easier to read.
 
 ### Supported BBs

--- a/packages/bb-agent/README.md
+++ b/packages/bb-agent/README.md
@@ -796,7 +796,8 @@ const agent = new Agent(scope, 'assistant', {
   toolContextSchema: z.object({ userId: z.string() }),
   tools: (tool) => ({
     // every operation is locked to the caller's own key
-    ...store.toAgentTools({ scope: (ctx) => ({ key: ctx.userId }) }),
+    // (scan is excluded — it can't be scope-isolated; see the note below)
+    ...store.toAgentTools({ scope: (ctx) => ({ key: ctx.userId }), exclude: ['scan'] }),
   }),
 });
 

--- a/packages/bb-agent/src/index.test.ts
+++ b/packages/bb-agent/src/index.test.ts
@@ -382,6 +382,22 @@ describe('CannedProvider', () => {
 		assert.deepStrictEqual(started, ['getOrder']);
 	});
 
+	// toAgentTools() generates names as `{bbId}__{methodName}` (e.g. memory__get).
+	// The matcher must split on `__` so a natural prompt mentioning the method word
+	// triggers the tool — otherwise BB-provided tools are untestable via the canned provider.
+	test('triggers a BB tool named {bbId}__{method} when the method word appears', async () => {
+		const provider = new CannedProvider();
+		const toolSpecs = [{ name: 'memory__scan', description: 'List entries', inputSchema: {} }];
+		const started: string[] = [];
+		for await (const event of provider.stream(
+			[{ role: 'user', content: [{ text: 'please scan the store' }] }] as any,
+			{ toolSpecs } as any,
+		)) {
+			if (event.type === 'modelContentBlockStartEvent' && event.start?.type === 'toolUseStart') started.push(event.start.name);
+		}
+		assert.deepStrictEqual(started, ['memory__scan']);
+	});
+
 	test('responds to tool result with acknowledgment', async () => {
 		const provider = new CannedProvider();
 		const chunks: string[] = [];

--- a/packages/bb-agent/src/providers/canned.ts
+++ b/packages/bb-agent/src/providers/canned.ts
@@ -57,9 +57,15 @@ function findAllToolMatches(prompt: string, toolSpecs?: { name: string }[]): str
 	return toolSpecs.filter(t => {
 		const name = t.name.toLowerCase();
 		if (promptMentionsWord(lower, name)) return true;
-		// Split camelCase into words (getWeather -> "get weather") and match each
-		// on word boundaries. Skip short words (<=2 chars) to avoid noise.
-		const words = t.name.replace(/([a-z])([A-Z])/g, '$1 $2').toLowerCase().split(' ');
+		// Split into words and match each on word boundaries. Handles camelCase
+		// (getWeather -> "get weather") and the `{bbId}__{method}` convention that
+		// `toAgentTools()` generates (memory__get -> "memory get"). Skip short words
+		// (<=2 chars) to avoid noise.
+		const words = t.name
+			.replace(/([a-z])([A-Z])/g, '$1 $2')
+			.replace(/_+/g, ' ')
+			.toLowerCase()
+			.split(' ');
 		return words.some(w => w.length > 2 && promptMentionsWord(lower, w));
 	}).map(t => t.name);
 }

--- a/packages/bb-kv-store/API.md
+++ b/packages/bb-kv-store/API.md
@@ -4,6 +4,7 @@
 
 ```ts
 
+import type { AgentToolProviderOptions } from '@aws-blocks/core';
 import type { ChildLogger } from '@aws-blocks/bb-logger';
 import { Scope } from '@aws-blocks/core';
 import type { ScopeParent } from '@aws-blocks/core';
@@ -44,6 +45,8 @@ export class KVStore<T = string> extends Scope {
         key: string;
         value: T;
     }>;
+    // (undocumented)
+    toAgentTools(options?: AgentToolProviderOptions): Record<string, any>;
 }
 
 // @public

--- a/packages/bb-kv-store/DESIGN.md
+++ b/packages/bb-kv-store/DESIGN.md
@@ -36,6 +36,8 @@ When `options.schema` is provided (any `StandardSchemaV1` implementation — Zod
 
 `toAgentTools(options?)` exposes KVStore operations as agent tools via the shared `KV_TOOL_METHODS` registry in `agent-tools.ts`. Both mock and AWS runtimes delegate to `kvToAgentTools()` which calls core's `buildAgentTools()` helper.
 
+A KVStore can be keyed by `userId`, so `kvToAgentTools()` passes `{ requiresScope: true }`: callers must supply either `scope` or `unscoped: true`, otherwise `toAgentTools()` throws at construction. See core's `buildAgentTools` for the mechanism.
+
 ### Tool Registry (`KV_TOOL_METHODS`)
 
 | Method | `needsApproval` | `trustable` | Notes |

--- a/packages/bb-kv-store/DESIGN.md
+++ b/packages/bb-kv-store/DESIGN.md
@@ -38,6 +38,8 @@ When `options.schema` is provided (any `StandardSchemaV1` implementation — Zod
 
 A KVStore can be keyed by `userId`, so `kvToAgentTools()` passes `{ requiresScope: true }`: callers must supply either `scope` or `unscoped: true`, otherwise `toAgentTools()` throws at construction. See core's `buildAgentTools` for the mechanism.
 
+`scan` is marked `scopeSafe: false`. `scope` pins an exact key, but `scan` lists the whole store, so on a scoped store it would return every user's entries. `buildAgentTools` therefore throws if `scan` is exposed under `scope` — scoped stores must `exclude: ['scan']` (or opt out with `unscoped: true` when the data is genuinely shared).
+
 ### Tool Registry (`KV_TOOL_METHODS`)
 
 | Method | `needsApproval` | `trustable` | Notes |

--- a/packages/bb-kv-store/DESIGN.md
+++ b/packages/bb-kv-store/DESIGN.md
@@ -47,7 +47,7 @@ When `options.schema` is provided (any `StandardSchemaV1` implementation — Zod
 
 ### Parameters
 
-Tool parameters use JSON Schema objects (not zod). Callers can override parameters with a zod schema via `overrides: { methodName: { schema: z.object({...}) } }` — the Agent BB accepts both JSON Schema and `z.ZodType`.
+Tool parameters are defined as JSON Schema objects. Users can override with zod via `overrides: { methodName: { schema: z.object({...}) } }`.
 
 ### Scan Default Limit
 

--- a/packages/bb-kv-store/DESIGN.md
+++ b/packages/bb-kv-store/DESIGN.md
@@ -32,6 +32,27 @@ When `options.schema` is provided (any `StandardSchemaV1` implementation — Zod
 - Schema validation on `put()` when configured, throws `ValidationFailedException`.
 - Validates the 400 KB item size limit; throws `ItemTooLargeException` (`KVStoreErrors.ItemTooLarge`) on oversized items. On AWS, DynamoDB raises a generic `ValidationException`; the runtime narrows on the size-specific message and re-maps only that case to `ItemTooLarge`, so both layers surface the same `error.name`.
 
+## Agent Tools
+
+`toAgentTools(options?)` exposes KVStore operations as agent tools via the shared `KV_TOOL_METHODS` registry in `agent-tools.ts`. Both mock and AWS runtimes delegate to `kvToAgentTools()` which calls core's `buildAgentTools()` helper.
+
+### Tool Registry (`KV_TOOL_METHODS`)
+
+| Method | `needsApproval` | `trustable` | Notes |
+|--------|-----------------|-------------|-------|
+| `get` | `false` | — | Read-only |
+| `put` | `true` | `true` | Agent can repeat writes without re-prompting |
+| `delete` | `true` | `false` | Each deletion requires explicit approval |
+| `scan` | `false` | — | Default limit of 100 entries; collects AsyncIterable into array |
+
+### Parameters
+
+Tool parameters use JSON Schema objects (not zod). Callers can override parameters with a zod schema via `overrides: { methodName: { schema: z.object({...}) } }` — the Agent BB accepts both JSON Schema and `z.ZodType`.
+
+### Scan Default Limit
+
+`scan` caps results at 100 entries by default to prevent unbounded responses. The agent can pass `{ limit: N }` to override. The handler breaks out of the AsyncIterable once the limit is reached.
+
 ### Mock vs AWS Behavior Differences
 
 | Behavior Difference | Impact | Mitigation |

--- a/packages/bb-kv-store/README.md
+++ b/packages/bb-kv-store/README.md
@@ -129,6 +129,20 @@ const legacy = new KVStore(scope, 'legacy', {
 });
 ```
 
+## Agent Tools
+
+KVStore supports `toAgentTools()` to expose its operations as tools for the [Agent BB](../bb-agent/README.md#bb-provided-tools-toagenttools). Available methods: `get`, `put`, `delete`, `scan`.
+
+```typescript
+const agent = new Agent(scope, 'assistant', {
+  tools: (tool) => ({
+    ...store.toAgentTools({ include: ['get', 'put'] }),
+  }),
+});
+```
+
+See the [Agent BB documentation](../bb-agent/README.md#bb-provided-tools-toagenttools) for filtering, overrides, and full usage.
+
 ## Best Practices
 
 - Keep keys short and descriptive (e.g., `user:{id}`, `session:{token}`)

--- a/packages/bb-kv-store/README.md
+++ b/packages/bb-kv-store/README.md
@@ -133,13 +133,26 @@ const legacy = new KVStore(scope, 'legacy', {
 
 KVStore supports `toAgentTools()` to expose its operations as tools for the [Agent BB](../bb-agent/README.md#bb-provided-tools-toagenttools). Available methods: `get`, `put`, `delete`, `scan`.
 
+A KVStore can hold per-user data, so `toAgentTools()` requires either `scope` (lock operations to the current user) or `unscoped: true` (opt out for a shared store) — otherwise it throws:
+
 ```typescript
+// shared store — opt out of scoping
 const agent = new Agent(scope, 'assistant', {
   tools: (tool) => ({
-    ...store.toAgentTools({ include: ['get', 'put'] }),
+    ...store.toAgentTools({ include: ['get', 'put'], unscoped: true }),
+  }),
+});
+
+// per-user store — scope every operation to the caller
+const agent = new Agent(scope, 'assistant', {
+  toolContextSchema: z.object({ userId: z.string() }),
+  tools: (tool) => ({
+    ...store.toAgentTools({ scope: (ctx) => ({ key: ctx.userId }), exclude: ['scan'] }),
   }),
 });
 ```
+
+`scan` cannot be scope-isolated — it lists the whole store, so on a scoped store it would return every user's entries. `toAgentTools()` throws if `scan` is exposed under `scope`; exclude it as above, or use `unscoped: true` only when cross-user results are intended.
 
 See the [Agent BB documentation](../bb-agent/README.md#bb-provided-tools-toagenttools) for filtering, overrides, and full usage.
 

--- a/packages/bb-kv-store/src/agent-tools.ts
+++ b/packages/bb-kv-store/src/agent-tools.ts
@@ -14,7 +14,8 @@ interface KVStoreLike {
 
 export const KV_TOOL_METHODS: Record<string, ToolMethodDef<KVStoreLike>> = {
 	get: {
-		description: 'Retrieve a value by key',
+		description:
+			'Retrieve a stored value by its exact key. Use when you know the specific key you are looking for. Returns null if the key does not exist.',
 		parameters: {
 			type: 'object',
 			properties: { key: { type: 'string', description: 'The key to retrieve' } },
@@ -26,7 +27,8 @@ export const KV_TOOL_METHODS: Record<string, ToolMethodDef<KVStoreLike>> = {
 				self.get(input.key),
 	},
 	put: {
-		description: 'Store a value at a key',
+		description:
+			'Store or overwrite a value at a key. Use when you want to save or update a value. Overwrites any existing value at that key without warning — use with care if data loss is a concern.',
 		parameters: {
 			type: 'object',
 			properties: {
@@ -45,7 +47,8 @@ export const KV_TOOL_METHODS: Record<string, ToolMethodDef<KVStoreLike>> = {
 			},
 	},
 	delete: {
-		description: 'Delete a key',
+		description:
+			'Permanently delete a key and its value. Use when you want to remove an entry entirely. Cannot be undone.',
 		parameters: {
 			type: 'object',
 			properties: { key: { type: 'string', description: 'The key to delete' } },
@@ -61,7 +64,8 @@ export const KV_TOOL_METHODS: Record<string, ToolMethodDef<KVStoreLike>> = {
 			},
 	},
 	scan: {
-		description: 'List keys and values. Returns up to `limit` entries (default 100).',
+		description:
+			'List all key-value pairs in the store. Use when you need to browse or search across entries without knowing specific keys. Returns up to `limit` entries (default 100) — for large stores, prefer get if you know the key.',
 		parameters: {
 			type: 'object',
 			properties: { limit: { type: 'number', description: 'Maximum number of entries to return (default 100)' } },
@@ -81,7 +85,9 @@ export const KV_TOOL_METHODS: Record<string, ToolMethodDef<KVStoreLike>> = {
 };
 
 export function kvToAgentTools(self: Scope & KVStoreLike, options?: AgentToolProviderOptions): Record<string, any> {
-	return buildAgentTools(self, KV_TOOL_METHODS, options);
+	// A KVStore is commonly keyed by userId, so it can hold per-user data. Require the
+	// caller to scope it to the current user or explicitly opt out as a shared store.
+	return buildAgentTools(self, KV_TOOL_METHODS, options, { requiresScope: true });
 }
 
 // Compile-time check: fails the build if KVStoreLike drifts from the real KVStore class.

--- a/packages/bb-kv-store/src/agent-tools.ts
+++ b/packages/bb-kv-store/src/agent-tools.ts
@@ -1,0 +1,52 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { buildAgentTools } from '@aws-blocks/core';
+import type { AgentToolProviderOptions, ToolMethodDef } from '@aws-blocks/core';
+import type { Scope } from '@aws-blocks/core';
+
+interface KVStoreLike {
+	get(key: string): Promise<unknown>;
+	put(key: string, value: unknown): Promise<void>;
+	delete(key: string): Promise<void>;
+	scan(): AsyncIterable<{ key: string; value: unknown }>;
+}
+
+export const KV_TOOL_METHODS: Record<string, ToolMethodDef<KVStoreLike>> = {
+	get: {
+		description: 'Retrieve a value by key',
+		parameters: { type: 'object', properties: { key: { type: 'string', description: 'The key to retrieve' } }, required: ['key'] },
+		handler: (self) => async ({ input }) => self.get(input.key),
+	},
+	put: {
+		description: 'Store a value at a key',
+		parameters: { type: 'object', properties: { key: { type: 'string', description: 'The key to store' }, value: { description: 'The value to store' } }, required: ['key', 'value'] },
+		needsApproval: true,
+		trustable: true,
+		handler: (self) => async ({ input }) => { await self.put(input.key, input.value); return { success: true }; },
+	},
+	delete: {
+		description: 'Delete a key',
+		parameters: { type: 'object', properties: { key: { type: 'string', description: 'The key to delete' } }, required: ['key'] },
+		needsApproval: true,
+		trustable: true,
+		handler: (self) => async ({ input }) => { await self.delete(input.key); return { success: true }; },
+	},
+	scan: {
+		description: 'List keys and values. Returns up to `limit` entries (default 100).',
+		parameters: { type: 'object', properties: { limit: { type: 'number', description: 'Maximum number of entries to return (default 100)' } } },
+		handler: (self) => async ({ input }) => {
+			const max = input.limit ?? 100;
+			const items: { key: string; value: unknown }[] = [];
+			for await (const entry of self.scan()) {
+				items.push(entry);
+				if (items.length >= max) break;
+			}
+			return items;
+		},
+	},
+};
+
+export function kvToAgentTools(self: Scope & KVStoreLike, options?: AgentToolProviderOptions): Record<string, any> {
+	return buildAgentTools(self, KV_TOOL_METHODS, options);
+}

--- a/packages/bb-kv-store/src/agent-tools.ts
+++ b/packages/bb-kv-store/src/agent-tools.ts
@@ -1,9 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import type { AgentToolProviderOptions, Scope, ToolMethodDef } from '@aws-blocks/core';
 import { buildAgentTools } from '@aws-blocks/core';
-import type { AgentToolProviderOptions, ToolMethodDef } from '@aws-blocks/core';
-import type { Scope } from '@aws-blocks/core';
+import type { KVStore } from './index.mock.js';
 
 interface KVStoreLike {
 	get(key: string): Promise<unknown>;
@@ -15,38 +15,74 @@ interface KVStoreLike {
 export const KV_TOOL_METHODS: Record<string, ToolMethodDef<KVStoreLike>> = {
 	get: {
 		description: 'Retrieve a value by key',
-		parameters: { type: 'object', properties: { key: { type: 'string', description: 'The key to retrieve' } }, required: ['key'] },
-		handler: (self) => async ({ input }) => self.get(input.key),
+		parameters: {
+			type: 'object',
+			properties: { key: { type: 'string', description: 'The key to retrieve' } },
+			required: ['key'],
+		},
+		handler:
+			(self) =>
+			async ({ input }) =>
+				self.get(input.key),
 	},
 	put: {
 		description: 'Store a value at a key',
-		parameters: { type: 'object', properties: { key: { type: 'string', description: 'The key to store' }, value: { description: 'The value to store' } }, required: ['key', 'value'] },
+		parameters: {
+			type: 'object',
+			properties: {
+				key: { type: 'string', description: 'The key to store' },
+				value: { description: 'The value to store' },
+			},
+			required: ['key', 'value'],
+		},
 		needsApproval: true,
 		trustable: true,
-		handler: (self) => async ({ input }) => { await self.put(input.key, input.value); return { success: true }; },
+		handler:
+			(self) =>
+			async ({ input }) => {
+				await self.put(input.key, input.value);
+				return { success: true };
+			},
 	},
 	delete: {
 		description: 'Delete a key',
-		parameters: { type: 'object', properties: { key: { type: 'string', description: 'The key to delete' } }, required: ['key'] },
+		parameters: {
+			type: 'object',
+			properties: { key: { type: 'string', description: 'The key to delete' } },
+			required: ['key'],
+		},
 		needsApproval: true,
 		trustable: false,
-		handler: (self) => async ({ input }) => { await self.delete(input.key); return { success: true }; },
+		handler:
+			(self) =>
+			async ({ input }) => {
+				await self.delete(input.key);
+				return { success: true };
+			},
 	},
 	scan: {
 		description: 'List keys and values. Returns up to `limit` entries (default 100).',
-		parameters: { type: 'object', properties: { limit: { type: 'number', description: 'Maximum number of entries to return (default 100)' } } },
-		handler: (self) => async ({ input }) => {
-			const max = input.limit ?? 100;
-			const items: { key: string; value: unknown }[] = [];
-			for await (const entry of self.scan()) {
-				items.push(entry);
-				if (items.length >= max) break;
-			}
-			return items;
+		parameters: {
+			type: 'object',
+			properties: { limit: { type: 'number', description: 'Maximum number of entries to return (default 100)' } },
 		},
+		handler:
+			(self) =>
+			async ({ input }) => {
+				const max = input.limit ?? 100;
+				const items: { key: string; value: unknown }[] = [];
+				for await (const entry of self.scan()) {
+					items.push(entry);
+					if (items.length >= max) break;
+				}
+				return items;
+			},
 	},
 };
 
 export function kvToAgentTools(self: Scope & KVStoreLike, options?: AgentToolProviderOptions): Record<string, any> {
 	return buildAgentTools(self, KV_TOOL_METHODS, options);
 }
+
+// Compile-time check: fails the build if KVStoreLike drifts from the real KVStore class.
+const _kvStoreSatisfiesInterface: KVStoreLike = {} as KVStore;

--- a/packages/bb-kv-store/src/agent-tools.ts
+++ b/packages/bb-kv-store/src/agent-tools.ts
@@ -29,7 +29,7 @@ export const KV_TOOL_METHODS: Record<string, ToolMethodDef<KVStoreLike>> = {
 		description: 'Delete a key',
 		parameters: { type: 'object', properties: { key: { type: 'string', description: 'The key to delete' } }, required: ['key'] },
 		needsApproval: true,
-		trustable: true,
+		trustable: false,
 		handler: (self) => async ({ input }) => { await self.delete(input.key); return { success: true }; },
 	},
 	scan: {

--- a/packages/bb-kv-store/src/agent-tools.ts
+++ b/packages/bb-kv-store/src/agent-tools.ts
@@ -66,6 +66,9 @@ export const KV_TOOL_METHODS: Record<string, ToolMethodDef<KVStoreLike>> = {
 	scan: {
 		description:
 			'List all key-value pairs in the store. Use when you need to browse or search across entries without knowing specific keys. Returns up to `limit` entries (default 100) — for large stores, prefer get if you know the key.',
+		// scan lists the whole store; it can't honor an exact-key `scope`, so it must be
+		// excluded on a scoped store (or the store opted out with `unscoped: true`).
+		scopeSafe: false,
 		parameters: {
 			type: 'object',
 			properties: { limit: { type: 'number', description: 'Maximum number of entries to return (default 100)' } },

--- a/packages/bb-kv-store/src/index.aws.ts
+++ b/packages/bb-kv-store/src/index.aws.ts
@@ -5,6 +5,8 @@ import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { DynamoDBDocumentClient, GetCommand, PutCommand, DeleteCommand, ScanCommand } from '@aws-sdk/lib-dynamodb';
 import { Scope, registerSdkIdentifiers, getSdkIdentifiers } from '@aws-blocks/core';
 import type { ScopeParent } from '@aws-blocks/core';
+import type { AgentToolProviderOptions } from '@aws-blocks/core';
+import { kvToAgentTools } from './agent-tools.js';
 import { Logger } from '@aws-blocks/bb-logger';
 import type { ChildLogger } from '@aws-blocks/bb-logger';
 import { BB_NAME, BB_VERSION } from './version.js';
@@ -157,6 +159,12 @@ export class KVStore<T = string> extends Scope {
 			}
 			lastKey = result.LastEvaluatedKey;
 		} while (lastKey);
+	}
+
+	// ── Agent tools ──────────────────────────────────────────────────────
+
+	toAgentTools(options?: AgentToolProviderOptions): Record<string, any> {
+		return kvToAgentTools(this, options);
 	}
 
 	/**

--- a/packages/bb-kv-store/src/index.browser.ts
+++ b/packages/bb-kv-store/src/index.browser.ts
@@ -4,5 +4,8 @@
 // Browser stub - KVStore runs server-side only
 export class KVStore {
   constructor(...args: any[]) {}
+  toAgentTools(..._args: any[]): never {
+    throw new Error('KVStore.toAgentTools() is not available in the browser.');
+  }
 }
 export { KVStoreErrors } from './errors.js';

--- a/packages/bb-kv-store/src/index.cdk.test.ts
+++ b/packages/bb-kv-store/src/index.cdk.test.ts
@@ -67,7 +67,7 @@ test('CDK: KVStore.fromExisting returns a branded ref', () => {
 test('CDK: calling a runtime data method throws an actionable error (not a cryptic TypeError)', () => {
   const { parent } = setup();
   const store = new KVStore(parent, 'sessions') as any;
-  for (const method of ['get', 'put', 'delete', 'scan']) {
+  for (const method of ['get', 'put', 'delete', 'scan', 'toAgentTools']) {
     assert.throws(
       () => store[method]('k'),
       /cannot be called during CDK synth/,

--- a/packages/bb-kv-store/src/index.cdk.ts
+++ b/packages/bb-kv-store/src/index.cdk.ts
@@ -60,4 +60,5 @@ export class KVStore extends Scope {
 	put(..._args: unknown[]): never { return synthGuard('KVStore', 'put'); }
 	delete(..._args: unknown[]): never { return synthGuard('KVStore', 'delete'); }
 	scan(..._args: unknown[]): never { return synthGuard('KVStore', 'scan'); }
+	toAgentTools(..._args: unknown[]): never { return synthGuard('KVStore', 'toAgentTools'); }
 }

--- a/packages/bb-kv-store/src/index.mock.ts
+++ b/packages/bb-kv-store/src/index.mock.ts
@@ -3,6 +3,8 @@
 
 import { Scope, registerSdkIdentifiers } from '@aws-blocks/core';
 import type { ScopeParent } from '@aws-blocks/core';
+import type { AgentToolProviderOptions } from '@aws-blocks/core';
+import { kvToAgentTools } from './agent-tools.js';
 import { Logger } from '@aws-blocks/bb-logger';
 import type { ChildLogger } from '@aws-blocks/bb-logger';
 import { getMockDataDir } from '@aws-blocks/core/bb-utils';
@@ -168,6 +170,12 @@ export class KVStore<T = string> extends Scope {
 	 */
 	static fromExisting(tableName: string): ExternalTableRef {
 		return { __brand: 'ExternalTableRef' as const, tableName };
+	}
+
+	// ── Agent tools ──────────────────────────────────────────────────────
+
+	toAgentTools(options?: AgentToolProviderOptions): Record<string, any> {
+		return kvToAgentTools(this, options);
 	}
 
 	// ── Disk persistence ──────────────────────────────────────────────────

--- a/packages/bb-kv-store/src/index.test.ts
+++ b/packages/bb-kv-store/src/index.test.ts
@@ -4,6 +4,7 @@
 import { test, beforeEach, describe } from 'node:test';
 import assert from 'node:assert';
 import { rmSync } from 'node:fs';
+import { z } from 'zod';
 import { isBlocksError, Scope } from '@aws-blocks/core';
 import { KVStore, KVStoreErrors } from './index.mock.js';
 
@@ -219,10 +220,23 @@ test('fullId generation with parent', () => {
 // ── toAgentTools() ──────────────────────────────────────────────────────────
 
 describe('toAgentTools()', () => {
-	test('exposes get, put, delete, scan', () => {
+	test('throws unless scoped or explicitly unscoped', () => {
 		const scope = new Scope('app');
 		const store = new KVStore(scope, 'memory');
-		const tools = store.toAgentTools();
+		assert.throws(() => store.toAgentTools(), /holds per-user data/);
+	});
+
+	test('unscoped: true opts out of the scoping requirement', () => {
+		const scope = new Scope('app');
+		const store = new KVStore(scope, 'memory');
+		const tools = store.toAgentTools({ unscoped: true });
+		assert.deepStrictEqual(Object.keys(tools).sort(), ['memory__delete', 'memory__get', 'memory__put', 'memory__scan']);
+	});
+
+	test('scope satisfies the scoping requirement', () => {
+		const scope = new Scope('app');
+		const store = new KVStore(scope, 'memory');
+		const tools = store.toAgentTools({ scope: (ctx: { userId: string }) => ({ key: ctx.userId }) });
 		assert.deepStrictEqual(Object.keys(tools).sort(), ['memory__delete', 'memory__get', 'memory__put', 'memory__scan']);
 	});
 
@@ -230,7 +244,7 @@ describe('toAgentTools()', () => {
 		const scope = new Scope('app');
 		const store = new KVStore(scope, 'memory');
 		await store.put('k', 'v');
-		const tools = store.toAgentTools();
+		const tools = store.toAgentTools({ unscoped: true });
 		const result = await tools['memory__get'].handler({ input: { key: 'k' }, context: {} });
 		assert.strictEqual(result, 'v');
 	});
@@ -238,9 +252,31 @@ describe('toAgentTools()', () => {
 	test('put handler writes to the store', async () => {
 		const scope = new Scope('app');
 		const store = new KVStore(scope, 'memory');
-		const tools = store.toAgentTools();
+		const tools = store.toAgentTools({ unscoped: true });
 		await tools['memory__put'].handler({ input: { key: 'k', value: 'v' }, context: {} });
 		assert.strictEqual(await store.get('k'), 'v');
+	});
+
+	test('scope pins the key to the caller', async () => {
+		const scope = new Scope('app');
+		const store = new KVStore(scope, 'memory');
+		await store.put('user-123', 'mine');
+		const tools = store.toAgentTools({ scope: (ctx: { userId: string }) => ({ key: ctx.userId }) });
+		// model tries to read another user's key; scope overrides it to the caller's
+		const result = await tools['memory__get'].handler({
+			input: { key: 'user-999' },
+			context: { userId: 'user-123' },
+		});
+		assert.strictEqual(result, 'mine');
+	});
+
+	test('scoped key is stripped from the parameters the model sees', () => {
+		const scope = new Scope('app');
+		const store = new KVStore(scope, 'memory');
+		const tools = store.toAgentTools({ scope: (ctx: { userId: string }) => ({ key: ctx.userId }) });
+		const props = (tools['memory__get'].parameters as any).properties;
+		assert.ok(!('key' in props), 'scoped key should not be exposed to the model');
+		assert.deepStrictEqual((tools['memory__get'].parameters as any).required, []);
 	});
 
 	test('scan handler collects all entries', async () => {
@@ -248,7 +284,7 @@ describe('toAgentTools()', () => {
 		const store = new KVStore(scope, 'memory');
 		await store.put('a', '1');
 		await store.put('b', '2');
-		const tools = store.toAgentTools();
+		const tools = store.toAgentTools({ unscoped: true });
 		const result = await tools['memory__scan'].handler({ input: {}, context: {} }) as any[];
 		assert.strictEqual(result.length, 2);
 	});
@@ -257,8 +293,19 @@ describe('toAgentTools()', () => {
 		const scope = new Scope('app');
 		const store = new KVStore(scope, 'memory');
 		for (let i = 0; i < 5; i++) await store.put(`key${i}`, `val${i}`);
-		const tools = store.toAgentTools();
+		const tools = store.toAgentTools({ unscoped: true });
 		const result = await tools['memory__scan'].handler({ input: { limit: 2 }, context: {} }) as any[];
 		assert.strictEqual(result.length, 2);
+	});
+
+	test('a zod schema override replaces the parameters the model sees', () => {
+		const scope = new Scope('app');
+		const store = new KVStore(scope, 'memory');
+		const putSchema = z.object({ key: z.string(), value: z.object({ note: z.string() }) });
+		const tools = store.toAgentTools({
+			unscoped: true,
+			overrides: { put: { schema: putSchema } },
+		});
+		assert.strictEqual(tools['memory__put'].parameters, putSchema);
 	});
 });

--- a/packages/bb-kv-store/src/index.test.ts
+++ b/packages/bb-kv-store/src/index.test.ts
@@ -1,10 +1,10 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { test, beforeEach } from 'node:test';
+import { test, beforeEach, describe } from 'node:test';
 import assert from 'node:assert';
 import { rmSync } from 'node:fs';
-import { isBlocksError } from '@aws-blocks/core';
+import { isBlocksError, Scope } from '@aws-blocks/core';
 import { KVStore, KVStoreErrors } from './index.mock.js';
 
 // Clean mock data between tests to avoid cross-contamination
@@ -214,4 +214,51 @@ test('KVStoreErrors.ItemTooLarge is a distinct name, not generic ValidationExcep
 test('fullId generation with parent', () => {
 	const store = new KVStore({ id: 'parent' } as any, 'child');
 	assert.strictEqual(store.fullId, 'parent-child');
+});
+
+// ── toAgentTools() ──────────────────────────────────────────────────────────
+
+describe('toAgentTools()', () => {
+	test('exposes get, put, delete, scan', () => {
+		const scope = new Scope('app');
+		const store = new KVStore(scope, 'memory');
+		const tools = store.toAgentTools();
+		assert.deepStrictEqual(Object.keys(tools).sort(), ['memory__delete', 'memory__get', 'memory__put', 'memory__scan']);
+	});
+
+	test('get handler reads from the store', async () => {
+		const scope = new Scope('app');
+		const store = new KVStore(scope, 'memory');
+		await store.put('k', 'v');
+		const tools = store.toAgentTools();
+		const result = await tools['memory__get'].handler({ input: { key: 'k' }, context: {} });
+		assert.strictEqual(result, 'v');
+	});
+
+	test('put handler writes to the store', async () => {
+		const scope = new Scope('app');
+		const store = new KVStore(scope, 'memory');
+		const tools = store.toAgentTools();
+		await tools['memory__put'].handler({ input: { key: 'k', value: 'v' }, context: {} });
+		assert.strictEqual(await store.get('k'), 'v');
+	});
+
+	test('scan handler collects all entries', async () => {
+		const scope = new Scope('app');
+		const store = new KVStore(scope, 'memory');
+		await store.put('a', '1');
+		await store.put('b', '2');
+		const tools = store.toAgentTools();
+		const result = await tools['memory__scan'].handler({ input: {}, context: {} }) as any[];
+		assert.strictEqual(result.length, 2);
+	});
+
+	test('scan handler respects limit', async () => {
+		const scope = new Scope('app');
+		const store = new KVStore(scope, 'memory');
+		for (let i = 0; i < 5; i++) await store.put(`key${i}`, `val${i}`);
+		const tools = store.toAgentTools();
+		const result = await tools['memory__scan'].handler({ input: { limit: 2 }, context: {} }) as any[];
+		assert.strictEqual(result.length, 2);
+	});
 });

--- a/packages/bb-kv-store/src/index.test.ts
+++ b/packages/bb-kv-store/src/index.test.ts
@@ -236,8 +236,25 @@ describe('toAgentTools()', () => {
 	test('scope satisfies the scoping requirement', () => {
 		const scope = new Scope('app');
 		const store = new KVStore(scope, 'memory');
-		const tools = store.toAgentTools({ scope: (ctx: { userId: string }) => ({ key: ctx.userId }) });
-		assert.deepStrictEqual(Object.keys(tools).sort(), ['memory__delete', 'memory__get', 'memory__put', 'memory__scan']);
+		// scan can't be scope-isolated, so a scoped store must exclude it
+		const tools = store.toAgentTools({ scope: (ctx: { userId: string }) => ({ key: ctx.userId }), exclude: ['scan'] });
+		assert.deepStrictEqual(Object.keys(tools).sort(), ['memory__delete', 'memory__get', 'memory__put']);
+	});
+
+	test('scoping while exposing scan throws', () => {
+		const scope = new Scope('app');
+		const store = new KVStore(scope, 'memory');
+		assert.throws(
+			() => store.toAgentTools({ scope: (ctx: { userId: string }) => ({ key: ctx.userId }) }),
+			/scan.*cannot be scope-isolated/,
+		);
+	});
+
+	test('scan is allowed on an unscoped store', () => {
+		const scope = new Scope('app');
+		const store = new KVStore(scope, 'memory');
+		const tools = store.toAgentTools({ unscoped: true });
+		assert.ok('memory__scan' in tools);
 	});
 
 	test('get handler reads from the store', async () => {
@@ -261,7 +278,7 @@ describe('toAgentTools()', () => {
 		const scope = new Scope('app');
 		const store = new KVStore(scope, 'memory');
 		await store.put('user-123', 'mine');
-		const tools = store.toAgentTools({ scope: (ctx: { userId: string }) => ({ key: ctx.userId }) });
+		const tools = store.toAgentTools({ scope: (ctx: { userId: string }) => ({ key: ctx.userId }), exclude: ['scan'] });
 		// model tries to read another user's key; scope overrides it to the caller's
 		const result = await tools['memory__get'].handler({
 			input: { key: 'user-999' },
@@ -273,7 +290,7 @@ describe('toAgentTools()', () => {
 	test('scoped key is stripped from the parameters the model sees', () => {
 		const scope = new Scope('app');
 		const store = new KVStore(scope, 'memory');
-		const tools = store.toAgentTools({ scope: (ctx: { userId: string }) => ({ key: ctx.userId }) });
+		const tools = store.toAgentTools({ scope: (ctx: { userId: string }) => ({ key: ctx.userId }), exclude: ['scan'] });
 		const props = (tools['memory__get'].parameters as any).properties;
 		assert.ok(!('key' in props), 'scoped key should not be exposed to the model');
 		assert.deepStrictEqual((tools['memory__get'].parameters as any).required, []);

--- a/packages/core/API.md
+++ b/packages/core/API.md
@@ -245,6 +245,7 @@ export interface ToolMethodDef<TSelf = any> {
     needsApproval?: boolean;
     // (undocumented)
     parameters: unknown;
+    scopeSafe?: boolean;
     // (undocumented)
     trustable?: boolean;
 }

--- a/packages/core/API.md
+++ b/packages/core/API.md
@@ -4,6 +4,8 @@
 
 ```ts
 
+import type { StandardSchemaV1 } from '@standard-schema/spec';
+
 // @public
 export interface AgentToolProvider {
     // (undocumented)
@@ -16,6 +18,7 @@ export interface AgentToolProviderOptions<TContext = any> {
     include?: string[];
     overrides?: Record<string, MethodOverrides>;
     scope?: (context: TContext) => Record<string, unknown>;
+    unscoped?: boolean;
 }
 
 // @public
@@ -62,7 +65,12 @@ export type BlocksContext = {
 };
 
 // @public
-export function buildAgentTools<TSelf extends Scope>(self: TSelf, toolMethods: Record<string, ToolMethodDef<TSelf>>, options?: AgentToolProviderOptions<any>): Record<string, any>;
+export function buildAgentTools<TSelf extends Scope>(self: TSelf, toolMethods: Record<string, ToolMethodDef<TSelf>>, options?: AgentToolProviderOptions<any>, config?: BuildAgentToolsConfig): Record<string, any>;
+
+// @public
+export interface BuildAgentToolsConfig {
+    requiresScope?: boolean;
+}
 
 // @public
 export interface BuildingBlockMeta {
@@ -129,7 +137,7 @@ export interface MethodOverrides {
     fixed?: Record<string, unknown>;
     // (undocumented)
     needsApproval?: boolean;
-    schema?: unknown;
+    schema?: StandardSchemaV1;
     // (undocumented)
     trustable?: boolean;
 }

--- a/packages/core/API.md
+++ b/packages/core/API.md
@@ -5,6 +5,20 @@
 ```ts
 
 // @public
+export interface AgentToolProvider {
+    // (undocumented)
+    toAgentTools<TContext = any>(options?: AgentToolProviderOptions<TContext>): Record<string, any>;
+}
+
+// @public (undocumented)
+export interface AgentToolProviderOptions<TContext = any> {
+    exclude?: string[];
+    include?: string[];
+    overrides?: Record<string, MethodOverrides>;
+    scope?: (context: TContext) => Record<string, unknown>;
+}
+
+// @public
 export class ApiError extends Error {
     constructor(message: string, status: number, options?: {
         name?: string;
@@ -46,6 +60,9 @@ export type BlocksContext = {
         send: (body: any) => void;
     };
 };
+
+// @public
+export function buildAgentTools<TSelf extends Scope>(self: TSelf, toolMethods: Record<string, ToolMethodDef<TSelf>>, options?: AgentToolProviderOptions<any>): Record<string, any>;
 
 // @public
 export interface BuildingBlockMeta {
@@ -104,6 +121,18 @@ export function matchRoute(method: string, path: string): {
     route: RegisteredRoute;
     params: Record<string, string>;
 } | null;
+
+// @public (undocumented)
+export interface MethodOverrides {
+    // (undocumented)
+    description?: string;
+    fixed?: Record<string, unknown>;
+    // (undocumented)
+    needsApproval?: boolean;
+    schema?: unknown;
+    // (undocumented)
+    trustable?: boolean;
+}
 
 // @public
 export function preloadConfig(): Promise<void>;
@@ -194,6 +223,23 @@ export interface ScopeOptions {
 export type ScopeParent = Scope | {
     id: string;
 };
+
+// @public
+export interface ToolMethodDef<TSelf = any> {
+    // (undocumented)
+    description: string;
+    // (undocumented)
+    handler: (self: TSelf) => (args: {
+        input: any;
+        context: any;
+    }) => Promise<unknown>;
+    // (undocumented)
+    needsApproval?: boolean;
+    // (undocumented)
+    parameters: unknown;
+    // (undocumented)
+    trustable?: boolean;
+}
 
 // @public
 export function unlockRouteRegistry(): void;

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -66,6 +66,7 @@
     "@aws-blocks/pipeline": "*",
     "@aws-sdk/client-s3": "^3.700.0",
     "@aws-sdk/client-ssm": "^3.700.0",
+    "@standard-schema/spec": "^1.1.0",
     "cross-spawn": "^7.0.6",
     "http-proxy": "^1.18.1"
   },

--- a/packages/core/src/agent-tools.test.ts
+++ b/packages/core/src/agent-tools.test.ts
@@ -160,7 +160,7 @@ describe('buildAgentTools', () => {
 			assert.strictEqual(result.userId, 'real-user');
 		});
 
-		test('scope and fixed combine', async () => {
+		test('scope and fixed combine on disjoint keys', async () => {
 			const methods: Record<string, ToolMethodDef<any>> = {
 				query: {
 					description: 'Query items',
@@ -177,6 +177,25 @@ describe('buildAgentTools', () => {
 				context: { userId: 'user-123' },
 			});
 			assert.deepStrictEqual(result, { status: 'active', userId: 'user-123', limit: 10 });
+		});
+
+		test('fixed wins over scope when both target the same key', async () => {
+			const methods: Record<string, ToolMethodDef<any>> = {
+				query: {
+					description: 'Query items',
+					parameters: { type: 'object', properties: {} },
+					handler: () => async ({ input }) => input,
+				},
+			};
+			const tools = buildAgentTools(mockBB, methods, {
+				scope: (ctx: { tenant: string }) => ({ tenant: ctx.tenant }),
+				overrides: { query: { fixed: { tenant: 'pinned-tenant' } } },
+			});
+			const result = await tools['store__query'].handler({
+				input: { status: 'active' },
+				context: { tenant: 'context-tenant' },
+			});
+			assert.strictEqual(result.tenant, 'pinned-tenant');
 		});
 	});
 });

--- a/packages/core/src/agent-tools.test.ts
+++ b/packages/core/src/agent-tools.test.ts
@@ -165,6 +165,23 @@ describe('buildAgentTools', () => {
 			assert.strictEqual(result.userId, 'real-user');
 		});
 
+		test('scoped tool invoked without context throws instead of running unscoped', async () => {
+			const methods: Record<string, ToolMethodDef<any>> = {
+				query: {
+					description: 'Query items',
+					parameters: { type: 'object', properties: {} },
+					handler: () => async ({ input }) => input,
+				},
+			};
+			const tools = buildAgentTools(mockBB, methods, {
+				scope: (ctx: { userId: string }) => ({ userId: ctx.userId }),
+			});
+			await assert.rejects(
+				() => tools['store__query'].handler({ input: { status: 'active' }, context: undefined }),
+				/scoped but was invoked without a context/,
+			);
+		});
+
 		test('scope and fixed combine on disjoint keys', async () => {
 			const methods: Record<string, ToolMethodDef<any>> = {
 				query: {

--- a/packages/core/src/agent-tools.test.ts
+++ b/packages/core/src/agent-tools.test.ts
@@ -1,0 +1,182 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert';
+import { buildAgentTools } from './agent-tools.js';
+import { Scope } from './common/index.js';
+import type { ToolMethodDef } from './agent-tools.js';
+
+const scope = new Scope('test-app');
+
+// Simulates a BB's tool registry — tests buildAgentTools logic in isolation
+// so each BB only needs to test its own handlers, not filtering/scope/overrides.
+const MOCK_METHODS: Record<string, ToolMethodDef<any>> = {
+	get: {
+		description: 'Retrieve a value',
+		parameters: { type: 'object', properties: { key: { type: 'string' } }, required: ['key'] },
+		handler: (self) => async ({ input }) => `got:${input.key}`,
+	},
+	put: {
+		description: 'Store a value',
+		parameters: { type: 'object', properties: { key: { type: 'string' }, value: {} }, required: ['key', 'value'] },
+		needsApproval: true,
+		trustable: true,
+		handler: (self) => async ({ input }) => ({ stored: input.key }),
+	},
+	delete: {
+		description: 'Delete a value',
+		parameters: { type: 'object', properties: { key: { type: 'string' } }, required: ['key'] },
+		needsApproval: true,
+		handler: (self) => async ({ input }) => ({ deleted: input.key }),
+	},
+};
+
+// Use a minimal Scope-like object for testing
+const mockBB = new Scope('store', { parent: scope });
+
+describe('buildAgentTools', () => {
+	test('returns all methods by default', () => {
+		const tools = buildAgentTools(mockBB, MOCK_METHODS);
+		assert.deepStrictEqual(Object.keys(tools).sort(), ['store__delete', 'store__get', 'store__put']);
+	});
+
+	test('tool naming is bbId__methodName', () => {
+		const bb = new Scope('my-store', { parent: scope });
+		const tools = buildAgentTools(bb, MOCK_METHODS);
+		assert.ok('my-store__get' in tools);
+		assert.ok('my-store__put' in tools);
+		assert.ok('my-store__delete' in tools);
+	});
+
+	test('preserves description, parameters, needsApproval, trustable', () => {
+		const tools = buildAgentTools(mockBB, MOCK_METHODS);
+		assert.strictEqual(tools['store__get'].description, 'Retrieve a value');
+		assert.strictEqual(tools['store__get'].needsApproval, false);
+		assert.strictEqual(tools['store__put'].needsApproval, true);
+		assert.strictEqual(tools['store__put'].trustable, true);
+		assert.strictEqual(tools['store__delete'].needsApproval, true);
+		assert.strictEqual(tools['store__delete'].trustable, undefined);
+	});
+
+	test('handler is a callable function', async () => {
+		const tools = buildAgentTools(mockBB, MOCK_METHODS);
+		const result = await tools['store__get'].handler({ input: { key: 'abc' }, context: {} });
+		assert.strictEqual(result, 'got:abc');
+	});
+
+	describe('include/exclude', () => {
+		test('include filters to specified methods', () => {
+			const tools = buildAgentTools(mockBB, MOCK_METHODS, { include: ['get'] });
+			assert.deepStrictEqual(Object.keys(tools), ['store__get']);
+		});
+
+		test('exclude removes specified methods', () => {
+			const tools = buildAgentTools(mockBB, MOCK_METHODS, { exclude: ['delete'] });
+			assert.deepStrictEqual(Object.keys(tools).sort(), ['store__get', 'store__put']);
+		});
+
+		test('include and exclude together throws', () => {
+			assert.throws(
+				() => buildAgentTools(mockBB, MOCK_METHODS, { include: ['get'], exclude: ['put'] }),
+				/mutually exclusive/,
+			);
+		});
+	});
+
+	describe('overrides', () => {
+		test('override description', () => {
+			const tools = buildAgentTools(mockBB, MOCK_METHODS, {
+				overrides: { get: { description: 'Custom description' } },
+			});
+			assert.strictEqual(tools['store__get'].description, 'Custom description');
+		});
+
+		test('override needsApproval', () => {
+			const tools = buildAgentTools(mockBB, MOCK_METHODS, {
+				overrides: { get: { needsApproval: true } },
+			});
+			assert.strictEqual(tools['store__get'].needsApproval, true);
+		});
+
+		test('override schema replaces parameters', () => {
+			const customSchema = { type: 'object', properties: { id: { type: 'number' } } };
+			const tools = buildAgentTools(mockBB, MOCK_METHODS, {
+				overrides: { get: { schema: customSchema } },
+			});
+			assert.deepStrictEqual(tools['store__get'].parameters, customSchema);
+		});
+
+		test('fixed values are injected into handler input', async () => {
+			const methods: Record<string, ToolMethodDef<any>> = {
+				query: {
+					description: 'Query items',
+					parameters: { type: 'object', properties: {} },
+					handler: () => async ({ input }) => input,
+				},
+			};
+			const tools = buildAgentTools(mockBB, methods, {
+				overrides: { query: { fixed: { region: 'us-east-1' } } },
+			});
+			const result = await tools['store__query'].handler({ input: { status: 'active' }, context: {} });
+			assert.deepStrictEqual(result, { status: 'active', region: 'us-east-1' });
+		});
+	});
+
+	describe('scope', () => {
+		test('scope injects context fields into input', async () => {
+			const methods: Record<string, ToolMethodDef<any>> = {
+				query: {
+					description: 'Query items',
+					parameters: { type: 'object', properties: {} },
+					handler: () => async ({ input }) => input,
+				},
+			};
+			const tools = buildAgentTools(mockBB, methods, {
+				scope: (ctx: { userId: string }) => ({ userId: ctx.userId }),
+			});
+			const result = await tools['store__query'].handler({
+				input: { status: 'active' },
+				context: { userId: 'user-123' },
+			});
+			assert.deepStrictEqual(result, { status: 'active', userId: 'user-123' });
+		});
+
+		test('scope overrides user-provided input for scoped fields', async () => {
+			const methods: Record<string, ToolMethodDef<any>> = {
+				query: {
+					description: 'Query items',
+					parameters: { type: 'object', properties: {} },
+					handler: () => async ({ input }) => input,
+				},
+			};
+			const tools = buildAgentTools(mockBB, methods, {
+				scope: (ctx: { userId: string }) => ({ userId: ctx.userId }),
+			});
+			const result = await tools['store__query'].handler({
+				input: { userId: 'attacker', status: 'active' },
+				context: { userId: 'real-user' },
+			});
+			assert.strictEqual(result.userId, 'real-user');
+		});
+
+		test('scope and fixed combine', async () => {
+			const methods: Record<string, ToolMethodDef<any>> = {
+				query: {
+					description: 'Query items',
+					parameters: { type: 'object', properties: {} },
+					handler: () => async ({ input }) => input,
+				},
+			};
+			const tools = buildAgentTools(mockBB, methods, {
+				scope: (ctx: { userId: string }) => ({ userId: ctx.userId }),
+				overrides: { query: { fixed: { limit: 10 } } },
+			});
+			const result = await tools['store__query'].handler({
+				input: { status: 'active' },
+				context: { userId: 'user-123' },
+			});
+			assert.deepStrictEqual(result, { status: 'active', userId: 'user-123', limit: 10 });
+		});
+	});
+});

--- a/packages/core/src/agent-tools.test.ts
+++ b/packages/core/src/agent-tools.test.ts
@@ -3,6 +3,7 @@
 
 import { test, describe } from 'node:test';
 import assert from 'node:assert';
+import type { StandardSchemaV1 } from '@standard-schema/spec';
 import { buildAgentTools } from './agent-tools.js';
 import { Scope } from './common/index.js';
 import type { ToolMethodDef } from './agent-tools.js';
@@ -100,11 +101,15 @@ describe('buildAgentTools', () => {
 		});
 
 		test('override schema replaces parameters', () => {
-			const customSchema = { type: 'object', properties: { id: { type: 'number' } } };
+			// Minimal Standard Schema value — core stays library-agnostic, so the unit test
+			// uses a bare `~standard` stub. See bb-kv-store for the zod developer path.
+			const customSchema: StandardSchemaV1 = {
+				'~standard': { version: 1, vendor: 'test', validate: (value) => ({ value }) },
+			};
 			const tools = buildAgentTools(mockBB, MOCK_METHODS, {
 				overrides: { get: { schema: customSchema } },
 			});
-			assert.deepStrictEqual(tools['store__get'].parameters, customSchema);
+			assert.strictEqual(tools['store__get'].parameters, customSchema);
 		});
 
 		test('fixed values are injected into handler input', async () => {
@@ -196,6 +201,86 @@ describe('buildAgentTools', () => {
 				context: { tenant: 'context-tenant' },
 			});
 			assert.strictEqual(result.tenant, 'pinned-tenant');
+		});
+	});
+
+	describe('parameter stripping', () => {
+		const paramMethods: Record<string, ToolMethodDef<any>> = {
+			query: {
+				description: 'Query items',
+				parameters: {
+					type: 'object',
+					properties: { userId: { type: 'string' }, status: { type: 'string' } },
+					required: ['userId'],
+				},
+				handler: () => async ({ input }) => input,
+			},
+		};
+
+		test('scope keys are removed from the parameters the model sees', () => {
+			const tools = buildAgentTools(mockBB, paramMethods, {
+				scope: (ctx: { userId: string }) => ({ userId: ctx.userId }),
+			});
+			const props = (tools['store__query'].parameters as any).properties;
+			assert.ok(!('userId' in props), 'userId should be stripped');
+			assert.ok('status' in props, 'unscoped fields remain');
+		});
+
+		test('scope keys are removed from required', () => {
+			const tools = buildAgentTools(mockBB, paramMethods, {
+				scope: (ctx: { userId: string }) => ({ userId: ctx.userId }),
+			});
+			assert.deepStrictEqual((tools['store__query'].parameters as any).required, []);
+		});
+
+		test('fixed keys are removed from the parameters the model sees', () => {
+			const tools = buildAgentTools(mockBB, paramMethods, {
+				unscoped: true,
+				overrides: { query: { fixed: { status: 'active' } } },
+			});
+			const props = (tools['store__query'].parameters as any).properties;
+			assert.ok(!('status' in props), 'fixed field should be stripped');
+			assert.ok('userId' in props, 'other fields remain');
+		});
+
+		test('scope still overrides at runtime after stripping', async () => {
+			const tools = buildAgentTools(mockBB, paramMethods, {
+				scope: (ctx: { userId: string }) => ({ userId: ctx.userId }),
+			});
+			const result = await tools['store__query'].handler({
+				input: { status: 'active' },
+				context: { userId: 'real-user' },
+			});
+			assert.strictEqual(result.userId, 'real-user');
+		});
+	});
+
+	describe('requiresScope', () => {
+		test('throws when neither scope nor unscoped is passed', () => {
+			assert.throws(
+				() => buildAgentTools(mockBB, MOCK_METHODS, undefined, { requiresScope: true }),
+				/holds per-user data/,
+			);
+		});
+
+		test('scope satisfies the requirement', () => {
+			const tools = buildAgentTools(
+				mockBB,
+				MOCK_METHODS,
+				{ scope: (ctx: { userId: string }) => ({ key: ctx.userId }) },
+				{ requiresScope: true },
+			);
+			assert.ok('store__get' in tools);
+		});
+
+		test('unscoped: true satisfies the requirement', () => {
+			const tools = buildAgentTools(mockBB, MOCK_METHODS, { unscoped: true }, { requiresScope: true });
+			assert.ok('store__get' in tools);
+		});
+
+		test('no requirement when requiresScope is unset', () => {
+			const tools = buildAgentTools(mockBB, MOCK_METHODS);
+			assert.ok('store__get' in tools);
 		});
 	});
 });

--- a/packages/core/src/agent-tools.test.ts
+++ b/packages/core/src/agent-tools.test.ts
@@ -255,6 +255,42 @@ describe('buildAgentTools', () => {
 		});
 	});
 
+	describe('scopeSafe', () => {
+		const withScan: Record<string, ToolMethodDef<any>> = {
+			get: {
+				description: 'Get',
+				parameters: { type: 'object', properties: { key: { type: 'string' } }, required: ['key'] },
+				handler: () => async ({ input }) => input,
+			},
+			scan: {
+				description: 'List everything',
+				parameters: { type: 'object', properties: {} },
+				scopeSafe: false,
+				handler: () => async () => [],
+			},
+		};
+
+		test('throws when a scopeSafe:false method is exposed under scope', () => {
+			assert.throws(
+				() => buildAgentTools(mockBB, withScan, { scope: (ctx: { userId: string }) => ({ key: ctx.userId }) }),
+				/scan.*cannot be scope-isolated/,
+			);
+		});
+
+		test('excluding the scopeSafe:false method allows scoping', () => {
+			const tools = buildAgentTools(mockBB, withScan, {
+				scope: (ctx: { userId: string }) => ({ key: ctx.userId }),
+				exclude: ['scan'],
+			});
+			assert.deepStrictEqual(Object.keys(tools), ['store__get']);
+		});
+
+		test('scopeSafe:false method is fine when unscoped', () => {
+			const tools = buildAgentTools(mockBB, withScan, { unscoped: true });
+			assert.ok('store__scan' in tools);
+		});
+	});
+
 	describe('requiresScope', () => {
 		test('throws when neither scope nor unscoped is passed', () => {
 			assert.throws(

--- a/packages/core/src/agent-tools.ts
+++ b/packages/core/src/agent-tools.ts
@@ -56,8 +56,9 @@ export interface AgentToolProvider {
  * Build agent tools from a BB's tool method registry.
  * Handles include/exclude filtering, overrides, and scope injection.
  *
- * Returns `Record<string, any>` so the result can be spread directly into
- * an Agent's `tools` callback without type conflicts.
+ * Returns `Record<string, any>` — this bypasses the Agent BB's branded AgentTool type
+ * check. Core can't import the brand without a circular dep, so shape/override errors
+ * are caught at runtime, not compile time. The tool() factory remains the type-safe path.
  */
 export function buildAgentTools<TSelf extends Scope>(
 	self: TSelf,

--- a/packages/core/src/agent-tools.ts
+++ b/packages/core/src/agent-tools.ts
@@ -17,7 +17,10 @@ export interface AgentToolProviderOptions<TContext = any> {
 	exclude?: string[];
 	/** Per-method overrides of the BB's defaults, keyed by method name. */
 	overrides?: Record<string, MethodOverrides>;
-	/** Maps context fields to fixed constraints applied across all methods. */
+	/**
+	 * Injects request-scoped fields (e.g. userId) into tool input from context.
+	 * Precedence when the same key appears in multiple sources: fixed > scope > model input.
+	 */
 	scope?: (context: TContext) => Record<string, unknown>;
 }
 
@@ -37,6 +40,8 @@ export interface ToolMethodDef<TSelf = any> {
 	parameters: unknown;
 	needsApproval?: boolean;
 	trustable?: boolean;
+	// `input: any` because parameters are JSON Schema objects — no compile-time type link.
+	// Core avoids a zod dependency, so we can't derive input types from the schema.
 	handler: (self: TSelf) => (args: { input: any; context: any }) => Promise<unknown>;
 }
 

--- a/packages/core/src/agent-tools.ts
+++ b/packages/core/src/agent-tools.ts
@@ -6,6 +6,7 @@
  * Lives in core so any BB can implement the interface without depending on `bb-agent`.
  */
 
+import type { StandardSchemaV1 } from '@standard-schema/spec';
 import type { Scope } from './common/index.js';
 
 // ── Types ───────────────────────────────────────────────────────────────────
@@ -22,6 +23,12 @@ export interface AgentToolProviderOptions<TContext = any> {
 	 * Precedence when the same key appears in multiple sources: fixed > scope > model input.
 	 */
 	scope?: (context: TContext) => Record<string, unknown>;
+	/**
+	 * Opt out of the scoping requirement for a BB that declares `requiresScope`.
+	 * Asserts the store holds no per-user data (a cache, feature flags, shared config).
+	 * Ignored for BBs that don't require scope.
+	 */
+	unscoped?: boolean;
 }
 
 export interface MethodOverrides {
@@ -29,7 +36,7 @@ export interface MethodOverrides {
 	/** Pin parameter values — injected server-side, stripped from what the model sees. */
 	fixed?: Record<string, unknown>;
 	/** Narrow or replace the parameters schema the model sees. */
-	schema?: unknown;
+	schema?: StandardSchemaV1;
 	needsApproval?: boolean;
 	trustable?: boolean;
 }
@@ -53,8 +60,57 @@ export interface AgentToolProvider {
 // ── Builder ─────────────────────────────────────────────────────────────────
 
 /**
+ * Discover the key names a `scope` callback injects, without a request context.
+ * The documented pattern maps context fields to a fixed set of keys
+ * (`(ctx) => ({ key: ctx.userId })`), so we probe with a proxy that tolerates any
+ * property access and read the returned object's keys. Falls back to no stripping
+ * if the callback throws or returns a non-object.
+ */
+function discoverScopeKeys(scope?: (context: any) => Record<string, unknown>): string[] {
+	if (!scope) return [];
+	try {
+		const probe = new Proxy({}, { get: () => '' });
+		const injected = scope(probe);
+		return injected && typeof injected === 'object' ? Object.keys(injected) : [];
+	} catch {
+		return [];
+	}
+}
+
+/**
+ * Remove server-injected keys from a JSON Schema `parameters` object so the model
+ * never sees a field it can't control. Only applies to plain JSON Schema objects;
+ * a Standard Schema override is returned untouched (core can't `.omit()` generically
+ * without depending on a concrete validation library — a BB that authors its
+ * parameters with a schema library omits scoped fields itself before this point).
+ */
+function stripKeysFromParameters(parameters: unknown, keys: string[]): unknown {
+	if (keys.length === 0 || !parameters || typeof parameters !== 'object') return parameters;
+	if ('~standard' in parameters) return parameters;
+	const schema = parameters as { properties?: Record<string, unknown>; required?: string[] };
+	if (!schema.properties || typeof schema.properties !== 'object') return parameters;
+	const properties = { ...schema.properties };
+	for (const key of keys) delete properties[key];
+	const required = Array.isArray(schema.required)
+		? schema.required.filter((name) => !keys.includes(name))
+		: schema.required;
+	return { ...schema, properties, required };
+}
+
+/** Build-time configuration a BB passes to describe its tool registry. */
+export interface BuildAgentToolsConfig {
+	/**
+	 * The BB can hold per-user data. When true, `buildAgentTools` throws unless the
+	 * caller passes either `scope` or `unscoped: true`, so an accidental unscoped
+	 * spread can't quietly expose every user's data.
+	 */
+	requiresScope?: boolean;
+}
+
+/**
  * Build agent tools from a BB's tool method registry.
- * Handles include/exclude filtering, overrides, and scope injection.
+ * Handles include/exclude filtering, overrides, scope injection, and the
+ * scoping requirement for BBs that hold per-user data.
  *
  * Returns `Record<string, any>` — this bypasses the Agent BB's branded AgentTool type
  * check. Core can't import the brand without a circular dep, so shape/override errors
@@ -64,13 +120,25 @@ export function buildAgentTools<TSelf extends Scope>(
 	self: TSelf,
 	toolMethods: Record<string, ToolMethodDef<TSelf>>,
 	options?: AgentToolProviderOptions<any>,
+	config?: BuildAgentToolsConfig,
 ): Record<string, any> {
 	if (options?.include && options?.exclude) {
 		throw new Error('toAgentTools: `include` and `exclude` are mutually exclusive');
 	}
 
 	const bbId = self.id;
+
+	// A BB that can hold per-user data must be scoped to the caller or explicitly
+	// opted out. Throws at construction so the mistake never reaches production.
+	if (config?.requiresScope && !options?.scope && !options?.unscoped) {
+		throw new Error(
+			`toAgentTools: ${self.constructor.name} "${bbId}" holds per-user data — pass \`scope\` to lock it to the caller, or \`unscoped: true\` if it is shared`,
+		);
+	}
 	const result: Record<string, any> = {};
+
+	// Keys injected by `scope` are the same for every method; discover them once.
+	const scopeKeys = discoverScopeKeys(options?.scope);
 
 	for (const [methodName, def] of Object.entries(toolMethods)) {
 		if (options?.include && !options.include.includes(methodName)) continue;
@@ -80,7 +148,11 @@ export function buildAgentTools<TSelf extends Scope>(
 		const description = override?.description ?? def.description;
 		const needsApproval = override?.needsApproval ?? def.needsApproval ?? false;
 		const trustable = override?.trustable ?? def.trustable;
-		const parameters = override?.schema ?? def.parameters;
+
+		// Fields injected server-side (scope + fixed) are stripped from what the model
+		// sees, so it never receives a parameter it can't control.
+		const injectedKeys = [...scopeKeys, ...Object.keys(override?.fixed ?? {})];
+		const parameters = stripKeysFromParameters(override?.schema ?? def.parameters, injectedKeys);
 
 		const baseHandler = def.handler(self);
 		const handler = async (args: { input: any; context: any }) => {

--- a/packages/core/src/agent-tools.ts
+++ b/packages/core/src/agent-tools.ts
@@ -47,6 +47,13 @@ export interface ToolMethodDef<TSelf = any> {
 	parameters: unknown;
 	needsApproval?: boolean;
 	trustable?: boolean;
+	/**
+	 * Whether this method honors an injected `scope`. Defaults to true.
+	 * Set false for methods whose handler ignores the scoped fields (e.g. a `scan`
+	 * that lists the whole store): under `scope` such a method would run unscoped and
+	 * leak across users, so `buildAgentTools` throws if it is exposed on a scoped BB.
+	 */
+	scopeSafe?: boolean;
 	// `input: any` because parameters are JSON Schema objects — no compile-time type link.
 	// Core avoids a zod dependency, so we can't derive input types from the schema.
 	handler: (self: TSelf) => (args: { input: any; context: any }) => Promise<unknown>;
@@ -143,6 +150,15 @@ export function buildAgentTools<TSelf extends Scope>(
 	for (const [methodName, def] of Object.entries(toolMethods)) {
 		if (options?.include && !options.include.includes(methodName)) continue;
 		if (options?.exclude && options.exclude.includes(methodName)) continue;
+
+		// A method whose handler ignores the scoped fields (scopeSafe: false) would run
+		// unscoped under `scope` and leak across users. Throw so the caller excludes it
+		// or opts the whole store out of scoping.
+		if (options?.scope && def.scopeSafe === false) {
+			throw new Error(
+				`toAgentTools: "${methodName}" cannot be scope-isolated on ${self.constructor.name} "${bbId}" — its handler ignores the scoped fields, so under \`scope\` it would return data across users. Either exclude it (e.g. \`exclude: ['${methodName}']\`), or pass \`unscoped: true\` if this store is shared and cross-user results are intended.`,
+			);
+		}
 
 		const override = options?.overrides?.[methodName];
 		const description = override?.description ?? def.description;

--- a/packages/core/src/agent-tools.ts
+++ b/packages/core/src/agent-tools.ts
@@ -1,0 +1,97 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Shared types and helper for BBs that expose operations as agent tools via `toAgentTools()`.
+ * Lives in core so any BB can implement the interface without depending on `bb-agent`.
+ */
+
+import type { Scope } from './common/index.js';
+
+// ── Types ───────────────────────────────────────────────────────────────────
+
+export interface AgentToolProviderOptions<TContext = any> {
+	/** Only expose these methods (from the BB's tool-eligible set). Mutually exclusive with `exclude`. */
+	include?: string[];
+	/** Expose all tool-eligible methods except these. Mutually exclusive with `include`. */
+	exclude?: string[];
+	/** Per-method overrides of the BB's defaults, keyed by method name. */
+	overrides?: Record<string, MethodOverrides>;
+	/** Maps context fields to fixed constraints applied across all methods. */
+	scope?: (context: TContext) => Record<string, unknown>;
+}
+
+export interface MethodOverrides {
+	description?: string;
+	/** Pin parameter values — injected server-side, stripped from what the model sees. */
+	fixed?: Record<string, unknown>;
+	/** Narrow or replace the parameters schema the model sees. */
+	schema?: unknown;
+	needsApproval?: boolean;
+	trustable?: boolean;
+}
+
+/** A single tool-eligible method definition inside a BB's tool registry. */
+export interface ToolMethodDef<TSelf = any> {
+	description: string;
+	parameters: unknown;
+	needsApproval?: boolean;
+	trustable?: boolean;
+	handler: (self: TSelf) => (args: { input: any; context: any }) => Promise<unknown>;
+}
+
+/** Contract that BBs implement to expose operations as agent tools. */
+export interface AgentToolProvider {
+	toAgentTools<TContext = any>(options?: AgentToolProviderOptions<TContext>): Record<string, any>;
+}
+
+// ── Builder ─────────────────────────────────────────────────────────────────
+
+/**
+ * Build agent tools from a BB's tool method registry.
+ * Handles include/exclude filtering, overrides, and scope injection.
+ *
+ * Returns `Record<string, any>` so the result can be spread directly into
+ * an Agent's `tools` callback without type conflicts.
+ */
+export function buildAgentTools<TSelf extends Scope>(
+	self: TSelf,
+	toolMethods: Record<string, ToolMethodDef<TSelf>>,
+	options?: AgentToolProviderOptions<any>,
+): Record<string, any> {
+	if (options?.include && options?.exclude) {
+		throw new Error('toAgentTools: `include` and `exclude` are mutually exclusive');
+	}
+
+	const bbId = self.id;
+	const result: Record<string, any> = {};
+
+	for (const [methodName, def] of Object.entries(toolMethods)) {
+		if (options?.include && !options.include.includes(methodName)) continue;
+		if (options?.exclude && options.exclude.includes(methodName)) continue;
+
+		const override = options?.overrides?.[methodName];
+		const description = override?.description ?? def.description;
+		const needsApproval = override?.needsApproval ?? def.needsApproval ?? false;
+		const trustable = override?.trustable ?? def.trustable;
+		const parameters = override?.schema ?? def.parameters;
+
+		const baseHandler = def.handler(self);
+		const handler = async (args: { input: any; context: any }) => {
+			let input = args.input;
+			if (options?.scope && args.context) {
+				const scoped = options.scope(args.context);
+				input = { ...input, ...scoped };
+			}
+			if (override?.fixed) {
+				input = { ...input, ...override.fixed };
+			}
+			return baseHandler({ input, context: args.context });
+		};
+
+		const toolName = `${bbId}__${methodName}`;
+		result[toolName] = { description, parameters, needsApproval, trustable, handler };
+	}
+
+	return result;
+}

--- a/packages/core/src/agent-tools.ts
+++ b/packages/core/src/agent-tools.ts
@@ -170,10 +170,18 @@ export function buildAgentTools<TSelf extends Scope>(
 		const injectedKeys = [...scopeKeys, ...Object.keys(override?.fixed ?? {})];
 		const parameters = stripKeysFromParameters(override?.schema ?? def.parameters, injectedKeys);
 
+		const toolName = `${bbId}__${methodName}`;
 		const baseHandler = def.handler(self);
 		const handler = async (args: { input: any; context: any }) => {
 			let input = args.input;
-			if (options?.scope && args.context) {
+			if (options?.scope) {
+				// A scoped tool must never run without context — that would silently drop
+				// the isolation field and call the store unscoped. Fail loud instead.
+				if (args.context == null) {
+					throw new Error(
+						`toAgentTools: "${toolName}" is scoped but was invoked without a context — cannot derive the scoped fields. Pass \`context\` when calling the agent.`,
+					);
+				}
 				const scoped = options.scope(args.context);
 				input = { ...input, ...scoped };
 			}
@@ -183,7 +191,6 @@ export function buildAgentTools<TSelf extends Scope>(
 			return baseHandler({ input, context: args.context });
 		};
 
-		const toolName = `${bbId}__${methodName}`;
 		result[toolName] = { description, parameters, needsApproval, trustable, handler };
 	}
 

--- a/packages/core/src/index.cdk.ts
+++ b/packages/core/src/index.cdk.ts
@@ -8,6 +8,7 @@ export { EventSourceMapping } from './lambda-handler.js';
 export { BlocksStackProps } from './common/index.js';
 export { registerSdkIdentifiers, getSdkIdentifiers, getAllSdkIdentifiers, _resetSdkRegistry } from './common/sdk-registry.js';
 export { getConfig, getConfigSync, preloadConfig, loadConfigToProcessEnv, _resetConfigCache } from './common/config.js';
+export { buildAgentTools, type AgentToolProvider, type AgentToolProviderOptions, type BuildAgentToolsConfig, type MethodOverrides, type ToolMethodDef } from './agent-tools.js';
 export { BlocksStack, Scope, SandboxDisableDeletionProtection, BlocksBackend, registerConfig, finalizeConfigRegistry, synthGuard, DEFAULT_NODE_RUNTIME, type BlocksBackendProps } from './cdk/index.js';
 export {
   Hosting,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -20,3 +20,4 @@ export {
   type RegisteredRoute,
 } from './raw-route.js';
 export { RawRoute } from './raw-route.mock.js';
+export { buildAgentTools, type AgentToolProvider, type AgentToolProviderOptions, type MethodOverrides, type ToolMethodDef } from './agent-tools.js';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -20,4 +20,4 @@ export {
   type RegisteredRoute,
 } from './raw-route.js';
 export { RawRoute } from './raw-route.mock.js';
-export { buildAgentTools, type AgentToolProvider, type AgentToolProviderOptions, type MethodOverrides, type ToolMethodDef } from './agent-tools.js';
+export { buildAgentTools, type AgentToolProvider, type AgentToolProviderOptions, type BuildAgentToolsConfig, type MethodOverrides, type ToolMethodDef } from './agent-tools.js';

--- a/test-apps/comprehensive/aws-blocks/index.ts
+++ b/test-apps/comprehensive/aws-blocks/index.ts
@@ -395,6 +395,22 @@ const presetAgents = Object.fromEntries(
 	]),
 );
 
+// Agent with toAgentTools() — tests BB-provided tools alongside manual tools
+const toolStore = new KVStore(scope, 'tool-store');
+const asToolAgent = new Agent(scope, 'astool', {
+  removalPolicy: 'destroy',
+  model: { deployed: { provider: 'canned' }, local: { provider: 'canned' } },
+  systemPrompt: 'You are a test agent with BB-provided tools. Use tools when asked.',
+  tools: (tool) => ({
+    ...toolStore.toAgentTools({ include: ['get', 'put'], unscoped: true }),
+    manualTool: tool({
+      description: 'A manually defined echo tool',
+      parameters: z.object({ msg: z.string() }),
+      handler: async ({ input }) => ({ echo: input.msg }),
+    }),
+  }),
+});
+
 // Agent with model fallback — first candidate is unreachable, should fall through to canned
 const fallbackAgent = new Agent(scope, 'fallback', {
   removalPolicy: 'destroy',
@@ -1672,6 +1688,12 @@ export const api = new ApiNamespace(scope, 'api', (context) => ({
   },
   async cannedGetConversation(conversationId: string) {
     return { messages: await cannedAgent.getConversation(conversationId) };
+  },
+
+  // toAgentTools() e2e — BB-provided tools alongside manual tools
+  async asToolStream(message: string, conversationId?: string) {
+    const result = await asToolAgent.stream(message, { conversationId, userId: 'test-user' });
+    return { channelId: result.channelId };
   },
 
   async fallbackStream(message: string) {

--- a/test-apps/comprehensive/aws-blocks/index.ts
+++ b/test-apps/comprehensive/aws-blocks/index.ts
@@ -411,6 +411,21 @@ const asToolAgent = new Agent(scope, 'astool', {
   }),
 });
 
+
+// Agent with toAgentTools() + zod schema override — tests that zod replaces JSON Schema parameters
+const zodOverrideAgent = new Agent(scope, 'astool-zod', {
+  removalPolicy: 'destroy',
+  model: { deployed: { provider: 'canned' }, local: { provider: 'canned' } },
+  systemPrompt: 'You are a test agent.',
+  tools: (tool) => ({
+    ...toolStore.toAgentTools({
+      include: ['get'],
+      unscoped: true,
+      overrides: { get: { schema: z.object({ key: z.string().describe('The record key to look up') }) } },
+    }),
+  }),
+});
+
 // Agent with model fallback — first candidate is unreachable, should fall through to canned
 const fallbackAgent = new Agent(scope, 'fallback', {
   removalPolicy: 'destroy',
@@ -1693,6 +1708,10 @@ export const api = new ApiNamespace(scope, 'api', (context) => ({
   // toAgentTools() e2e — BB-provided tools alongside manual tools
   async asToolStream(message: string, conversationId?: string) {
     const result = await asToolAgent.stream(message, { conversationId, userId: 'test-user' });
+    return { channelId: result.channelId };
+  },
+  async asToolZodOverrideStream(message: string) {
+    const result = await zodOverrideAgent.stream(message, { userId: 'test-user' });
     return { channelId: result.channelId };
   },
 

--- a/test-apps/comprehensive/test/agent.test.ts
+++ b/test-apps/comprehensive/test/agent.test.ts
@@ -197,6 +197,14 @@ export function agentTests(getApi: () => typeof apiType) {
       });
     });
 
+    describe('toAgentTools()', () => {
+      test('BB tools and manual tools coexist — stream completes', async () => {
+        const api = getApi();
+        const { channelId } = await api.asToolStream('hello');
+        assert.ok(channelId, 'should return a channelId');
+      });
+    });
+
 
     describe('Long-Running Agent (>29s)', () => {
       test('agent with slow tool completes beyond API Gateway timeout', async () => {

--- a/test-apps/comprehensive/test/agent.test.ts
+++ b/test-apps/comprehensive/test/agent.test.ts
@@ -203,6 +203,12 @@ export function agentTests(getApi: () => typeof apiType) {
         const { channelId } = await api.asToolStream('hello');
         assert.ok(channelId, 'should return a channelId');
       });
+
+      test('zod schema override works with BB tools — stream completes', async () => {
+        const api = getApi();
+        const { channelId } = await api.asToolZodOverrideStream('hello');
+        assert.ok(channelId, 'should return a channelId');
+      });
     });
 
 


### PR DESCRIPTION
## Problem

<!--
Describe the issue this PR is solving. For trivial changes, a short one-liner is fine.
-->
Building Blocks have no way to expose their operations as agent tools without boilerplate. Today, giving an agent access to a **KVStore** requires manually defining each tool:

```typescript
const store = new KVStore(scope, 'items');

const agent = new Agent(scope, 'assistant', {
  model: { deployed: BedrockModels.BALANCED },
  systemPrompt: 'You are a helpful assistant.',
  tools: (tool) => ({
    get_item: tool({
      description: 'Retrieve a value by key',
      parameters: z.object({ key: z.string() }),
      needsApproval: false,
      handler: async ({ input, context }) => {
        return store.get(input.key);
      },
    }),
    put_item: tool({
      description: 'Store a value at a key',
      parameters: z.object({ key: z.string(), value: z.unknown() }),
      needsApproval: true,
      trustable: true,
      handler: async ({ input, context }) => {
        await store.put(input.key, input.value);
        return { success: true };
      },
    }),
  }),
});
```
With toAgentTools(), the same thing becomes:
```typescript
const store = new KVStore(scope, 'items');

const agent = new Agent(scope, 'assistant', {
  model: { deployed: BedrockModels.BALANCED },
  systemPrompt: 'You are a helpful assistant.',
  tools: (tool) => ({
    ...store.toAgentTools({include: ['get', 'put'], unscoped: true}),
  }),
});
```
Schemas, descriptions, approval settings, and handlers are all derived from the BB's built-in tool registry.

### Safe by default: scoping

A `KVStore` can be keyed by `userId`, so it can hold per-user data. To prevent an agent from reaching across users, `toAgentTools()` **requires** the caller to make a choice — it throws at construction unless you pass either `scope` or `unscoped: true`:

```typescript
const profiles = new KVStore(scope, 'profiles');

const agent = new Agent(scope, 'assistant', {
  model: { deployed: BedrockModels.BALANCED },
  systemPrompt: 'You are a helpful assistant.',
  toolContextSchema: z.object({ userId: z.string() }),
  tools: (tool) => ({
    // every operation is locked to the caller's own key; scan can't be
    // scope-isolated (it lists the whole store), so it's excluded
    ...profiles.toAgentTools({ scope: (ctx) => ({ key: ctx.userId }), exclude: ['scan'] }),
  }),
});

// userId comes from the authenticated session — never from the model
const user = await auth.getCurrentUser(requestContext);
await agent.stream(message, { conversationId, userId: user.userId, context: { userId: user.userId } });
```

The scoped `key` is injected server-side and stripped from the parameters the model sees, so the model can't choose it. `...profiles.toAgentTools()` with neither `scope` nor `unscoped: true` throws,
turning an accidental cross-user leak into a build-time error.


## Changes

<!--
Summarize the changes introduced in this PR. Call out critical or potentially problematic parts of the change.
-->
- **`@aws-blocks/core`** — New `buildAgentTools()` helper and types (`AgentToolProvider`, `AgentToolProviderOptions`, `MethodOverrides`, `ToolMethodDef`, `BuildAgentToolsConfig`). Handles include/exclude
filtering, per-method overrides, scope injection from context, and fixed values. Input precedence: `fixed > scope > model input`.
  - **Secure-by-default scoping** — A BB that can hold per-user data declares `requiresScope`; `buildAgentTools()` then throws at construction unless the caller passes `scope` (to lock operations to the
current user) or `unscoped: true` (explicit opt-out for shared stores). An accidental unscoped spread can't silently expose every user's data.
  - **Scope-unsafe methods** — Registry methods can declare `scopeSafe: false` (e.g. a `scan` that lists the whole store). `buildAgentTools()` throws if such a method is exposed under `scope`, so a
whole-store list can't leak across users behind an exact-key scope. A scoped tool invoked without a context also throws rather than silently running unscoped.
  - **Parameter stripping** — Fields injected server-side by `scope` or `fixed` are removed from the JSON Schema `parameters` the model sees, so the model never receives a parameter it can't control.
(Applies to JSON Schema registries; a Standard Schema override is left to the BB.)
  - **Schema typing** — `MethodOverrides.schema` is typed as `StandardSchemaV1` via the types-only `@standard-schema/spec` dependency, so core stays validation-library-agnostic (no zod dependency in core)
while accepting zod/valibot/arktype overrides.
- **`@aws-blocks/bb-kv-store`** — New `toAgentTools()` method on all four layers:
  - `index.mock.ts` / `index.aws.ts` — expose get, put, delete, scan as agent tools via shared `KV_TOOL_METHODS` registry; opts into `requiresScope` (a KVStore can be keyed by `userId`) and marks `scan` as
`scopeSafe: false`
  - `index.cdk.ts` — synthGuard stub (actionable error instead of TypeError)
  - `index.browser.ts` — throwing stub
  - Compile-time drift check ensures `KVStoreLike` stays in sync with the real class
  - Tool descriptions written for LLM tool-selection (what the tool does / when to use it / returns / caveats)
- **Defaults**: `put` → `needsApproval: true, trustable: true`; `delete` → `needsApproval: true, trustable: false`; `scan` → capped at 100 entries (overridable via `limit`)
- **Docs**: Agent BB README guide (filtering, overrides, fixed, scope, precedence), KVStore README section, BB-author guide in `docs/reference/building-block-structure.md`, KVStore DESIGN.md agent tools
section (incl. the scoping requirement and the `scan`-under-scope limitation)

## Validation

<!--
Describe how changes have been validated — added/updated unit, integration, or E2E tests, manual verification, etc.
If no automated tests were added, explain why.
-->
- Core `buildAgentTools` unit tests: filtering, overrides, scope injection, fixed values, scope/fixed precedence collision, `requiresScope` enforcement (throws without `scope`/`unscoped`),
`scopeSafe:false` enforcement (throws when exposed under `scope`), scoped-tool-without-context throw, and parameter stripping (scoped/fixed keys removed from `properties` and `required`)
- KVStore unit tests: `toAgentTools` output shape, handler behavior, `requiresScope` throw, `unscoped` opt-out, `scope` pinning the key to the caller, scoped key stripped from the parameters the model
sees, `scan`-under-scope throw, a zod schema override, and the CDK synthGuard regression across all 5 methods
- E2e test: zod schema override with BB-provided tools against the canned provider
- All tests pass locally — `@aws-blocks/core` 571/571, `@aws-blocks/bb-kv-store` 55/55; `npm run build` clean for both packages
- Lint clean (`npm run lint`); API reports regenerated (`npm run update:api`)


## Checklist

- [x] PR description included
- [x] Tests are changed or added
- [x] Relevant documentation is changed or added (and PR referenced)

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
