### PR TITLE
fix(core): bind dev server to all interfaces for WSL2 compatibility

### DIFF
--- a/.changeset/fix-wsl-dev-server.md
+++ b/.changeset/fix-wsl-dev-server.md
@@ -1,0 +1,5 @@
+---
+"@aws-blocks/core": patch
+---
+
+fix: bind dev server to all interfaces (0.0.0.0) for WSL2 compatibility

--- a/packages/core/src/scripts/dev-server.ts
+++ b/packages/core/src/scripts/dev-server.ts
@@ -319,7 +319,7 @@ export async function startDevServer(options: DevServerOptions) {
   }
 
   // ── Start listening ────────────────────────────────────────────────────
-  server.listen(port, '127.0.0.1', async () => {
+  server.listen(port, async () => {
     console.log(`AWS Blocks local server running on http://localhost:${port}`);
     buildAndSendEvent({ command: 'dev', state: 'SUCCESS', duration: Date.now() - devStartTime });
 


### PR DESCRIPTION
## Summary

Remove the explicit `127.0.0.1` binding from `server.listen()` so the dev server listens on `0.0.0.0` (all interfaces). This allows Windows browsers to reach the server when running under WSL2, which uses a virtual network adapter that cannot route to `127.0.0.1` inside the Linux VM.

Fixes #121

## Change

```diff
- server.listen(port, '127.0.0.1', async () => {
+ server.listen(port, async () => {
```

When no host is specified, Node.js defaults to `0.0.0.0` ([docs](https://nodejs.org/api/net.html#serverlistenport-host-backlog-callback)), which listens on all available interfaces.

## Precedent

This is consistent with how other frameworks handle dev server binding:

- **Create React App** — binds to all hostnames by default ([docs](https://create-react-app.dev/docs/advanced-configuration/): "By default, the development web server binds to all hostnames on the device (localhost, LAN network address, etc.)")
- **Vite** — supports `--host` / `server.host: true` to bind to `0.0.0.0` for WSL/Docker/LAN access ([docs](https://v7.vite.dev/config/server-options))
- **Next.js** — uses `-H 0.0.0.0` for WSL compatibility ([community guidance](https://nulldog.com/nextjs-development-server-network-access))
- **webpack-dev-server** — recommends `--host 0.0.0.0` for containers and WSL ([docs](https://docs.webpack.js.org/configuration/devserver))

## Scope check

Searched the entire repo for other restrictive `.listen()` bindings in non-test production code:

- `packages/core/src/scripts/dev-server.ts` — **this fix** ✅  
- `scripts/publish/serve-local-registry.ts` — internal CI script, intentionally local-only, not customer-facing

No other customer-facing servers bind restrictively.

## Testing

- Build passes ✅
- Core package tests pass (398 tests) ✅