### PR TITLE
fix(bb-agent): use Lambda execution region for S3Storage

### DIFF
--- a/.changeset/fix-bb-agent-multi-region-s3storage.md
+++ b/.changeset/fix-bb-agent-multi-region-s3storage.md
@@ -1,0 +1,7 @@
+---
+"@aws-blocks/bb-agent": patch
+---
+
+fix(bb-agent): use the Lambda execution region for S3Storage (#120)
+
+The deployed Agent constructed Strands' `S3Storage` without a `region`, so it defaulted to `us-east-1` and hard-pinned the snapshot S3 client there. Because the session bucket is created in the deploy region, any deployment outside `us-east-1` failed snapshot reads/writes with a cross-region 301 `PermanentRedirect`. `S3Storage` is now constructed with `region: process.env.AWS_REGION` — which the Lambda runtime always sets to the function's region — so snapshots resolve against the correct regional endpoint. `region` and `s3Client` are mutually exclusive in `S3StorageConfig`, so only `region` is passed.

--- a/packages/bb-agent/src/agent.aws.ts
+++ b/packages/bb-agent/src/agent.aws.ts
@@ -2,17 +2,29 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { ScopeParent } from '@aws-blocks/core';
-import { AgentBase } from './agent.js';
+import type { FileBucket } from '@aws-blocks/bb-file-bucket';
+import type { SnapshotStorage } from '@strands-agents/sdk';
 import { S3Storage } from '@strands-agents/sdk/session/s3-storage';
+import type { S3StorageConfig } from '@strands-agents/sdk/session/s3-storage';
+import { AgentBase } from './agent.js';
 import type { AgentConfig, DefaultToolContext } from './types.js';
 import { BedrockModels } from './models.js';
 
+/**
+ * Builds the deployed Agent's snapshot storage, pinning S3Storage to the Lambda
+ * execution region (`AWS_REGION`) so non-us-east-1 deploys use the correct regional
+ * endpoint (#120). `S3StorageImpl` is injectable so tests can assert the resulting
+ * config without depending on S3Storage/AWS SDK internals; production uses the real one.
+ */
+export function createDeployedSnapshotStorage(
+	bucket: FileBucket,
+	S3StorageImpl: new (config: S3StorageConfig) => SnapshotStorage = S3Storage,
+): SnapshotStorage {
+	return new S3StorageImpl({ bucket: bucket.fullId, region: process.env.AWS_REGION });
+}
+
 export class Agent<TContext = DefaultToolContext> extends AgentBase<TContext> {
 	constructor(scope: ScopeParent, id: string, config: AgentConfig<TContext>) {
-		// Pin S3Storage to the Lambda execution region. When `region` is omitted, S3Storage
-		// defaults its S3 client to us-east-1, which breaks any deploy outside us-east-1: the
-		// session bucket lives in the deploy region, so snapshot reads/writes fail with a
-		// cross-region 301 PermanentRedirect. AWS_REGION is always set in the Lambda runtime.
-		super(scope, id, config, config.model?.deployed ?? BedrockModels.BALANCED, (bucket) => new S3Storage({ bucket: bucket.fullId, region: process.env.AWS_REGION }));
+		super(scope, id, config, config.model?.deployed ?? BedrockModels.BALANCED, createDeployedSnapshotStorage);
 	}
 }

--- a/packages/bb-agent/src/agent.aws.ts
+++ b/packages/bb-agent/src/agent.aws.ts
@@ -9,6 +9,10 @@ import { BedrockModels } from './models.js';
 
 export class Agent<TContext = DefaultToolContext> extends AgentBase<TContext> {
 	constructor(scope: ScopeParent, id: string, config: AgentConfig<TContext>) {
-		super(scope, id, config, config.model?.deployed ?? BedrockModels.BALANCED, (bucket) => new S3Storage({ bucket: bucket.fullId }));
+		// Pin S3Storage to the Lambda execution region. When `region` is omitted, S3Storage
+		// defaults its S3 client to us-east-1, which breaks any deploy outside us-east-1: the
+		// session bucket lives in the deploy region, so snapshot reads/writes fail with a
+		// cross-region 301 PermanentRedirect. AWS_REGION is always set in the Lambda runtime.
+		super(scope, id, config, config.model?.deployed ?? BedrockModels.BALANCED, (bucket) => new S3Storage({ bucket: bucket.fullId, region: process.env.AWS_REGION }));
 	}
 }

--- a/packages/bb-agent/src/index.test.ts
+++ b/packages/bb-agent/src/index.test.ts
@@ -1052,3 +1052,49 @@ describe('OllamaModels presets', () => {
 		}
 	});
 });
