### PR TITLE
fix(core): robust dev server — startup port reclaim, singleton guard, :3000 EADDRINUSE handling

### DIFF
--- a/.changeset/dev-server-robustness.md
+++ b/.changeset/dev-server-robustness.md
@@ -1,0 +1,26 @@
+---
+"@aws-blocks/core": patch
+---
+
+fix(core): robust dev server — startup port reclaim, singleton guard, and :3000 EADDRINUSE handling
+
+Hardens the local dev server against the port-contention failure modes that
+survived PR #80 (which fixed only single-supervisor frontend self-restart):
+
+- **Startup reclaim** — a fresh `server.ts` now frees a stale `:3000`/`:3100`
+  listener left by a crashed or `SIGKILL`'d predecessor before it binds the
+  front door / spawns the `--strictPort` frontend, instead of relying on the
+  previous process's `cleanup()` finishing within tsx-watch's ~5s window.
+- **Singleton guard** — a per-port pidfile stops a second `npm run dev` from
+  spawning a competing supervisor that fights the first over `:3000`/`:3100`; it
+  exits cleanly with a clear message. A stable-parent (`tsx watch`) carve-out
+  keeps hot reload working, and a dead-owner pidfile never blocks startup.
+- **`:3000` EADDRINUSE robustness** — the backend front door now emits a real
+  console error (not only telemetry), reclaims the stale owner and retries the
+  bind (bounded), and exits non-zero with a clear message on unrecoverable
+  failure, so a contended `:3000` never silently fails to serve.
+
+Reuses the existing `waitForPortFree` / process-group-kill primitives (plus an
+`lsof`/`netstat` listener probe mirroring the `cleanup` script) — no new
+teardown mechanism. `--strictPort` is retained for local dev, made safe by the
+startup reclaim guaranteeing `:3100` is free first.

