### PR TITLE
chore(swift): implement Swift SDK release process

### DIFF
--- a/.github/workflows/publish-swift.yml
+++ b/.github/workflows/publish-swift.yml
@@ -1,0 +1,181 @@
+name: Publish Swift SDK
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: publish-swift
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  build-and-test:
+    name: Build & Test
+    runs-on: macos-15
+    defaults:
+      run:
+        working-directory: native/swift
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build
+        run: swift build
+
+      - name: Run unit tests
+        run: swift test --filter "BlocksCodegenTests|BlocksRuntimeTests"
+
+      - name: Build for iOS
+        run: xcodebuild build -scheme aws-blocks-swift-Package -destination 'platform=iOS Simulator,name=iPhone 16'
+
+      - name: Run unit tests on iOS
+        run: xcodebuild test -scheme aws-blocks-swift-Package -destination 'platform=iOS Simulator,name=iPhone 16' -only-testing BlocksCodegenTests -only-testing BlocksRuntimeTests
+
+  create-release-prs:
+    name: Create Release PRs
+    needs: build-and-test
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: native/swift
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.OPS_GITHUB_TOKEN }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+          cache-dependency-path: native/swift/package-lock.json
+
+      - name: Install changeset CLI
+        run: npm ci
+
+      - name: Verify pending changesets
+        run: npx changeset status --since=origin/main
+
+      - name: Run changeset version
+        env:
+          GITHUB_TOKEN: ${{ secrets.OPS_GITHUB_TOKEN }}
+        run: npx changeset version
+
+      - name: Read version
+        id: version
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Swift SDK version: $VERSION"
+
+      - name: Guard against existing release branch
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          if git ls-remote --heads origin "release/swift-${VERSION}" | grep -q .; then
+            echo "::error::Release branch release/swift-${VERSION} already exists."
+            exit 1
+          fi
+
+      - name: Read CHANGELOG entry
+        id: changelog
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          ENTRY=$(./scripts/extract-changelog.sh CHANGELOG.md "$VERSION")
+          echo "entry<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$ENTRY" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+
+      - name: Create monorepo release PR
+        env:
+          GH_TOKEN: ${{ secrets.OPS_GITHUB_TOKEN }}
+        working-directory: .
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          BRANCH="release/swift-${VERSION}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git checkout -b "$BRANCH"
+          git add -A
+          git commit -m "chore(swift): release ${VERSION}"
+          git push origin "$BRANCH"
+
+          gh pr create \
+            --title "chore(swift): release ${VERSION}" \
+            --body "$(cat <<EOF
+          ## Swift SDK Release ${VERSION}
+
+          ${{ steps.changelog.outputs.entry }}
+
+          On merge, this will be tagged \`swift@${VERSION}\` and synced to aws-blocks-swift.
+          EOF
+          )"
+
+      - name: Checkout aws-blocks-swift
+        uses: actions/checkout@v4
+        with:
+          repository: aws-devtools-labs/aws-blocks-swift
+          path: target-repo
+          token: ${{ secrets.OPS_GITHUB_TOKEN }}
+
+      - name: Sync files to aws-blocks-swift
+        run: |
+          # Remove synced content (preserve repo-only files)
+          find ../../target-repo -maxdepth 1 \
+            -not -name '.git' \
+            -not -name '.github' \
+            -not -name 'LICENSE' \
+            -not -name 'NOTICE' \
+            -not -name 'CODE_OF_CONDUCT.md' \
+            -not -name 'CONTRIBUTING.md' \
+            -not -name '.' \
+            -not -name '..' \
+            -exec rm -rf {} +
+
+          # Copy native/swift contents to target repo root
+          rsync -a --exclude='.changeset' \
+                   --exclude='node_modules' \
+                   --exclude='.build' \
+                   --exclude='package.json' \
+                   --exclude='package-lock.json' \
+                   --exclude='Demo/typescript-demo/node_modules' \
+                   ./ ../../target-repo/
+
+      - name: Create aws-blocks-swift release PR
+        working-directory: target-repo
+        env:
+          GH_TOKEN: ${{ secrets.OPS_GITHUB_TOKEN }}
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          BRANCH="release/${VERSION}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git checkout -b "$BRANCH"
+          git add -A
+
+          if git diff --cached --quiet; then
+            echo "::error::No changes to sync"
+            exit 1
+          fi
+
+          git commit -m "chore: release ${VERSION}"
+          git push origin "$BRANCH"
+
+          gh pr create \
+            --title "chore: release ${VERSION}" \
+            --body "$(cat <<EOF
+          ## Release ${VERSION}
+
+          ${{ steps.changelog.outputs.entry }}
+
+          Synced from aws-blocks monorepo branch \`release/swift-${VERSION}\`.
+
+          On merge, a git tag \`${VERSION}\` will be created automatically and a GitHub Release published. Swift Package Manager will pick up the new version via the tag.
+          EOF
+          )"

--- a/.github/workflows/publish-swift.yml
+++ b/.github/workflows/publish-swift.yml
@@ -151,7 +151,7 @@ jobs:
           GH_TOKEN: ${{ secrets.OPS_GITHUB_TOKEN }}
         run: |
           VERSION="${{ steps.version.outputs.version }}"
-          BRANCH="release/${VERSION}"
+          BRANCH="release/swift-${VERSION}"
 
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/publish-tag-swift-release.yml
+++ b/.github/workflows/publish-tag-swift-release.yml
@@ -1,0 +1,36 @@
+name: Tag Swift Release
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    name: Tag swift@x.y.z
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/swift-')
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Extract version from branch name
+        id: version
+        run: |
+          BRANCH="${{ github.event.pull_request.head.ref }}"
+          VERSION="${BRANCH#release/swift-}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Tagging swift@${VERSION}"
+
+      - name: Create tag
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+
+          git config user.name "AWS Blocks Team"
+          git config user.email "aws-blocks-team@amazon.com"
+          git tag "swift@${VERSION}" -m "Swift SDK ${VERSION}"
+          git push origin "swift@${VERSION}"

--- a/.github/workflows/publish-tag-swift-release.yml
+++ b/.github/workflows/publish-tag-swift-release.yml
@@ -30,7 +30,7 @@ jobs:
         run: |
           VERSION="${{ steps.version.outputs.version }}"
 
-          git config user.name "AWS Blocks Team"
-          git config user.email "aws-blocks-team@amazon.com"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
           git tag "swift@${VERSION}" -m "Swift SDK ${VERSION}"
           git push origin "swift@${VERSION}"

--- a/native/swift/scripts/extract-changelog.sh
+++ b/native/swift/scripts/extract-changelog.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Extracts the body of a specific version section from CHANGELOG.md.
+#
+# Usage: extract-changelog.sh <changelog-path> <version>
+#
+# Exits 0 with the section body on stdout (blank lines trimmed).
+# Exits 1 if the version heading is not found.
+
+set -euo pipefail
+
+CHANGELOG="${1:?Usage: extract-changelog.sh <changelog-path> <version>}"
+VERSION="${2:?Usage: extract-changelog.sh <changelog-path> <version>}"
+
+if [ ! -f "$CHANGELOG" ]; then
+  echo "Error: file not found: $CHANGELOG" >&2
+  exit 1
+fi
+
+# Extract lines between "## <version>" and the next "## " heading.
+# Uses whole-line match so "0.1" doesn't match "0.1.0".
+BODY=$(awk -v ver="$VERSION" '
+  BEGIN { found=0 }
+  /^## / {
+    if (found) exit
+    if ($0 == "## " ver) { found=1; next }
+  }
+  found { print }
+' "$CHANGELOG")
+
+if [ -z "$BODY" ]; then
+  # Distinguish: heading exists but empty vs heading not found
+  if grep -q "^## ${VERSION}$" "$CHANGELOG"; then
+    exit 0
+  fi
+  echo "Error: version ${VERSION} not found in ${CHANGELOG}" >&2
+  exit 1
+fi
+
+# Trim leading and trailing blank lines
+echo "$BODY" | awk '
+  NF { found=1 }
+  found { lines[++n] = $0 }
+  END {
+    # Trim trailing blanks
+    while (n > 0 && lines[n] == "") n--
+    for (i = 1; i <= n; i++) print lines[i]
+  }
+'

--- a/native/swift/scripts/extract-changelog.test.sh
+++ b/native/swift/scripts/extract-changelog.test.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Tests for extract-changelog.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+EXTRACT="$SCRIPT_DIR/extract-changelog.sh"
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+# Create a sample CHANGELOG
+cat > "$TMPDIR/CHANGELOG.md" <<'CHANGELOG'
+# aws-blocks-swift
+
+## 0.3.0
+
+### Minor Changes
+
+- feat: add realtime cursor tracking
+- feat: add file bucket support
+
+### Patch Changes
+
+- fix: correct cookie handling
+
+## 0.2.0
+
+### Patch Changes
+
+- fix: identifier naming cleanup
+- chore: add SwiftLint configuration
+
+## 0.1.0
+
+- Initial release
+CHANGELOG
+
+PASS=0
+FAIL=0
+
+run_test() {
+  local name="$1"
+  shift
+  if "$@"; then
+    echo "✓ $name"
+    PASS=$((PASS + 1))
+  else
+    echo "✗ $name"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# Case 1: Extract latest version (0.3.0)
+test_latest() {
+  local output
+  output=$("$EXTRACT" "$TMPDIR/CHANGELOG.md" "0.3.0")
+  echo "$output" | grep -q "Minor Changes" || return 1
+  echo "$output" | grep -q "add realtime cursor tracking" || return 1
+  echo "$output" | grep -q "Patch Changes" || return 1
+  echo "$output" | grep -q "correct cookie handling" || return 1
+  # Should NOT contain content from 0.2.0
+  echo "$output" | grep -q "identifier naming" && return 1
+  return 0
+}
+run_test "Case 1: extracts latest (0.3.0) section" test_latest
+
+# Case 2: Extract middle version (0.2.0)
+test_middle() {
+  local output
+  output=$("$EXTRACT" "$TMPDIR/CHANGELOG.md" "0.2.0")
+  echo "$output" | grep -q "identifier naming cleanup" || return 1
+  echo "$output" | grep -q "SwiftLint configuration" || return 1
+  # Should NOT contain content from 0.3.0 or 0.1.0
+  echo "$output" | grep -q "realtime" && return 1
+  echo "$output" | grep -q "Initial release" && return 1
+  return 0
+}
+run_test "Case 2: extracts middle (0.2.0) section" test_middle
+
+# Case 3: Extract oldest version (0.1.0)
+test_oldest() {
+  local output
+  output=$("$EXTRACT" "$TMPDIR/CHANGELOG.md" "0.1.0")
+  echo "$output" | grep -q "Initial release" || return 1
+  return 0
+}
+run_test "Case 3: extracts oldest (0.1.0) section" test_oldest
+
+# Case 4: Unknown version exits non-zero
+test_unknown() {
+  if "$EXTRACT" "$TMPDIR/CHANGELOG.md" "5.5.5" > /dev/null 2>&1; then
+    return 1
+  fi
+  return 0
+}
+run_test "Case 4: unknown version exits non-zero" test_unknown
+
+# Case 5: Partial version match is rejected (0.1 vs 0.1.0)
+test_partial() {
+  if "$EXTRACT" "$TMPDIR/CHANGELOG.md" "0.1" > /dev/null 2>&1; then
+    return 1
+  fi
+  return 0
+}
+run_test "Case 5: partial version match (0.1) is rejected" test_partial
+
+# Case 6: Heading line itself is excluded from output
+test_no_heading() {
+  local output
+  output=$("$EXTRACT" "$TMPDIR/CHANGELOG.md" "0.3.0")
+  echo "$output" | grep -q "^## " && return 1
+  return 0
+}
+run_test "Case 6: heading line excluded from output" test_no_heading
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Problem

<!--
Describe the issue this PR is solving. For trivial changes, a short one-liner is fine.
-->

**Issue #, if available:**
NA

## Changes

- Adds a `publish-swift.yml` workflow that builds/tests the Swift SDK, creates versioned release PRs in both the monorepo and `aws-blocks-swift`, and syncs files between repos
- Adds a `publish-tag-swift-release.yml` workflow that automatically tags `swift@x.y.z` when a release PR merges to main
- Adds `extract-changelog.sh` utility (with tests) to pull version-specific entries from CHANGELOG.md for PR bodies

### Details

The release process is triggered manually via `workflow_dispatch` and:
1. Builds and tests the Swift SDK on macOS (Swift CLI + iOS simulator)
2. Runs `changeset version` to bump versions and generate changelog
3. Creates a release branch + PR in the monorepo (`release/swift-{version}`)
4. Syncs the `native/swift` directory to the public `aws-blocks-swift` repo and creates a corresponding release PR there
5. On merge, a separate workflow tags the commit for Swift Package Manager consumption

### Test plan
- [ ] Trigger `Publish Swift SDK` workflow manually and verify both PRs are created correctly
- [ ] Merge the monorepo release PR and verify the `swift@x.y.z` tag is created
- [ ] Run `native/swift/scripts/extract-changelog.test.sh` to validate changelog extraction

## Checklist

- [x] PR description included
- [x] Tests are changed or added
- [ ] Relevant documentation is changed or added (and PR referenced)

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
