### PR TITLE
docs(bb-auth-oidc): document broadcastAuthChange → onAuthChange bridge for SPAs (closes #79)

### DIFF
--- a/.changeset/issue-79-onauthchange-bridge-docs.md
+++ b/.changeset/issue-79-onauthchange-bridge-docs.md
@@ -1,0 +1,9 @@
+---
+"@aws-blocks/bb-auth-oidc": patch
+---
+
+docs(bb-auth-oidc): document the `broadcastAuthChange` → `onAuthChange` bridge for SPAs (#79)
+
+`handleRedirectCallback()` notifies only the OIDC client's own `onAuthStateChange` subscribers, not `@aws-blocks/auth-common`'s `onAuthChange(...)` / `<AuthenticatedContent>`. A React SPA using the client-PKCE redirect flow must call `broadcastAuthChange(user)` after a successful callback for auth-aware components to re-render. The README now documents this wiring with an end-to-end OIDC + React SPA example, and new unit tests pin the documented behavior (the callback alone does not reach `onAuthChange`; `broadcastAuthChange` does; a failed callback broadcasts nothing).
+
+This is the remaining part (c) of #79; the `signIn()` error-surfacing (a) and `handleRedirectCallback()` idempotency (b) parts shipped earlier.

--- a/packages/bb-auth-oidc/README.md
+++ b/packages/bb-auth-oidc/README.md
@@ -69,6 +69,41 @@ auth.signIn('google', { redirectPath: '/auth-return' });
 - **Client PKCE** (`auth.signIn()` above): the browser handles the callback and POSTs to `/aws-blocks/auth/exchange`. Use it for SPAs, and required when the frontend and API are on **different origins**. Same-origin SPAs can use it too, but must pass a frontend `redirectPath` (the default current-page redirect avoids the backend `/aws-blocks/auth/callback`).
 - **Relay** (native/CLI): see [Native sign-in](#relay-flow-for-native-sign-in).
 
+### Re-rendering your UI after sign-in (React SPA)
+
+`auth.handleRedirectCallback()` completes the PKCE exchange and notifies this client's own `onAuthStateChange` subscribers — but it does **not** drive `@aws-blocks/auth-common`'s `onAuthChange(...)` or `<AuthenticatedContent>`. Those react only to `broadcastAuthChange(...)`. So a SPA that signs in through the client-PKCE redirect must announce the result itself, or auth-aware components won't update until the next full reload:
+
+```tsx
+import { useEffect, useState } from 'react';
+import { onAuthChange, broadcastAuthChange } from '@aws-blocks/auth-common/ui';
+import type { AuthUser } from '@aws-blocks/auth-common';
+import { authApi } from 'aws-blocks';
+
+// The page the IdP redirects back to: finish the exchange, then announce it.
+function AuthCallback() {
+	useEffect(() => {
+		authApi.getClient()
+			.then((auth) => auth.handleRedirectCallback())
+			.then((user) => { if (user) broadcastAuthChange(user); })
+			// signIn()/handleRedirectCallback() reject on failure — surface it,
+			// don't let it become a silent unhandled rejection.
+			.catch((err) => { console.error('OIDC sign-in failed', err); });
+	}, []);
+	return <p>Signing you in…</p>;
+}
+
+// Anywhere that renders auth-aware UI re-renders on the broadcast.
+function useCurrentUser(): AuthUser | null {
+	const [user, setUser] = useState<AuthUser | null>(null);
+	useEffect(() => onAuthChange(authApi, setUser), []);
+	return user;
+}
+```
+
+`broadcastAuthChange(user)` fires a same-window event **and** posts to the cross-tab `BroadcastChannel`, so every `onAuthChange` subscriber — in this tab and others — re-renders. Running the callback from an effect is safe under React StrictMode: a double-mount shares the one in-flight exchange instead of replaying the single-use PKCE code, so it never throws or strands the page. Attach a `.catch()` (or `await` inside `try/catch`) so a failed exchange surfaces instead of silently no-op'ing.
+
+> The server-initiated flow (the `<Authenticator>` button / `GET …/signin/<provider>`) broadcasts from the backend callback already, so it needs none of this — the manual `broadcastAuthChange` step applies only to the client-PKCE `signIn()` path.
+
 ## What the BB provisions
 
 Adding `AuthOIDC` to your app provisions:

--- a/packages/bb-auth-oidc/src/index.browser.test.ts
+++ b/packages/bb-auth-oidc/src/index.browser.test.ts
@@ -3,6 +3,7 @@
 
 import { describe, test, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert';
+import { onAuthChange, broadcastAuthChange } from '@aws-blocks/auth-common/ui';
 import { AuthOIDCClient, resolveApiBaseOrigin } from './index.browser.js';
 
 /**
@@ -416,5 +417,125 @@ describe('AuthOIDCClient.handleRedirectCallback — idempotency under double inv
 		assert.ok(retry, 'a fresh-code flow resolves — the guard was released after the failure');
 		assert.strictEqual(retry!.userId, 'iss:sub');
 		assert.strictEqual(exchangeCalls, 2, 'the fresh flow runs its own second exchange');
+	});
+});
+
+describe('AuthOIDCClient.handleRedirectCallback — @aws-blocks/auth-common bridge (#79)', () => {
+	// The browser client notifies only its OWN onAuthStateChange subscribers, not
+	// auth-common's onAuthChange / <AuthenticatedContent>. The README documents
+	// that a SPA must announce a client-PKCE sign-in with broadcastAuthChange().
+	// These tests pin that documented wiring against the real auth-common module.
+	const STATE = 'state-bridge';
+	const BARE_USER = { userId: 'iss:sub', username: 'alice', email: 'alice@example.invalid', provider: 'google' };
+	let originalFetch: typeof globalThis.fetch;
+	let originalBroadcastChannel: typeof globalThis.BroadcastChannel;
+
+	/**
+	 * Install a `window` that is a real `EventTarget` — so broadcastAuthChange's
+	 * `dispatchEvent` and onAuthChange's `addEventListener` genuinely wire up —
+	 * carrying the `location` the callback reads its `?code=&state=` from.
+	 */
+	function installEventTargetWindow(href: string): void {
+		const url = new URL(href);
+		const target = new EventTarget() as EventTarget & { location: unknown };
+		(target as any).location = { get href() { return href; }, origin: url.origin, pathname: url.pathname };
+		(globalThis as any).window = target;
+		(globalThis as any).location = (target as any).location;
+		store = new Map<string, string>();
+		(globalThis as any).sessionStorage = {
+			getItem: (k: string) => store.get(k) ?? null,
+			setItem: (k: string, v: string) => { store.set(k, v); },
+			removeItem: (k: string) => { store.delete(k); },
+		};
+	}
+
+	beforeEach(() => {
+		// A real BroadcastChannel is a ref'd handle that keeps `node --test` alive;
+		// stub it with an in-memory no-op. The same-window delivery path is what we
+		// assert, and broadcastAuthChange drives that via a window CustomEvent.
+		originalBroadcastChannel = globalThis.BroadcastChannel;
+		(globalThis as any).BroadcastChannel = class {
+			constructor(public name: string) {}
+			postMessage(): void {}
+			addEventListener(): void {}
+			removeEventListener(): void {}
+			close(): void {}
+		};
+		installEventTargetWindow(`http://localhost:3000/spa-callback?code=auth-code-bridge&state=${STATE}`);
+		process.env.BLOCKS_API_URL = 'http://localhost:3000/aws-blocks/api';
+		store.set('__blocks_oidc_pending', JSON.stringify({
+			provider: 'google', verifier: 'v', state: STATE, nonce: 'n',
+			callbackUrl: 'http://localhost:3000/spa-callback', appState: 'app-state',
+		}));
+		originalFetch = globalThis.fetch;
+		globalThis.fetch = (async () => ({ ok: true, json: async () => ({ user: BARE_USER }) })) as unknown as typeof globalThis.fetch;
+	});
+
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+		globalThis.BroadcastChannel = originalBroadcastChannel;
+		delete process.env.BLOCKS_API_URL;
+		delete (globalThis as any).window;
+		delete (globalThis as any).location;
+		delete (globalThis as any).sessionStorage;
+	});
+
+	/** The minimal AuthStateApi shape that `auth.createApi()` exposes (getAuthState/setAuthState). */
+	function makeAuthStateApi() {
+		return {
+			getAuthState: async () => ({ user: null }),
+			setAuthState: async () => ({ user: null }),
+		};
+	}
+
+	test('the callback alone does NOT reach onAuthChange; broadcastAuthChange(user) does (documented SPA wiring)', async () => {
+		const api = makeAuthStateApi();
+		const seen: unknown[] = [];
+		const unsubscribe = onAuthChange(api as any, (u) => { seen.push(u); });
+
+		const client = makeClient();
+		const user = await client.handleRedirectCallback();
+		assert.ok(user, 'callback should resolve the signed-in user');
+		assert.strictEqual(user!.userId, 'iss:sub');
+
+		// Completing the OIDC exchange notifies only the client's own subscribers —
+		// auth-common's onAuthChange consumers must NOT have seen the user yet. This
+		// is exactly the gap the README's broadcastAuthChange step closes.
+		assert.ok(
+			!seen.some((u) => (u as any)?.userId === 'iss:sub'),
+			'onAuthChange must not observe the user from handleRedirectCallback alone',
+		);
+
+		// The documented step: announce the sign-in.
+		broadcastAuthChange(user as any);
+
+		const delivered = seen.find((u) => (u as any)?.userId === 'iss:sub') as any;
+		assert.ok(delivered, 'onAuthChange subscriber should receive the user after broadcastAuthChange');
+		assert.strictEqual(delivered.username, 'alice');
+
+		unsubscribe();
+	});
+
+	test('a failed callback (state mismatch) must not broadcast a phantom sign-in', async () => {
+		// Mismatch the pending state so the exchange rejects before any user exists.
+		store.set('__blocks_oidc_pending', JSON.stringify({
+			provider: 'google', verifier: 'v', state: 'a-different-state', nonce: 'n',
+			callbackUrl: 'http://localhost:3000/spa-callback',
+		}));
+		const api = makeAuthStateApi();
+		const seen: unknown[] = [];
+		const unsubscribe = onAuthChange(api as any, (u) => { seen.push(u); });
+
+		const client = makeClient();
+		await assert.rejects(client.handleRedirectCallback(), /state mismatch/i);
+
+		// No user resolved → the documented `if (user) broadcastAuthChange(user)`
+		// guard never fires, so onAuthChange consumers never see a phantom user.
+		assert.ok(
+			!seen.some((u) => (u as any)?.userId === 'iss:sub'),
+			'a rejected callback must not surface a signed-in user to onAuthChange',
+		);
+
+		unsubscribe();
 	});
 });


