### PR TITLE
feat(kotlin): implement Kotlin SDK release process

### DIFF
--- a/.github/workflows/prepare-kotlin-release.yml
+++ b/.github/workflows/prepare-kotlin-release.yml
@@ -43,6 +43,10 @@ jobs:
           fi
 
       - name: Apply version bump
+        # @changesets/changelog-github calls the GitHub API to build changelog
+        # links, so `changeset version` needs a token (matches publish-packages.yml).
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: npx changeset version
 
       - name: Sync Gradle version

--- a/.github/workflows/prepare-kotlin-release.yml
+++ b/.github/workflows/prepare-kotlin-release.yml
@@ -7,6 +7,10 @@ permissions:
   contents: write
   pull-requests: write
 
+concurrency:
+  group: prepare-kotlin-release
+  cancel-in-progress: false
+
 jobs:
   prepare:
     name: Version bump + release PR
@@ -18,11 +22,15 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
+          # Use a PAT (not the default GITHUB_TOKEN) so the pushed branch and the
+          # PR it opens trigger downstream CI on the release PR.
           token: ${{ secrets.OPS_GITHUB_TOKEN }}
 
       - uses: actions/setup-node@v5
         with:
           node-version-file: '.nvmrc'
+          cache: npm
+          cache-dependency-path: native/kotlin/package-lock.json
 
       - run: npm ci
 

--- a/.github/workflows/prepare-kotlin-release.yml
+++ b/.github/workflows/prepare-kotlin-release.yml
@@ -1,0 +1,90 @@
+name: Prepare Kotlin Release
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  prepare:
+    name: Version bump + release PR
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: native/kotlin
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.OPS_GITHUB_TOKEN }}
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version-file: '.nvmrc'
+
+      - run: npm ci
+
+      - name: Verify pending changesets exist
+        run: |
+          # `changeset status` exits non-zero when there is nothing to release.
+          if ! npx changeset status --since=origin/main; then
+            echo "::error::No pending changesets — nothing to release."
+            exit 1
+          fi
+
+      - name: Apply version bump
+        run: npx changeset version
+
+      - name: Sync Gradle version
+        run: ./scripts/sync-version.sh
+
+      - name: Read new version
+        id: ver
+        run: echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - name: Assert gradle.properties matches package.json
+        run: |
+          PKG="${{ steps.ver.outputs.version }}"
+          GRADLE=$(grep '^VERSION_NAME=' gradle.properties | cut -d= -f2)
+          if [ "$PKG" != "$GRADLE" ]; then
+            echo "::error::Version mismatch: package.json=$PKG gradle.properties=$GRADLE"
+            exit 1
+          fi
+          echo "Versions match: $PKG"
+
+      - name: Guard against existing release branch
+        env:
+          GH_TOKEN: ${{ secrets.OPS_GITHUB_TOKEN }}
+        run: |
+          BRANCH="release/kotlin-${{ steps.ver.outputs.version }}"
+          if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+            echo "::error::Branch $BRANCH already exists — a release for this version is already in flight."
+            exit 1
+          fi
+
+      - name: Create branch, commit, push
+        env:
+          GH_TOKEN: ${{ secrets.OPS_GITHUB_TOKEN }}
+        run: |
+          VERSION="${{ steps.ver.outputs.version }}"
+          BRANCH="release/kotlin-${VERSION}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git add -A
+          git commit -m "chore(kotlin): Release ${VERSION}"
+          git push origin "$BRANCH"
+
+      - name: Open release PR
+        env:
+          GH_TOKEN: ${{ secrets.OPS_GITHUB_TOKEN }}
+        run: |
+          VERSION="${{ steps.ver.outputs.version }}"
+          NOTES="$(./scripts/extract-changelog.sh CHANGELOG.md "$VERSION")"
+          gh pr create \
+            --base main \
+            --head "release/kotlin-${VERSION}" \
+            --title "chore(kotlin): Release ${VERSION}" \
+            --body "$NOTES"

--- a/.github/workflows/publish-kotlin-maven.yml
+++ b/.github/workflows/publish-kotlin-maven.yml
@@ -15,6 +15,10 @@ permissions:
   id-token: write
   contents: write
 
+concurrency:
+  group: publish-kotlin-maven
+  cancel-in-progress: false
+
 jobs:
   publish:
     # Publish on a manual dispatch, or when a release/kotlin-* PR is merged.
@@ -90,6 +94,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.OPS_GITHUB_TOKEN }}
         run: |
+          set -euo pipefail
           VERSION=$(grep '^VERSION_NAME=' gradle.properties | cut -d= -f2)
           TAG="kotlin@${VERSION}"
 
