### PR TITLE
fix: recover incomplete PGlite data dirs

### DIFF
--- a/.changeset/pglite-incomplete-data-dir.md
+++ b/.changeset/pglite-incomplete-data-dir.md
@@ -1,0 +1,5 @@
+---
+"@aws-blocks/bb-data": patch
+---
+
+Recover incomplete local PGlite data directories before opening the database so an interrupted first boot does not permanently prevent local dev startup.

--- a/packages/bb-data/src/engines/pglite-engine.test.ts
+++ b/packages/bb-data/src/engines/pglite-engine.test.ts
@@ -194,3 +194,39 @@ test('constructor recovers an incomplete PGlite init directory', async () => {
   assert.strictEqual(corruptDirs.length, 1);
   assert.strictEqual(existsSync(join(TEST_DIR, corruptDirs[0], 'PG_VERSION')), true);
 });
+
+test('constructor recovers a PGlite init directory with empty required directories', async () => {
+  const partial = join(TEST_DIR, 'empty-required-dirs');
+  mkdirSync(join(partial, 'base'), { recursive: true });
+  mkdirSync(join(partial, 'global'), { recursive: true });
+  writeFileSync(join(partial, 'PG_VERSION'), '16\n');
+
+  engine = new PGliteEngine(partial);
+  await engine.execute('CREATE TABLE t (id TEXT PRIMARY KEY)');
+  await engine.execute("INSERT INTO t (id) VALUES ('ok')");
+
+  const rows = await engine.query<{ id: string }>('SELECT id FROM t');
+  assert.deepStrictEqual(rows, [{ id: 'ok' }]);
+  assert.strictEqual(existsSync(join(partial, 'global', 'pg_control')), true);
+
+  const corruptDirs = readdirSync(TEST_DIR).filter((entry) => entry.startsWith('empty-required-dirs.corrupt-'));
+  assert.strictEqual(corruptDirs.length, 1);
+  assert.strictEqual(existsSync(join(TEST_DIR, corruptDirs[0], 'global')), true);
+});
+
+test('constructor recovers a PGlite leaf directory before PG_VERSION is written', async () => {
+  const partial = join(TEST_DIR, 'pre-version-init');
+  mkdirSync(join(partial, 'base'), { recursive: true });
+
+  engine = new PGliteEngine(partial);
+  await engine.execute('CREATE TABLE t (id TEXT PRIMARY KEY)');
+  await engine.execute("INSERT INTO t (id) VALUES ('ok')");
+
+  const rows = await engine.query<{ id: string }>('SELECT id FROM t');
+  assert.deepStrictEqual(rows, [{ id: 'ok' }]);
+  assert.strictEqual(existsSync(join(partial, 'PG_VERSION')), true);
+
+  const corruptDirs = readdirSync(TEST_DIR).filter((entry) => entry.startsWith('pre-version-init.corrupt-'));
+  assert.strictEqual(corruptDirs.length, 1);
+  assert.strictEqual(existsSync(join(TEST_DIR, corruptDirs[0], 'base')), true);
+});

--- a/packages/bb-data/src/engines/pglite-engine.test.ts
+++ b/packages/bb-data/src/engines/pglite-engine.test.ts
@@ -5,7 +5,7 @@ import { test, afterEach } from 'node:test';
 import assert from 'node:assert';
 import { PGliteEngine } from './pglite-engine.js';
 import { DatabaseErrors } from '../errors.js';
-import { rmSync, existsSync } from 'node:fs';
+import { rmSync, existsSync, mkdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 const TEST_DIR = '.bb-data-test-' + process.pid;
@@ -174,4 +174,19 @@ test('constructor does not crash when parent directory is missing', async () => 
   await engine.execute('CREATE TABLE t (id TEXT PRIMARY KEY)');
   const rows = await engine.query('SELECT * FROM t');
   assert.deepStrictEqual(rows, []);
+});
+
+test('constructor recovers an incomplete PGlite init directory', async () => {
+  const partial = join(TEST_DIR, 'partial-init');
+  mkdirSync(partial, { recursive: true });
+  writeFileSync(join(partial, 'PG_VERSION'), '16\n');
+
+  engine = new PGliteEngine(partial);
+  await engine.execute('CREATE TABLE t (id TEXT PRIMARY KEY)');
+  await engine.execute("INSERT INTO t (id) VALUES ('ok')");
+
+  const rows = await engine.query<{ id: string }>('SELECT id FROM t');
+  assert.deepStrictEqual(rows, [{ id: 'ok' }]);
+  assert.strictEqual(existsSync(join(partial, 'base')), true);
+  assert.strictEqual(existsSync(join(partial, 'global')), true);
 });

