### PR TITLE
fix(auth): propagate structured error name through setAuthState()

### DIFF
--- a/.changeset/issue-81-setauthstate-error-name.md
+++ b/.changeset/issue-81-setauthstate-error-name.md
@@ -1,0 +1,24 @@
+---
+"@aws-blocks/core": minor
+"@aws-blocks/auth-common": minor
+"@aws-blocks/bb-auth-basic": patch
+"@aws-blocks/bb-auth-cognito": patch
+---
+
+fix(auth): propagate the structured error name through `setAuthState()`
+
+The recommended client auth path is `createApi()` → `setAuthState()`. When an
+action failed, `setAuthState()` caught the thrown `ApiError` and returned an
+`AuthState` carrying only `error: e.message`, discarding the structured
+`e.name` (e.g. `'InvalidCredentialsException'`). Because `AuthState` had no
+field for an error name, a hand-rolled client could not branch on error type
+(e.g. "try sign-in, fall back to sign-up for a brand-new user") without
+brittle string-matching the human-facing message.
+
+`AuthState` now carries an optional `errorName`, and the `bb-auth-basic` and
+`bb-auth-cognito` `setAuthState` implementations populate it from the thrown
+`ApiError.name` (skipping the generic `'ApiError'` default). A new
+`hasAuthError(state, name)` type guard in `@aws-blocks/core` lets clients
+branch on the returned state — `isBlocksError` only matches thrown `Error`
+instances, so it cannot be used on the plain `AuthState` object. Rule of
+thumb: throw path → `isBlocksError`; returned `AuthState` → `hasAuthError`.

--- a/.changeset/issue-81-setauthstate-error-name.md
+++ b/.changeset/issue-81-setauthstate-error-name.md
@@ -3,6 +3,7 @@
 "@aws-blocks/auth-common": patch
 "@aws-blocks/bb-auth-basic": patch
 "@aws-blocks/bb-auth-cognito": patch
+"@aws-blocks/bb-auth-oidc": patch
 ---
 
 fix(auth): propagate the structured error name through `setAuthState()`

--- a/.changeset/issue-81-setauthstate-error-name.md
+++ b/.changeset/issue-81-setauthstate-error-name.md
@@ -1,6 +1,6 @@
 ---
-"@aws-blocks/core": minor
-"@aws-blocks/auth-common": minor
+"@aws-blocks/core": patch
+"@aws-blocks/auth-common": patch
 "@aws-blocks/bb-auth-basic": patch
 "@aws-blocks/bb-auth-cognito": patch
 ---