@@ -98,11 +103,8 @@ jobs:
             exit 0
           fi
 
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag "$TAG"
-          git push origin "$TAG"
-
+          # Extract release notes BEFORE pushing the tag, so a missing/malformed
+          # changelog entry fails here rather than stranding a tag with no release.
           NOTES="$(./scripts/extract-changelog.sh CHANGELOG.md "$VERSION")"
 
           PRERELEASE=""
@@ -110,6 +112,11 @@ jobs:
           if [ "$MAJOR" = "0" ]; then
             PRERELEASE="--prerelease"
           fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag "$TAG"
+          git push origin "$TAG"
 
           gh release create "$TAG" \
             --title "Kotlin SDK ${VERSION}" \

--- a/.github/workflows/publish-kotlin-maven.yml
+++ b/.github/workflows/publish-kotlin-maven.yml
@@ -1,6 +1,9 @@
 name: Publish Kotlin to Maven Central
 
 on:
+  pull_request:
+    types: [closed]
+    branches: [main]
   workflow_dispatch:
     inputs:
       dry_run:
@@ -10,10 +13,15 @@ on:
 
 permissions:
   id-token: write
-  contents: read
+  contents: write
 
 jobs:
   publish:
+    # Publish on a manual dispatch, or when a release/kotlin-* PR is merged.
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.pull_request.merged == true &&
+       startsWith(github.event.pull_request.head.ref, 'release/kotlin-'))
     runs-on: macos-latest
     environment: publish-maven
     defaults:
@@ -21,6 +29,12 @@ jobs:
         working-directory: native/kotlin
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          # For the merge event, check out main (the merged commit). For a manual
+          # dispatch, fall back to the dispatched ref (empty ref => default). Use a
+          # token that can push the release tag.
+          ref: ${{ github.event_name == 'pull_request' && 'main' || '' }}
+          token: ${{ secrets.OPS_GITHUB_TOKEN }}
 
       - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
@@ -58,6 +72,9 @@ jobs:
             printf 'signingInMemoryKey=%s\n' "$(printf '%s' "$SIGNING_SECRET" | jq -r .inMemoryKey)"
           } >> "$PROPS"
 
+      - name: Build and test (pre-publish gate)
+        run: ./gradlew build
+
       - name: Publish to Maven Central
         if: inputs.dry_run != true
         run: ./gradlew publishAllPublicationsToMavenCentralRepository
@@ -65,3 +82,36 @@ jobs:
       - name: Publish dry-run
         if: inputs.dry_run == true
         run: ./gradlew publishToMavenLocal
+
+      - name: Tag and create GitHub Release
+        # Only on a real publish (not dry-run). Runs after a successful publish,
+        # so a failed Maven upload never creates an orphan tag.
+        if: inputs.dry_run != true
+        env:
+          GH_TOKEN: ${{ secrets.OPS_GITHUB_TOKEN }}
+        run: |
+          VERSION=$(grep '^VERSION_NAME=' gradle.properties | cut -d= -f2)
+          TAG="kotlin@${VERSION}"
+
+          if git ls-remote --exit-code --tags origin "$TAG" >/dev/null 2>&1; then
+            echo "Tag $TAG already exists — skipping tag/release (safe re-run)."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag "$TAG"
+          git push origin "$TAG"
+
+          NOTES="$(./scripts/extract-changelog.sh CHANGELOG.md "$VERSION")"
+
+          PRERELEASE=""
+          MAJOR="${VERSION%%.*}"
+          if [ "$MAJOR" = "0" ]; then
+            PRERELEASE="--prerelease"
+          fi
+
+          gh release create "$TAG" \
+            --title "Kotlin SDK ${VERSION}" \
+            --notes "$NOTES" \
+            $PRERELEASE

--- a/native/kotlin/gradle.properties
+++ b/native/kotlin/gradle.properties
@@ -38,4 +38,4 @@ POM_DEVELOPER_NAME=amazonwebservices
 
 RELEASE_SIGNING_ENABLED=true
 mavenCentralPublishing=true
-mavenCentralAutomaticPublishing=false
+mavenCentralAutomaticPublishing=true