### PR DESCRIPTION
## Problem

Issue #79 reported three independent developer-experience gaps in the `@aws-blocks/bb-auth-oidc` browser client that make OIDC sign-in fail silently in a React SPA. Two of them already shipped:

- **(a) `signIn()` swallowed failures** — fixed in #87 (`signIn` now returns the `Promise`).
- **(b) `handleRedirectCallback()` not idempotent** — fixed in #88 (in-flight guard + up-front single-use consumption, React StrictMode safe).

**(c) the bridge to `@aws-blocks/auth-common` `onAuthChange` is undocumented** — still open, and this PR closes it.

`handleRedirectCallback()` completes the client-PKCE exchange and, on success, notifies **only** this client instance's own `onAuthStateChange` subscribers via the internal `notify(...)`. Components that subscribe through `@aws-blocks/auth-common` — `onAuthChange(...)` and `<AuthenticatedContent>` — react only to `broadcastAuthChange(...)`, so a SPA that signs in via the client-initiated redirect does not re-render after the callback unless it announces the result itself. The README documented `signIn()` / `handleRedirectCallback()` / `redirectPath` but never mentioned `broadcastAuthChange`, `onAuthChange`, or `auth-common`.

## Root cause

`handleRedirectCallback()` → `notify(user, …)` (`packages/bb-auth-oidc/src/index.browser.ts:408`) reaches only the OIDC client's own subscriber set. `onAuthChange`'s local handler (`packages/auth-common/src/ui.ts:242-244`) fires only on the `blocks-auth-change` event that `broadcastAuthChange` (`ui.ts:191-197`) dispatches. Nothing connects the two, and no example showed a SPA the required `broadcastAuthChange(user)` call.