--- a/packages/auth-common/API.md
+++ b/packages/auth-common/API.md
@@ -121,6 +121,7 @@ export interface AuthField {
 export interface AuthState {
     actions: AuthAction[];
     error?: string;
+    errorName?: string;
     retriable?: boolean;
     state: 'signedOut' | 'signedIn' | 'confirmingSignUp' | 'confirmingSignIn' | 'confirmingMfa' | 'confirmingPasswordReset';
     user?: AuthUser;

--- a/packages/auth-common/src/index.ts
+++ b/packages/auth-common/src/index.ts
@@ -169,6 +169,16 @@ export interface AuthState {
 	error?: string;
 
 	/**
+	 * Machine-readable name of the error from the last action — mirrors the
+	 * `name` of the `ApiError` thrown on the imperative API path (e.g.
+	 * `'InvalidCredentialsException'`). Lets clients branch on error type via
+	 * `hasAuthError(state, name)` instead of matching the human-facing `error`
+	 * string. Absent when the action succeeded or the failure carried no
+	 * specific name (a generic `ApiError`).
+	 */
+	errorName?: string;
+
+	/**
 	 * Signals that the last action failed in a way the caller can recover
 	 * from by resubmitting on the **same** state without restarting the
 	 * flow — typical of challenge-response errors like a wrong MFA code

--- a/packages/bb-auth-basic/README.md
+++ b/packages/bb-auth-basic/README.md
@@ -126,6 +126,23 @@ try {
 | `AuthBasicErrors.SessionExpired` | `SessionExpiredException` | `requireAuth` with no/expired session |
 | `AuthBasicErrors.InvalidCode` | `InvalidCodeException` | Wrong or expired verification code (signup or reset) |
 
+### Branching on the `setAuthState` client path
+
+`isBlocksError` works on a **thrown** error. The recommended client path (`createApi()` → `setAuthState()`) does not throw — it returns an `AuthState` whose `errorName` carries the same structured name. Use `hasAuthError` to branch on the returned state, e.g. to fall back to sign-up for a brand-new user:
+
+```typescript
+import { hasAuthError } from '@aws-blocks/core';
+import { AuthBasicErrors } from '@aws-blocks/bb-auth-basic';
+
+let next = await authApi.setAuthState({ action: 'signIn', username, password });
+if (hasAuthError(next, AuthBasicErrors.InvalidCredentials)) {
+  // unknown or wrong-credential user → offer sign-up instead
+  next = await authApi.setAuthState({ action: 'signUp', username, password });
+}
+```
+
+Rule of thumb: **throw path → `isBlocksError`; returned `AuthState` → `hasAuthError`.** Never match on the human-facing `error` string.
+
 ## UI Components
 
 This package does not include UI components. Use the provider-agnostic Authenticator from `@aws-blocks/auth-common/ui`:

--- a/packages/bb-auth-basic/src/index.test.ts
+++ b/packages/bb-auth-basic/src/index.test.ts
@@ -63,7 +63,7 @@ describe('AuthBasic setAuthState errorName', () => {
 	test('a generic ApiError (no structured name) yields no errorName', async () => {
 		// resetPassword throws a plain ApiError('Password reset not configured')
 		// with no `name` when codeDelivery is unset — `.name` defaults to
-		// 'ApiError', which must not leak as a meaningful errorName.
+		// DEFAULT_API_ERROR_NAME, which must not leak as a meaningful errorName.
 		const auth = makeAuth();
 		const api = apiFor(auth, ctx());
 

--- a/packages/bb-auth-basic/src/index.test.ts
+++ b/packages/bb-auth-basic/src/index.test.ts
@@ -1,0 +1,69 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * setAuthState error-name propagation tests for AuthBasic (#81). The
+ * recommended client path catches the thrown ApiError and must surface its
+ * structured `name` as `AuthState.errorName` so clients can branch with
+ * `hasAuthError` instead of string-matching the human-facing message.
+ */
+
+import { describe, test } from 'node:test';
+import assert from 'node:assert';
+import type { BlocksContext } from '@aws-blocks/core';
+import { Scope, hasAuthError } from '@aws-blocks/core';
+import { AuthBasic, AuthBasicErrors, type AuthBasicOptions } from './index.js';
+
+function ctx(origin?: string): BlocksContext {
+	const headers = new Headers();
+	if (origin) headers.set('origin', origin);
+	return {
+		request: { headers },
+		response: { headers: new Headers() },
+	} as unknown as BlocksContext;
+}
+
+let counter = 0;
+function makeAuth(options?: AuthBasicOptions): AuthBasic {
+	const scope = new Scope(`basic-errname-${++counter}-${Math.random().toString(36).slice(2, 6)}`);
+	return new AuthBasic(scope, 'auth', options);
+}
+
+describe('AuthBasic setAuthState errorName', () => {
+	test('signIn for an unknown user surfaces errorName = InvalidCredentials', async () => {
+		const auth = makeAuth();
+		const api = (auth.createApi() as any)(ctx());
+
+		const next = await api.setAuthState({ action: 'signIn', username: 'nobody', password: 'whatever1' });
+
+		assert.strictEqual(next.state, 'signedOut');
+		assert.strictEqual(next.errorName, AuthBasicErrors.InvalidCredentials);
+		// The documented client idiom now reaches this path.
+		assert.ok(hasAuthError(next, AuthBasicErrors.InvalidCredentials));
+	});
+
+	test('signIn with a wrong password surfaces errorName = InvalidCredentials', async () => {
+		const auth = makeAuth();
+		await auth.signUp('alice', 'password123');
+		const api = (auth.createApi() as any)(ctx());
+
+		const next = await api.setAuthState({ action: 'signIn', username: 'alice', password: 'wrong-password' });
+
+		assert.strictEqual(next.state, 'signedOut');
+		assert.strictEqual(next.errorName, AuthBasicErrors.InvalidCredentials);
+	});
+
+	test('a generic ApiError (no structured name) yields no errorName', async () => {
+		// resetPassword throws a plain ApiError('Password reset not configured')
+		// with no `name` when codeDelivery is unset — `.name` defaults to
+		// 'ApiError', which must not leak as a meaningful errorName.
+		const auth = makeAuth();
+		const api = (auth.createApi() as any)(ctx());
+
+		const next = await api.setAuthState({ action: 'resetPassword', username: 'alice' });
+
+		assert.strictEqual(next.state, 'signedOut');
+		assert.ok(next.error);
+		assert.strictEqual(next.errorName, undefined);
+	});
+});

--- a/packages/bb-auth-basic/src/index.test.ts
+++ b/packages/bb-auth-basic/src/index.test.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * setAuthState error-name propagation tests for AuthBasic (#81). The
+ * setAuthState error-name propagation tests for AuthBasic (issue #81). The
  * recommended client path catches the thrown ApiError and must surface its
  * structured `name` as `AuthState.errorName` so clients can branch with
  * `hasAuthError` instead of string-matching the human-facing message.

--- a/packages/bb-auth-basic/src/index.test.ts
+++ b/packages/bb-auth-basic/src/index.test.ts
@@ -12,6 +12,7 @@ import { describe, test } from 'node:test';
 import assert from 'node:assert';
 import type { BlocksContext } from '@aws-blocks/core';
 import { Scope, hasAuthError } from '@aws-blocks/core';
+import type { AuthStateApi } from '@aws-blocks/auth-common';
 import { AuthBasic, AuthBasicErrors, type AuthBasicOptions } from './index.js';
 
 function ctx(origin?: string): BlocksContext {
@@ -29,10 +30,16 @@ function makeAuth(options?: AuthBasicOptions): AuthBasic {
 	return new AuthBasic(scope, 'auth', options);
 }
 
+// `createApi()` returns a context-bound `ApiNamespace` callable; narrow it to
+// the public `AuthStateApi` surface the test exercises instead of `as any`.
+function apiFor(auth: AuthBasic, context: BlocksContext): AuthStateApi {
+	return (auth.createApi() as unknown as (c: BlocksContext) => AuthStateApi)(context);
+}
+
 describe('AuthBasic setAuthState errorName', () => {
 	test('signIn for an unknown user surfaces errorName = InvalidCredentials', async () => {
 		const auth = makeAuth();
-		const api = (auth.createApi() as any)(ctx());
+		const api = apiFor(auth, ctx());
 
 		const next = await api.setAuthState({ action: 'signIn', username: 'nobody', password: 'whatever1' });
 
@@ -45,7 +52,7 @@ describe('AuthBasic setAuthState errorName', () => {
 	test('signIn with a wrong password surfaces errorName = InvalidCredentials', async () => {
 		const auth = makeAuth();
 		await auth.signUp('alice', 'password123');
-		const api = (auth.createApi() as any)(ctx());
+		const api = apiFor(auth, ctx());
 
 		const next = await api.setAuthState({ action: 'signIn', username: 'alice', password: 'wrong-password' });
 
@@ -58,7 +65,7 @@ describe('AuthBasic setAuthState errorName', () => {
 		// with no `name` when codeDelivery is unset — `.name` defaults to
 		// 'ApiError', which must not leak as a meaningful errorName.
 		const auth = makeAuth();
-		const api = (auth.createApi() as any)(ctx());
+		const api = apiFor(auth, ctx());
 
 		const next = await api.setAuthState({ action: 'resetPassword', username: 'alice' });
 

--- a/packages/bb-auth-basic/src/index.ts
+++ b/packages/bb-auth-basic/src/index.ts
@@ -479,7 +479,8 @@ export class AuthBasic extends Scope implements BlocksAuth {
 				} catch (e: any) {
 					const currentUser = await this.getUserFromCookie(context);
 					const base = currentUser ? signedInState(currentUser) : this.signedOutState();
-					return { ...base, error: e.message };
+					const errorName = e instanceof ApiError && e.name && e.name !== 'ApiError' ? e.name : undefined;
+					return { ...base, error: e.message, ...(errorName ? { errorName } : {}) };
 				}
 			},
 		}));

--- a/packages/bb-auth-basic/src/index.ts
+++ b/packages/bb-auth-basic/src/index.ts
@@ -479,7 +479,7 @@ export class AuthBasic extends Scope implements BlocksAuth {
 				} catch (e: any) {
 					const currentUser = await this.getUserFromCookie(context);
 					const base = currentUser ? signedInState(currentUser) : this.signedOutState();
-					const errorName = e instanceof ApiError && e.name && e.name !== 'ApiError' ? e.name : undefined;
+					const errorName = e instanceof ApiError && e.name !== 'ApiError' ? e.name : undefined;
 					return { ...base, error: e.message, ...(errorName ? { errorName } : {}) };
 				}
 			},

--- a/packages/bb-auth-basic/src/index.ts
+++ b/packages/bb-auth-basic/src/index.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Scope, type ScopeParent, type BlocksContext, ApiNamespace, ApiError } from '@aws-blocks/core';
+import { Scope, type ScopeParent, type BlocksContext, ApiNamespace, ApiError, DEFAULT_API_ERROR_NAME } from '@aws-blocks/core';
 import { constantTimeEquals } from '@aws-blocks/core/bb-utils';
 import { KVStore } from '@aws-blocks/bb-kv-store';
 import { AppSetting } from '@aws-blocks/bb-app-setting';
@@ -479,7 +479,7 @@ export class AuthBasic extends Scope implements BlocksAuth {
 				} catch (e: any) {
 					const currentUser = await this.getUserFromCookie(context);
 					const base = currentUser ? signedInState(currentUser) : this.signedOutState();
-					const errorName = e instanceof ApiError && e.name !== 'ApiError' ? e.name : undefined;
+					const errorName = e instanceof ApiError && e.name !== DEFAULT_API_ERROR_NAME ? e.name : undefined;
 					return { ...base, error: e.message, ...(errorName ? { errorName } : {}) };
 				}
 			},

--- a/packages/bb-auth-cognito/README.md
+++ b/packages/bb-auth-cognito/README.md
@@ -370,6 +370,22 @@ Error names match Cognito's wire-format exceptions, so customers familiar with A
 
 > **Non-obvious mapping:** `AuthCognitoErrors.GroupNotFound` resolves to `'ResourceNotFoundException'`, **not** a `GroupNotFound*` string. Cognito has no dedicated "group not found" exception, so a missing user-pool group surfaces as the generic `ResourceNotFoundException`. Always match with `isBlocksError(e, AuthCognitoErrors.GroupNotFound)` rather than the literal string so the intent stays clear.
 
+### Branching on the `setAuthState` client path
+
+`isBlocksError` works on a **thrown** error. The recommended client path (`createApi()` → `setAuthState()`) does not throw — it returns an `AuthState` whose `errorName` carries the same structured name. Use `hasAuthError` to branch on the returned state:
+
+```typescript
+import { hasAuthError } from '@aws-blocks/core';
+import { AuthCognitoErrors } from '@aws-blocks/bb-auth-cognito';
+
+const next = await authApi.setAuthState({ action: 'signIn', username, password });
+if (hasAuthError(next, AuthCognitoErrors.NotAuthorized)) {
+  // wrong username or password
+}
+```
+
+Rule of thumb: **throw path → `isBlocksError`; returned `AuthState` → `hasAuthError`.** Never match on the human-facing `error` string.
+
 ## UI Components
 
 Use the provider-agnostic Authenticator from `@aws-blocks/auth-common/ui` — same shape as for `AuthBasic`:

--- a/packages/bb-auth-cognito/src/index.aws.ts
+++ b/packages/bb-auth-cognito/src/index.aws.ts
@@ -50,6 +50,7 @@ import { CognitoJwtVerifier } from 'aws-jwt-verify';
 import {
 	ApiError,
 	ApiNamespace,
+	DEFAULT_API_ERROR_NAME,
 	Scope,
 	registerSdkIdentifiers,
 	getSdkIdentifiers,
@@ -1920,7 +1921,7 @@ export class AuthCognito<O extends AuthCognitoOptions = AuthCognitoOptions>
 					}
 				} catch (e: unknown) {
 					const message = e instanceof Error ? e.message : 'An error occurred';
-					const errorName = e instanceof ApiError && e.name !== 'ApiError' ? e.name : undefined;
+					const errorName = e instanceof ApiError && e.name !== DEFAULT_API_ERROR_NAME ? e.name : undefined;
 					// Retriable errors keep the challenge session valid. Surface
 					// the flag to the client so its Authenticator renderer can
 					// keep the user on the current step instead of resetting.

--- a/packages/bb-auth-cognito/src/index.aws.ts
+++ b/packages/bb-auth-cognito/src/index.aws.ts
@@ -1937,7 +1937,7 @@ export class AuthCognito<O extends AuthCognitoOptions = AuthCognitoOptions>
 							...(errorName ? { errorName } : {}),
 						};
 					}
-					return { ...baseSignedOut(message, errorName) };
+					return baseSignedOut(message, errorName);
 				}
 			},
 		}));

--- a/packages/bb-auth-cognito/src/index.aws.ts
+++ b/packages/bb-auth-cognito/src/index.aws.ts
@@ -1772,13 +1772,14 @@ export class AuthCognito<O extends AuthCognitoOptions = AuthCognitoOptions>
 
 	createApi(): AuthStateApi {
 		const enablePasskeys = this.options.enablePasskeys === true;
-		const baseSignedOut = (error?: string): AuthState =>
+		const baseSignedOut = (error?: string, errorName?: string): AuthState =>
 			signedOut({
 				selfSignUp: this.options.selfSignUp ?? true,
 				userAttributes: this.options.userAttributes ?? [],
 				enablePasskeys,
 				signInWith: this.options.signInWith,
 				error,
+				errorName,
 			});
 		const baseSignedIn = (user: CognitoUser<O>): AuthState =>
 			signedInState(user, { enablePasskeys });
@@ -1919,6 +1920,7 @@ export class AuthCognito<O extends AuthCognitoOptions = AuthCognitoOptions>
 					}
 				} catch (e: unknown) {
 					const message = e instanceof Error ? e.message : 'An error occurred';
+					const errorName = e instanceof ApiError && e.name !== 'ApiError' ? e.name : undefined;
 					// Retriable errors keep the challenge session valid. Surface
 					// the flag to the client so its Authenticator renderer can
 					// keep the user on the current step instead of resetting.
@@ -1926,9 +1928,15 @@ export class AuthCognito<O extends AuthCognitoOptions = AuthCognitoOptions>
 					// nextStep server-side — the client already has it in its
 					// cached state and can overlay the error there.
 					if (e instanceof ApiError && e.retriable) {
-						return { state: 'signedOut', actions: [], error: message, retriable: true };
+						return {
+							state: 'signedOut',
+							actions: [],
+							error: message,
+							retriable: true,
+							...(errorName ? { errorName } : {}),
+						};
 					}
-					return { ...baseSignedOut(message) };
+					return { ...baseSignedOut(message, errorName) };
 				}
 			},
 		}));