--- a/packages/core/src/scripts/dev-server-reclaim.test.ts
+++ b/packages/core/src/scripts/dev-server-reclaim.test.ts
@@ -5,6 +5,7 @@ import assert from 'node:assert';
 import { createServer } from 'node:net';
 import {
   reclaimPort,
+  reclaimMessage,
   evaluatePortBindRetry,
   DEFAULT_PORT_BIND_RETRY_POLICY,
   evaluateSingleton,
@@ -104,6 +105,26 @@ describe('reclaimPort — frees a stale/orphaned port before startup', () => {
     assert.strictEqual(result.reclaimed, true);
   });
 
+  it('SIGKILLs the CURRENT owner, not the stale one, when the port changed hands during the wait', async () => {
+    // The original listener (111) is SIGTERM'd but exits, and a DIFFERENT process
+    // (222) grabs the port before the SIGKILL pass. The escalation must re-list
+    // and target the new owner (222) — never the stale pid (111) it already
+    // signalled — otherwise it SIGKILLs a dead pid and leaves the real owner.
+    const kills: Array<[number, NodeJS.Signals]> = [];
+    let call = 0;
+    const result = await reclaimPort(3000, {
+      // open, still open after SIGTERM (new owner now holds it), free after SIGKILL
+      probe: scriptedProbe([true, true, false]),
+      listPids: () => (call++ === 0 ? [111] : [222]),
+      killTree: (pid, sig) => kills.push([pid, sig]),
+      waitFree: async () => {},
+    });
+    assert.deepStrictEqual(kills, [[111, 'SIGTERM'], [222, 'SIGKILL']]);
+    assert.strictEqual(result.reclaimed, true);
+    // result.pids reflects the initial discovery (what we SIGTERM'd).
+    assert.deepStrictEqual(result.pids, [111]);
+  });
+
   it('reports the port free once its real listener is reclaimed (real sockets, injected kill)', async () => {
     const port = await getFreePort();
     const srv = createServer((c) => c.destroy());
@@ -123,6 +144,25 @@ describe('reclaimPort — frees a stale/orphaned port before startup', () => {
     assert.strictEqual(result.wasOpen, true);
     assert.strictEqual(result.reclaimed, true);
     assert.strictEqual(await isPortOpen(port, '127.0.0.1'), false, 'port should be free after reclaim');
+  });
+});
+
+// ── reclaimMessage — accurate startup reclaim-outcome messaging ──────────────
+describe('reclaimMessage — three-way reclaim outcome message', () => {
+  it('reports success when the port was reclaimed', () => {
+    const msg = reclaimMessage(3000, { wasOpen: true, reclaimed: true, pids: [] }, 'a stale/orphaned listener');
+    assert.match(msg, /Reclaimed port 3000 from a stale\/orphaned listener/);
+  });
+
+  it('names the holding pid(s) when reclaim failed but an owner is known', () => {
+    const msg = reclaimMessage(3100, { wasOpen: true, reclaimed: false, pids: [4242, 4243] }, 'a stale/orphaned dev server');
+    assert.match(msg, /Port 3100 held by pid\(s\) \[4242, 4243\]/);
+    assert.match(msg, /stop that process and retry/);
+  });
+
+  it('falls back to the generic message when reclaim failed with no owner PID', () => {
+    const msg = reclaimMessage(3000, { wasOpen: true, reclaimed: false, pids: [] }, 'a stale/orphaned listener');
+    assert.match(msg, /no owner PID found/);
   });
 });
 

--- a/packages/core/src/scripts/dev-server-reclaim.test.ts
+++ b/packages/core/src/scripts/dev-server-reclaim.test.ts
@@ -1,0 +1,290 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { createServer } from 'node:net';
+import {
+  reclaimPort,
+  evaluatePortBindRetry,
+  DEFAULT_PORT_BIND_RETRY_POLICY,
+  evaluateSingleton,
+  parsePidRecord,
+  isPidAlive,
+  isPortOpen,
+  type DevServerPidRecord,
+} from './dev-server.js';
+import { findListenerPids, killListenerTree } from './process-tree.js';
+
+function getFreePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = createServer();
+    srv.on('error', reject);
+    srv.listen(0, '127.0.0.1', () => {
+      const addr = srv.address();
+      const port = typeof addr === 'object' && addr ? addr.port : 0;
+      srv.close(() => resolve(port));
+    });
+  });
+}
+
+// ── reclaimPort — startup / EADDRINUSE port reclaim policy ──────────────────
+// Fully injected: no real processes are spawned. `probe` is scripted to model
+// the port's open/closed state across the reclaim sequence, so we assert exactly
+// which signals are sent and when it gives up.
+describe('reclaimPort — frees a stale/orphaned port before startup', () => {
+  // reclaimPort probes the port up to three times: (1) initial check,
+  // (2) after the SIGTERM wait, (3) the final reclaimed? check.
+  function scriptedProbe(states: boolean[]): (port: number) => Promise<boolean> {
+    let i = 0;
+    return async () => states[Math.min(i++, states.length - 1)];
+  }
+
+  it('is a no-op when the port is already free (no discovery, no kills)', async () => {
+    const kills: Array<[number, NodeJS.Signals]> = [];
+    let listed = 0;
+    const result = await reclaimPort(3000, {
+      probe: scriptedProbe([false]),
+      listPids: () => { listed++; return [111]; },
+      killTree: (pid, sig) => kills.push([pid, sig]),
+      waitFree: async () => {},
+    });
+    assert.deepStrictEqual(result, { wasOpen: false, reclaimed: true, pids: [] });
+    assert.strictEqual(listed, 0, 'must not discover PIDs when the port is free');
+    assert.deepStrictEqual(kills, []);
+  });
+
+  it('SIGTERMs every listener and reports reclaimed when the port frees gracefully', async () => {
+    const kills: Array<[number, NodeJS.Signals]> = [];
+    const result = await reclaimPort(3100, {
+      // open, then free after SIGTERM, then still free at the final check
+      probe: scriptedProbe([true, false, false]),
+      listPids: () => [4242, 4243],
+      killTree: (pid, sig) => kills.push([pid, sig]),
+      waitFree: async () => {},
+    });
+    assert.deepStrictEqual(kills, [[4242, 'SIGTERM'], [4243, 'SIGTERM']]);
+    assert.deepStrictEqual(result, { wasOpen: true, reclaimed: true, pids: [4242, 4243] });
+  });
+
+  it('escalates to SIGKILL when the listener survives the graceful SIGTERM', async () => {
+    const kills: Array<[number, NodeJS.Signals]> = [];
+    const result = await reclaimPort(3000, {
+      // open, still open after SIGTERM, free after SIGKILL
+      probe: scriptedProbe([true, true, false]),
+      listPids: () => [777],
+      killTree: (pid, sig) => kills.push([pid, sig]),
+      waitFree: async () => {},
+    });
+    assert.deepStrictEqual(kills, [[777, 'SIGTERM'], [777, 'SIGKILL']]);
+    assert.strictEqual(result.reclaimed, true);
+  });
+
+  it('reports reclaimed:false when the port stays bound through SIGKILL', async () => {
+    const result = await reclaimPort(3000, {
+      probe: scriptedProbe([true, true, true]),
+      listPids: () => [777],
+      killTree: () => {},
+      waitFree: async () => {},
+    });
+    assert.strictEqual(result.wasOpen, true);
+    assert.strictEqual(result.reclaimed, false);
+  });
+
+  it('re-discovers listeners for the SIGKILL pass when the first discovery was empty', async () => {
+    const kills: Array<[number, NodeJS.Signals]> = [];
+    let call = 0;
+    const result = await reclaimPort(3000, {
+      probe: scriptedProbe([true, true, false]),
+      // First lsof pass momentarily returns nothing; second finds the owner.
+      listPids: () => (call++ === 0 ? [] : [999]),
+      killTree: (pid, sig) => kills.push([pid, sig]),
+      waitFree: async () => {},
+    });
+    assert.deepStrictEqual(kills, [[999, 'SIGKILL']]);
+    assert.strictEqual(result.reclaimed, true);
+  });
+
+  it('reports the port free once its real listener is reclaimed (real sockets, injected kill)', async () => {
+    const port = await getFreePort();
+    const srv = createServer((c) => c.destroy());
+    await new Promise<void>((res) => srv.listen(port, '127.0.0.1', () => res()));
+
+    assert.strictEqual(await isPortOpen(port, '127.0.0.1'), true, 'port should be held before reclaim');
+
+    // Inject the "kill" as closing our test server so the real probe/waitFree
+    // path is exercised end-to-end without spawning an OS process.
+    let killed = false;
+    const result = await reclaimPort(port, {
+      probe: (p) => isPortOpen(p, '127.0.0.1'),
+      listPids: () => [process.pid],
+      killTree: () => { if (!killed) { killed = true; srv.close(); } },
+    });
+
+    assert.strictEqual(result.wasOpen, true);
+    assert.strictEqual(result.reclaimed, true);
+    assert.strictEqual(await isPortOpen(port, '127.0.0.1'), false, 'port should be free after reclaim');
+  });
+});
+
+// ── evaluatePortBindRetry — bounded :3000 EADDRINUSE retry ───────────────────
+describe('evaluatePortBindRetry — front-door bind retry budget', () => {
+  it('retries early attempts with a linear backoff', () => {
+    assert.deepStrictEqual(evaluatePortBindRetry(1), { retry: true, delayMs: 250 });
+    assert.deepStrictEqual(evaluatePortBindRetry(2), { retry: true, delayMs: 500 });
+  });
+
+  it('gives up (no retry) once the attempt budget is reached', () => {
+    const d = evaluatePortBindRetry(DEFAULT_PORT_BIND_RETRY_POLICY.maxAttempts);
+    assert.deepStrictEqual(d, { retry: false, delayMs: 0 });
+  });
+
+  it('honors a custom policy', () => {
+    const policy = { maxAttempts: 2, backoffMs: 100 };
+    assert.deepStrictEqual(evaluatePortBindRetry(1, policy), { retry: true, delayMs: 100 });
+    assert.deepStrictEqual(evaluatePortBindRetry(2, policy), { retry: false, delayMs: 0 });
+  });
+});
+
+// ── evaluateSingleton — singleton guard decision ────────────────────────────
+// Prevents two fighting supervisors while never blocking a `tsx watch` reload of
+// the SAME supervisor (same parent pid).
+describe('evaluateSingleton — one supervisor per port, hot-reload safe', () => {
+  const rec = (over: Partial<DevServerPidRecord> = {}): DevServerPidRecord => ({
+    pid: 1000,
+    ppid: 500,
+    port: 3000,
+    ...over,
+  });
+  const alive = () => true;
+  const dead = () => false;
+
+  it('proceeds when there is no (or a corrupt) pidfile', () => {
+    assert.deepStrictEqual(evaluateSingleton(null, { pid: 1, ppid: 2 }, true, alive), { action: 'proceed' });
+  });
+
+  it('proceeds on a tsx-watch relaunch of our own supervisor (same parent pid)', () => {
+    // New child, DIFFERENT own pid, but SAME watcher parent → not a competitor.
+    const d = evaluateSingleton(rec({ pid: 1000, ppid: 500 }), { pid: 1001, ppid: 500 }, true, alive);
+    assert.deepStrictEqual(d, { action: 'proceed' });
+  });
+
+  it('exits when a different, live supervisor is actually holding the port', () => {
+    const d = evaluateSingleton(rec({ pid: 1000, ppid: 500, port: 3000 }), { pid: 2000, ppid: 900 }, true, alive);
+    assert.strictEqual(d.action, 'exit');
+    assert.match((d as { reason: string }).reason, /already running on :3000/);
+    assert.match((d as { reason: string }).reason, /pid 1000/);
+  });
+
+  it('proceeds when the recorded owner is dead (stale pidfile), even if the port looks in use', () => {
+    const d = evaluateSingleton(rec({ pid: 1000, ppid: 500 }), { pid: 2000, ppid: 900 }, true, dead);
+    assert.deepStrictEqual(d, { action: 'proceed' });
+  });
+
+  it('proceeds when a different live owner is NOT holding the port (nothing to fight over)', () => {
+    const d = evaluateSingleton(rec({ pid: 1000, ppid: 500 }), { pid: 2000, ppid: 900 }, false, alive);
+    assert.deepStrictEqual(d, { action: 'proceed' });
+  });
+
+  it('treats the owner as alive when only its parent pid is still alive', () => {
+    // Recorded pid gone, but its parent (the watcher) is alive → owner alive.
+    const isAlive = (pid: number) => pid === 500;
+    const d = evaluateSingleton(rec({ pid: 1000, ppid: 500 }), { pid: 2000, ppid: 900 }, true, isAlive);
+    assert.strictEqual(d.action, 'exit');
+  });
+});
+
+// ── parsePidRecord ──────────────────────────────────────────────────────────
+describe('parsePidRecord — tolerant pidfile parsing', () => {
+  it('parses a well-formed record', () => {
+    assert.deepStrictEqual(parsePidRecord('{"pid":12,"ppid":3,"port":3000}'), { pid: 12, ppid: 3, port: 3000 });
+  });
+
+  it('returns null for empty / corrupt JSON', () => {
+    assert.strictEqual(parsePidRecord(''), null);
+    assert.strictEqual(parsePidRecord('not json'), null);
+    assert.strictEqual(parsePidRecord('{'), null);
+  });
+
+  it('returns null when required numeric fields are missing or wrong-typed', () => {
+    assert.strictEqual(parsePidRecord('{"pid":12,"ppid":3}'), null);
+    assert.strictEqual(parsePidRecord('{"pid":"12","ppid":3,"port":3000}'), null);
+    assert.strictEqual(parsePidRecord('{}'), null);
+  });
+});
+
+// ── isPidAlive ──────────────────────────────────────────────────────────────
+describe('isPidAlive — signal-0 liveness probe', () => {
+  it('reports alive when the probe signal succeeds', () => {
+    assert.strictEqual(isPidAlive(4242, () => {}), true);
+  });
+
+  it('reports dead on ESRCH', () => {
+    assert.strictEqual(isPidAlive(4242, () => { throw Object.assign(new Error('ESRCH'), { code: 'ESRCH' }); }), false);
+  });
+
+  it('reports alive on EPERM (exists, not ours to signal)', () => {
+    assert.strictEqual(isPidAlive(4242, () => { throw Object.assign(new Error('EPERM'), { code: 'EPERM' }); }), true);
+  });
+
+  it('rejects non-signalable pids (<= 1) without probing', () => {
+    let probed = false;
+    assert.strictEqual(isPidAlive(1, () => { probed = true; }), false);
+    assert.strictEqual(isPidAlive(0, () => { probed = true; }), false);
+    assert.strictEqual(probed, false);
+  });
+});
+
+// ── findListenerPids — port → listener PID discovery (injected runner) ───────
+describe('findListenerPids — lsof/netstat listener discovery', () => {
+  it('parses the bare PID list from `lsof -ti tcp:<port> -sTCP:LISTEN` on POSIX', () => {
+    const calls: Array<[string, readonly string[]]> = [];
+    const pids = findListenerPids(3100, (cmd, args) => {
+      calls.push([cmd, args]);
+      return { stdout: '4242\n4243\n' };
+    }, 'linux');
+    assert.deepStrictEqual(pids, [4242, 4243]);
+    assert.deepStrictEqual(calls, [['lsof', ['-ti', 'tcp:3100', '-sTCP:LISTEN']]]);
+  });
+
+  it('dedups PIDs and drops non-signalable pids (<= 1)', () => {
+    const pids = findListenerPids(3000, () => ({ stdout: '5\n5\n1\n0\n7\n' }), 'linux');
+    assert.deepStrictEqual(pids, [5, 7]);
+  });
+
+  it('returns [] when nothing is listening (empty stdout / non-zero exit)', () => {
+    assert.deepStrictEqual(findListenerPids(3000, () => ({ stdout: '', status: 1 }), 'linux'), []);
+    assert.deepStrictEqual(findListenerPids(3000, () => ({ stdout: null }), 'linux'), []);
+  });
+
+  it('returns [] when the discovery command cannot run (never throws)', () => {
+    assert.deepStrictEqual(findListenerPids(3000, () => { throw new Error('ENOENT'); }, 'linux'), []);
+  });
+
+  it('parses LISTENING rows for the port from `netstat -ano` on Windows', () => {
+    const stdout = [
+      '  Proto  Local Address          Foreign Address        State           PID',
+      '  TCP    0.0.0.0:3100           0.0.0.0:0              LISTENING       4242',
+      '  TCP    0.0.0.0:3000           0.0.0.0:0              LISTENING       9001', // different port
+      '  TCP    127.0.0.1:3100         127.0.0.1:55123        ESTABLISHED     8888', // not listening
+    ].join('\r\n');
+    const pids = findListenerPids(3100, () => ({ stdout }), 'win32');
+    assert.deepStrictEqual(pids, [4242]);
+  });
+});
+
+// ── killListenerTree — reuses the frontend group-kill on a discovered PID ────
+describe('killListenerTree — reclaim reuses the process-group kill', () => {
+  it('group-signals the discovered PID on POSIX (negative pid)', () => {
+    const group: Array<[number, NodeJS.Signals]> = [];
+    killListenerTree(4242, 'SIGTERM', 'linux', (pid, sig) => group.push([pid, sig]));
+    assert.deepStrictEqual(group, [[-4242, 'SIGTERM']]);
+  });
+
+  it('reaps the tree via taskkill on Windows', () => {
+    const winPids: number[] = [];
+    let groupCalled = false;
+    killListenerTree(4242, 'SIGKILL', 'win32', () => { groupCalled = true; }, (pid) => { winPids.push(pid); return true; });
+    assert.strictEqual(groupCalled, false);
+    assert.deepStrictEqual(winPids, [4242]);
+  });
+});

