### PR TITLE
fix(release): bump @aws-blocks/blocks in changeset

### DIFF
--- a/.changeset/issue-81-setauthstate-error-name.md
+++ b/.changeset/issue-81-setauthstate-error-name.md
@@ -4,6 +4,7 @@
 "@aws-blocks/bb-auth-basic": patch
 "@aws-blocks/bb-auth-cognito": patch
 "@aws-blocks/bb-auth-oidc": patch
+"@aws-blocks/blocks": patch
 ---
 
 fix(auth): propagate the structured error name through `setAuthState()`


### PR DESCRIPTION
## Problem

The `publish-packages.yml` workflow fails at the **Publish to S3** step on merge to `main` (run #58), with `@aws-blocks/blocks@0.1.5 already exists with different content. Did you forget to include it in your changeset?`

## Root cause

The umbrella `@aws-blocks/blocks` bundles every `bb-*` README into its `docs/` directory at build time (`scripts/sync-block-docs.mjs`, shipped via `files: ["docs"]`). The issue-81 changeset bumps the `bb-auth-*` packages and edits their READMEs, but doesn't name `@aws-blocks/blocks` — so `changeset version` leaves the umbrella unbumped while its packed docs change, and the integrity guard in `scripts/publish/publish.ts` correctly rejects the changed-but-same-version tarball.

## Fix

Add `'@aws-blocks/blocks': patch` to the pending changeset so the umbrella is version-bumped (`0.1.5 → 0.1.6`) and republishes cleanly. Verified locally with `changeset version`. Same fix as #69.