--- a/packages/bb-auth-cognito/src/index.test.ts
+++ b/packages/bb-auth-cognito/src/index.test.ts
@@ -907,7 +907,7 @@ describe('USER_AUTH flow', () => {
 		assert.strictEqual(s3.user.username, 'ursula');
 	});
 
-	test('setAuthState surfaces errorName on a failed sign-in (#81)', async () => {
+	test('setAuthState surfaces errorName on a failed sign-in (issue #81)', async () => {
 		const { auth } = await confirmedUser('ua-err', { preferredChallenge: 'PASSWORD' });
 		const { ctx } = freshContext();
 		const api = (auth.createApi() as any)(ctx);

--- a/packages/bb-auth-cognito/src/index.test.ts
+++ b/packages/bb-auth-cognito/src/index.test.ts
@@ -4,7 +4,7 @@
 import { test, describe, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert';
 import { rmSync } from 'node:fs';
-import { isBlocksError } from '@aws-blocks/core';
+import { isBlocksError, hasAuthError } from '@aws-blocks/core';
 import type { BlocksContext } from '@aws-blocks/core';
 import { AuthCognito, AuthCognitoErrors } from './index.js';
 
@@ -905,6 +905,22 @@ describe('USER_AUTH flow', () => {
 		const s3 = await api.setAuthState({ action: 'confirmSignIn', challenge: 'password', session: pwSession.defaultValue, password: 'Password!1' });
 		assert.strictEqual(s3.state, 'signedIn');
 		assert.strictEqual(s3.user.username, 'ursula');
+	});
+
+	test('setAuthState surfaces errorName on a failed sign-in (#81)', async () => {
+		const { auth } = await confirmedUser('ua-err', { preferredChallenge: 'PASSWORD' });
+		const { ctx } = freshContext();
+		const api = (auth.createApi() as any)(ctx);
+
+		// Drive the password challenge to completion with a wrong password so
+		// the thrown ApiError carries NotAuthorizedException.
+		const s1 = await api.setAuthState({ action: 'signIn', username: 'ursula', password: '' });
+		const pwSession = s1.actions[0].fields.find((f: any) => f.name === 'session');
+		const next = await api.setAuthState({ action: 'confirmSignIn', challenge: 'password', session: pwSession.defaultValue, password: 'Wrong1!Password' });
+
+		assert.strictEqual(next.state, 'signedOut');
+		assert.strictEqual(next.errorName, AuthCognitoErrors.NotAuthorized);
+		assert.ok(hasAuthError(next, AuthCognitoErrors.NotAuthorized));
 	});
 });
 

--- a/packages/bb-auth-cognito/src/index.test.ts
+++ b/packages/bb-auth-cognito/src/index.test.ts
@@ -6,7 +6,14 @@ import assert from 'node:assert';
 import { rmSync } from 'node:fs';
 import { isBlocksError, hasAuthError } from '@aws-blocks/core';
 import type { BlocksContext } from '@aws-blocks/core';
+import type { AuthStateApi, AuthField } from '@aws-blocks/auth-common';
 import { AuthCognito, AuthCognitoErrors } from './index.js';
+
+// `createApi()` returns a context-bound `ApiNamespace` callable; narrow it to
+// the public `AuthStateApi` surface instead of `as any`.
+function apiFor(auth: AuthCognito, context: BlocksContext): AuthStateApi {
+	return (auth.createApi() as unknown as (c: BlocksContext) => AuthStateApi)(context);
+}
 
 // ── Test harness ─────────────────────────────────────────────────────────────
 
@@ -910,12 +917,13 @@ describe('USER_AUTH flow', () => {
 	test('setAuthState surfaces errorName on a failed sign-in (issue #81)', async () => {
 		const { auth } = await confirmedUser('ua-err', { preferredChallenge: 'PASSWORD' });
 		const { ctx } = freshContext();
-		const api = (auth.createApi() as any)(ctx);
+		const api = apiFor(auth, ctx);
 
 		// Drive the password challenge to completion with a wrong password so
 		// the thrown ApiError carries NotAuthorizedException.
 		const s1 = await api.setAuthState({ action: 'signIn', username: 'ursula', password: '' });
-		const pwSession = s1.actions[0].fields.find((f: any) => f.name === 'session');
+		const pwSession = s1.actions[0].fields.find((f: AuthField) => f.name === 'session');
+		assert.ok(pwSession?.defaultValue, 'expected a session field with a default value');
 		const next = await api.setAuthState({ action: 'confirmSignIn', challenge: 'password', session: pwSession.defaultValue, password: 'Wrong1!Password' });
 
 		assert.strictEqual(next.state, 'signedOut');

--- a/packages/bb-auth-cognito/src/index.ts
+++ b/packages/bb-auth-cognito/src/index.ts
@@ -15,6 +15,7 @@ import { join } from 'node:path';
 import {
 	ApiError,
 	ApiNamespace,
+	DEFAULT_API_ERROR_NAME,
 	Scope,
 	registerSdkIdentifiers,
 } from '@aws-blocks/core';
@@ -1650,7 +1651,7 @@ export class AuthCognito<O extends AuthCognitoMockOptions = AuthCognitoMockOptio
 					}
 				} catch (e: unknown) {
 					const message = e instanceof Error ? e.message : 'An error occurred';
-					const errorName = e instanceof ApiError && e.name !== 'ApiError' ? e.name : undefined;
+					const errorName = e instanceof ApiError && e.name !== DEFAULT_API_ERROR_NAME ? e.name : undefined;
 					// Match the AWS runtime: retriable failures (wrong MFA
 					// code, rejected shape) emit a thin signedOut shape with
 					// `retriable: true` so the client can preserve its current

--- a/packages/bb-auth-cognito/src/index.ts
+++ b/packages/bb-auth-cognito/src/index.ts
@@ -1665,7 +1665,7 @@ export class AuthCognito<O extends AuthCognitoMockOptions = AuthCognitoMockOptio
 							...(errorName ? { errorName } : {}),
 						};
 					}
-					return { ...baseSignedOut(message, errorName) };
+					return baseSignedOut(message, errorName);
 				}
 			},
 		}));