--- a/native/kotlin/scripts/extract-changelog.sh
+++ b/native/kotlin/scripts/extract-changelog.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Print the body of a single CHANGELOG section.
+# Usage: extract-changelog.sh <changelog-path> <version>
+# Prints everything between "## <version>" and the next "## " heading,
+# trimming surrounding blank lines. Exits non-zero if the version is absent.
+set -euo pipefail
+
+CHANGELOG="${1:?usage: extract-changelog.sh <changelog-path> <version>}"
+VERSION="${2:?usage: extract-changelog.sh <changelog-path> <version>}"
+
+# awk: start printing after the matching "## <version>" heading; stop at the
+# next line beginning with "## ". Track whether we matched at all.
+BODY="$(awk -v ver="$VERSION" '
+  $0 == "## " ver { found=1; next }
+  found && /^## / { exit }
+  found { print }
+' "$CHANGELOG")"
+
+if [ -z "${BODY//[$' \t\n']/}" ]; then
+  # Distinguish "version not found" from "found but empty". Re-scan for the heading.
+  if ! grep -qF "## $VERSION" "$CHANGELOG"; then
+    echo "ERROR: version $VERSION not found in $CHANGELOG" >&2
+    exit 1
+  fi
+fi
+
+# Trim leading/trailing blank lines (portable across GNU and BSD/macOS).
+printf '%s\n' "$BODY" | awk '
+  /[^[:space:]]/ { for (; held > 0; held--) print ""; print; started=1; next }
+  started { held++ }
+'

--- a/native/kotlin/scripts/extract-changelog.sh
+++ b/native/kotlin/scripts/extract-changelog.sh
@@ -18,7 +18,7 @@ BODY="$(awk -v ver="$VERSION" '
 
 if [ -z "${BODY//[$' \t\n']/}" ]; then
   # Distinguish "version not found" from "found but empty". Re-scan for the heading.
-  if ! grep -qF "## $VERSION" "$CHANGELOG"; then
+  if ! grep -qxF "## $VERSION" "$CHANGELOG"; then
     echo "ERROR: version $VERSION not found in $CHANGELOG" >&2
     exit 1
   fi

--- a/native/kotlin/scripts/extract-changelog.test.sh
+++ b/native/kotlin/scripts/extract-changelog.test.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Test for extract-changelog.sh.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXTRACT="$SCRIPT_DIR/extract-changelog.sh"
+
+fail() { echo "FAIL: $1" >&2; exit 1; }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+cat > "$WORK/CHANGELOG.md" <<'MD'
+# aws-blocks-kotlin
+
+## 0.2.0
+
+### Minor Changes
+
+- Added realtime channel support
+
+### Patch Changes
+
+- Fixed a cookie bug
+
+## 0.1.0
+
+Initial version
+MD
+
+# --- Case 1: extract the latest (0.2.0) section ---
+OUT="$(bash "$EXTRACT" "$WORK/CHANGELOG.md" 0.2.0)"
+echo "$OUT" | grep -q "Added realtime channel support" \
+  || fail "Case 1: missing minor-change line"
+echo "$OUT" | grep -q "Fixed a cookie bug" \
+  || fail "Case 1: missing patch-change line"
+if echo "$OUT" | grep -q "Initial version"; then
+  fail "Case 1: leaked content from the next (0.1.0) section"
+fi
+if echo "$OUT" | grep -q "^## 0.2.0"; then
+  fail "Case 1: should not include the heading line itself"
+fi
+
+# --- Case 2: extract a middle/last section (0.1.0) ---
+OUT2="$(bash "$EXTRACT" "$WORK/CHANGELOG.md" 0.1.0)"
+echo "$OUT2" | grep -q "Initial version" \
+  || fail "Case 2: missing 0.1.0 body"
+
+# --- Case 3: unknown version exits non-zero ---
+if bash "$EXTRACT" "$WORK/CHANGELOG.md" 5.5.5 2>/dev/null; then
+  fail "Case 3: unknown version should exit non-zero"
+fi
+
+echo "PASS: extract-changelog.test.sh"

--- a/native/kotlin/scripts/extract-changelog.test.sh
+++ b/native/kotlin/scripts/extract-changelog.test.sh
@@ -51,4 +51,9 @@ if bash "$EXTRACT" "$WORK/CHANGELOG.md" 5.5.5 2>/dev/null; then
   fail "Case 3: unknown version should exit non-zero"
 fi
 
+# --- Case 4: a version that is only a substring of a real heading exits non-zero ---
+if bash "$EXTRACT" "$WORK/CHANGELOG.md" 0.1 2>/dev/null; then
+  fail "Case 4: partial version 0.1 should not match ## 0.1.0"
+fi
+
 echo "PASS: extract-changelog.test.sh"

--- a/native/kotlin/scripts/sync-version.sh
+++ b/native/kotlin/scripts/sync-version.sh
@@ -2,11 +2,29 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+# PROJECT_DIR defaults to the package root (parent of scripts/) but can be
+# overridden (e.g. by tests) to point at a fixture directory.
+PROJECT_DIR="${PROJECT_DIR:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 
 VERSION=$(node -p "require('$PROJECT_DIR/package.json').version")
 
