### PR TITLE
fix(bb-auth-basic): keep error constants browser-safe

### DIFF
--- a/.changeset/auth-basic-browser-errors.md
+++ b/.changeset/auth-basic-browser-errors.md
@@ -1,0 +1,5 @@
+---
+"@aws-blocks/bb-auth-basic": patch
+---
+
+Keep AuthBasic error constants browser-safe by exporting them from a shared module instead of re-exporting through the server entry.

--- a/packages/bb-auth-basic/src/errors.ts
+++ b/packages/bb-auth-basic/src/errors.ts
@@ -1,0 +1,27 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Error constants for AuthBasic. Use with `isBlocksError()` for typed error handling.
+ *
+ * @example
+ * ```typescript
+ * import { isBlocksError } from '@aws-blocks/core';
+ * import { AuthBasicErrors } from '@aws-blocks/bb-auth-basic';
+ *
+ * try {
+ *   await auth.signIn('alice', 'wrong', context);
+ * } catch (e) {
+ *   if (isBlocksError(e, AuthBasicErrors.InvalidCredentials)) {
+ *     // handle bad credentials
+ *   }
+ * }
+ * ```
+ */
+export const AuthBasicErrors = {
+	InvalidCredentials: 'InvalidCredentialsException',
+	UserAlreadyExists: 'UserAlreadyExistsException',
+	InvalidCode: 'InvalidCodeException',
+	SessionExpired: 'SessionExpiredException',
+	InvalidPassword: 'InvalidPasswordException',
+} as const;

--- a/packages/bb-auth-basic/src/index.browser.test.ts
+++ b/packages/bb-auth-basic/src/index.browser.test.ts
@@ -1,0 +1,21 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, test } from 'node:test';
+import assert from 'node:assert';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { AuthBasicErrors } from './index.browser.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+describe('AuthBasic browser entry', () => {
+	test('exports browser-safe error constants without importing the server entry', () => {
+		assert.strictEqual(AuthBasicErrors.InvalidCredentials, 'InvalidCredentialsException');
+
+		const browserEntry = readFileSync(join(__dirname, 'index.browser.js'), 'utf8');
+		assert.ok(!browserEntry.includes("from './index.js'"), browserEntry);
+		assert.ok(!browserEntry.includes('from "./index.js"'), browserEntry);
+	});
+});

--- a/packages/bb-auth-basic/src/index.browser.ts
+++ b/packages/bb-auth-basic/src/index.browser.ts
@@ -6,7 +6,7 @@ import { ApiNamespace } from '@aws-blocks/core';
 
 export type { BlocksAuth, AuthUser, AuthState, AuthAction, AuthField } from '@aws-blocks/auth-common';
 export type { AuthBasicUser, PasswordPolicy, AuthBasicOptions } from './index.js';
-export { AuthBasicErrors } from './index.js';
+export { AuthBasicErrors } from './errors.js';
 
 export class AuthBasic {
 	constructor(...args: any[]) {}

--- a/packages/bb-auth-basic/src/index.ts
+++ b/packages/bb-auth-basic/src/index.ts
@@ -12,9 +12,11 @@ import jwt from 'jsonwebtoken';
 import crypto from 'crypto';
 import { Logger } from '@aws-blocks/bb-logger';
 import type { ChildLogger } from '@aws-blocks/bb-logger';
+import { AuthBasicErrors } from './errors.js';
 
 export type { BlocksAuth, AuthUser, AuthState, AuthActionInput } from '@aws-blocks/auth-common';
 export type { AuthAction, AuthField } from '@aws-blocks/auth-common';
+export { AuthBasicErrors } from './errors.js';
 
 /**
  * User shape returned by AuthBasic. Extends the common `AuthUser`
@@ -83,31 +85,6 @@ export interface AuthBasicOptions {
 	/** Optional logger for internal operations. When omitted, a default Logger at error level is created. */
 	logger?: ChildLogger;
 }
-
-/**
- * Error constants for AuthBasic. Use with `isBlocksError()` for typed error handling.
- *
- * @example
- * ```typescript
- * import { isBlocksError } from '@aws-blocks/core';
- * import { AuthBasicErrors } from '@aws-blocks/bb-auth-basic';
- *
- * try {
- *   await auth.signIn('alice', 'wrong', context);
- * } catch (e) {
- *   if (isBlocksError(e, AuthBasicErrors.InvalidCredentials)) {
- *     // handle bad credentials
- *   }
- * }
- * ```
- */
-export const AuthBasicErrors = {
-	InvalidCredentials: 'InvalidCredentialsException',
-	UserAlreadyExists: 'UserAlreadyExistsException',
-	InvalidCode: 'InvalidCodeException',
-	SessionExpired: 'SessionExpiredException',
-	InvalidPassword: 'InvalidPasswordException',
-} as const;
 
 /** Internal user record stored in KVStore. */
 interface UserRecord {


### PR DESCRIPTION
## Problem

**Issue #, if available:** Closes #140

`@aws-blocks/bb-auth-basic` exposes a browser conditional export, but the browser entry re-exported `AuthBasicErrors` from the server entry. The server entry imports Node-only runtime dependencies such as `crypto`, so the documented client-side `AuthBasicErrors` import could pull server code into browser bundles.

## Changes

- Move `AuthBasicErrors` into a browser-safe shared module with no Node runtime imports.
- Re-export the same constants from both the server and browser entries.
- Add a regression test that imports the browser entry and verifies the emitted browser entry no longer references `./index.js`.
- Add a patch changeset for `@aws-blocks/bb-auth-basic`.

## Validation

- `npm run build -w packages/bb-auth-basic`
- `npm run test -w packages/bb-auth-basic`
- `./node_modules/.bin/changeset status --since=origin/main`
- `./node_modules/.bin/tsx scripts/verify-changeset-coverage.ts`
- `git diff --cached --check`

## Checklist

- [x] PR description included
- [x] Tests are changed or added
- [x] Relevant documentation is changed or added (the existing documented import path is preserved and fixed in code)

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