--- a/packages/bb-auth-cognito/src/index.ts
+++ b/packages/bb-auth-cognito/src/index.ts
@@ -1510,13 +1510,14 @@ export class AuthCognito<O extends AuthCognitoMockOptions = AuthCognitoMockOptio
 
 	createApi(): AuthStateApi {
 		const enablePasskeys = this.options.enablePasskeys === true;
-		const baseSignedOut = (error?: string): AuthState =>
+		const baseSignedOut = (error?: string, errorName?: string): AuthState =>
 			signedOut({
 				selfSignUp: this.options.selfSignUp ?? true,
 				userAttributes: this.options.userAttributes ?? [],
 				enablePasskeys,
 				signInWith: this.options.signInWith,
 				error,
+				errorName,
 			});
 		const baseSignedIn = (user: CognitoUser<O>): AuthState =>
 			signedInState(user, { enablePasskeys });
@@ -1649,14 +1650,21 @@ export class AuthCognito<O extends AuthCognitoMockOptions = AuthCognitoMockOptio
 					}
 				} catch (e: unknown) {
 					const message = e instanceof Error ? e.message : 'An error occurred';
+					const errorName = e instanceof ApiError && e.name !== 'ApiError' ? e.name : undefined;
 					// Match the AWS runtime: retriable failures (wrong MFA
 					// code, rejected shape) emit a thin signedOut shape with
 					// `retriable: true` so the client can preserve its current
 					// challenge form instead of tearing it down.
 					if (e instanceof ApiError && e.retriable) {
-						return { state: 'signedOut', actions: [], error: message, retriable: true };
+						return {
+							state: 'signedOut',
+							actions: [],
+							error: message,
+							retriable: true,
+							...(errorName ? { errorName } : {}),
+						};
 					}
-					return { ...baseSignedOut(message) };
+					return { ...baseSignedOut(message, errorName) };
 				}
 			},
 		}));