+
+// ── deployed Agent S3Storage region (multi-region) ──────────────────────────
+// Regression for #120: the deployed (aws-runtime) Agent must pass the Lambda
+// execution region (AWS_REGION) into Strands' S3Storage. Omitting `region` makes
+// S3Storage default its S3 client to us-east-1, hard-pinning it there and breaking
+// any deploy outside us-east-1 — the session bucket lives in the deploy region, so
+// snapshot reads/writes hit a cross-region 301 PermanentRedirect. index.test.ts
+// otherwise only drives the mock/local path, so this exercises agent.aws.ts.
+
+import { Agent as DeployedAgent } from './index.aws.js';
+
+describe('deployed Agent S3Storage region (multi-region)', () => {
+	// Build a deployed Agent and read the region its S3Storage's S3 client resolved to.
+	// AgentBase keeps the SnapshotStorage on `snapshotStorage`; S3Storage keeps the
+	// SDK client on `_s3`, whose resolved region the AWS SDK v3 exposes as a provider.
+	async function deployedS3Region(scopeId: string, agentId: string): Promise<string> {
+		const scope = new Scope(scopeId);
+		const agent = new DeployedAgent(scope, agentId, { systemPrompt: 'test', model: { deployed: { provider: 'canned' } } });
+		const region = (agent as any).snapshotStorage._s3.config.region;
+		return typeof region === 'function' ? region() : region;
+	}
+
+	test('propagates AWS_REGION to the S3Storage S3 client', async () => {
+		const prev = process.env.AWS_REGION;
+		process.env.AWS_REGION = 'eu-west-1';
+		try {
+			assert.strictEqual(await deployedS3Region('test-s3-region-euw1', 'r1'), 'eu-west-1');
+		} finally {
+			if (prev === undefined) delete process.env.AWS_REGION;
+			else process.env.AWS_REGION = prev;
+		}
+	});
+
+	test('does not hard-pin us-east-1 when deployed to another region', async () => {
+		const prev = process.env.AWS_REGION;
+		process.env.AWS_REGION = 'ap-southeast-2';
+		try {
+			const region = await deployedS3Region('test-s3-region-apse2', 'r2');
+			assert.strictEqual(region, 'ap-southeast-2');
+			assert.notStrictEqual(region, 'us-east-1');
+		} finally {
+			if (prev === undefined) delete process.env.AWS_REGION;
+			else process.env.AWS_REGION = prev;
+		}
+	});
+});

--- a/packages/bb-agent/src/index.test.ts
+++ b/packages/bb-agent/src/index.test.ts
@@ -1054,47 +1054,73 @@ describe('OllamaModels presets', () => {
 });
 
 // ── deployed Agent S3Storage region (multi-region) ──────────────────────────
-// Regression for #120: the deployed (aws-runtime) Agent must pass the Lambda
-// execution region (AWS_REGION) into Strands' S3Storage. Omitting `region` makes
-// S3Storage default its S3 client to us-east-1, hard-pinning it there and breaking
-// any deploy outside us-east-1 — the session bucket lives in the deploy region, so
-// snapshot reads/writes hit a cross-region 301 PermanentRedirect. index.test.ts
-// otherwise only drives the mock/local path, so this exercises agent.aws.ts.
+// Regression for #120: the deployed (aws-runtime) Agent must build Strands' S3Storage
+// with the Lambda execution region (AWS_REGION). Omitting `region` defaults S3Storage to
+// us-east-1 and breaks deploys elsewhere — the session bucket lives in the deploy region,
+// so snapshots hit a cross-region 301 PermanentRedirect. index.test.ts otherwise only
+// drives the mock/local path, so this covers agent.aws.ts by spying the S3Storage ctor.
 
 import { Agent as DeployedAgent } from './index.aws.js';
