### PR TITLE
ci(native-e2e): detect changes per platform

### DIFF
--- a/.github/workflows/native-sdk-e2e.yml
+++ b/.github/workflows/native-sdk-e2e.yml
@@ -23,8 +23,17 @@ jobs:
   detect-changes:
     name: Detect Changes
     runs-on: ubuntu-latest
+    # Per-platform change detection so each platform's e2e jobs run only when
+    # that platform's code (or shared infra) changed, instead of every platform
+    # running on any native change. `common-changed` covers shared infra that
+    # affects ALL platforms (the native-bindings test backend that produces the
+    # spec, and this workflow file itself); when it changes, every platform runs.
+    # The union of the four outputs equals the previous coarse `source-changed`.
     outputs:
-      source-changed: ${{ steps.check.outputs.source-changed }}
+      dart-changed: ${{ steps.check.outputs.dart-changed }}
+      kotlin-changed: ${{ steps.check.outputs.kotlin-changed }}
+      swift-changed: ${{ steps.check.outputs.swift-changed }}
+      common-changed: ${{ steps.check.outputs.common-changed }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -32,19 +41,40 @@ jobs:
           fetch-depth: 0
       - id: check
         run: |
+          # On manual dispatch there is no diff base, so run everything: mark
+          # every platform plus common as changed (matches the old coarse
+          # "source-changed=true on dispatch" behavior).
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "source-changed=true" >> "$GITHUB_OUTPUT"
-          elif git diff --name-only origin/main...HEAD | grep -qE '^(native/(dart|kotlin|swift)|test-apps/native-bindings)/|^\.github/workflows/native-sdk-e2e\.yml$'; then
-            echo "source-changed=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "source-changed=false" >> "$GITHUB_OUTPUT"
+            {
+              echo "dart-changed=true"
+              echo "kotlin-changed=true"
+              echo "swift-changed=true"
+              echo "common-changed=true"
+            } >> "$GITHUB_OUTPUT"
+            exit 0
           fi
+
+          # Same diff base as before; classify the changed paths per platform.
+          CHANGED="$(git diff --name-only origin/main...HEAD)"
+
+          emit() { echo "$1=$2" >> "$GITHUB_OUTPUT"; echo "$1=$2"; }
+
+          if echo "$CHANGED" | grep -qE '^native/dart/'; then emit dart-changed true; else emit dart-changed false; fi
+          if echo "$CHANGED" | grep -qE '^native/kotlin/'; then emit kotlin-changed true; else emit kotlin-changed false; fi
+          if echo "$CHANGED" | grep -qE '^native/swift/'; then emit swift-changed true; else emit swift-changed false; fi
+          if echo "$CHANGED" | grep -qE '^test-apps/native-bindings/|^\.github/workflows/native-sdk-e2e\.yml$'; then emit common-changed true; else emit common-changed false; fi
 
   # Shared setup: build monorepo, generate spec, upload artifact
   setup:
     name: Build & Generate Spec
     needs: [detect-changes]
-    if: needs.detect-changes.outputs.source-changed == 'true'
+    # Produces the shared spec artifact all platform jobs consume, so run it
+    # whenever any platform (or common infra) changed.
+    if: >-
+      needs.detect-changes.outputs.dart-changed == 'true' ||
+      needs.detect-changes.outputs.kotlin-changed == 'true' ||
+      needs.detect-changes.outputs.swift-changed == 'true' ||
+      needs.detect-changes.outputs.common-changed == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     outputs:
@@ -81,7 +111,9 @@ jobs:
   dart-e2e:
     name: Dart E2E
     needs: [detect-changes, setup]
-    if: needs.detect-changes.outputs.source-changed == 'true'
+    if: >-
+      needs.detect-changes.outputs.dart-changed == 'true' ||
+      needs.detect-changes.outputs.common-changed == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -163,13 +195,17 @@ jobs:
   # kotlin-e2e:
   #   name: Kotlin E2E
   #   needs: [detect-changes, setup]
-  #   if: needs.detect-changes.outputs.source-changed == 'true'
+  #   if: >-
+  #     needs.detect-changes.outputs.kotlin-changed == 'true' ||
+  #     needs.detect-changes.outputs.common-changed == 'true'
   #   ...
 
   swift-e2e:
     name: Swift E2E
     needs: [detect-changes, setup]
-    if: needs.detect-changes.outputs.source-changed == 'true'
+    if: >-
+      needs.detect-changes.outputs.swift-changed == 'true' ||
+      needs.detect-changes.outputs.common-changed == 'true'
     runs-on: macos-15
     timeout-minutes: 20
     steps:
@@ -255,7 +291,8 @@ jobs:
     name: Dart E2E (sandbox)
     needs: [detect-changes, dart-e2e]
     if: >-
-      needs.detect-changes.outputs.source-changed == 'true' &&
+      (needs.detect-changes.outputs.dart-changed == 'true' ||
+       needs.detect-changes.outputs.common-changed == 'true') &&
       (github.event_name == 'workflow_dispatch' ||
        github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
@@ -388,7 +425,8 @@ jobs:
     name: Swift E2E (sandbox)
     needs: [detect-changes, swift-e2e]
     if: >-
-      needs.detect-changes.outputs.source-changed == 'true' &&
+      (needs.detect-changes.outputs.swift-changed == 'true' ||
+       needs.detect-changes.outputs.common-changed == 'true') &&
       (github.event_name == 'workflow_dispatch' ||
        github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: macos-15


### PR DESCRIPTION

## Problem

Native E2E suite was running on changes to ANY file under /native

**Issue #, if available:**

## Changes

Split the single source-changed flag into per-platform outputs (dart-changed, kotlin-changed, swift-changed) plus a shared common-changed for infra that affects all platforms (the native-bindings test backend and this workflow file).

Each platform's e2e jobs now gate on its own flag OR common, so a Dart-only change no longer runs the Swift suite and vice versa.

## Validation

ci will be the test as this is an actions run

## Checklist

- [ ] PR description included
- [ ] Tests are changed or added
- [ ] Relevant documentation is changed or added (and PR referenced)

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