--- a/packages/bb-auth-cognito/src/state-machine.ts
+++ b/packages/bb-auth-cognito/src/state-machine.ts
@@ -65,6 +65,8 @@ export interface SignedOutInput {
 	 */
 	signInWith?: SignInWith | readonly SignInWith[];
 	error?: string;
+	/** Structured name of the failing error (e.g. `ApiError.name`), surfaced on the signed-out state. */
+	errorName?: string;
 }
 
 /**
@@ -185,7 +187,12 @@ export function signedOut(input: SignedOutInput): AuthState {
 		fields: [usernameField()],
 	});
 
-	return { state: 'signedOut', actions, ...(input.error ? { error: input.error } : {}) };
+	return {
+		state: 'signedOut',
+		actions,
+		...(input.error ? { error: input.error } : {}),
+		...(input.errorName ? { errorName: input.errorName } : {}),
+	};
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/packages/bb-auth-oidc/README.md
+++ b/packages/bb-auth-oidc/README.md
@@ -236,6 +236,8 @@ catch (e) {
 
 `SdkOutdated` is surfaced from `/aws-blocks/auth/callback` when a relay state envelope version is unrecognized — the client SDK is older than the backend expects and should be updated.
 
+Unlike the password providers, OIDC sign-in is a browser redirect to the IdP, so there is no `setAuthState` error-branching path here — react to errors on the imperative API with `isBlocksError` as shown above. (For the returned-`AuthState` idiom on password providers, see `hasAuthError` in the `bb-auth-basic` / `bb-auth-cognito` READMEs.)
+
 ## Cognito-mediated federation
 
 Delegate the OIDC flow to a Cognito User Pool. Cognito handles PKCE, token verification, MFA, and brute-force protection. Your Lambda only exchanges the code and reads the session.

--- a/packages/core/API.md
+++ b/packages/core/API.md
@@ -75,6 +75,13 @@ export function getSdkIdentifiers(bb: {
     fullId: string;
 }): Record<string, string>;
 
+// @public
+export function hasAuthError<N extends string>(state: {
+    errorName?: string;
+} | null | undefined, name: N): state is {
+    errorName: N;
+};
+
 // @public (undocumented)
 export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH' | 'HEAD' | 'OPTIONS';
 

--- a/packages/core/API.md
+++ b/packages/core/API.md
@@ -56,6 +56,9 @@ export interface BuildingBlockMeta {
 // @public
 export function clearRouteRegistry(): void;
 
+// @public
+export const DEFAULT_API_ERROR_NAME = "ApiError";
+
 // Warning: (ae-forgotten-export) The symbol "ResourceEntry" needs to be exported by the entry point index.d.ts
 //
 // @public

--- a/packages/core/API.md
+++ b/packages/core/API.md
@@ -76,9 +76,9 @@ export function getSdkIdentifiers(bb: {
 }): Record<string, string>;
 
 // @public
-export function hasAuthError<N extends string>(state: {
+export function hasAuthError<T extends {
     errorName?: string;
-} | null | undefined, name: N): state is {
+}, N extends string>(state: T | null | undefined, name: N): state is T & {
     errorName: N;
 };
 

--- a/packages/core/src/cdk/index.ts
+++ b/packages/core/src/cdk/index.ts
@@ -22,7 +22,7 @@ export { SandboxDisableDeletionProtection } from './mixins.js';
 export { registerConfig, finalizeConfigRegistry } from './config-registry.js';
 export { synthGuard } from './synth-guard.js';
 export type { ScopeOptions } from '../index.js';
-export { ApiError, isBlocksError, hasAuthError } from '../errors.js';
+export { ApiError, isBlocksError, hasAuthError, DEFAULT_API_ERROR_NAME } from '../errors.js';
 
 export class BlocksStack extends cdk.Stack implements BaseBlocksStack {
   public readonly id: string;

--- a/packages/core/src/cdk/index.ts
+++ b/packages/core/src/cdk/index.ts
@@ -22,7 +22,7 @@ export { SandboxDisableDeletionProtection } from './mixins.js';
 export { registerConfig, finalizeConfigRegistry } from './config-registry.js';
 export { synthGuard } from './synth-guard.js';
 export type { ScopeOptions } from '../index.js';
-export { ApiError, isBlocksError } from '../errors.js';
+export { ApiError, isBlocksError, hasAuthError } from '../errors.js';
 
 export class BlocksStack extends cdk.Stack implements BaseBlocksStack {
   public readonly id: string;

--- a/packages/core/src/client/index.ts
+++ b/packages/core/src/client/index.ts
@@ -316,5 +316,5 @@ export function ApiNamespaceClient<T extends Record<string, (...args: any[]) => 
   });
 }
 
-export { ApiError, isBlocksError, hasAuthError } from '../errors.js';
+export { ApiError, isBlocksError, hasAuthError, DEFAULT_API_ERROR_NAME } from '../errors.js';
 export { Scope, type ScopeOptions } from '../common/index.js';

--- a/packages/core/src/client/index.ts
+++ b/packages/core/src/client/index.ts
@@ -316,5 +316,5 @@ export function ApiNamespaceClient<T extends Record<string, (...args: any[]) => 
   });
 }
 
-export { ApiError, isBlocksError } from '../errors.js';
+export { ApiError, isBlocksError, hasAuthError } from '../errors.js';
 export { Scope, type ScopeOptions } from '../common/index.js';

--- a/packages/core/src/errors.test.ts
+++ b/packages/core/src/errors.test.ts
@@ -33,7 +33,7 @@ describe('hasAuthError', () => {
   });
 
   it('does not match a state with no errorName', () => {
-    const state: { errorName?: string } = { error: 'Invalid username or password' } as { errorName?: string };
+    const state: { errorName?: string } = {};
     assert.ok(!hasAuthError(state, 'InvalidCredentialsException'));
   });
 

--- a/packages/core/src/errors.test.ts
+++ b/packages/core/src/errors.test.ts
@@ -1,0 +1,55 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { ApiError, isBlocksError, hasAuthError } from './errors.js';
+
+describe('isBlocksError', () => {
+  it('matches a thrown ApiError by name', () => {
+    const e = new ApiError('nope', 401, { name: 'InvalidCredentialsException' });
+    assert.ok(isBlocksError(e, 'InvalidCredentialsException'));
+  });
+
+  it('does not match a different name', () => {
+    const e = new ApiError('nope', 401, { name: 'InvalidCredentialsException' });
+    assert.ok(!isBlocksError(e, 'SomeOtherException'));
+  });
+
+  it('does not match a plain object (not an Error)', () => {
+    assert.ok(!isBlocksError({ name: 'InvalidCredentialsException' }, 'InvalidCredentialsException'));
+  });
+});
+
+describe('hasAuthError', () => {
+  it('matches a state carrying the given errorName', () => {
+    const state = { state: 'signedOut', errorName: 'InvalidCredentialsException' } as const;
+    assert.ok(hasAuthError(state, 'InvalidCredentialsException'));
+  });
+
+  it('does not match a different errorName', () => {
+    const state = { errorName: 'InvalidCredentialsException' };
+    assert.ok(!hasAuthError(state, 'UserAlreadyExistsException'));
+  });
+
+  it('does not match a state with no errorName', () => {
+    const state: { errorName?: string } = { error: 'Invalid username or password' } as { errorName?: string };
+    assert.ok(!hasAuthError(state, 'InvalidCredentialsException'));
+  });
+
+  it('is safe on null / undefined', () => {
+    assert.ok(!hasAuthError(null, 'InvalidCredentialsException'));
+    assert.ok(!hasAuthError(undefined, 'InvalidCredentialsException'));
+  });
+
+  it('narrows the errorName to the matched literal', () => {
+    const state: { errorName?: string } = { errorName: 'InvalidCredentialsException' };
+    if (hasAuthError(state, 'InvalidCredentialsException')) {
+      // Type-level: state.errorName is narrowed to the literal.
+      const name: 'InvalidCredentialsException' = state.errorName;
+      assert.strictEqual(name, 'InvalidCredentialsException');
+    } else {
+      assert.fail('expected match');
+    }
+  });
+});

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -2,6 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
+ * The `name` an `ApiError` falls back to when no structured error name is
+ * given. A name equal to this carries no BB-level meaning, so consumers
+ * branching on the structured identity should treat it as "no name".
+ */
+export const DEFAULT_API_ERROR_NAME = 'ApiError';
+
+/**
  * Error subclass for errors that cross the wire between server and client.
  *
  * Carries a `status` (HTTP status code) and sets `name` to the BB-level
@@ -46,7 +53,7 @@ export class ApiError extends Error {
 
 	constructor(message: string, status: number, options?: { name?: string; cause?: unknown; retriable?: boolean }) {
 		super(message, options?.cause ? { cause: options.cause } : undefined);
-		this.name = options?.name ?? 'ApiError';
+		this.name = options?.name ?? DEFAULT_API_ERROR_NAME;
 		this.status = status;
 		this.retriable = options?.retriable ?? false;
 	}

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -70,3 +70,27 @@ export class ApiError extends Error {
 export function isBlocksError<N extends string>(e: unknown, name: N): e is Error & { name: N } {
 	return e instanceof Error && e.name === name;
 }
+
+/**
+ * Type guard for branching on a failed `AuthState` (the recommended
+ * `setAuthState` client path) by its structured `errorName`.
+ *
+ * The returned state is a plain object, not a thrown `Error`, so
+ * `isBlocksError` does not apply — use this on the value returned by
+ * `setAuthState`/`getAuthState`. Match on the BB error constant, never on
+ * the human-facing `error` string.
+ *
+ * @example
+ * ```typescript
+ * const next = await authApi.setAuthState({ action: 'signIn', username, password });
+ * if (hasAuthError(next, AuthBasicErrors.InvalidCredentials)) {
+ *   // unknown user → fall back to sign-up
+ * }
+ * ```
+ */
+export function hasAuthError<N extends string>(
+	state: { errorName?: string } | null | undefined,
+	name: N,
+): state is { errorName: N } {
+	return state?.errorName === name;
+}

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -88,9 +88,9 @@ export function isBlocksError<N extends string>(e: unknown, name: N): e is Error
  * }
  * ```
  */
-export function hasAuthError<N extends string>(
-	state: { errorName?: string } | null | undefined,
+export function hasAuthError<T extends { errorName?: string }, N extends string>(
+	state: T | null | undefined,
 	name: N,
-): state is { errorName: N } {
+): state is T & { errorName: N } {
 	return state?.errorName === name;
 }

--- a/packages/core/src/index.cdk.ts
+++ b/packages/core/src/index.cdk.ts
@@ -3,7 +3,7 @@
 
 export { ApiNamespace, type BlocksContext, type ApiHandler } from './api.js';
 export { BLOCKS_RPC_PREFIX, BLOCKS_AUTH_PREFIX } from './constants.js';
-export { ApiError, isBlocksError, hasAuthError } from './errors.js';
+export { ApiError, isBlocksError, hasAuthError, DEFAULT_API_ERROR_NAME } from './errors.js';
 export { EventSourceMapping } from './lambda-handler.js';
 export { BlocksStackProps } from './common/index.js';
 export { registerSdkIdentifiers, getSdkIdentifiers, getAllSdkIdentifiers, _resetSdkRegistry } from './common/sdk-registry.js';

--- a/packages/core/src/index.cdk.ts
+++ b/packages/core/src/index.cdk.ts
@@ -3,7 +3,7 @@
 
 export { ApiNamespace, type BlocksContext, type ApiHandler } from './api.js';
 export { BLOCKS_RPC_PREFIX, BLOCKS_AUTH_PREFIX } from './constants.js';
-export { ApiError, isBlocksError } from './errors.js';
+export { ApiError, isBlocksError, hasAuthError } from './errors.js';
 export { EventSourceMapping } from './lambda-handler.js';
 export { BlocksStackProps } from './common/index.js';
 export { registerSdkIdentifiers, getSdkIdentifiers, getAllSdkIdentifiers, _resetSdkRegistry } from './common/sdk-registry.js';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,7 +3,7 @@
 
 export { ApiNamespace, type BlocksContext, type ApiHandler } from './api.js';
 export { BLOCKS_RPC_PREFIX, BLOCKS_AUTH_PREFIX } from './constants.js';
-export { ApiError, isBlocksError } from './errors.js';
+export { ApiError, isBlocksError, hasAuthError } from './errors.js';
 export { Scope, type ScopeOptions, type ScopeParent, type BuildingBlockMeta } from './common/index.js';
 export { registerSdkIdentifiers, getSdkIdentifiers, getAllSdkIdentifiers, _resetSdkRegistry } from './common/sdk-registry.js';
 export { getConfig, getConfigSync, preloadConfig, loadConfigToProcessEnv, _resetConfigCache } from './common/config.js';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,7 +3,7 @@
 
 export { ApiNamespace, type BlocksContext, type ApiHandler } from './api.js';
 export { BLOCKS_RPC_PREFIX, BLOCKS_AUTH_PREFIX } from './constants.js';
-export { ApiError, isBlocksError, hasAuthError } from './errors.js';
+export { ApiError, isBlocksError, hasAuthError, DEFAULT_API_ERROR_NAME } from './errors.js';
 export { Scope, type ScopeOptions, type ScopeParent, type BuildingBlockMeta } from './common/index.js';
 export { registerSdkIdentifiers, getSdkIdentifiers, getAllSdkIdentifiers, _resetSdkRegistry } from './common/sdk-registry.js';
 export { getConfig, getConfigSync, preloadConfig, loadConfigToProcessEnv, _resetConfigCache } from './common/config.js';


### PR DESCRIPTION
## Problem

The recommended client auth path is `createApi()` → `setAuthState()`. When an action failed, `setAuthState()` caught the thrown `ApiError` and returned an `AuthState` carrying only `error: e.message`, **discarding the structured `e.name`** (e.g. `'InvalidCredentialsException'`). Because `AuthState` had no field for an error name, a hand-rolled client could not branch on error type (e.g. "try sign-in, fall back to sign-up for a brand-new user") without brittle string-matching the human-facing message.

> [!NOTE]
> The issue's suggested fix (`isBlocksError(next, ...)` on the returned state) cannot work: `isBlocksError` is guarded by `e instanceof Error` and never matches a plain `AuthState` object. This PR adds a companion guard that works on the returned state.

**Issue #, if available:** Fixes #81

## Changes

- **`@aws-blocks/auth-common`**: add optional `AuthState.errorName`.
- **`@aws-blocks/core`**: add `hasAuthError(state, name)` type guard (exported from all 4 barrels) for branching on a returned `AuthState`.
- **`bb-auth-basic` / `bb-auth-cognito`**: populate `errorName` from `ApiError.name` in the `setAuthState` catch blocks, skipping the generic `'ApiError'` default. `bb-auth-oidc` unchanged (IdP redirect flow has no `setAuthState` throw path).
- **Docs**: document the idiom in all three provider READMEs — *throw path → `isBlocksError`; returned `AuthState` → `hasAuthError`; never string-match `error`.*
- Regenerated API reports (`core/API.md`, `auth-common/API.md`) + added a changeset.

## Validation

- `npm run build` — all affected packages compile clean.
- New/extended unit tests: `core/src/errors.test.ts` (`hasAuthError`), `bb-auth-basic/src/index.test.ts` (new — errorName propagation + generic-name skip), extended `bb-auth-cognito/src/index.test.ts`. Results: core 491/491, bb-auth-basic 8/8, and the new cognito `#81` test pass.
- The 7 pre-existing cognito failures (a `.bb-data` filesystem race when all test files run concurrently) reproduce identically on `main` and are unrelated to this change — they pass in isolation.

## Checklist

- [x] PR description included
- [x] Tests are changed or added
- [x] Relevant documentation is changed or added (and PR referenced)

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._

🤖 Generated with [Claude Code](https://claude.com/claude-code)