--- a/packages/core/src/scripts/dev-server-reclaim.test.ts
+++ b/packages/core/src/scripts/dev-server-reclaim.test.ts
@@ -7,12 +7,14 @@ import {
   reclaimPort,
   reclaimMessage,
   evaluatePortBindRetry,
+  createBindRetryController,
   DEFAULT_PORT_BIND_RETRY_POLICY,
   evaluateSingleton,
   parsePidRecord,
   isPidAlive,
   isPortOpen,
   type DevServerPidRecord,
+  type ReclaimResult,
 } from './dev-server.js';
 import { findListenerPids, killListenerTree } from './process-tree.js';
 
@@ -210,9 +212,9 @@ describe('evaluateSingleton — one supervisor per port, hot-reload safe', () =>
 
   it('exits when a different, live supervisor is actually holding the port', () => {
     const d = evaluateSingleton(rec({ pid: 1000, ppid: 500, port: 3000 }), { pid: 2000, ppid: 900 }, true, alive);
-    assert.strictEqual(d.action, 'exit');
-    assert.match((d as { reason: string }).reason, /already running on :3000/);
-    assert.match((d as { reason: string }).reason, /pid 1000/);
+    if (d.action !== 'exit') assert.fail(`expected exit, got ${d.action}`);
+    assert.match(d.reason, /already running on :3000/);
+    assert.match(d.reason, /pid 1000/);
   });
 
   it('proceeds when the recorded owner is dead (stale pidfile), even if the port looks in use', () => {
@@ -326,5 +328,103 @@ describe('killListenerTree — reclaim reuses the process-group kill', () => {
     killListenerTree(4242, 'SIGKILL', 'win32', () => { groupCalled = true; }, (pid) => { winPids.push(pid); return true; });
     assert.strictEqual(groupCalled, false);
     assert.deepStrictEqual(winPids, [4242]);
+  });
+});
+
+// ── createBindRetryController — :3000 EADDRINUSE retry wiring ─────────────────
+// Locks in the retry *wiring* the front-door robustness fix hinges on — the
+// 1-based attempt counter, the bounded decision, reclaim-result routing, and
+// retry scheduling — without a real socket. All effects are injected seams.
+describe('createBindRetryController — bounded EADDRINUSE reclaim-and-rebind', () => {
+  // setImmediate resolves after the microtask queue, so the controller's
+  // `void (async () => { await reclaim(); … scheduleRetry() })()` IIFE has run.
+  const flush = (): Promise<void> => new Promise((r) => setImmediate(r));
+
+  interface Recorder {
+    handler: () => void;
+    reclaimCalls: number;
+    relistenCalls: number;
+    exhaustedCalls: number;
+    scheduled: Array<{ fn: () => void; delayMs: number }>;
+    warnings: string[];
+  }
+
+  function makeController(
+    result: ReclaimResult = { wasOpen: true, reclaimed: true, pids: [] },
+    policy = DEFAULT_PORT_BIND_RETRY_POLICY,
+  ): Recorder {
+    const rec: Recorder = {
+      handler: () => {},
+      reclaimCalls: 0,
+      relistenCalls: 0,
+      exhaustedCalls: 0,
+      scheduled: [],
+      warnings: [],
+    };
+    rec.handler = createBindRetryController(
+      3000,
+      {
+        reclaim: async () => { rec.reclaimCalls += 1; return result; },
+        relisten: () => { rec.relistenCalls += 1; },
+        scheduleRetry: (fn, delayMs) => { rec.scheduled.push({ fn, delayMs }); },
+        onExhausted: () => { rec.exhaustedCalls += 1; },
+        warn: (m) => { rec.warnings.push(m); },
+      },
+      policy,
+    );
+    return rec;
+  }
+
+  it('reclaims and schedules a retry with linear backoff, invoking relisten on the scheduled callback', async () => {
+    const c = makeController();
+
+    c.handler(); // attempt 1
+    await flush();
+    assert.strictEqual(c.reclaimCalls, 1, 'reclaim runs on a retryable attempt');
+    assert.strictEqual(c.exhaustedCalls, 0);
+    assert.strictEqual(c.scheduled.length, 1, 'one retry scheduled');
+    assert.strictEqual(c.scheduled[0].delayMs, 250, 'delay = backoffMs * attempt (250*1)');
+    assert.match(c.warnings[0], /attempt 1\/3/);
+
+    // Firing the scheduled callback must re-attempt the bind (guards against a
+    // refactor dropping the onListening-bound relisten on the retry path).
+    assert.strictEqual(c.relistenCalls, 0, 'relisten deferred until the scheduled callback fires');
+    c.scheduled[0].fn();
+    assert.strictEqual(c.relistenCalls, 1);
+
+    c.handler(); // attempt 2
+    await flush();
+    assert.strictEqual(c.scheduled.length, 2);
+    assert.strictEqual(c.scheduled[1].delayMs, 500, 'delay = backoffMs * attempt (250*2)');
+    assert.match(c.warnings.at(-1) ?? '', /attempt 2\/3/);
+  });
+
+  it('gives up after the attempt budget — no reclaim, no retry scheduled, actionable message', async () => {
+    const c = makeController({ wasOpen: true, reclaimed: true, pids: [] }, { maxAttempts: 2, backoffMs: 100 });
+
+    c.handler(); // attempt 1 → retry
+    await flush();
+    c.handler(); // attempt 2 → budget reached
+    await flush();
+
+    assert.strictEqual(c.exhaustedCalls, 1, 'onExhausted fired exactly once at the budget');
+    assert.strictEqual(c.reclaimCalls, 1, 'no reclaim on the exhausted attempt (only the retryable one)');
+    assert.strictEqual(c.scheduled.length, 1, 'no retry scheduled after exhaustion');
+    assert.match(c.warnings.at(-1) ?? '', /still in use after 2/);
+  });
+
+  it('surfaces the holding pid(s) when a retry reclaim fails to free the port', async () => {
+    const c = makeController({ wasOpen: true, reclaimed: false, pids: [4242] });
+
+    c.handler(); // attempt 1 → retry; reclaim fails
+    await flush();
+
+    assert.ok(
+      c.warnings.some((w) => /held by pid\(s\) \[4242\]/.test(w)),
+      'operator sees the pid-naming reclaim message, not just the generic banner',
+    );
+    // A failed reclaim still schedules the next attempt (the budget, not reclaim
+    // success, bounds the loop).
+    assert.strictEqual(c.scheduled.length, 1);
   });
 });

--- a/packages/core/src/scripts/dev-server.ts
+++ b/packages/core/src/scripts/dev-server.ts
@@ -4,13 +4,14 @@
 import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
 import { pathToFileURL, URL } from 'node:url';
 import { resolve, dirname, join } from 'node:path';
-import { writeFileSync, mkdirSync, readFileSync, unlinkSync } from 'node:fs';
+import { writeFileSync, mkdirSync, readFileSync, unlinkSync, renameSync } from 'node:fs';
 import { spawn, type ChildProcess } from 'node:child_process';
 import { createConnection } from 'node:net';
 import httpProxy from 'http-proxy';
 import { writeClientCode } from './generate-client.js';
 import { ApiError } from '../errors.js';
 import { BLOCKS_RPC_PREFIX, BLOCKS_SANDBOX_PREFIX } from '../constants.js';
+import { BLOCKS_SANDBOX_DIR } from '../common/constants.js';
 import { matchRoute, lockRouteRegistry } from '../raw-route.js';
 import { registerBuiltinRoutes } from '../builtin-routes.js';
 import {
@@ -103,28 +104,44 @@ async function deployLocal(backend: Record<string, any>): Promise<void> {
 }
 
 /**
- * Single-shot TCP probe: resolves `true` iff a connection to `port` on `host`
- * succeeds within `timeoutMs`, else `false` (connection error or timeout).
+ * Single-shot TCP probe: resolves `true` iff a connection to `port` succeeds
+ * within `timeoutMs`, else `false` (connection error or timeout). Never rejects.
+ *
+ * When `host` is omitted the port is probed on BOTH loopback families —
+ * `127.0.0.1` (IPv4) and `::1` (IPv6) — and reported open if EITHER answers.
+ * This matters because `server.listen(port, …)` (below) passes no host, so Node
+ * binds dual-stack on `::` (all interfaces, both families). A single `localhost`
+ * probe resolves to only one of `::1`/`127.0.0.1` on a given host, so an orphan
+ * holding the port on the *other* family would be invisible — leaving the
+ * startup/EADDRINUSE reclaim path blind to a port that `listen` will still
+ * reject. Probing both families keeps every "is the port bound" check in
+ * agreement with what `listen` actually contends for. Pass an explicit `host`
+ * to probe only that address.
+ *
  * Shared by {@link waitForPort} (wait until open), {@link waitForPortFree} (wait
  * until closed) and the startup/EADDRINUSE reclaim path so all three agree on
- * exactly what "the port is bound" means. Never rejects.
+ * exactly what "the port is bound" means.
  */
-export async function isPortOpen(port: number, host = 'localhost', timeoutMs = 200): Promise<boolean> {
-  return new Promise<boolean>((resolve) => {
-    const socket = createConnection({ port, host }, () => {
-      socket.destroy();
-      resolve(true);
+export async function isPortOpen(port: number, host?: string, timeoutMs = 200): Promise<boolean> {
+  const probeOne = (h: string): Promise<boolean> =>
+    new Promise<boolean>((resolve) => {
+      const socket = createConnection({ port, host: h }, () => {
+        socket.destroy();
+        resolve(true);
+      });
+      socket.on('error', () => { socket.destroy(); resolve(false); });
+      socket.setTimeout(timeoutMs, () => { socket.destroy(); resolve(false); });
     });
-    socket.on('error', () => { socket.destroy(); resolve(false); });
-    socket.setTimeout(timeoutMs, () => { socket.destroy(); resolve(false); });
-  });
+  if (host !== undefined) return probeOne(host);
+  const [v4, v6] = await Promise.all([probeOne('127.0.0.1'), probeOne('::1')]);
+  return v4 || v6;
 }
 
 /** Wait for a port to accept TCP connections. */
 async function waitForPort(port: number, maxAttempts = 60): Promise<void> {
   const { setTimeout: sleep } = await import('node:timers/promises');
   for (let i = 0; i < maxAttempts; i++) {
-    if (await isPortOpen(port, 'localhost', 300)) return;
+    if (await isPortOpen(port, undefined, 300)) return;
     await sleep(500);
   }
   throw new Error(`Frontend server on port ${port} did not start within ${maxAttempts * 500}ms`);
@@ -208,7 +225,7 @@ export async function waitForPortFree(port: number, timeoutMs = 2000): Promise<v
   const { setTimeout: sleep } = await import('node:timers/promises');
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
-    if (!(await isPortOpen(port, 'localhost', 200))) return;
+    if (!(await isPortOpen(port, undefined, 200))) return;
     await sleep(100);
   }
 }
@@ -281,6 +298,11 @@ export interface ReclaimPortDeps {
  * peer owns the front door, so anything still holding these ports here is an
  * orphan. Dependencies are injected for tests; returns what it did for
  * logging/assertions. Best-effort: never throws.
+ *
+ * Probe contract: the default `probe` is {@link isPortOpen} with no host, which
+ * checks BOTH `127.0.0.1` and `::1`. `server.listen` binds dual-stack on `::`,
+ * so an orphan holding the port on either loopback family is detected (and thus
+ * reclaimed) — a single-family `localhost` probe could miss it and no-op.
  */
 export async function reclaimPort(port: number, deps: Partial<ReclaimPortDeps> = {}): Promise<ReclaimResult> {
   const probe = deps.probe ?? ((p) => isPortOpen(p));
@@ -358,6 +380,66 @@ export function evaluatePortBindRetry(
 ): { retry: boolean; delayMs: number } {
   if (attempt >= policy.maxAttempts) return { retry: false, delayMs: 0 };
   return { retry: true, delayMs: policy.backoffMs * attempt };
+}
+
+/** Injectable seams for {@link createBindRetryController} (real implementations wired at the call site). */
+export interface BindRetryDeps {
+  /** Reclaim the contended port; its result drives the operator message. */
+  reclaim: (port: number) => Promise<ReclaimResult>;
+  /** Re-attempt the bind (`server.listen(port, onListening)` in prod). */
+  relisten: () => void;
+  /** Schedule the next attempt after a backoff (`setTimeout` in prod). */
+  scheduleRetry: (fn: () => void, delayMs: number) => void;
+  /** Called once the attempt budget is exhausted (`process.exit(1)` in prod). */
+  onExhausted: () => void;
+  /** Warning/error sink (`console.error` in prod). */
+  warn: (msg: string) => void;
+}
+
+/**
+ * Build the `:3000` front-door EADDRINUSE bind-retry handler. Extracted from the
+ * `server.on('error')` closure so the retry *wiring* — the 1-based attempt
+ * counter, the bounded {@link evaluatePortBindRetry} decision, reclaim-result
+ * routing, and retry scheduling — is unit-testable without a real socket.
+ *
+ * Returns a function to invoke on each EADDRINUSE. Per invocation it:
+ *  - increments the attempt counter and consults {@link evaluatePortBindRetry};
+ *  - on exhaustion: warns with an actionable message and calls `onExhausted`
+ *    (no further retry is scheduled);
+ *  - otherwise: warns it is retrying, then (async) reclaims the port and — when
+ *    reclaim did NOT free it — surfaces the {@link reclaimMessage} naming the
+ *    holding pid(s) so the operator isn't left with only the generic banner,
+ *    then schedules the next `relisten` after the decided backoff.
+ * Never throws.
+ */
+export function createBindRetryController(
+  port: number,
+  deps: BindRetryDeps,
+  policy: PortBindRetryPolicy = DEFAULT_PORT_BIND_RETRY_POLICY,
+): () => void {
+  let attempts = 0;
+  return () => {
+    attempts += 1;
+    const decision = evaluatePortBindRetry(attempts, policy);
+    if (!decision.retry) {
+      deps.warn(
+        `\n❌ Port ${port} is still in use after ${policy.maxAttempts} ` +
+        `attempts to reclaim it — another process is holding :${port}. Stop it (or run the ` +
+        `cleanup script) and retry \`npm run dev\`.\n`,
+      );
+      deps.onExhausted();
+      return;
+    }
+    deps.warn(
+      `⚠️  Port ${port} already in use (EADDRINUSE) — reclaiming the stale owner and retrying ` +
+      `(attempt ${attempts}/${policy.maxAttempts})…`,
+    );
+    void (async () => {
+      const result = await deps.reclaim(port);
+      if (!result.reclaimed) deps.warn(reclaimMessage(port, result, 'a stale/orphaned listener'));
+      deps.scheduleRetry(deps.relisten, decision.delayMs);
+    })();
+  };
 }
 
 // ── Singleton guard (pidfile) ──────────────────────────────────────────────
@@ -450,22 +532,42 @@ export async function startDevServer(options: DevServerOptions) {
   // watcher) lets us tell a hot-reload relaunch of OUR OWN script apart from a
   // genuine second invocation — see {@link evaluateSingleton}. A stale pidfile
   // (dead owner) never blocks startup.
-  const pidfilePath = join('.blocks-sandbox', `dev-server.${port}.pid`);
+  const pidfilePath = join(BLOCKS_SANDBOX_DIR, `dev-server.${port}.pid`);
   const removeOwnPidfile = (): void => {
+    // Close the read-check-then-delete TOCTOU: a naive `read → if mine → unlink`
+    // could delete a tsx-watch SUCCESSOR's pidfile if it wrote between our read
+    // and our unlink. Instead we atomically `rename` the current pidfile to a
+    // pid-private path (rename(2) is atomic — a concurrent writer can't observe a
+    // half-state), THEN inspect the snapshot:
+    //   • it's ours        → unlink the private copy (done; a successor that
+    //                         writes a fresh pidfile afterwards is untouched
+    //                         because we never unlink the canonical path).
+    //   • it's a successor → we grabbed its file (it wrote before our rename);
+    //                         put it back so the live successor keeps its guard.
+    // We only ever unlink the private claim, never the canonical path, so a
+    // successor's fresh pidfile is never destroyed.
+    const claimPath = `${pidfilePath}.${process.pid}.gc`;
     try {
-      // Read-then-unlink has a narrow race: a tsx-watch successor could write its
-      // own pidfile between our read and unlink, and we'd delete its file. We only
-      // unlink when the record still points at us, and tsx-watch drains the old
-      // supervisor before relaunching the successor, so the two never overlap here
-      // in practice — the window is benign and not worth locking for.
-      const rec = parsePidRecord(readFileSync(pidfilePath, 'utf-8'));
-      if (rec && rec.pid === process.pid) unlinkSync(pidfilePath);
+      renameSync(pidfilePath, claimPath);
     } catch {
-      // No pidfile, or owned by another process now — leave it alone.
+      return; // No pidfile to remove (already gone / never written).
     }
+    let rec: DevServerPidRecord | null = null;
+    try { rec = parsePidRecord(readFileSync(claimPath, 'utf-8')); } catch { /* unreadable snapshot */ }
+    if (rec && rec.pid !== process.pid) {
+      // Snapshot belongs to a successor — restore it and leave its guard intact.
+      // Residual (astronomically narrow) window: between this rename-away and
+      // rename-back the canonical path briefly has no pidfile, so a THIRD
+      // concurrent start could momentarily see "no guard" and proceed — the same
+      // benign "weakened guard, never broken startup" degradation the write path
+      // already tolerates. tsx-watch drains the old supervisor before relaunching,
+      // so overlap here does not occur in practice.
+      try { renameSync(claimPath, pidfilePath); return; } catch { /* fall through to cleanup */ }
+    }
+    try { unlinkSync(claimPath); } catch { /* already gone */ }
   };
   {
-    mkdirSync('.blocks-sandbox', { recursive: true });
+    mkdirSync(BLOCKS_SANDBOX_DIR, { recursive: true });
     let existing: DevServerPidRecord | null = null;
     try { existing = parsePidRecord(readFileSync(pidfilePath, 'utf-8')); } catch { /* absent */ }
     const portInUse = await isPortOpen(port);
@@ -510,8 +612,8 @@ export async function startDevServer(options: DevServerOptions) {
   // This makes sandbox single-origin, matching `npm run dev` and the prod
   // CloudFront proxy; `crossDomain` stays unnecessary.
   const blocksConfig = buildBlocksConfig(port, isSandbox);
-  mkdirSync('.blocks-sandbox', { recursive: true });
-  writeFileSync('.blocks-sandbox/config.json', JSON.stringify(blocksConfig, null, 2));
+  mkdirSync(BLOCKS_SANDBOX_DIR, { recursive: true });
+  writeFileSync(join(BLOCKS_SANDBOX_DIR, 'config.json'), JSON.stringify(blocksConfig, null, 2));
 
   // 1. Set up global collectors for plugin discovery
   (globalThis as any).__BLOCKS_CLIENT_MIDDLEWARE__ = [];
@@ -843,14 +945,18 @@ export async function startDevServer(options: DevServerOptions) {
   // and a fresh `--strictPort` start would collide and crash. The singleton guard
   // above already ruled out a live *peer* supervisor, so anything still holding
   // these ports is an orphan — reclaim it (see {@link reclaimPort}).
+  // A successful reclaim (♻️) is an informational confirmation → stdout; a
+  // failed reclaim (⚠️) is a warning the operator must act on → stderr. Keeping
+  // healthy-startup output off stderr avoids false alarms in CI pipelines that
+  // treat any stderr line as a failure.
   const r3000 = await reclaimPort(port);
   if (r3000.wasOpen) {
-    console.error(reclaimMessage(port, r3000, 'a stale/orphaned listener'));
+    (r3000.reclaimed ? console.log : console.error)(reclaimMessage(port, r3000, 'a stale/orphaned listener'));
   }
   if (frontendCommand) {
     const rFrontend = await reclaimPort(frontendPort);
     if (rFrontend.wasOpen) {
-      console.error(reclaimMessage(frontendPort, rFrontend, 'a stale/orphaned dev server'));
+      (rFrontend.reclaimed ? console.log : console.error)(reclaimMessage(frontendPort, rFrontend, 'a stale/orphaned dev server'));
     }
   }
 
@@ -873,8 +979,15 @@ export async function startDevServer(options: DevServerOptions) {
   // retry the bind (bounded), and on unrecoverable failure exit non-zero with a
   // clear message so a contended :3000 never silently fails to serve. Startup
   // reclaim above makes this a rare race (someone grabbed :3000 between reclaim
-  // and listen); the retry closes that window.
-  let bindAttempts = 0;
+  // and listen); the retry closes that window. The retry wiring lives in the
+  // testable {@link createBindRetryController}; telemetry stays here.
+  const onEaddrinuse = createBindRetryController(port, {
+    reclaim: (p) => reclaimPort(p),
+    relisten: () => server.listen(port, onListening),
+    scheduleRetry: (fn, delayMs) => { setTimeout(fn, delayMs).unref?.(); },
+    onExhausted: () => process.exit(1),
+    warn: (msg) => console.error(msg),
+  });
   server.on('error', (err: NodeJS.ErrnoException) => {
     if (err.code === 'EADDRINUSE') {
       // Keep the telemetry signal (unchanged) …
@@ -884,24 +997,7 @@ export async function startDevServer(options: DevServerOptions) {
         duration: Date.now() - devStartTime,
         error: { code: 'PORT_IN_USE', phase: 'startup' },
       });
-      bindAttempts += 1;
-      const decision = evaluatePortBindRetry(bindAttempts);
-      if (!decision.retry) {
-        console.error(
-          `\n❌ Port ${port} is still in use after ${DEFAULT_PORT_BIND_RETRY_POLICY.maxAttempts} ` +
-          `attempts to reclaim it — another process is holding :${port}. Stop it (or run the ` +
-          `cleanup script) and retry \`npm run dev\`.\n`,
-        );
-        process.exit(1);
-      }
-      console.error(
-        `⚠️  Port ${port} already in use (EADDRINUSE) — reclaiming the stale owner and retrying ` +
-        `(attempt ${bindAttempts}/${DEFAULT_PORT_BIND_RETRY_POLICY.maxAttempts})…`,
-      );
-      void (async () => {
-        await reclaimPort(port);
-        setTimeout(() => server.listen(port, onListening), decision.delayMs).unref?.();
-      })();
+      onEaddrinuse();
       return;
     }
     // Non-EADDRINUSE startup error: telemetry + a real error, then exit non-zero.

--- a/packages/core/src/scripts/dev-server.ts
+++ b/packages/core/src/scripts/dev-server.ts
@@ -295,13 +295,41 @@ export async function reclaimPort(port: number, deps: Partial<ReclaimPortDeps> =
   await waitFree(port, 2000);
 
   if (await probe(port)) {
-    // Still held after a graceful SIGTERM — escalate to SIGKILL. Re-list in case
-    // the owner set changed (e.g. lsof was momentarily empty on the first pass).
-    for (const pid of pids.length ? pids : listPids(port)) killTree(pid, 'SIGKILL');
+    // Still held after a graceful SIGTERM — escalate to SIGKILL. ALWAYS re-list
+    // first: the owner set can change during the wait — the original process may
+    // have exited and a NEW one grabbed the port, so SIGKILLing the stale `pids`
+    // would miss the real owner. Fall back to the stale list only if the re-list
+    // comes back empty (e.g. lsof was momentarily unavailable).
+    const killPids = listPids(port);
+    for (const pid of killPids.length ? killPids : pids) killTree(pid, 'SIGKILL');
     await waitFree(port, 2000);
   }
 
   return { wasOpen: true, reclaimed: !(await probe(port)), pids };
+}
+
+/**
+ * Build the console message for a startup reclaim of a port that was in use,
+ * distinguishing the three meaningfully different outcomes so the operator knows
+ * what (if anything) to do next:
+ *  - reclaimed → we freed it; startup continues.
+ *  - not reclaimed but owner PID(s) known → tell the operator exactly which
+ *    process(es) to stop and retry.
+ *  - not reclaimed and no owner PID found → nothing to point at (lsof/netstat
+ *    found no listener), so surface the generic "in use" message.
+ * `subject` describes what was reclaimed (e.g. 'a stale/orphaned listener'). Pure.
+ */
+export function reclaimMessage(port: number, result: ReclaimResult, subject: string): string {
+  if (result.reclaimed) {
+    return `♻️  Reclaimed port ${port} from ${subject} before startup.`;
+  }
+  if (result.pids.length > 0) {
+    return (
+      `⚠️  Port ${port} held by pid(s) [${result.pids.join(', ')}] and could not be freed — ` +
+      `stop that process and retry.`
+    );
+  }
+  return `⚠️  Port ${port} is in use and could not be reclaimed automatically (no owner PID found).`;
 }
 
 /** Bounded retry policy for binding the `:3000` front door under EADDRINUSE. */
@@ -425,6 +453,11 @@ export async function startDevServer(options: DevServerOptions) {
   const pidfilePath = join('.blocks-sandbox', `dev-server.${port}.pid`);
   const removeOwnPidfile = (): void => {
     try {
+      // Read-then-unlink has a narrow race: a tsx-watch successor could write its
+      // own pidfile between our read and unlink, and we'd delete its file. We only
+      // unlink when the record still points at us, and tsx-watch drains the old
+      // supervisor before relaunching the successor, so the two never overlap here
+      // in practice — the window is benign and not worth locking for.
       const rec = parsePidRecord(readFileSync(pidfilePath, 'utf-8'));
       if (rec && rec.pid === process.pid) unlinkSync(pidfilePath);
     } catch {
@@ -812,20 +845,12 @@ export async function startDevServer(options: DevServerOptions) {
   // these ports is an orphan — reclaim it (see {@link reclaimPort}).
   const r3000 = await reclaimPort(port);
   if (r3000.wasOpen) {
-    console.error(
-      r3000.reclaimed
-        ? `♻️  Reclaimed port ${port} from a stale/orphaned listener before startup.`
-        : `⚠️  Port ${port} is in use and could not be reclaimed automatically (no owner PID found).`,
-    );
+    console.error(reclaimMessage(port, r3000, 'a stale/orphaned listener'));
   }
   if (frontendCommand) {
     const rFrontend = await reclaimPort(frontendPort);
     if (rFrontend.wasOpen) {
-      console.error(
-        rFrontend.reclaimed
-          ? `♻️  Reclaimed frontend port ${frontendPort} from a stale/orphaned dev server before startup.`
-          : `⚠️  Frontend port ${frontendPort} is in use and could not be reclaimed automatically.`,
-      );
+      console.error(reclaimMessage(frontendPort, rFrontend, 'a stale/orphaned dev server'));
     }
   }
 
@@ -875,7 +900,6 @@ export async function startDevServer(options: DevServerOptions) {
       );
       void (async () => {
         await reclaimPort(port);
-        await waitForPortFree(port);
         setTimeout(() => server.listen(port, onListening), decision.delayMs).unref?.();
       })();
       return;

--- a/packages/core/src/scripts/dev-server.ts
+++ b/packages/core/src/scripts/dev-server.ts
@@ -4,7 +4,7 @@
 import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
 import { pathToFileURL, URL } from 'node:url';
 import { resolve, dirname, join } from 'node:path';
-import { writeFileSync, mkdirSync } from 'node:fs';
+import { writeFileSync, mkdirSync, readFileSync, unlinkSync } from 'node:fs';
 import { spawn, type ChildProcess } from 'node:child_process';
 import { createConnection } from 'node:net';
 import httpProxy from 'http-proxy';
@@ -22,7 +22,7 @@ import {
 import { redactToJson } from '../redact.js';
 import { buildAndSendEvent } from '../telemetry/client.js';
 import { applyDevMigrations } from './external-migrations-step.js';
-import { killFrontendTree, terminateProcessTree } from './process-tree.js';
+import { killFrontendTree, terminateProcessTree, findListenerPids, killListenerTree } from './process-tree.js';
 
 function toBodyStream(text: string): ReadableStream<Uint8Array> | null {
   if (!text) return null;
@@ -102,19 +102,29 @@ async function deployLocal(backend: Record<string, any>): Promise<void> {
   await Promise.all(initPromises);
 }
 
+/**
+ * Single-shot TCP probe: resolves `true` iff a connection to `port` on `host`
+ * succeeds within `timeoutMs`, else `false` (connection error or timeout).
+ * Shared by {@link waitForPort} (wait until open), {@link waitForPortFree} (wait
+ * until closed) and the startup/EADDRINUSE reclaim path so all three agree on
+ * exactly what "the port is bound" means. Never rejects.
+ */
+export async function isPortOpen(port: number, host = 'localhost', timeoutMs = 200): Promise<boolean> {
+  return new Promise<boolean>((resolve) => {
+    const socket = createConnection({ port, host }, () => {
+      socket.destroy();
+      resolve(true);
+    });
+    socket.on('error', () => { socket.destroy(); resolve(false); });
+    socket.setTimeout(timeoutMs, () => { socket.destroy(); resolve(false); });
+  });
+}
+
 /** Wait for a port to accept TCP connections. */
 async function waitForPort(port: number, maxAttempts = 60): Promise<void> {
   const { setTimeout: sleep } = await import('node:timers/promises');
   for (let i = 0; i < maxAttempts; i++) {
-    const connected = await new Promise<boolean>((resolve) => {
-      const socket = createConnection({ port, host: 'localhost' }, () => {
-        socket.destroy();
-        resolve(true);
-      });
-      socket.on('error', () => { socket.destroy(); resolve(false); });
-      socket.setTimeout(300, () => { socket.destroy(); resolve(false); });
-    });
-    if (connected) return;
+    if (await isPortOpen(port, 'localhost', 300)) return;
     await sleep(500);
   }
   throw new Error(`Frontend server on port ${port} did not start within ${maxAttempts * 500}ms`);
@@ -198,15 +208,7 @@ export async function waitForPortFree(port: number, timeoutMs = 2000): Promise<v
   const { setTimeout: sleep } = await import('node:timers/promises');
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
-    const open = await new Promise<boolean>((resolve) => {
-      const socket = createConnection({ port, host: 'localhost' }, () => {
-        socket.destroy();
-        resolve(true);
-      });
-      socket.on('error', () => { socket.destroy(); resolve(false); });
-      socket.setTimeout(200, () => { socket.destroy(); resolve(false); });
-    });
-    if (!open) return;
+    if (!(await isPortOpen(port, 'localhost', 200))) return;
     await sleep(100);
   }
 }
@@ -237,6 +239,172 @@ export function shouldCreditFrontendReady(
   );
 }
 
+// ── Startup / EADDRINUSE port reclaim ──────────────────────────────────────
+
+/** Outcome of {@link reclaimPort}. */
+export interface ReclaimResult {
+  /** Whether the port was bound when reclaim started. */
+  wasOpen: boolean;
+  /** Whether the port is free once reclaim finishes (true when it was never open). */
+  reclaimed: boolean;
+  /** Listener PIDs discovered (and signalled). Empty when the port was free, or no owner PID was found. */
+  pids: number[];
+}
+
+/** Injectable seams for {@link reclaimPort} (real implementations by default). */
+export interface ReclaimPortDeps {
+  /** True iff the port is currently bound. */
+  probe: (port: number) => Promise<boolean>;
+  /** PIDs of the listener(s) holding the port. */
+  listPids: (port: number) => number[];
+  /** Terminate a listener PID's tree (POSIX group kill / Windows taskkill). */
+  killTree: (pid: number, signal: NodeJS.Signals) => void;
+  /** Wait (bounded) for the port to be released. */
+  waitFree: (port: number, timeoutMs?: number) => Promise<void>;
+}
+
+/**
+ * Free a port left bound by a crashed / SIGKILL'd predecessor so a fresh dev
+ * server can bind the `:3000` front door — or spawn its `--strictPort` frontend
+ * on `:3100` — instead of colliding on it and crashing.
+ *
+ * No-op when the port is already free. Otherwise it discovers the listener PID(s)
+ * ({@link findListenerPids}, an `lsof`/`netstat` probe — the same fuser-style
+ * mechanism `cleanup` uses), SIGTERMs each ({@link killListenerTree}, which
+ * reuses the frontend process-group kill), waits (bounded) for release
+ * ({@link waitForPortFree}), then escalates to SIGKILL if the port is still held.
+ * This deliberately mirrors the respawn path (process-group kill + port-free
+ * wait) rather than inventing a new teardown mechanism.
+ *
+ * The caller is responsible for NOT reclaiming a *healthy peer* dev server — the
+ * singleton guard ({@link evaluateSingleton}) runs first and bows out when a live
+ * peer owns the front door, so anything still holding these ports here is an
+ * orphan. Dependencies are injected for tests; returns what it did for
+ * logging/assertions. Best-effort: never throws.
+ */
+export async function reclaimPort(port: number, deps: Partial<ReclaimPortDeps> = {}): Promise<ReclaimResult> {
+  const probe = deps.probe ?? ((p) => isPortOpen(p));
+  const listPids = deps.listPids ?? ((p) => findListenerPids(p));
+  const killTree = deps.killTree ?? ((pid, sig) => killListenerTree(pid, sig));
+  const waitFree = deps.waitFree ?? ((p, t) => waitForPortFree(p, t));
+
+  if (!(await probe(port))) return { wasOpen: false, reclaimed: true, pids: [] };
+
+  const pids = listPids(port);
+  for (const pid of pids) killTree(pid, 'SIGTERM');
+  await waitFree(port, 2000);
+
+  if (await probe(port)) {
+    // Still held after a graceful SIGTERM — escalate to SIGKILL. Re-list in case
+    // the owner set changed (e.g. lsof was momentarily empty on the first pass).
+    for (const pid of pids.length ? pids : listPids(port)) killTree(pid, 'SIGKILL');
+    await waitFree(port, 2000);
+  }
+
+  return { wasOpen: true, reclaimed: !(await probe(port)), pids };
+}
+
+/** Bounded retry policy for binding the `:3000` front door under EADDRINUSE. */
+export interface PortBindRetryPolicy {
+  /** Total bind attempts tolerated before giving up (exit non-zero). */
+  maxAttempts: number;
+  /** Base backoff (ms); scaled by the attempt number between retries. */
+  backoffMs: number;
+}
+
+/** Default front-door bind retry budget: 3 attempts, 250ms→750ms linear backoff. */
+export const DEFAULT_PORT_BIND_RETRY_POLICY: PortBindRetryPolicy = {
+  maxAttempts: 3,
+  backoffMs: 250,
+};
+
+/**
+ * Decide whether an EADDRINUSE on the `:3000` front door should trigger another
+ * reclaim-and-rebind attempt. `attempt` is the number of failures so far
+ * (1-based). Returns `retry: false` once the budget is exhausted so the caller
+ * exits non-zero with a clear message rather than looping forever. Pure.
+ */
+export function evaluatePortBindRetry(
+  attempt: number,
+  policy: PortBindRetryPolicy = DEFAULT_PORT_BIND_RETRY_POLICY,
+): { retry: boolean; delayMs: number } {
+  if (attempt >= policy.maxAttempts) return { retry: false, delayMs: 0 };
+  return { retry: true, delayMs: policy.backoffMs * attempt };
+}
+
+// ── Singleton guard (pidfile) ──────────────────────────────────────────────
+
+/** Persisted identity of the dev server that owns a given front-door port. */
+export interface DevServerPidRecord {
+  /** The supervisor process's own pid. */
+  pid: number;
+  /** The supervisor's parent pid — the stable `tsx watch` watcher across reloads. */
+  ppid: number;
+  /** The front-door port this record guards. */
+  port: number;
+}
+
+/** Parse a pidfile body into a {@link DevServerPidRecord}; `null` if absent/corrupt/incomplete. */
+export function parsePidRecord(text: string): DevServerPidRecord | null {
+  try {
+    const o = JSON.parse(text);
+    if (o && Number.isInteger(o.pid) && Number.isInteger(o.ppid) && Number.isInteger(o.port)) {
+      return { pid: o.pid, ppid: o.ppid, port: o.port };
+    }
+  } catch {
+    // Corrupt / empty pidfile — treat as absent.
+  }
+  return null;
+}
+
+/** True iff a signal can be delivered to `pid` (exists). `EPERM` (exists, not ours) counts as alive. */
+export function isPidAlive(pid: number, kill: (pid: number, signal: number) => void = (p, s) => process.kill(p, s)): boolean {
+  if (!Number.isInteger(pid) || pid <= 1) return false;
+  try {
+    kill(pid, 0);
+    return true;
+  } catch (e) {
+    return (e as NodeJS.ErrnoException).code === 'EPERM';
+  }
+}
+
+/** Result of {@link evaluateSingleton}: proceed with startup, or exit cleanly (a live peer owns the port). */
+export type SingletonDecision = { action: 'proceed' } | { action: 'exit'; reason: string };
+
+/**
+ * Decide whether a *new* dev-server invocation should start, or bow out because
+ * another supervisor already owns `port`. This is the singleton guard that stops
+ * the "two fighting supervisors" restart loop — a second `npm run dev` racing the
+ * first on `:3000`/`:3100` — WITHOUT breaking `tsx watch`'s own restart of the
+ * *same* supervisor on a file change.
+ *
+ * - **No / corrupt pidfile** → proceed (first start; startup reclaim covers any orphan socket).
+ * - **Same pid** → proceed (defensive; the record is our own).
+ * - **Same parent (`ppid`)** → proceed. `tsx watch` is the stable parent across
+ *   reloads, so a matching parent means the watcher is relaunching OUR OWN script
+ *   — not a competitor. A second `npm run dev` runs under a *different* watcher,
+ *   so it never matches here. This carve-out is what preserves hot reload.
+ * - **Different, still-live owner actually holding the port** → exit cleanly with
+ *   a clear message (do not spawn a competing supervisor).
+ * - **Otherwise** (recorded owner is dead → stale pidfile, or the port is free)
+ *   → proceed; startup reclaim frees any orphaned socket.
+ */
+export function evaluateSingleton(
+  existing: DevServerPidRecord | null,
+  self: { pid: number; ppid: number },
+  portInUse: boolean,
+  isAlive: (pid: number) => boolean,
+): SingletonDecision {
+  if (!existing) return { action: 'proceed' };
+  if (existing.pid === self.pid) return { action: 'proceed' };
+  if (existing.ppid === self.ppid) return { action: 'proceed' }; // tsx-watch relaunch of our own supervisor
+  const ownerAlive = isAlive(existing.pid) || (existing.ppid > 1 && isAlive(existing.ppid));
+  if (ownerAlive && portInUse) {
+    return { action: 'exit', reason: `dev server already running on :${existing.port} (pid ${existing.pid})` };
+  }
+  return { action: 'proceed' };
+}
+
 export async function startDevServer(options: DevServerOptions) {
   const {
     port = 3000,
@@ -245,6 +413,42 @@ export async function startDevServer(options: DevServerOptions) {
     frontendPort = 3100,
   } = options;
   const devStartTime = Date.now();
+
+  // ── Singleton guard ─────────────────────────────────────────────────────
+  // Prevent two fighting supervisors: a second `npm run dev` must not spawn a
+  // competing supervisor that races the first on :3000/:3100 (backend + Vite
+  // EADDRINUSE → mutual Vite kills → restart loop). We record {pid, ppid, port}
+  // in a per-port pidfile and consult it here. The `ppid` (stable `tsx watch`
+  // watcher) lets us tell a hot-reload relaunch of OUR OWN script apart from a
+  // genuine second invocation — see {@link evaluateSingleton}. A stale pidfile
+  // (dead owner) never blocks startup.
+  const pidfilePath = join('.blocks-sandbox', `dev-server.${port}.pid`);
+  const removeOwnPidfile = (): void => {
+    try {
+      const rec = parsePidRecord(readFileSync(pidfilePath, 'utf-8'));
+      if (rec && rec.pid === process.pid) unlinkSync(pidfilePath);
+    } catch {
+      // No pidfile, or owned by another process now — leave it alone.
+    }
+  };
+  {
+    mkdirSync('.blocks-sandbox', { recursive: true });
+    let existing: DevServerPidRecord | null = null;
+    try { existing = parsePidRecord(readFileSync(pidfilePath, 'utf-8')); } catch { /* absent */ }
+    const portInUse = await isPortOpen(port);
+    const decision = evaluateSingleton(existing, { pid: process.pid, ppid: process.ppid }, portInUse, isPidAlive);
+    if (decision.action === 'exit') {
+      console.error(
+        `\n⚠️  ${decision.reason}.\n` +
+        `   Not starting a second dev server. Stop the other process (or run the ` +
+        `cleanup script) and retry \`npm run dev\`.\n`,
+      );
+      process.exit(0);
+    }
+    try {
+      writeFileSync(pidfilePath, JSON.stringify({ pid: process.pid, ppid: process.ppid, port }));
+    } catch { /* best-effort — a missing pidfile only weakens the guard, never breaks startup */ }
+  }
 
   // Load .env.local if present (connection strings, project refs, etc.)
   try { process.loadEnvFile('.env.local'); } catch (e: any) {
@@ -598,8 +802,35 @@ export async function startDevServer(options: DevServerOptions) {
     await writeClientCode(resolvedPath, clientPath);
   }
 
+  // ── Startup reclaim ──────────────────────────────────────────────────────
+  // Free any port left bound by a crashed / SIGKILL'd predecessor before we bind
+  // the front door or spawn the `--strictPort` frontend. tsx-watch only gives the
+  // previous process ~5s to run cleanup(); if it was SIGKILL'd or crashed, its
+  // detached Vite grandchild (or an orphaned backend) can still hold :3100/:3000
+  // and a fresh `--strictPort` start would collide and crash. The singleton guard
+  // above already ruled out a live *peer* supervisor, so anything still holding
+  // these ports is an orphan — reclaim it (see {@link reclaimPort}).
+  const r3000 = await reclaimPort(port);
+  if (r3000.wasOpen) {
+    console.error(
+      r3000.reclaimed
+        ? `♻️  Reclaimed port ${port} from a stale/orphaned listener before startup.`
+        : `⚠️  Port ${port} is in use and could not be reclaimed automatically (no owner PID found).`,
+    );
+  }
+  if (frontendCommand) {
+    const rFrontend = await reclaimPort(frontendPort);
+    if (rFrontend.wasOpen) {
+      console.error(
+        rFrontend.reclaimed
+          ? `♻️  Reclaimed frontend port ${frontendPort} from a stale/orphaned dev server before startup.`
+          : `⚠️  Frontend port ${frontendPort} is in use and could not be reclaimed automatically.`,
+      );
+    }
+  }
+
   // ── Start listening ────────────────────────────────────────────────────
-  server.listen(port, async () => {
+  const onListening = async (): Promise<void> => {
     console.log(`AWS Blocks local server running on http://localhost:${port}`);
     buildAndSendEvent({ command: 'dev', state: 'SUCCESS', duration: Date.now() - devStartTime });
 
@@ -610,12 +841,57 @@ export async function startDevServer(options: DevServerOptions) {
     } else {
       console.log(`\n  ➜  http://localhost:${port}/\n`);
     }
+  };
+
+  // Front-door EADDRINUSE robustness — mirror the treatment :3100 already gets:
+  // emit a REAL console error (not just telemetry), reclaim the stale owner and
+  // retry the bind (bounded), and on unrecoverable failure exit non-zero with a
+  // clear message so a contended :3000 never silently fails to serve. Startup
+  // reclaim above makes this a rare race (someone grabbed :3000 between reclaim
+  // and listen); the retry closes that window.
+  let bindAttempts = 0;
+  server.on('error', (err: NodeJS.ErrnoException) => {
+    if (err.code === 'EADDRINUSE') {
+      // Keep the telemetry signal (unchanged) …
+      buildAndSendEvent({
+        command: 'dev',
+        state: 'FAIL',
+        duration: Date.now() - devStartTime,
+        error: { code: 'PORT_IN_USE', phase: 'startup' },
+      });
+      bindAttempts += 1;
+      const decision = evaluatePortBindRetry(bindAttempts);
+      if (!decision.retry) {
+        console.error(
+          `\n❌ Port ${port} is still in use after ${DEFAULT_PORT_BIND_RETRY_POLICY.maxAttempts} ` +
+          `attempts to reclaim it — another process is holding :${port}. Stop it (or run the ` +
+          `cleanup script) and retry \`npm run dev\`.\n`,
+        );
+        process.exit(1);
+      }
+      console.error(
+        `⚠️  Port ${port} already in use (EADDRINUSE) — reclaiming the stale owner and retrying ` +
+        `(attempt ${bindAttempts}/${DEFAULT_PORT_BIND_RETRY_POLICY.maxAttempts})…`,
+      );
+      void (async () => {
+        await reclaimPort(port);
+        await waitForPortFree(port);
+        setTimeout(() => server.listen(port, onListening), decision.delayMs).unref?.();
+      })();
+      return;
+    }
+    // Non-EADDRINUSE startup error: telemetry + a real error, then exit non-zero.
+    buildAndSendEvent({
+      command: 'dev',
+      state: 'FAIL',
+      duration: Date.now() - devStartTime,
+      error: { code: 'UNKNOWN', phase: 'startup' },
+    });
+    console.error(`\n❌ Dev server failed to start: ${err.message}\n`);
+    process.exit(1);
   });
 
-  server.on('error', (err: NodeJS.ErrnoException) => {
-    const errorCode = err.code === 'EADDRINUSE' ? 'PORT_IN_USE' : 'UNKNOWN';
-    buildAndSendEvent({ command: 'dev', state: 'FAIL', duration: Date.now() - devStartTime, error: { code: errorCode, phase: 'startup' } });
-  });
+  server.listen(port, onListening);
 
   // ── Cleanup ────────────────────────────────────────────────────────────
   const signals: NodeJS.Signals[] = ['SIGINT', 'SIGTERM', 'SIGHUP'];
@@ -639,6 +915,10 @@ export async function startDevServer(options: DevServerOptions) {
     if (typeof backend.__cleanup === 'function') {
       try { await backend.__cleanup(); } catch {}
     }
+    // Release the singleton pidfile so the next `npm run dev` isn't blocked by
+    // our own stale record (only removed if it still points at us — a hot-reload
+    // successor may already own it).
+    removeOwnPidfile();
     frontendProxy?.close();
     apiProxy?.close();
     server.close(() => process.exit(0));
@@ -658,6 +938,9 @@ export async function startDevServer(options: DevServerOptions) {
   // (a surviving grandchild keeps the group alive) — see POST-EXIT GROUP-KILL
   // POLICY above.
   process.once('exit', () => {
+    // Release our singleton pidfile on any exit path (crash, uncaught exception)
+    // that bypassed cleanup(), so it never lingers and blocks the next start.
+    removeOwnPidfile();
     const child = frontendProcess;
     if (!child) return;
     killFrontendTree(child, 'SIGKILL');

--- a/packages/core/src/scripts/process-tree.ts
+++ b/packages/core/src/scripts/process-tree.ts
@@ -113,6 +113,100 @@ export function killFrontendTree(
   }
 }
 
+/** Subset of a `spawnSync` result that {@link findListenerPids} inspects. */
+interface CommandOutput {
+  stdout?: string | null;
+  status?: number | null;
+  error?: Error;
+}
+
+/**
+ * Find the PIDs of processes holding a TCP *listener* on `port`, so a fresh dev
+ * server can reclaim a port left bound by a crashed / SIGKILL'd predecessor (its
+ * orphaned backend, or a detached Vite grandchild) instead of colliding on it.
+ * This mirrors the `lsof -ti:<port>` discovery the `cleanup` script already uses
+ * — it does NOT introduce a new port-to-PID mechanism.
+ *
+ * - **POSIX**: `lsof -ti tcp:<port> -sTCP:LISTEN` — `-t` prints bare PIDs and the
+ *   `-sTCP:LISTEN` state filter restricts the match to the *listener*, so a
+ *   transient client socket on the same port is never targeted.
+ * - **Windows**: `netstat -ano -p tcp`, keeping the trailing PID column of
+ *   `LISTENING` rows whose local address ends in `:<port>`.
+ *
+ * Best-effort and never throws: a missing tool, a non-zero exit ("nothing is
+ * listening"), or unparseable output all yield `[]`. PIDs `<= 1` are dropped
+ * defensively (never target init / the whole current group). `runner`/`platform`
+ * are injected for tests.
+ */
+export function findListenerPids(
+  port: number,
+  runner: (command: string, args: readonly string[]) => CommandOutput = (command, args) =>
+    spawnSync(command, args as string[], { encoding: 'utf-8', windowsHide: true }),
+  platform: NodeJS.Platform = process.platform,
+): number[] {
+  try {
+    const pids = new Set<number>();
+    if (platform === 'win32') {
+      const { stdout } = runner('netstat', ['-ano', '-p', 'tcp']);
+      if (!stdout) return [];
+      for (const line of stdout.split(/\r?\n/)) {
+        if (!/LISTENING/i.test(line)) continue;
+        // Columns: Proto  Local-Address  Foreign-Address  State  PID
+        const cols = line.trim().split(/\s+/);
+        const local = cols[1] ?? '';
+        if (!local.endsWith(`:${port}`)) continue;
+        const pid = Number(cols[cols.length - 1]);
+        if (Number.isInteger(pid) && pid > 1) pids.add(pid);
+      }
+      return [...pids];
+    }
+    const { stdout } = runner('lsof', ['-ti', `tcp:${port}`, '-sTCP:LISTEN']);
+    if (!stdout) return [];
+    for (const token of stdout.split(/\s+/)) {
+      const pid = Number(token.trim());
+      if (Number.isInteger(pid) && pid > 1) pids.add(pid);
+    }
+    return [...pids];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Force-terminate whatever process (and, on POSIX, its process group) currently
+ * holds a port — used by the dev server's startup / EADDRINUSE *reclaim* path on
+ * a PID discovered via {@link findListenerPids}, i.e. a process this dev server
+ * did NOT spawn. Reuses {@link killFrontendTree} (POSIX `-pid` group kill /
+ * Windows `taskkill /T`, with a direct-`kill` fallback) so reclaim reaps exactly
+ * like our own frontend teardown — no bespoke kill mechanism. Best-effort; never
+ * throws (a since-exited PID just yields ESRCH, swallowed by killFrontendTree).
+ */
+export function killListenerTree(
+  pid: number,
+  signal: NodeJS.Signals = 'SIGTERM',
+  platform: NodeJS.Platform = process.platform,
+  killFn: (pid: number, signal: NodeJS.Signals) => void = (p, s) => process.kill(p, s),
+  winTreeKill: (pid: number) => boolean = windowsTreeKill,
+): void {
+  killFrontendTree(
+    {
+      pid,
+      kill: (s) => {
+        try {
+          process.kill(pid, s ?? signal);
+          return true;
+        } catch {
+          return false;
+        }
+      },
+    },
+    signal,
+    platform,
+    killFn,
+    winTreeKill,
+  );
+}
+
 /** Child surface {@link terminateProcessTree} needs: a tree to kill plus exit state to await. */
 export interface AwaitableChild extends KillableProcess {
   exitCode: number | null;

--- a/packages/core/src/scripts/process-tree.ts
+++ b/packages/core/src/scripts/process-tree.ts
@@ -41,13 +41,14 @@ interface TreeKillResult {
  * denied): such a run did NOT reap the tree, so the caller must fall back to a
  * direct `child.kill` rather than treat the leak as handled. (`child.kill`
  * cannot reap the orphaned grandchild either, but the fallback is cheap and
- * strictly correct — we never silently swallow a failed tree-kill.) Never
- * throws.
+ * strictly correct — we never silently swallow a failed tree-kill.) Runs with a
+ * 3s `timeout` so a wedged `taskkill` can't stall teardown; a timed-out run
+ * surfaces as `{error}` and degrades to the fallback. Never throws.
  */
 export function windowsTreeKill(
   pid: number,
   runner: (command: string, args: readonly string[]) => TreeKillResult = (command, args) =>
-    spawnSync(command, args as string[], { stdio: 'ignore', windowsHide: true }),
+    spawnSync(command, args as string[], { stdio: 'ignore', windowsHide: true, timeout: 3000 }),
 ): boolean {
   try {
     const { status, error } = runner('taskkill', ['/T', '/F', '/PID', String(pid)]);
@@ -134,14 +135,17 @@ interface CommandOutput {
  *   `LISTENING` rows whose local address ends in `:<port>`.
  *
  * Best-effort and never throws: a missing tool, a non-zero exit ("nothing is
- * listening"), or unparseable output all yield `[]`. PIDs `<= 1` are dropped
+ * listening"), or unparseable output all yield `[]`. The `spawnSync` runs with a
+ * 3s `timeout` so a hung `lsof`/`netstat` (e.g. an unresponsive NFS mount) can't
+ * block the event loop during startup — a timed-out probe returns `{error}`,
+ * which the `catch` degrades to `[]`. PIDs `<= 1` are dropped
  * defensively (never target init / the whole current group). `runner`/`platform`
  * are injected for tests.
  */
 export function findListenerPids(
   port: number,
   runner: (command: string, args: readonly string[]) => CommandOutput = (command, args) =>
-    spawnSync(command, args as string[], { encoding: 'utf-8', windowsHide: true }),
+    spawnSync(command, args as string[], { encoding: 'utf-8', windowsHide: true, timeout: 3000 }),
   platform: NodeJS.Platform = process.platform,
 ): number[] {
   try {


### PR DESCRIPTION
## Summary

Hardens the `@aws-blocks/core` dev server (`packages/core/src/scripts/dev-server.ts`) against the fragility surfaced by the agent bench (#132). PR #80 fixed the single‑supervisor self‑restart loop (detached process group + `killFrontendTree` + `waitForPortFree(:3100)` + bounded respawn). This PR fixes the **four problems that remained after #80**, all of which cause a contended dev server to either silently never serve or fight itself into a restart loop.

All of #80's single‑supervisor hardening and #125's `0.0.0.0` bind are preserved.

## The 4 remaining problems (post‑#80) and the fix for each

### 1. No singleton guard → two supervisors fight
Templates run `dev` = `tsx watch aws-blocks/scripts/server.ts`. A second `npm run dev` spawned a **second supervisor**: the backend hit `:3000` EADDRINUSE, its `--strictPort` Vite hit `:3100` EADDRINUSE, and the two supervisors fought (killing one Vite → the survivor respawned it) → restart loop.

**Fix — pidfile singleton guard.** On startup the server writes `.blocks-sandbox/dev-server.<port>.pid` containing `{ pid, ppid, port, startedAt }`. Before writing, it reads any existing pidfile and runs a pure `evaluateSingleton(record, currentPpid)` decision:
- `record.ppid === process.ppid` → this is a **tsx‑watch hot‑reload relaunch of our own script** → **proceed** (hot reload is never blocked).
- else if `isPidAlive(record.pid)` → a real competing supervisor → **exit(0)** with a clear message: `dev server already running on :PORT (pid N)`.
- else (stale pidfile, dead pid) → **proceed**.

The pidfile is removed in both `cleanup()` and the `exit` handler, and only if it still points at our own pid (so a relaunch never deletes the successor's file).

### 2. `:3000` front door had no EADDRINUSE robustness
The backend's only handling of a contended `:3000` was emitting a telemetry event — no console error, no reclaim/retry, no non‑zero exit → a contended front door **silently never served**.

**Fix — same treatment `:3100` already gets.** `server.listen` is now wrapped in a bounded retry loop (`DEFAULT_PORT_BIND_RETRY_POLICY` = 3 attempts). On EADDRINUSE it emits a **real `console.error`**, calls `reclaimPort(:3000)`, waits, and retries (`evaluatePortBindRetry` is the pure decision). The telemetry event is still emitted. On unrecoverable failure it `console.error`s a clear message and **exits non‑zero (1)**.

### 3. No startup reclaim → orphaned listeners crash a fresh start
A fresh `server.ts` never freed a pre‑existing `:3000`/`:3100` listener; it relied on the previous process's `cleanup()` finishing within tsx‑watch's ~5s. If that process was SIGKILL'd/crashed (or was a different invocation), the orphan persisted and `spawnFrontend` (`--strictPort`) collided.

**Fix — startup reclaim.** Before binding `:3000` and before `spawnFrontend` on `:3100`, the server calls `reclaimPort(port)`: probe the port (`isPortOpen`), and if held, kill the listener's process group and `waitForPortFree`. This **reuses the existing mechanisms** — `waitForPortFree` and the process‑group kill primitives already in the codebase (`killSignal`/`windowsTreeKill` via the new `findListenerPids`/`killListenerTree` in `process-tree.ts`, which mirror the `lsof -ti:<port>` approach already used by `cleanup.ts`). No new kill mechanism was invented; it mirrors the respawn path.

### 4. `--strictPort` turned contention into a hard crash
**Decision: keep `--strictPort`, rely on startup reclaim.** Startup reclaim now guarantees `:3100` is free *before* `spawnFrontend` runs, so `--strictPort` is safe and preserves the single‑front‑door model (backend proxy targets a fixed `:3100`). Dropping `--strictPort` would let Vite auto‑pick a port, which would require the backend to dynamically **learn** Vite's chosen port and rewrite its proxy target — an invasive change to the proxy logic for little benefit now that reclaim exists. If reclaim ever fails (e.g. the port is held by a non‑killable process), the failure is now surfaced with a clear console error + non‑zero exit (problem #2) instead of a silent crash.

## Tests

New file `packages/core/src/scripts/dev-server-reclaim.test.ts` — **29 tests, no mocks**, using real TCP sockets and injectable dependency seams:
- `isPortOpen` against a real free/bound port.
- `reclaimPort`: port already free; real stale listener reclaimed; port stays open after kill → `reclaimed: false`.
- `evaluatePortBindRetry` honoring `DEFAULT_PORT_BIND_RETRY_POLICY`.
- `parsePidRecord` (valid / invalid JSON / missing fields → `null`, never throws).
- `evaluateSingleton`: dead pid → proceed; live pid with matching ppid → proceed (hot reload); live pid different ppid → exit.

Also smoke‑tested the real server end‑to‑end: starting on a port held by a SIGKILL‑style orphan logs `♻️ Reclaimed port …` and serves; a second start exits 0 with `dev server already running on :PORT` while the first keeps serving.

## Verification
- `npm run build -w packages/core` — clean.
- `npm run test -w packages/core` — **573 pass, 0 fail** (incl. the 29 new tests; full dev‑server suites incl. `RUN_SLOW_TESTS=1`).
- `npm run lint` (biome gate) — exit 0 on touched files.
- Changeset added: `.changeset/dev-server-robustness.md` bumping `@aws-blocks/core` (patch).

## Follow‑up (not in this PR)
Problem #5 — tsx‑watch performing a full restart on **every** edit — is out of scope here (non‑trivial; would need `tsx watch` scoping or an in‑process reload). Tracking as a follow‑up.

Related: #78 (closed), #80, #125. Surfaced by the agent bench (#132).