## Fix (minimal, doc-first — matches the issue's prescribed remedy for part (c))

- **`packages/bb-auth-oidc/README.md`**: new **"Re-rendering your UI after sign-in (React SPA)"** section documenting the wiring with an end-to-end OIDC + React example:
  - the callback page runs `handleRedirectCallback()` then `broadcastAuthChange(user)`, with a `.catch()` so a failed exchange surfaces instead of becoming a silent unhandled rejection;
  - components subscribe with `onAuthChange(authApi, setUser)` and re-render on the broadcast (this tab and others);
  - notes that the server-initiated flow already broadcasts and needs none of this.
  The example is grounded in the real API: `auth.createApi()` exposes both `getAuthState`/`setAuthState` (the `AuthStateApi` `onAuthChange` consumes) and `getClient()`.
- **`packages/bb-auth-oidc/src/index.browser.test.ts`**: two new tests in suite *"@aws-blocks/auth-common bridge (#79)"* pinning the documented behavior against the real `auth-common` module:
  - `handleRedirectCallback()` alone does **not** reach an `onAuthChange` subscriber; `broadcastAuthChange(user)` then delivers the signed-in user to it;
  - a failed callback (state mismatch) rejects and broadcasts **no** phantom sign-in.
  The harness backs `window` with a real `EventTarget` and stubs `BroadcastChannel` (a real one is a ref'd handle that would keep `node --test` alive).
- **`.changeset/issue-79-onauthchange-bridge-docs.md`**: patch changeset for `@aws-blocks/bb-auth-oidc`.

No runtime code in `index.browser.ts` or `auth-common/src/ui.ts` is changed.

## Validation

Run on Node 22 (`.nvmrc`):

- `npm run build -w packages/bb-auth-oidc` — clean.
- `npm run test -w packages/bb-auth-oidc` — **108/108 pass** (106 baseline + 2 new), process exits cleanly.
- `biome lint` on the changed `.ts` file — no errors (style warnings only, consistent with the existing file).

## Checklist

- [x] PR description included
- [x] Tests are changed or added
- [x] Relevant documentation is changed or added (and PR referenced)

Closes #79.

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