-sed -i.bak "s/^VERSION_NAME=.*/VERSION_NAME=$VERSION/" "$PROJECT_DIR/gradle.properties"
-rm -f "$PROJECT_DIR/gradle.properties.bak"
+PROPS="$PROJECT_DIR/gradle.properties"
+
+# Fail loudly if there is no VERSION_NAME line to replace. `sed` exits 0 even
+# when its pattern matches nothing, which would otherwise leave a stale version
+# and silently publish/tag the wrong number.
+if ! grep -q '^VERSION_NAME=' "$PROPS"; then
+  echo "ERROR: no VERSION_NAME= line found in $PROPS" >&2
+  exit 1
+fi
+
+sed -i.bak "s/^VERSION_NAME=.*/VERSION_NAME=$VERSION/" "$PROPS"
+rm -f "$PROPS.bak"
+
+# Verify the write landed.
+if ! grep -q "^VERSION_NAME=$VERSION$" "$PROPS"; then
+  echo "ERROR: failed to set VERSION_NAME=$VERSION in $PROPS" >&2
+  exit 1
+fi
 
 echo "Synced version $VERSION to gradle.properties"

--- a/native/kotlin/scripts/sync-version.test.sh
+++ b/native/kotlin/scripts/sync-version.test.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Test for sync-version.sh. Run from native/kotlin/scripts/.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SYNC="$SCRIPT_DIR/sync-version.sh"
+
+WORK2=""
+
+fail() { echo "FAIL: $1" >&2; exit 1; }
+
+# --- Case 1: happy path — VERSION_NAME is updated from package.json ---
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK" "$WORK2"' EXIT
+cat > "$WORK/package.json" <<'JSON'
+{ "name": "aws-blocks-kotlin", "version": "9.9.9" }
+JSON
+cat > "$WORK/gradle.properties" <<'PROPS'
+GROUP=com.aws.blocks.kotlin
+VERSION_NAME=0.0.0
+RELEASE_SIGNING_ENABLED=true
+PROPS
+
+PROJECT_DIR="$WORK" bash "$SYNC"
+grep -q '^VERSION_NAME=9.9.9$' "$WORK/gradle.properties" \
+  || fail "Case 1: VERSION_NAME not updated to 9.9.9"
+
+# --- Case 2: missing VERSION_NAME line must fail (non-zero exit) ---
+WORK2="$(mktemp -d)"
+cat > "$WORK2/package.json" <<'JSON'
+{ "name": "aws-blocks-kotlin", "version": "9.9.9" }
+JSON
+cat > "$WORK2/gradle.properties" <<'PROPS'
+GROUP=com.aws.blocks.kotlin
+RELEASE_SIGNING_ENABLED=true
+PROPS
+
+if PROJECT_DIR="$WORK2" bash "$SYNC" 2>/dev/null; then
+  fail "Case 2: sync-version.sh should have failed on missing VERSION_NAME line"
+fi
+
+echo "PASS: sync-version.test.sh"


### PR DESCRIPTION
## Summary

Implements the end-to-end AWS Blocks Kotlin SDK release process (release-PR model):

- **`prepare-kotlin-release.yml`** (new) — manual workflow: consumes changesets, bumps the version, syncs `gradle.properties`, asserts the two versions match, and opens a `chore(kotlin): Release X.Y.Z` PR.
- **`publish-kotlin-maven.yml`** (modified) — now also triggers when a `release/kotlin-*` PR is merged to `main`; adds a `./gradlew build` pre-publish gate and post-publish tagging (`kotlin@X.Y.Z`) + GitHub Release. Manual `workflow_dispatch` + `dry_run` retained.
- **`mavenCentralAutomaticPublishing=true`** — artifacts release straight to Central, no manual Sonatype portal step.
- **Helper scripts** — hardened `sync-version.sh` (fails on no-op sed) and new `extract-changelog.sh` (release notes), both with bash tests.

## Design decisions

- Release-PR model (human review gate per release), intentionally distinct from the TypeScript `publish-packages.yml` direct-on-main flow.
- Publish trigger gates on `pull_request` closed + `merged == true` + head ref `release/kotlin-*` (fork-safe: only collaborators can merge).
- Tagging runs last, gated on publish success, and skips if the tag exists — no orphan tags, safe re-runs.

## Test plan

- [x] `sync-version.test.sh` passes
- [x] `extract-changelog.test.sh` passes
- [x] `./gradlew :plugin:validatePlugins` passes
- [x] Both workflows validate as YAML
- [x] Dry-run publish exercised the build gate (which correctly caught #109/#110)
- [ ] Full `./gradlew build` green — blocked on #109/#110
- [ ] First real release end-to-end (validates the runbook)