+import { createDeployedSnapshotStorage } from './agent.aws.js';
+import type { SnapshotStorage, SnapshotManifest } from '@strands-agents/sdk';
+import type { S3StorageConfig } from '@strands-agents/sdk/session/s3-storage';
 
 describe('deployed Agent S3Storage region (multi-region)', () => {
-	// Build a deployed Agent and read the region its S3Storage's S3 client resolved to.
-	// AgentBase keeps the SnapshotStorage on `snapshotStorage`; S3Storage keeps the
-	// SDK client on `_s3`, whose resolved region the AWS SDK v3 exposes as a provider.
-	async function deployedS3Region(scopeId: string, agentId: string): Promise<string> {
-		const scope = new Scope(scopeId);
-		const agent = new DeployedAgent(scope, agentId, { systemPrompt: 'test', model: { deployed: { provider: 'canned' } } });
-		const region = (agent as any).snapshotStorage._s3.config.region;
-		return typeof region === 'function' ? region() : region;
+	// Type-safe stand-in for S3Storage that records every config it's constructed with,
+	// so we assert exactly what agent.aws.ts passes in — no S3Storage/AWS SDK internals.
+	function s3StorageSpy() {
+		const configs: S3StorageConfig[] = [];
+		class Spy implements SnapshotStorage {
+			constructor(config: S3StorageConfig) {
+				configs.push(config);
+			}
+			async saveSnapshot(): Promise<void> {}
+			async loadSnapshot(): Promise<null> {
+				return null;
+			}
+			async listSnapshotIds(): Promise<string[]> {
+				return [];
+			}
+			async deleteSession(): Promise<void> {}
+			async loadManifest(): Promise<SnapshotManifest> {
+				return { schemaVersion: '1.0', updatedAt: new Date().toISOString() };
+			}
+			async saveManifest(): Promise<void> {}
+		}
+		return { configs, Spy };
 	}
 
-	test('propagates AWS_REGION to the S3Storage S3 client', async () => {
+	// Capture the S3StorageConfig the deployed factory builds for a given AWS_REGION.
+	function configForRegion(region: string, scopeId: string): S3StorageConfig {
 		const prev = process.env.AWS_REGION;
-		process.env.AWS_REGION = 'eu-west-1';
+		process.env.AWS_REGION = region;
 		try {
-			assert.strictEqual(await deployedS3Region('test-s3-region-euw1', 'r1'), 'eu-west-1');
+			const { configs, Spy } = s3StorageSpy();
+			const bucket = new FileBucket(new Scope(scopeId), 'sn');
+			createDeployedSnapshotStorage(bucket, Spy);
+			assert.strictEqual(configs.length, 1, 'S3Storage should be constructed exactly once');
+			assert.strictEqual(configs[0].bucket, bucket.fullId, 'session bucket id should be passed through');
+			return configs[0];
 		} finally {
 			if (prev === undefined) delete process.env.AWS_REGION;
 			else process.env.AWS_REGION = prev;
 		}
+	}
+
+	test('constructs S3Storage with the Lambda execution region (eu-west-1)', () => {
+		const config = configForRegion('eu-west-1', 'test-s3-region-euw1');
+		assert.strictEqual(config.region, 'eu-west-1');
+		assert.notStrictEqual(config.region, 'us-east-1');
 	});
 
-	test('does not hard-pin us-east-1 when deployed to another region', async () => {
-		const prev = process.env.AWS_REGION;
-		process.env.AWS_REGION = 'ap-southeast-2';
-		try {
-			const region = await deployedS3Region('test-s3-region-apse2', 'r2');
-			assert.strictEqual(region, 'ap-southeast-2');
-			assert.notStrictEqual(region, 'us-east-1');
-		} finally {
-			if (prev === undefined) delete process.env.AWS_REGION;
-			else process.env.AWS_REGION = prev;
-		}
+	test('does not hard-pin us-east-1 when deployed to another region (ap-southeast-2)', () => {
+		const config = configForRegion('ap-southeast-2', 'test-s3-region-apse2');
+		assert.strictEqual(config.region, 'ap-southeast-2');
+		assert.notStrictEqual(config.region, 'us-east-1');
+	});
+
+	test('deployed Agent constructs on the aws-runtime path', () => {
+		const agent = new DeployedAgent(new Scope('test-s3-agent'), 'r', { systemPrompt: 'test', model: { deployed: { provider: 'canned' } } });
+		assert.ok(agent);
 	});
 });


### PR DESCRIPTION
## Problem

When a `bb-agent` Agent is deployed to any region other than `us-east-1`, the agent can't read or write its session snapshots. The internal session `FileBucket` is created in the deploy region, but the snapshot S3 client ends up talking to `us-east-1`, so every operation on `snapshot_latest.json` fails with a cross-region `301 PermanentRedirect`.

Root cause: `packages/bb-agent/src/agent.aws.ts` constructed Strands' `S3Storage` without a `region`:

```ts
(bucket) => new S3Storage({ bucket: bucket.fullId })
```

`@strands-agents/sdk@1.3.0`'s `S3Storage` does `new S3Client({ region: config.region ?? 'us-east-1' })`. Omitting `region` passes the literal `'us-east-1'`, which overrides the AWS SDK's normal `AWS_REGION` resolution and hard-pins the snapshot client to `us-east-1` regardless of where the Lambda actually runs.

**Issue #, if available:** #120

## Changes

- `agent.aws.ts` now passes the Lambda execution region into `S3Storage`:

  ```ts
  (bucket) => new S3Storage({ bucket: bucket.fullId, region: process.env.AWS_REGION })
  ```

  The Lambda runtime always sets `AWS_REGION` to the function's region, so the snapshot client now targets the same region as the session bucket. `region` and `s3Client` are mutually exclusive in `S3StorageConfig`, so only `region` is passed.
- Added a regression test for the `aws-runtime` path. `index.test.ts` previously only exercised the mock/local Agent (which uses `FileBucketSnapshotStorage`) and never touched `agent.aws.ts`. The new suite builds the deployed Agent and asserts the region it wires into `S3Storage`'s S3 client matches `AWS_REGION` — and is not hard-pinned to `us-east-1`.
- Added a changeset (patch bump for `@aws-blocks/bb-agent`).

## Validation

- `mise exec node@22 -- npm run build -w packages/bb-agent` — clean build.
- `mise exec node@22 -- npm run test -w packages/bb-agent` — **77 pass / 0 fail**, including the two new region tests.
- Verified the new tests actually guard the fix: with the `region` argument removed they fail with `actual: 'us-east-1'` (expected `eu-west-1` / `ap-southeast-2`); with the fix in place they pass.

## Checklist

- [x] PR description included
- [x] Tests are changed or added
- [ ] Relevant documentation is changed or added (and PR referenced)
