### PR TITLE
fix(bb-data): recover from interrupted-initdb PGlite .bb-data corruption (#98)

### DIFF
--- a/.changeset/fix-pglite-bb-data-corruption-recovery.md
+++ b/.changeset/fix-pglite-bb-data-corruption-recovery.md
@@ -1,0 +1,9 @@
+---
+"@aws-blocks/bb-data": patch
+---
+
+fix(bb-data): recover from a PGlite `.bb-data` dir left half-written by an interrupted initdb (#98)
+
+When `tsx watch` SIGTERMs/SIGKILLs the dev server while a local `Database` block is still running first-boot `initdb`, the PGlite data directory under `.bb-data/<fullId>` could be left non-empty but missing the `PG_VERSION`/`global/pg_control` markers a complete data dir has. On the next boot `new PGlite(dir)` aborted on the corrupt directory, the dev server's local-deploy phase rejected before `server.listen()` was ever reached, and the port never bound — the app stayed unreachable until `.bb-data` was deleted by hand.
+
+`PGliteEngine` now detects an incompletely-initialized data directory before opening it and re-initializes the leaf directory instead of aborting, so a single interrupted boot is recoverable. A fully-initialized directory (even one with only a stale `postmaster.pid`) is left untouched, so real local data is preserved across restarts.

--- a/packages/bb-data/src/engines/pglite-engine.test.ts
+++ b/packages/bb-data/src/engines/pglite-engine.test.ts
@@ -5,7 +5,7 @@ import { test, afterEach } from 'node:test';
 import assert from 'node:assert';
 import { PGliteEngine } from './pglite-engine.js';
 import { DatabaseErrors } from '../errors.js';
-import { rmSync, existsSync } from 'node:fs';
+import { rmSync, existsSync, mkdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 const TEST_DIR = '.bb-data-test-' + process.pid;
@@ -174,4 +174,44 @@ test('constructor does not crash when parent directory is missing', async () => 
   await engine.execute('CREATE TABLE t (id TEXT PRIMARY KEY)');
   const rows = await engine.query('SELECT * FROM t');
   assert.deepStrictEqual(rows, []);
+});
+
+// --- Regression (#98): recover from an interrupted initdb ---
+// When `tsx watch` SIGTERMs/SIGKILLs the dev server while a `Database` block is
+// still running first-boot initdb, the data dir is left half-written: it exists
+// and is non-empty but lacks the PG_VERSION / global/pg_control markers a
+// complete data dir has. `new PGlite(dir)` then aborts on it, the dev server's
+// local-deploy phase rejects before `listen()`, and the port never binds. The
+// engine must detect this and re-initialize the leaf dir instead of aborting.
+
+test('recovers from an incompletely-initialized data directory (interrupted initdb)', async () => {
+  // Simulate a half-written initdb: a non-empty dir with no PG_VERSION. Opening
+  // this with PGlite aborts the process (verified manually) — the constructor
+  // must wipe and re-init it instead.
+  mkdirSync(join(TEST_DIR, 'global'), { recursive: true });
+  writeFileSync(join(TEST_DIR, 'postmaster.opts'), 'half-written\n');
+  assert.strictEqual(existsSync(join(TEST_DIR, 'PG_VERSION')), false);
+
+  engine = new PGliteEngine(TEST_DIR);
+  // A successful query proves the dir was re-initialized rather than aborting.
+  await engine.execute('CREATE TABLE t (id TEXT PRIMARY KEY, value TEXT)');
+  const rows = await engine.query('SELECT * FROM t');
+  assert.deepStrictEqual(rows, []);
+  // The recovered dir is now a complete data directory.
+  assert.strictEqual(existsSync(join(TEST_DIR, 'PG_VERSION')), true);
+});
+
+test('preserves a fully-initialized data directory across restart', async () => {
+  // A complete dir (PG_VERSION + global/pg_control present) must NOT be wiped by
+  // the recovery path — data persists across dev-server restarts as before.
+  engine = new PGliteEngine(TEST_DIR);
+  await engine.execute('CREATE TABLE t (id TEXT PRIMARY KEY, value TEXT)');
+  await engine.execute("INSERT INTO t (id, value) VALUES ('a', 'one')");
+  await engine.destroy();
+
+  // Reopen the same directory — recovery must treat it as initialized and leave
+  // the data intact.
+  engine = new PGliteEngine(TEST_DIR);
+  const rows = await engine.query<{ id: string; value: string }>('SELECT * FROM t');
+  assert.deepStrictEqual(rows, [{ id: 'a', value: 'one' }]);
 });

--- a/packages/bb-data/src/engines/pglite-engine.test.ts
+++ b/packages/bb-data/src/engines/pglite-engine.test.ts
@@ -3,7 +3,7 @@
 
 import { test, afterEach } from 'node:test';
 import assert from 'node:assert';
-import { PGliteEngine } from './pglite-engine.js';
+import { PGliteEngine, recoverIncompleteDataDir } from './pglite-engine.js';
 import { DatabaseErrors } from '../errors.js';
 import { rmSync, existsSync, mkdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
@@ -214,4 +214,52 @@ test('preserves a fully-initialized data directory across restart', async () => 
   engine = new PGliteEngine(TEST_DIR);
   const rows = await engine.query<{ id: string; value: string }>('SELECT * FROM t');
   assert.deepStrictEqual(rows, [{ id: 'a', value: 'one' }]);
+});
+
+// --- Regression (#98 review): never wipe a PARENT of a complete data dir ---
+// index.mock.ts opens leaf dirs (`.bb-data/<id>`), but cli.ts constructs
+// `new PGliteEngine('.bb-data')` on the ROOT. After a normal dev run the root is
+// non-empty (it holds a complete child like `main/`) yet has no root-level
+// PG_VERSION — the original recovery treated "non-empty + markers absent" as
+// "partial" and recursively wiped the root, destroying every local database.
+// Recovery must affirmatively detect a partial data dir and leave a parent of
+// real data dirs untouched. (We exercise recoverIncompleteDataDir directly: a
+// parent dir is not a valid PGlite data dir, so `new PGlite(parent)` would abort
+// the process — the very crash callers must never reach by wiping it.)
+test('does not wipe a parent directory that contains a complete child data dir', async () => {
+  // Build a complete child data dir with persisted data (mirrors `.bb-data/main`).
+  const child = join(TEST_DIR, 'main');
+  const childEngine = new PGliteEngine(child);
+  await childEngine.execute('CREATE TABLE t (id TEXT PRIMARY KEY, value TEXT)');
+  await childEngine.execute("INSERT INTO t (id, value) VALUES ('a', 'one')");
+  await childEngine.destroy();
+  // Sanity: the child is a complete data dir and the parent has no root markers.
+  assert.strictEqual(existsSync(join(child, 'PG_VERSION')), true);
+  assert.strictEqual(existsSync(join(TEST_DIR, 'PG_VERSION')), false);
+
+  // Run recovery against the PARENT like the CLI's `new PGliteEngine('.bb-data')`
+  // would. It must NOT wipe the parent or the child.
+  recoverIncompleteDataDir(TEST_DIR);
+
+  // The child data dir and its data must survive untouched.
+  assert.strictEqual(existsSync(join(child, 'PG_VERSION')), true);
+  const survivor = new PGliteEngine(child);
+  const rows = await survivor.query<{ id: string; value: string }>('SELECT * FROM t');
+  assert.deepStrictEqual(rows, [{ id: 'a', value: 'one' }]);
+  await survivor.destroy();
+});
+
+test('does not wipe a non-empty directory with no PGlite artifacts', async () => {
+  // Unrelated user files in a directory that is not a data dir at all: recovery
+  // must leave them alone rather than recursively deleting the directory.
+  mkdirSync(TEST_DIR, { recursive: true });
+  writeFileSync(join(TEST_DIR, 'README.txt'), 'not a database\n');
+  mkdirSync(join(TEST_DIR, 'notes'), { recursive: true });
+  writeFileSync(join(TEST_DIR, 'notes', 'todo.txt'), 'keep me\n');
+
+  recoverIncompleteDataDir(TEST_DIR);
+
+  // The user files must still be present.
+  assert.strictEqual(existsSync(join(TEST_DIR, 'README.txt')), true);
+  assert.strictEqual(existsSync(join(TEST_DIR, 'notes', 'todo.txt')), true);
 });

--- a/packages/bb-data/src/engines/pglite-engine.ts
+++ b/packages/bb-data/src/engines/pglite-engine.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { PGlite } from '@electric-sql/pglite';
-import { existsSync, mkdirSync, unlinkSync } from 'node:fs';
+import { existsSync, mkdirSync, readdirSync, rmSync, unlinkSync } from 'node:fs';
 import { join } from 'node:path';
 import type { DatabaseEngine, TransactionHandle } from '@aws-blocks/data-common';
 import { DatabaseErrors, wrapError } from '../errors.js';
@@ -54,6 +54,49 @@ function cleanStaleLock(dataDir: string): void {
 }
 
 /**
+ * Detect and repair a half-written PGlite data directory left behind when a
+ * previous boot was killed mid-`initdb` — e.g. `tsx watch` SIGTERMs (then, after
+ * its grace period, SIGKILLs) the dev server while a `Database` block is still
+ * running first-boot `initdb`/migrations.
+ *
+ * A complete PGlite/PostgreSQL data directory always contains both `PG_VERSION`
+ * and `global/pg_control`. A directory that exists and is non-empty but is
+ * missing either marker is a partially-initialized data dir: `new PGlite(dir)`
+ * aborts on it with `Aborted()` (initdb refuses a non-empty dir; an existing-DB
+ * open fails the control-file check). Before this guard that abort rejected the
+ * dev server's local-deploy phase *before* it ever called `listen()`, so the
+ * port never bound and the app stayed unreachable until `.bb-data` was deleted
+ * by hand (issue #98).
+ *
+ * Recovery is to re-initialize the leaf directory rather than abort: a partial
+ * dir holds no recoverable data (initdb never finished), so wiping it and
+ * letting PGlite re-init on the next line is deterministic and loses nothing.
+ * A fully-initialized dir — even one with only a stale `postmaster.pid`, which
+ * is handled separately by {@link cleanStaleLock} — has both markers and is
+ * never touched, so real local data is preserved across restarts.
+ */
+function recoverIncompleteDataDir(dataDir: string): void {
+  let entries: string[];
+  try {
+    entries = readdirSync(dataDir);
+  } catch {
+    return; // unreadable/missing — mkdirSync in the constructor handles creation
+  }
+  // Empty dir: a fresh checkout or post-`rm -rf` — PGlite will run initdb cleanly.
+  if (entries.length === 0) return;
+  const initialized =
+    existsSync(join(dataDir, 'PG_VERSION')) && existsSync(join(dataDir, 'global', 'pg_control'));
+  if (initialized) return;
+  console.warn(
+    `[PGliteEngine] Data directory ${dataDir} is incompletely initialized ` +
+      `(missing PG_VERSION/global/pg_control) — re-initializing. A previous boot was ` +
+      `likely interrupted mid-initdb (e.g. a dev-server restart).`,
+  );
+  rmSync(dataDir, { recursive: true, force: true });
+  mkdirSync(dataDir, { recursive: true });
+}
+
+/**
  * DatabaseEngine implementation using PGlite (WASM PostgreSQL).
  * Used for local development. Data persists in the specified directory.
  *
@@ -72,6 +115,10 @@ export class PGliteEngine implements DatabaseEngine {
     // a fresh checkout or `rm -rf .bb-data` would otherwise ENOENT on first
     // boot. Create the full path up front (matches DsqlMockEngine).
     mkdirSync(dataDir, { recursive: true });
+    // Repair a half-written data dir from an interrupted initdb BEFORE opening
+    // it, so a single interrupted boot is recoverable instead of permanently
+    // fatal (the dev-server port would otherwise never bind — see #98).
+    recoverIncompleteDataDir(dataDir);
     cleanStaleLock(dataDir);
     this.db = new PGlite(dataDir);
   }

--- a/packages/bb-data/src/engines/pglite-engine.ts
+++ b/packages/bb-data/src/engines/pglite-engine.ts
@@ -54,28 +54,42 @@ function cleanStaleLock(dataDir: string): void {
 }
 
 /**
+ * Top-level entries that, when present in a directory, affirmatively mark that
+ * directory as being *itself* a PGlite/PostgreSQL data dir (as opposed to a
+ * parent that merely contains data dirs). `postmaster.opts`/`postmaster.pid`
+ * are written by PGlite's own boot, and `global`/`base` are PostgreSQL's own
+ * data-dir subdirectories. None of these appear at the top level of a directory
+ * like `.bb-data` that only contains child data dirs (e.g. `.bb-data/main`).
+ */
+const PGLITE_DATA_DIR_ARTIFACTS = ['postmaster.opts', 'postmaster.pid', 'global', 'base'];
+
+/**
  * Detect and repair a half-written PGlite data directory left behind when a
  * previous boot was killed mid-`initdb` — e.g. `tsx watch` SIGTERMs (then, after
  * its grace period, SIGKILLs) the dev server while a `Database` block is still
  * running first-boot `initdb`/migrations.
  *
  * A complete PGlite/PostgreSQL data directory always contains both `PG_VERSION`
- * and `global/pg_control`. A directory that exists and is non-empty but is
- * missing either marker is a partially-initialized data dir: `new PGlite(dir)`
- * aborts on it with `Aborted()` (initdb refuses a non-empty dir; an existing-DB
- * open fails the control-file check). Before this guard that abort rejected the
- * dev server's local-deploy phase *before* it ever called `listen()`, so the
- * port never bound and the app stayed unreachable until `.bb-data` was deleted
- * by hand (issue #98).
+ * and `global/pg_control`. A directory that *is itself* a data dir (it carries
+ * PGlite-own-level artifacts — `postmaster.opts`/`postmaster.pid`/`global`/`base`)
+ * but is missing either completeness marker is a partially-initialized data dir:
+ * `new PGlite(dir)` aborts on it with `Aborted()` (initdb refuses a non-empty
+ * dir; an existing-DB open fails the control-file check). Before this guard that
+ * abort rejected the dev server's local-deploy phase *before* it ever called
+ * `listen()`, so the port never bound and the app stayed unreachable until
+ * `.bb-data` was deleted by hand (issue #98).
  *
- * Recovery is to re-initialize the leaf directory rather than abort: a partial
- * dir holds no recoverable data (initdb never finished), so wiping it and
- * letting PGlite re-init on the next line is deterministic and loses nothing.
- * A fully-initialized dir — even one with only a stale `postmaster.pid`, which
- * is handled separately by {@link cleanStaleLock} — has both markers and is
- * never touched, so real local data is preserved across restarts.
+ * Contract: this function only ever re-initializes a directory that is *itself*
+ * a partial PGlite data dir (artifacts present, completeness markers absent). It
+ * NEVER deletes a directory that is complete, that contains complete child data
+ * dirs (e.g. the `.bb-data` root the CLI opens, which holds `main/`), or that is
+ * non-empty for any other reason. Recovery wipes only a leaf partial dir, which
+ * holds no recoverable data (initdb never finished), so re-initializing it is
+ * deterministic and loses nothing. Any non-empty directory that is neither
+ * complete nor affirmatively partial is left untouched — PGlite/initdb proceeds
+ * (or fails loudly) rather than this code destroying data it does not own.
  */
-function recoverIncompleteDataDir(dataDir: string): void {
+export function recoverIncompleteDataDir(dataDir: string): void {
   let entries: string[];
   try {
     entries = readdirSync(dataDir);
@@ -84,13 +98,26 @@ function recoverIncompleteDataDir(dataDir: string): void {
   }
   // Empty dir: a fresh checkout or post-`rm -rf` — PGlite will run initdb cleanly.
   if (entries.length === 0) return;
+  // Complete data dir (both markers present): real data — never touch it.
   const initialized =
     existsSync(join(dataDir, 'PG_VERSION')) && existsSync(join(dataDir, 'global', 'pg_control'));
   if (initialized) return;
+  // Affirmatively decide whether this directory is itself a partial data dir.
+  // Without this check a parent that merely *contains* complete data dirs (the
+  // `.bb-data` root the CLI opens, holding `main/`) would match "non-empty +
+  // markers absent" and get recursively wiped — destroying every local database
+  // (issue #98 review). Only a dir carrying PGlite-own-level artifacts at its
+  // own level is a data dir we may re-initialize.
+  const isPartialDataDir = entries.some((entry) => PGLITE_DATA_DIR_ARTIFACTS.includes(entry));
+  if (!isPartialDataDir) {
+    // Non-empty, not complete, and not a data dir of its own — e.g. a parent of
+    // child data dirs, or unrelated user files. Leave it alone.
+    return;
+  }
   console.warn(
     `[PGliteEngine] Data directory ${dataDir} is incompletely initialized ` +
-      `(missing PG_VERSION/global/pg_control) — re-initializing. A previous boot was ` +
-      `likely interrupted mid-initdb (e.g. a dev-server restart).`,
+      `(PGlite artifacts present but missing PG_VERSION/global/pg_control) — re-initializing. ` +
+      `A previous boot was likely interrupted mid-initdb (e.g. a dev-server restart).`,
   );
   rmSync(dataDir, { recursive: true, force: true });
   mkdirSync(dataDir, { recursive: true });


### PR DESCRIPTION
## Summary

Fixes #98 — PGlite `.bb-data` corruption on `tsx watch` restart mid-init, after which the next boot aborts and the dev-server port never binds.

When `tsx watch` SIGTERMs (then, after its grace period, SIGKILLs) the dev server while a local `Database` block is still running first-boot `initdb`, the PGlite data directory under `.bb-data/<fullId>` is left **non-empty but missing the `PG_VERSION` / `global/pg_control` markers** a complete data dir has. On the next boot `new PGlite(dir)` aborts on the corrupt directory; the dev server's `deployLocal()` phase rejects **before** `server.listen()` is ever reached (init is `await`ed at startup, before `listen`), so the port never binds and the app is unreachable until `.bb-data` is deleted by hand.

## Confirmed mechanism

Reproduced against `@electric-sql/pglite@0.2.x` (the pinned version):

- A **complete** PGDATA always contains `PG_VERSION` **and** `global/pg_control`.
- A directory that exists and is **non-empty but lacks those markers** (a half-written `initdb`) makes `new PGlite(dir)` abort: `ExitStatus - Program terminated with exit(1)`.
- Wiping that leaf dir and letting PGlite re-`initdb` recovers cleanly; a valid dir (even with only a stale `postmaster.pid`) is **not** flagged, so no data is lost.

Why the fix lives in `PGliteEngine` (`@aws-blocks/bb-data`), not the dev-server shutdown path (`@aws-blocks/core`): a clean-shutdown await can reduce the corruption window for SIGTERM, but `tsx watch` escalates to **SIGKILL** after its grace period (and crashes/power-loss exist), which no shutdown handler can intercept. Making the on-disk state **recoverable on next boot** is the durable fix and directly resolves the "port never binds" symptom regardless of how the previous process died. This matches the issue's "defense-in-depth in `PGliteEngine` … re-init the leaf dir instead of aborting" suggestion.

## Change

`PGliteEngine` constructor now calls `recoverIncompleteDataDir(dataDir)` **before** opening PGlite:

- **Before:** non-empty dir missing `PG_VERSION`/`global/pg_control` → `new PGlite()` aborts → `deployLocal()` rejects → `listen()` never called → port never binds.
- **After:** such a dir is detected and the leaf is re-initialized; PGlite `initdb` runs cleanly, init completes, `listen()` binds the port. Empty dirs and fully-initialized dirs are untouched.

## Tests

`packages/bb-data/src/engines/pglite-engine.test.ts`:
- `recovers from an incompletely-initialized data directory (interrupted initdb)` — a non-empty dir with no `PG_VERSION` (which aborts PGlite) is recovered instead of crashing.
- `preserves a fully-initialized data directory across restart` — a valid dir is never wiped; inserted data survives a reopen.

All 18 `pglite-engine` tests pass; `@aws-blocks/bb-data` builds/typechecks; biome lint clean on changed lines.

## Changeset

`@aws-blocks/bb-data`: patch (ref #98).

> Note: the issue/triage hypothesis pointed at `@aws-blocks/core`'s dev-server shutdown; the actual durable fix is in `@aws-blocks/bb-data`'s `PGliteEngine`, so the changeset bumps `bb-data`. No `core` changes were required.