--- a/packages/bb-data/src/engines/pglite-engine.test.ts
+++ b/packages/bb-data/src/engines/pglite-engine.test.ts
@@ -5,7 +5,7 @@ import { test, afterEach } from 'node:test';
 import assert from 'node:assert';
 import { PGliteEngine } from './pglite-engine.js';
 import { DatabaseErrors } from '../errors.js';
-import { rmSync, existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { rmSync, existsSync, mkdirSync, writeFileSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
 
 const TEST_DIR = '.bb-data-test-' + process.pid;
@@ -189,4 +189,8 @@ test('constructor recovers an incomplete PGlite init directory', async () => {
   assert.deepStrictEqual(rows, [{ id: 'ok' }]);
   assert.strictEqual(existsSync(join(partial, 'base')), true);
   assert.strictEqual(existsSync(join(partial, 'global')), true);
+
+  const corruptDirs = readdirSync(TEST_DIR).filter((entry) => entry.startsWith('partial-init.corrupt-'));
+  assert.strictEqual(corruptDirs.length, 1);
+  assert.strictEqual(existsSync(join(TEST_DIR, corruptDirs[0], 'PG_VERSION')), true);
 });

--- a/packages/bb-data/src/engines/pglite-engine.ts
+++ b/packages/bb-data/src/engines/pglite-engine.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { PGlite } from '@electric-sql/pglite';
-import { existsSync, mkdirSync, unlinkSync } from 'node:fs';
+import { existsSync, mkdirSync, readdirSync, rmSync, unlinkSync } from 'node:fs';
 import { join } from 'node:path';
 import type { DatabaseEngine, TransactionHandle } from '@aws-blocks/data-common';
 import { DatabaseErrors, wrapError } from '../errors.js';
@@ -12,6 +12,15 @@ const PG_UNIQUE_VIOLATION = '23505';
 
 /** PostgreSQL error code class for connection exceptions. */
 const PG_CONNECTION_EXCEPTION_CLASS = '08';
+const PGLITE_REQUIRED_DATA_DIR_ENTRIES = ['PG_VERSION', 'base', 'global'];
+const PGLITE_DATA_DIR_MARKERS = [
+  ...PGLITE_REQUIRED_DATA_DIR_ENTRIES,
+  'pg_wal',
+  'postgresql.conf',
+  'pg_hba.conf',
+  'pg_ident.conf',
+  'postmaster.pid',
+];
 
 /**
  * Translate a PGlite/PostgreSQL error to a standardized DatabaseErrors name.
@@ -53,6 +62,22 @@ function cleanStaleLock(dataDir: string): void {
   }
 }
 
+function hasInitializedPgliteDataDir(dataDir: string): boolean {
+  return PGLITE_REQUIRED_DATA_DIR_ENTRIES.every((entry) => existsSync(join(dataDir, entry)));
+}
+
+function recoverIncompletePgliteDataDir(dataDir: string): void {
+  const entries = readdirSync(dataDir);
+  if (entries.length === 0 || hasInitializedPgliteDataDir(dataDir)) return;
+
+  const looksLikePgliteInit = entries.some((entry) => PGLITE_DATA_DIR_MARKERS.includes(entry));
+  if (!looksLikePgliteInit) return;
+
+  rmSync(dataDir, { recursive: true, force: true });
+  mkdirSync(dataDir, { recursive: true });
+  console.warn(`[PGliteEngine] Recreated incomplete PGlite data directory ${dataDir}`);
+}
+
 /**
  * DatabaseEngine implementation using PGlite (WASM PostgreSQL).
  * Used for local development. Data persists in the specified directory.
@@ -73,6 +98,7 @@ export class PGliteEngine implements DatabaseEngine {
     // boot. Create the full path up front (matches DsqlMockEngine).
     mkdirSync(dataDir, { recursive: true });
     cleanStaleLock(dataDir);
+    recoverIncompletePgliteDataDir(dataDir);
     this.db = new PGlite(dataDir);
   }
 

--- a/packages/bb-data/src/engines/pglite-engine.ts
+++ b/packages/bb-data/src/engines/pglite-engine.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { PGlite } from '@electric-sql/pglite';
+import { randomUUID } from 'node:crypto';
 import { existsSync, mkdirSync, readdirSync, renameSync, unlinkSync } from 'node:fs';
 import { join } from 'node:path';
 import type { DatabaseEngine, TransactionHandle } from '@aws-blocks/data-common';
@@ -12,7 +13,17 @@ const PG_UNIQUE_VIOLATION = '23505';
 
 /** PostgreSQL error code class for connection exceptions. */
 const PG_CONNECTION_EXCEPTION_CLASS = '08';
-const PGLITE_REQUIRED_DATA_DIR_ENTRIES = ['PG_VERSION', 'base', 'global'];
+const PGLITE_INITIALIZED_DATA_DIR_ENTRIES = ['PG_VERSION', 'base', 'global', 'global/pg_control'];
+const PGLITE_DATA_DIR_MARKERS = [
+  'PG_VERSION',
+  'base',
+  'global',
+  'pg_wal',
+  'pg_xact',
+  'postgresql.conf',
+  'postgresql.auto.conf',
+  'postmaster.pid',
+];
 
 /**
  * Translate a PGlite/PostgreSQL error to a standardized DatabaseErrors name.
@@ -55,36 +66,45 @@ function cleanStaleLock(dataDir: string): void {
 }
 
 function hasInitializedPgliteDataDir(dataDir: string): boolean {
-  return PGLITE_REQUIRED_DATA_DIR_ENTRIES.every((entry) => existsSync(join(dataDir, entry)));
+  // PGlite loadTar writes PG_VERSION before the directory tree. Requiring
+  // global/pg_control ensures base/global exist and contain PostgreSQL state.
+  return PGLITE_INITIALIZED_DATA_DIR_ENTRIES.every((entry) => existsSync(join(dataDir, entry)));
+}
+
+function hasInitializedPgliteChildDataDir(dataDir: string, entries: string[]): boolean {
+  return entries.some((entry) => hasInitializedPgliteDataDir(join(dataDir, entry)));
+}
+
+function looksLikePgliteDataDir(entries: string[]): boolean {
+  return entries.some((entry) => PGLITE_DATA_DIR_MARKERS.includes(entry));
+}
+
+function isErrnoException(error: unknown): error is { code?: string } {
+  return typeof error === 'object' && error !== null && 'code' in error;
 }
 
 function nextCorruptDataDir(dataDir: string): string {
   const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
-  let candidate = `${dataDir}.corrupt-${timestamp}`;
-  let suffix = 1;
-  while (existsSync(candidate)) {
-    candidate = `${dataDir}.corrupt-${timestamp}-${suffix}`;
-    suffix++;
-  }
-  return candidate;
+  return `${dataDir}.corrupt-${timestamp}-${process.pid}-${randomUUID().slice(0, 8)}`;
 }
 
 function recoverIncompletePgliteDataDir(dataDir: string): void {
   let entries: string[];
   try {
     entries = readdirSync(dataDir);
-  } catch {
-    return;
+  } catch (error) {
+    if (isErrnoException(error) && error.code === 'ENOENT') return;
+    throw error;
   }
   if (entries.length === 0 || hasInitializedPgliteDataDir(dataDir)) return;
 
-  if (!entries.includes('PG_VERSION')) return;
+  if (!looksLikePgliteDataDir(entries) || hasInitializedPgliteChildDataDir(dataDir, entries)) return;
 
   const corruptDataDir = nextCorruptDataDir(dataDir);
   renameSync(dataDir, corruptDataDir);
   mkdirSync(dataDir, { recursive: true });
-  console.warn(
-    `[PGliteEngine] Moved incomplete PGlite data directory from ${dataDir} to ${corruptDataDir}; created a fresh directory`
+  console.log(
+    `[PGliteEngine] Moved incomplete PGlite data directory from ${dataDir} to ${corruptDataDir}; created a fresh directory. Delete matching .corrupt-* directories when they are no longer needed.`
   );
 }
 
@@ -107,8 +127,8 @@ export class PGliteEngine implements DatabaseEngine {
     // a fresh checkout or `rm -rf .bb-data` would otherwise ENOENT on first
     // boot. Create the full path up front (matches DsqlMockEngine).
     mkdirSync(dataDir, { recursive: true });
-    cleanStaleLock(dataDir);
     recoverIncompletePgliteDataDir(dataDir);
+    cleanStaleLock(dataDir);
     this.db = new PGlite(dataDir);
   }
 

--- a/packages/bb-data/src/engines/pglite-engine.ts
+++ b/packages/bb-data/src/engines/pglite-engine.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { PGlite } from '@electric-sql/pglite';
-import { existsSync, mkdirSync, readdirSync, rmSync, unlinkSync } from 'node:fs';
+import { existsSync, mkdirSync, readdirSync, renameSync, unlinkSync } from 'node:fs';
 import { join } from 'node:path';
 import type { DatabaseEngine, TransactionHandle } from '@aws-blocks/data-common';
 import { DatabaseErrors, wrapError } from '../errors.js';
@@ -13,14 +13,6 @@ const PG_UNIQUE_VIOLATION = '23505';
 /** PostgreSQL error code class for connection exceptions. */
 const PG_CONNECTION_EXCEPTION_CLASS = '08';
 const PGLITE_REQUIRED_DATA_DIR_ENTRIES = ['PG_VERSION', 'base', 'global'];
-const PGLITE_DATA_DIR_MARKERS = [
-  ...PGLITE_REQUIRED_DATA_DIR_ENTRIES,
-  'pg_wal',
-  'postgresql.conf',
-  'pg_hba.conf',
-  'pg_ident.conf',
-  'postmaster.pid',
-];
 
 /**
  * Translate a PGlite/PostgreSQL error to a standardized DatabaseErrors name.
@@ -66,16 +58,34 @@ function hasInitializedPgliteDataDir(dataDir: string): boolean {
   return PGLITE_REQUIRED_DATA_DIR_ENTRIES.every((entry) => existsSync(join(dataDir, entry)));
 }
 
+function nextCorruptDataDir(dataDir: string): string {
+  const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+  let candidate = `${dataDir}.corrupt-${timestamp}`;
+  let suffix = 1;
+  while (existsSync(candidate)) {
+    candidate = `${dataDir}.corrupt-${timestamp}-${suffix}`;
+    suffix++;
+  }
+  return candidate;
+}
+
 function recoverIncompletePgliteDataDir(dataDir: string): void {
-  const entries = readdirSync(dataDir);
+  let entries: string[];
+  try {
+    entries = readdirSync(dataDir);
+  } catch {
+    return;
+  }
   if (entries.length === 0 || hasInitializedPgliteDataDir(dataDir)) return;
 
-  const looksLikePgliteInit = entries.some((entry) => PGLITE_DATA_DIR_MARKERS.includes(entry));
-  if (!looksLikePgliteInit) return;
+  if (!entries.includes('PG_VERSION')) return;
 
-  rmSync(dataDir, { recursive: true, force: true });
+  const corruptDataDir = nextCorruptDataDir(dataDir);
+  renameSync(dataDir, corruptDataDir);
   mkdirSync(dataDir, { recursive: true });
-  console.warn(`[PGliteEngine] Recreated incomplete PGlite data directory ${dataDir}`);
+  console.warn(
+    `[PGliteEngine] Moved incomplete PGlite data directory from ${dataDir} to ${corruptDataDir}; created a fresh directory`
+  );
 }
 
 /**


### PR DESCRIPTION
## Problem

Issue #98 describes a local dev failure mode where `tsx watch` or another restart interrupts PGlite during first-boot initialization. That can leave the local `.bb-data/<fullId>` PostgreSQL directory partially written. On the next boot, `new PGlite(dataDir)` may abort before the dev server reaches `listen()`, so the app stays unreachable until the directory is manually moved or deleted.

## Changes

- Detect incomplete local PGlite data directories before opening PGlite.
- Treat a directory as initialized only after `PG_VERSION`, `base`, `global`, and `global/pg_control` exist.
- Recover partial PGlite leaf directories even when initialization stopped before `PG_VERSION` was written.
- Avoid quarantining parent directories that contain already-initialized PGlite child data directories.
- Move incomplete data directories to a `.corrupt-<timestamp>-<pid>-<suffix>` sidecar instead of deleting them.
- Keep empty directories and already-initialized data directories untouched.
- Add regression tests for partial init directories, including `PG_VERSION`-only, empty `base`/`global`, and pre-`PG_VERSION` leaf states.
- Add a patch changeset for `@aws-blocks/bb-data`.

This is intentionally narrower than deleting any non-empty directory: it only targets leaf directories with PGlite/PostgreSQL markers such as `PG_VERSION`, `base`, `global`, `pg_wal`, or `postgresql.conf`, and it skips parent directories that contain initialized child data directories.

This addresses the PGliteEngine recovery path from #98. It does not attempt to change the `tsx watch` / process-group shutdown behavior that can interrupt first-boot initialization in the first place.

## Validation

Manual before/after reproduction of the corrupt-state symptom:

```text
# Before/failure mode: opening a partial PGlite data dir directly
partial dir contents: PG_VERSION only
result: RuntimeError: unreachable

# After/fixed path: opening the same partial dir through PGliteEngine
[PGliteEngine] Moved incomplete PGlite data directory from .../partial to .../partial.corrupt-...; created a fresh directory. Delete matching .corrupt-* directories when they are no longer needed.
{"rows":[{"id":"ok"}],"hasBase":true,"hasGlobal":true}
```

Automated checks:

```text
npm run build -w packages/bb-data
npm run test -w packages/bb-data
./node_modules/.bin/changeset status --since=origin/main
./node_modules/.bin/tsx scripts/verify-changeset-coverage.ts
git diff --check
git diff --cached --check
```

## Checklist

- [x] PR description included
- [x] Tests are changed or added
- [x] Relevant documentation is changed or added (changeset)

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
