### PR TITLE
fix(hosting): stop hardcoding image-opt reserved concurrency

### DIFF
--- a/.changeset/image-opt-reserved-concurrency.md
+++ b/.changeset/image-opt-reserved-concurrency.md
@@ -1,0 +1,8 @@
+---
+"@aws-blocks/hosting": patch
+"@aws-blocks/core": patch
+---
+
+fix(hosting): stop hardcoding image-optimization Lambda reserved concurrency
+
+The image-optimization Lambda hardcoded `reservedConcurrency: 10`, which made `cdk deploy` fail on fresh AWS accounts (the default account-level unreserved-concurrency limit is also 10, so reserving all 10 drops the account below its required minimum and Lambda returns a 400). It now defaults to no reservation and exposes `compute.imageOptimization.reservedConcurrency` so operators with headroom can still cap it.

--- a/packages/core/src/hosting.ts
+++ b/packages/core/src/hosting.ts
@@ -71,8 +71,29 @@ export type ComputeConfig = {
    * ```
    */
   timeout?: cdk.Duration | number;
-  /** Reserved concurrent executions. Default: undefined (no reservation). */
+  /** Reserved concurrent executions for the SSR Lambda. Default: undefined (no reservation). */
   reservedConcurrency?: number;
+  /**
+   * Overrides for the image-optimization Lambda.
+   *
+   * `reservedConcurrency` defaults to undefined (no reservation). It is left
+   * unreserved so deploys succeed on fresh AWS accounts, whose default
+   * account-level unreserved-concurrency limit is 10 — reserving any
+   * concurrency there can drop the account below its required minimum and
+   * cause Lambda to reject the stack with a 400. Set this only if you have
+   * headroom and want to cap image-opt throughput.
+   *
+   * @example
+   * ```ts
+   * compute: {
+   *   imageOptimization: { reservedConcurrency: 5 },
+   * }
+   * ```
+   */
+  imageOptimization?: {
+    /** Reserved concurrent executions. Default: undefined (no reservation). */
+    reservedConcurrency?: number;
+  };
   /** CloudWatch log retention for the SSR Lambda. Default: TWO_WEEKS. */
   logRetention?: cdk.aws_logs.RetentionDays;
 };

--- a/packages/hosting/src/constructs/hosting_construct.test.ts
+++ b/packages/hosting/src/constructs/hosting_construct.test.ts
@@ -788,6 +788,86 @@ void describe('HostingConstruct — Image optimization', () => {
     );
   });
 
+  void it('does not reserve concurrency on the image optimization Lambda by default', () => {
+    // Regression: a hardcoded reservedConcurrency of 10 broke `cdk deploy`
+    // on fresh AWS accounts (account-level unreserved limit is also 10).
+    // No reservation must be emitted unless the user opts in.
+    const staticDir = createStaticDir();
+    const bundleDir = createBundleDir();
+    const imgDir = path.join(tmpDir, 'image-fn');
+    fs.mkdirSync(imgDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(imgDir, 'index.mjs'),
+      'export const handler = async () => {};',
+    );
+
+    const stack = createStack();
+
+    const manifest: DeployManifest = {
+      ...ssrManifest(staticDir, bundleDir),
+      imageOptimization: {
+        bundle: imgDir,
+        handler: 'index.handler',
+        formats: ['webp', 'avif'],
+        sizes: [640, 1080],
+      },
+    };
+
+    new HostingConstruct(stack, 'Hosting', {
+      manifest,
+      skipRegionValidation: true,
+    });
+
+    const template = Template.fromStack(stack);
+    // No Lambda in the stack should carry a reservation by default.
+    const functions = template.findResources('AWS::Lambda::Function');
+    for (const [id, fn] of Object.entries(functions)) {
+      const props = (fn as Record<string, unknown>)['Properties'] as Record<
+        string,
+        unknown
+      >;
+      assert.strictEqual(
+        props['ReservedConcurrentExecutions'],
+        undefined,
+        `Function ${id} should not reserve concurrency by default`,
+      );
+    }
+  });
+
+  void it('reserves concurrency on the image optimization Lambda when configured', () => {
+    const staticDir = createStaticDir();
+    const bundleDir = createBundleDir();
+    const imgDir = path.join(tmpDir, 'image-fn');
+    fs.mkdirSync(imgDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(imgDir, 'index.mjs'),
+      'export const handler = async () => {};',
+    );
+
+    const stack = createStack();
+
+    const manifest: DeployManifest = {
+      ...ssrManifest(staticDir, bundleDir),
+      imageOptimization: {
+        bundle: imgDir,
+        handler: 'index.handler',
+        formats: ['webp', 'avif'],
+        sizes: [640, 1080],
+      },
+    };
+
+    new HostingConstruct(stack, 'Hosting', {
+      manifest,
+      skipRegionValidation: true,
+      compute: { imageOptimization: { reservedConcurrency: 5 } },
+    });
+
+    const template = Template.fromStack(stack);
+    template.hasResourceProperties('AWS::Lambda::Function', {
+      ReservedConcurrentExecutions: 5,
+    });
+  });
+
   void it('uses default x86_64 architecture for image optimization Lambda', () => {
     const staticDir = createStaticDir();
     const bundleDir = createBundleDir();

--- a/packages/hosting/src/constructs/hosting_construct.ts
+++ b/packages/hosting/src/constructs/hosting_construct.ts
@@ -138,6 +138,20 @@ export type HostingConstructProps = {
     timeout?: Duration | number;
     reservedConcurrency?: number;
     /**
+     * Reserved concurrent executions for the image-optimization Lambda.
+     * Default: undefined (no reservation).
+     *
+     * Historically this was hardcoded to 10, which broke `cdk deploy` on
+     * fresh AWS accounts: the default account-level unreserved-concurrency
+     * limit is 10, so reserving all 10 for image-opt drops the account
+     * below its required minimum and Lambda rejects the stack with a 400.
+     * Defaulting to no reservation keeps deploys working out of the box
+     * while still letting operators cap image-opt explicitly.
+     */
+    imageOptimization?: {
+      reservedConcurrency?: number;
+    };
+    /**
      * Provisioned concurrency for the SSR Lambda (cold-start elimination).
      * When > 0, the construct creates a `live` alias with this many
      * always-warm execution environments and points the SSR REST API
@@ -695,7 +709,11 @@ export class HostingConstruct extends Construct {
           memorySize: 1024,
           timeout: 25,
         },
-        reservedConcurrency: 10,
+        // No reservation by default. Reserving concurrency here used to be
+        // hardcoded to 10, which made deploys fail on fresh accounts whose
+        // account-level unreserved limit is also 10. Operators who need to
+        // cap image-opt can set `compute.imageOptimization.reservedConcurrency`.
+        reservedConcurrency: props.compute?.imageOptimization?.reservedConcurrency,
         // Propagate the SSR Lambda's logRetention to image-opt so a
         // user who bumped retention for debugability gets the same
         // window for image-opt logs (intermittent SVG/SSRF rejects

--- a/packages/hosting/src/types.ts
+++ b/packages/hosting/src/types.ts
@@ -155,6 +155,15 @@ export type HostingProps = {
     timeout?: Duration | number;
     /** Reserved concurrent executions. Default: undefined (no reservation). */
     reservedConcurrency?: number;
+    /**
+     * Image-optimization Lambda overrides. `reservedConcurrency` defaults to
+     * undefined (no reservation) — see the note in the L3 construct on why
+     * the old hardcoded value of 10 broke deploys on fresh AWS accounts.
+     */
+    imageOptimization?: {
+      /** Reserved concurrent executions. Default: undefined (no reservation). */
+      reservedConcurrency?: number;
+    };
     /** Provisioned concurrency for cold-start elimination. Default: undefined (no provisioning). */
     provisionedConcurrency?: number;
     /** CloudWatch log retention for the SSR Lambda. Default: ONE_MONTH. */


### PR DESCRIPTION
Fixes #92.

## Problem
The image-optimization Lambda hardcoded `reservedConcurrency: 10`. On a fresh AWS account the default unreserved-concurrency limit is also 10, so reserving all 10 drops the account below its required minimum and CloudFormation fails with a 400.

## Fix
- Default image-opt to **no reservation** (`hosting_construct.ts`), matching every other compute resource.
- Expose `compute.imageOptimization.reservedConcurrency` so operators with headroom can still cap it (public `core` API + internal `hosting` props).

## Tests
- image-opt reserves no concurrency by default
- image-opt honors `reservedConcurrency` when configured