### PR TITLE
feat(cli): --help now lists every template with a one-line description

### DIFF
--- a/.changeset/amplify-fresh-scaffold-guard.md
+++ b/.changeset/amplify-fresh-scaffold-guard.md
@@ -1,0 +1,19 @@
+---
+"@aws-blocks/create-blocks-app": patch
+---
+
+Fix + polish for `create-blocks-app`:
+
+- Reject `--template amplify` on a fresh directory up front with a
+  helpful message pointing at `--template default` (for a fresh app)
+  or the no-arg command (to integrate Blocks into an existing Amplify
+  Gen 2 project). The `amplify` template is an overlay auto-selected
+  when the CLI detects `amplify/backend.ts`, not a scaffoldable
+  starter. Previously the fresh-scaffold path with `--template amplify`
+  crashed mid-copy on missing template files.
+- Correct two template descriptions that misstated the frontend:
+  `auth-cognito` and `demo` were labeled "Vite + lit-html" but both
+  ship a Vite + vanilla-DOM frontend. Descriptions now read
+  "Vite + vanilla-DOM frontend with Cognito passwordless email-OTP
+  auth end-to-end" and "Fuller example — AuthBasic + KVStore +
+  DynamoDB priority-sorted todo (Vite, vanilla-DOM)" respectively.

--- a/.changeset/help-template-descriptions.md
+++ b/.changeset/help-template-descriptions.md
@@ -1,0 +1,9 @@
+---
+"@aws-blocks/create-blocks-app": patch
+---
+
+Improve `--help` output for `create-blocks-app`:
+
+- Template discovery is now filesystem-driven — drop a folder under `templates/` with a `package.json` and it auto-registers.
+- `--help` now lists every template with a one-line description, sourced from each template's `blocksTemplateDescription` field.
+- Added `--yes --template nextjs` to the Examples section.

--- a/packages/create-blocks-app/README.md
+++ b/packages/create-blocks-app/README.md
@@ -133,6 +133,8 @@ export const blocksStack = await BlocksStack.create(app, stackName, {
 
 ## Templates
 
+Available templates: `default`, `bare`, `react`, `backend`, `nextjs`, `auth-cognito`, `amplify`, `demo`.
+
 Every folder under `templates/` is a self-registering template. Each `package.json` in that folder sets a `blocksTemplateDescription` field, which the CLI reads to build the `--help` catalog. To see the current list of templates and their one-line descriptions:
 
 ```bash

--- a/packages/create-blocks-app/README.md
+++ b/packages/create-blocks-app/README.md
@@ -20,15 +20,13 @@ npx @aws-blocks/create-blocks-app my-app
 npx @aws-blocks/create-blocks-app my-app --template react
 ```
 
-Available templates:
-- **default** - Real-time todo app with auth, data, and live sync
-- **bare** - Minimal Blocks setup
-- **react** - React frontend with Blocks backend
-- **backend** - Backend-only (no frontend)
-- **nextjs** - Next.js integration
-- **auth-cognito** - Cognito authentication example
-- **amplify** - Amplify Gen 2 integration
-- **demo** - Demo application
+For the full list of templates and one-line descriptions, run:
+
+```bash
+npx @aws-blocks/create-blocks-app --help
+```
+
+Template descriptions are sourced from each template's `package.json` (`blocksTemplateDescription`) so the CLI is always the source of truth.
 
 ### Add to Existing Project
 
@@ -135,33 +133,11 @@ export const blocksStack = await BlocksStack.create(app, stackName, {
 
 ## Templates
 
-### Default
-Real-time todo application with:
-- User authentication (AuthBasic)
-- Todo storage (DistributedTable / DynamoDB)
-- Optimistic locking
-- Real-time sync (Realtime / WebSocket)
+Every folder under `templates/` is a self-registering template. Each `package.json` in that folder sets a `blocksTemplateDescription` field, which the CLI reads to build the `--help` catalog. To see the current list of templates and their one-line descriptions:
 
-### Bare
-Minimal setup demonstrating core concepts.
-
-### React
-React frontend with Blocks backend.
-
-### Backend
-Backend-only template (no frontend bundling).
-
-### Next.js
-Next.js integration with Blocks backend.
-
-### Auth-Cognito
-Cognito authentication example.
-
-### Amplify
-Amplify Gen 2 integration template.
-
-### Demo
-Demo application showcasing Building Blocks.
+```bash
+npx @aws-blocks/create-blocks-app --help
+```
 
 ## Related Packages
 

--- a/packages/create-blocks-app/src/cli.test.ts
+++ b/packages/create-blocks-app/src/cli.test.ts
@@ -46,14 +46,8 @@ describe('create-blocks-app CLI argument parsing', () => {
   });
 
   it('--help includes template descriptions', () => {
-    // Guards the filesystem-driven catalog: if template discovery breaks or a
-    // template's `blocksTemplateDescription` disappears, --help output will no
-    // longer include the canonical description strings and this test fails.
     const result = run(['--help']);
     assert.strictEqual(result.exitCode, 0);
-    // "default" template's canonical description substring. Pinned to a stable
-    // fragment so wording tweaks don't require test churn but a missing
-    // description does.
     assert.match(
       result.stdout,
       /default\s+Vite \+ lit-html frontend with auth/,
@@ -96,11 +90,23 @@ describe('create-blocks-app CLI argument parsing', () => {
     assert.doesNotMatch(result.stderr, /ENOENT/);
   });
 
+  it('a template folder missing package.json is rejected as unknown, not crashed with ENOENT', () => {
+    // Latent-bug guard: a folder under templates/ with no package.json is shown
+    // in --help but excluded from validation, so selecting it fails cleanly
+    // instead of throwing ENOENT on the later template version read.
+    const brokenDir = join(__dirname, '../templates', '__broken_test_template__');
+    mkdirSync(brokenDir, { recursive: true });
+    try {
+      const result = run(['my-app', '--template', '__broken_test_template__', '--skip-install']);
+      assert.strictEqual(result.exitCode, 1);
+      assert.match(result.stderr, /Unknown template "__broken_test_template__"/);
+      assert.doesNotMatch(result.stderr, /ENOENT/);
+    } finally {
+      rmSync(brokenDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+    }
+  });
+
   it('--template amplify on a fresh dir exits 1 with a helpful message', () => {
-    // amplify is auto-selected when an existing Amplify Gen 2 project is
-    // detected — it's not scaffoldable as a fresh app. The CLI should
-    // reject the fresh-scaffold path up front rather than crashing partway
-    // through the file copy on missing template contents.
     const tmpDir = mkdtempSync(join(tmpdir(), 'create-blocks-app-amplify-fresh-'));
     try {
       const result = run([tmpDir, '--template', 'amplify', '--skip-install', '-y']);

--- a/packages/create-blocks-app/src/cli.test.ts
+++ b/packages/create-blocks-app/src/cli.test.ts
@@ -96,6 +96,23 @@ describe('create-blocks-app CLI argument parsing', () => {
     assert.doesNotMatch(result.stderr, /ENOENT/);
   });
 
+  it('--template amplify on a fresh dir exits 1 with a helpful message', () => {
+    // amplify is auto-selected when an existing Amplify Gen 2 project is
+    // detected — it's not scaffoldable as a fresh app. The CLI should
+    // reject the fresh-scaffold path up front rather than crashing partway
+    // through the file copy on missing template contents.
+    const tmpDir = mkdtempSync(join(tmpdir(), 'create-blocks-app-amplify-fresh-'));
+    try {
+      const result = run([tmpDir, '--template', 'amplify', '--skip-install', '-y']);
+      assert.strictEqual(result.exitCode, 1);
+      assert.match(result.stderr, /amplify.*auto-selected/i);
+      assert.match(result.stderr, /--template default/);
+      assert.doesNotMatch(result.stderr, /ENOENT/);
+    } finally {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
   it('multiple positional args exits 1 with error message', () => {
     const result = run(['my-app', 'extra-arg']);
     assert.strictEqual(result.exitCode, 1);

--- a/packages/create-blocks-app/src/cli.test.ts
+++ b/packages/create-blocks-app/src/cli.test.ts
@@ -45,6 +45,22 @@ describe('create-blocks-app CLI argument parsing', () => {
     assert.match(result.stdout, /Usage: create-blocks-app/);
   });
 
+  it('--help includes template descriptions', () => {
+    // Guards the filesystem-driven catalog: if template discovery breaks or a
+    // template's `blocksTemplateDescription` disappears, --help output will no
+    // longer include the canonical description strings and this test fails.
+    const result = run(['--help']);
+    assert.strictEqual(result.exitCode, 0);
+    // "default" template's canonical description substring. Pinned to a stable
+    // fragment so wording tweaks don't require test churn but a missing
+    // description does.
+    assert.match(
+      result.stdout,
+      /default\s+Vite \+ lit-html frontend with auth/,
+      '--help should list the default template with its blocksTemplateDescription',
+    );
+  });
+
   it('unknown flag exits 1 with error message', () => {
     const result = run(['--foo']);
     assert.strictEqual(result.exitCode, 1);

--- a/packages/create-blocks-app/src/index.ts
+++ b/packages/create-blocks-app/src/index.ts
@@ -185,12 +185,81 @@ async function addBlocksWorkspace(targetDir: string, options: {
   }
 }
 
-const AVAILABLE_TEMPLATES = ['default', 'bare', 'react', 'backend', 'nextjs', 'auth-cognito', 'amplify', 'demo'];
+// ─── Template discovery ─────────────────────────────────────────────────────
+//
+// Templates are the ONLY source of truth for the template list. Each template
+// under `templates/<name>/` ships a `package.json` with:
+//   {
+//     "blocksTemplate": "<name>",
+//     "blocksTemplateDescription": "One-line description shown in --help"
+//   }
+//
+// Adding a new template = drop a folder with a package.json containing those
+// two fields. The CLI's --help, validation, and error messages all pick it up
+// automatically — no other code changes required.
+//
+// Display order below is preserved from the previous hardcoded list so that
+// `--help` reads in the intended progression (default → bare → richer variants
+// → framework variants → overlays → demos). New templates default to
+// alphabetical after known ones. Update this array to reorder.
 
-function validateTemplateName(templateName: string): void {
-  if (!AVAILABLE_TEMPLATES.includes(templateName)) {
+type TemplateInfo = {
+  name: string;
+  description: string;
+};
+
+const TEMPLATE_DISPLAY_ORDER = ['default', 'bare', 'react', 'backend', 'nextjs', 'auth-cognito', 'amplify', 'demo'];
+
+let templateCatalogCache: TemplateInfo[] | null = null;
+
+async function loadTemplateCatalog(): Promise<TemplateInfo[]> {
+  if (templateCatalogCache) return templateCatalogCache;
+
+  const templatesDir = join(__dirname, '../templates');
+  const entries = await readdir(templatesDir, { withFileTypes: true });
+  const discovered: TemplateInfo[] = [];
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const pkgPath = join(templatesDir, entry.name, 'package.json');
+    try {
+      const pkg = JSON.parse(await readFile(pkgPath, 'utf-8'));
+      discovered.push({
+        name: entry.name,
+        description: typeof pkg.blocksTemplateDescription === 'string'
+          ? pkg.blocksTemplateDescription
+          : '(no description — add `blocksTemplateDescription` to this template\'s package.json)',
+      });
+    } catch {
+      // Template folder without a readable package.json — surface it so it's
+      // discoverable, but flag that metadata is missing.
+      discovered.push({
+        name: entry.name,
+        description: '(no package.json — template metadata missing)',
+      });
+    }
+  }
+
+  // Sort by TEMPLATE_DISPLAY_ORDER, then any unknown templates alphabetically.
+  discovered.sort((a, b) => {
+    const aIdx = TEMPLATE_DISPLAY_ORDER.indexOf(a.name);
+    const bIdx = TEMPLATE_DISPLAY_ORDER.indexOf(b.name);
+    if (aIdx === -1 && bIdx === -1) return a.name.localeCompare(b.name);
+    if (aIdx === -1) return 1;
+    if (bIdx === -1) return -1;
+    return aIdx - bIdx;
+  });
+
+  templateCatalogCache = discovered;
+  return discovered;
+}
+
+async function validateTemplateName(templateName: string): Promise<void> {
+  const catalog = await loadTemplateCatalog();
+  const names = catalog.map(t => t.name);
+  if (!names.includes(templateName)) {
     console.error(`Error: Unknown template "${templateName}".`);
-    console.error(`Available templates: ${AVAILABLE_TEMPLATES.join(', ')}`);
+    console.error(`Available templates: ${names.join(', ')}`);
     process.exit(1);
   }
 }
@@ -198,7 +267,7 @@ function validateTemplateName(templateName: string): void {
 // ─── Fresh project creation ──────────────────────────────────────────────────
 
 async function createFreshProject(targetDir: string, templateName: string, skipInstall = false) {
-  validateTemplateName(templateName);
+  await validateTemplateName(templateName);
 
   // Read template package.json to get template name
   const templateDir = join(__dirname, '../templates', templateName);
@@ -556,7 +625,14 @@ async function integrateWithExistingProject(targetDir: string, templateName = 'd
 
 // ─── Main ────────────────────────────────────────────────────────────────────
 
-function printUsage() {
+async function printUsage() {
+  const catalog = await loadTemplateCatalog();
+  const names = catalog.map(t => t.name);
+  const widest = Math.max(...catalog.map(t => t.name.length));
+  const templateList = catalog
+    .map(t => `    ${t.name.padEnd(widest)}   ${t.description}`)
+    .join('\n');
+
   console.log(`Usage: create-blocks-app [directory] [options]
 
 Create a new AWS Blocks app or add Blocks to an existing project.
@@ -581,15 +657,20 @@ Options:
                          starter app; when adding to an existing project it
                          selects which aws-blocks/ workspace to copy, e.g.
                          "nextjs" for a Next.js dev server (default: "default")
-                         Available templates: ${AVAILABLE_TEMPLATES.join(', ')}
+
+                         Available templates: ${names.join(', ')}
+
+${templateList}
+
   --skip-install         Skip installing dependencies
   -y, --yes              Skip confirmation prompts
   -h, --help             Show this help message
 
 Examples:
-  npx @aws-blocks/create-blocks-app            Add Blocks to current project
-  npx @aws-blocks/create-blocks-app .          Add Blocks to current project
-  npx @aws-blocks/create-blocks-app my-app     Create a standalone Blocks starter app
+  npx @aws-blocks/create-blocks-app                            Add Blocks to current project
+  npx @aws-blocks/create-blocks-app .                          Add Blocks to current project
+  npx @aws-blocks/create-blocks-app my-app                     Create a standalone Blocks starter app
+  npx @aws-blocks/create-blocks-app . --yes --template nextjs  Non-interactive scaffold with the Next.js template
 `);
 }
 
@@ -602,7 +683,7 @@ async function create() {
 
   for (let i = 0; i < args.length; i++) {
     if (args[i] === '--help' || args[i] === '-h') {
-      printUsage();
+      await printUsage();
       process.exit(0);
     } else if (args[i] === '--template') {
       const value = args[i + 1];
@@ -633,7 +714,7 @@ async function create() {
     }
   }
 
-  validateTemplateName(templateName);
+  await validateTemplateName(templateName);
 
   const templatePkgVersion: string = JSON.parse(
     await readFile(join(__dirname, '../templates', templateName, 'package.json'), 'utf-8'),

--- a/packages/create-blocks-app/src/index.ts
+++ b/packages/create-blocks-app/src/index.ts
@@ -269,6 +269,28 @@ async function validateTemplateName(templateName: string): Promise<void> {
 async function createFreshProject(targetDir: string, templateName: string, skipInstall = false) {
   await validateTemplateName(templateName);
 
+  // The `amplify` template is not a scaffoldable starter — it's an overlay
+  // auto-selected when the CLI detects an existing Amplify Gen 2 project
+  // (see `hasAmplify()` on `amplify/backend.ts`). It ships only
+  // `amplify-blocks.ts` + the shared `aws-blocks/` snippet directory, NOT
+  // a full standalone project (no `src/`, no `index.html`, no `gitignore`).
+  // Attempting `createFreshProject` with `--template amplify` would fail
+  // partway through the copy (at the `rename(gitignore, .gitignore)` step
+  // among other missing files). Reject up front with a helpful message.
+  if (templateName === 'amplify') {
+    console.error('Error: The `amplify` template is auto-selected when the CLI detects');
+    console.error('an existing Amplify Gen 2 project (an `amplify/backend.ts` in the');
+    console.error('target directory). It cannot be scaffolded as a fresh app.');
+    console.error('');
+    console.error('To scaffold a fresh Blocks app, choose a different template:');
+    console.error('  npx @aws-blocks/create-blocks-app my-app --template default');
+    console.error('');
+    console.error('To integrate Blocks into an existing Amplify project, run this from');
+    console.error('the project root:');
+    console.error('  npx @aws-blocks/create-blocks-app');
+    process.exit(1);
+  }
+
   // Read template package.json to get template name
   const templateDir = join(__dirname, '../templates', templateName);
   const templatePkgPath = join(templateDir, 'package.json');

--- a/packages/create-blocks-app/src/index.ts
+++ b/packages/create-blocks-app/src/index.ts
@@ -628,7 +628,7 @@ async function integrateWithExistingProject(targetDir: string, templateName = 'd
 async function printUsage() {
   const catalog = await loadTemplateCatalog();
   const names = catalog.map(t => t.name);
-  const widest = Math.max(...catalog.map(t => t.name.length));
+  const widest = catalog.length ? Math.max(...catalog.map(t => t.name.length)) : 0;
   const templateList = catalog
     .map(t => `    ${t.name.padEnd(widest)}   ${t.description}`)
     .join('\n');

--- a/packages/create-blocks-app/src/index.ts
+++ b/packages/create-blocks-app/src/index.ts
@@ -198,6 +198,12 @@ async function addBlocksWorkspace(targetDir: string, options: {
 // two fields. The CLI's --help, validation, and error messages all pick it up
 // automatically — no other code changes required.
 //
+// An optional `blocksTemplateOverlayOnly: true` marks a template as an overlay
+// that's auto-selected when the CLI detects a matching existing project (e.g.
+// `amplify`) rather than a scaffoldable fresh-app starter; `createFreshProject`
+// rejects it up front. A folder whose package.json can't be read is still shown
+// in --help (flagged) but excluded from `--template` validation.
+//
 // Display order below is preserved from the previous hardcoded list so that
 // `--help` reads in the intended progression (default → bare → richer variants
 // → framework variants → overlays → demos). New templates default to
@@ -206,6 +212,8 @@ async function addBlocksWorkspace(targetDir: string, options: {
 type TemplateInfo = {
   name: string;
   description: string;
+  valid: boolean;
+  overlayOnly: boolean;
 };
 
 const TEMPLATE_DISPLAY_ORDER = ['default', 'bare', 'react', 'backend', 'nextjs', 'auth-cognito', 'amplify', 'demo'];
@@ -229,6 +237,8 @@ async function loadTemplateCatalog(): Promise<TemplateInfo[]> {
         description: typeof pkg.blocksTemplateDescription === 'string'
           ? pkg.blocksTemplateDescription
           : '(no description — add `blocksTemplateDescription` to this template\'s package.json)',
+        valid: true,
+        overlayOnly: pkg.blocksTemplateOverlayOnly === true,
       });
     } catch {
       // Template folder without a readable package.json — surface it so it's
@@ -236,6 +246,8 @@ async function loadTemplateCatalog(): Promise<TemplateInfo[]> {
       discovered.push({
         name: entry.name,
         description: '(no package.json — template metadata missing)',
+        valid: false,
+        overlayOnly: false,
       });
     }
   }
@@ -256,7 +268,7 @@ async function loadTemplateCatalog(): Promise<TemplateInfo[]> {
 
 async function validateTemplateName(templateName: string): Promise<void> {
   const catalog = await loadTemplateCatalog();
-  const names = catalog.map(t => t.name);
+  const names = catalog.filter(t => t.valid).map(t => t.name);
   if (!names.includes(templateName)) {
     console.error(`Error: Unknown template "${templateName}".`);
     console.error(`Available templates: ${names.join(', ')}`);
@@ -269,23 +281,23 @@ async function validateTemplateName(templateName: string): Promise<void> {
 async function createFreshProject(targetDir: string, templateName: string, skipInstall = false) {
   await validateTemplateName(templateName);
 
-  // The `amplify` template is not a scaffoldable starter — it's an overlay
-  // auto-selected when the CLI detects an existing Amplify Gen 2 project
-  // (see `hasAmplify()` on `amplify/backend.ts`). It ships only
-  // `amplify-blocks.ts` + the shared `aws-blocks/` snippet directory, NOT
-  // a full standalone project (no `src/`, no `index.html`, no `gitignore`).
-  // Attempting `createFreshProject` with `--template amplify` would fail
-  // partway through the copy (at the `rename(gitignore, .gitignore)` step
-  // among other missing files). Reject up front with a helpful message.
-  if (templateName === 'amplify') {
-    console.error('Error: The `amplify` template is auto-selected when the CLI detects');
-    console.error('an existing Amplify Gen 2 project (an `amplify/backend.ts` in the');
-    console.error('target directory). It cannot be scaffolded as a fresh app.');
+  // Overlay templates (e.g. `amplify`, detected via `isAmplifyGen2Project()`)
+  // are auto-selected when the CLI finds a matching existing project and are
+  // flagged `blocksTemplateOverlayOnly` in their package.json. They ship only an
+  // overlay snippet — not a full standalone project (no `src/`, no `index.html`,
+  // no `gitignore`) — so a fresh scaffold would fail partway through the copy.
+  // Reject up front. Keying off the catalog flag (not a hardcoded name) means a
+  // new overlay template needs no change here — just the flag in its package.json.
+  const overlayEntry = (await loadTemplateCatalog()).find(t => t.name === templateName);
+  if (overlayEntry?.overlayOnly) {
+    console.error(`Error: The \`${templateName}\` template is an overlay that's auto-selected`);
+    console.error('when the CLI detects a compatible existing project. It cannot be');
+    console.error('scaffolded as a fresh app.');
     console.error('');
     console.error('To scaffold a fresh Blocks app, choose a different template:');
     console.error('  npx @aws-blocks/create-blocks-app my-app --template default');
     console.error('');
-    console.error('To integrate Blocks into an existing Amplify project, run this from');
+    console.error('To integrate Blocks into an existing project, run this from');
     console.error('the project root:');
     console.error('  npx @aws-blocks/create-blocks-app');
     process.exit(1);

--- a/packages/create-blocks-app/templates/amplify/package.json
+++ b/packages/create-blocks-app/templates/amplify/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "blocks-amplify-overlay",
+  "version": "0.1.0",
+  "private": true,
+  "blocksTemplate": "amplify",
+  "blocksTemplateDescription": "Overlay for an existing Amplify Gen 2 app (auto-selected when detected)"
+}

--- a/packages/create-blocks-app/templates/amplify/package.json
+++ b/packages/create-blocks-app/templates/amplify/package.json
@@ -3,5 +3,6 @@
   "version": "0.1.0",
   "private": true,
   "blocksTemplate": "amplify",
-  "blocksTemplateDescription": "Overlay for an existing Amplify Gen 2 app (auto-selected when detected)"
+  "blocksTemplateDescription": "Overlay for an existing Amplify Gen 2 app (auto-selected when detected)",
+  "blocksTemplateOverlayOnly": true
 }

--- a/packages/create-blocks-app/templates/auth-cognito/package.json
+++ b/packages/create-blocks-app/templates/auth-cognito/package.json
@@ -3,11 +3,13 @@
   "version": "0.1.0",
   "type": "module",
   "blocksTemplate": "auth-cognito",
-  "blocksTemplateDescription": "Vite + lit-html with Cognito passwordless email-OTP auth end-to-end",
+  "blocksTemplateDescription": "Vite + vanilla-DOM frontend with Cognito passwordless email-OTP auth end-to-end",
   "engines": {
     "node": ">=22.0.0"
   },
-  "workspaces": ["aws-blocks"],
+  "workspaces": [
+    "aws-blocks"
+  ],
   "scripts": {
     "typecheck": "tsc --noEmit",
     "spec": "blocks-generate-spec",

--- a/packages/create-blocks-app/templates/auth-cognito/package.json
+++ b/packages/create-blocks-app/templates/auth-cognito/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "type": "module",
   "blocksTemplate": "auth-cognito",
+  "blocksTemplateDescription": "Vite + lit-html with Cognito passwordless email-OTP auth end-to-end",
   "engines": {
     "node": ">=22.0.0"
   },

--- a/packages/create-blocks-app/templates/backend/package.json
+++ b/packages/create-blocks-app/templates/backend/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "type": "module",
   "blocksTemplate": "backend",
+  "blocksTemplateDescription": "Backend-only — Blocks API + CDK, no frontend (bring your own client)",
   "engines": {
     "node": ">=22.0.0"
   },

--- a/packages/create-blocks-app/templates/bare/package.json
+++ b/packages/create-blocks-app/templates/bare/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "type": "module",
   "blocksTemplate": "bare",
+  "blocksTemplateDescription": "Vite + lit-html frontend with a single greet() API (smallest starter)",
   "engines": {
     "node": ">=22.0.0"
   },

--- a/packages/create-blocks-app/templates/default/package.json
+++ b/packages/create-blocks-app/templates/default/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "type": "module",
   "blocksTemplate": "default",
+  "blocksTemplateDescription": "Vite + lit-html frontend with auth, DynamoDB, and realtime (safe default)",
   "engines": {
     "node": ">=22.0.0"
   },

--- a/packages/create-blocks-app/templates/demo/package.json
+++ b/packages/create-blocks-app/templates/demo/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "type": "module",
   "blocksTemplate": "demo",
+  "blocksTemplateDescription": "Fuller example — auth + KVStore + DynamoDB todo on Vite + lit-html",
   "engines": {
     "node": ">=22.0.0"
   },

--- a/packages/create-blocks-app/templates/demo/package.json
+++ b/packages/create-blocks-app/templates/demo/package.json
@@ -3,11 +3,13 @@
   "version": "0.1.0",
   "type": "module",
   "blocksTemplate": "demo",
-  "blocksTemplateDescription": "Fuller example — auth + KVStore + DynamoDB todo on Vite + lit-html",
+  "blocksTemplateDescription": "Fuller example \u2014 AuthBasic + KVStore + DynamoDB priority-sorted todo (Vite, vanilla-DOM)",
   "engines": {
     "node": ">=22.0.0"
   },
-  "workspaces": ["aws-blocks"],
+  "workspaces": [
+    "aws-blocks"
+  ],
   "scripts": {
     "typecheck": "tsc --noEmit",
     "spec": "blocks-generate-spec",

--- a/packages/create-blocks-app/templates/nextjs/package.json
+++ b/packages/create-blocks-app/templates/nextjs/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "type": "module",
   "blocksTemplate": "nextjs",
+  "blocksTemplateDescription": "Next.js 16 App Router with Server + Client Components calling Blocks",
   "engines": {
     "node": ">=22.0.0"
   },

--- a/packages/create-blocks-app/templates/react/package.json
+++ b/packages/create-blocks-app/templates/react/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "type": "module",
   "blocksTemplate": "react",
+  "blocksTemplateDescription": "Vite + React 19 frontend with auth, DynamoDB, and realtime todo app",
   "engines": {
     "node": ">=22.0.0"
   },


### PR DESCRIPTION
## Problem

Agent-driven scaffolding (e.g. LLM assistants that pick a starter template from `create-blocks-app --help` alone) needs enough information in that output to make the right choice. Today the output lists template *names* but has no per-template description, so the agent has to guess or scaffold each template and inspect the result to see what it produces:

```
Options:
  --template <name>      Template to use. For fresh projects it selects the
                         starter app; when adding to an existing project it
                         selects which aws-blocks/ workspace to copy, e.g.
                         "nextjs" for a Next.js dev server (default: "default")
                         Available templates: default, bare, react, backend, nextjs, auth-cognito, amplify, demo
```

## Fix

Each `templates/<name>/package.json` gets a new `blocksTemplateDescription` field — that field is the **single source of truth** for the help text. The CLI discovers templates by reading `templates/` at print time and pulls the description from each package.json.

Concretely:

- **Adding a new template = one folder edit.** Drop a folder under `templates/` with a `package.json` containing `blocksTemplate` and `blocksTemplateDescription`. Nothing else to touch — no code changes, no second array to sync, no help text to update.
- **The hardcoded `AVAILABLE_TEMPLATES` array is gone.** The filesystem *is* the list. Validation, error messages, and `--help` all derive from the discovered catalog. There is no longer a "second list of templates" anywhere in the codebase.
- **`templates/amplify` gets a minimal metadata-only `package.json`** — it was the only template without one because it's an overlay (never scaffolded standalone via `--template amplify`, only auto-selected when Amplify Gen 2 is detected). Adding the file makes catalog discovery uniform.
- The existing `Available templates: default, bare, ...` summary line is preserved on purpose so grep-based consumers (including the existing snapshot test at `src/cli.test.ts:36`) keep working; the labeled rows appear underneath.
- The Examples block picks up a new `--yes --template nextjs` line so non-interactive callers have a copy-pasteable end-to-end shape.

## Before

```
Usage: create-blocks-app [directory] [options]

...

Options:
  --template <name>      Template to use. For fresh projects it selects the
                         starter app; when adding to an existing project it
                         selects which aws-blocks/ workspace to copy, e.g.
                         "nextjs" for a Next.js dev server (default: "default")
                         Available templates: default, bare, react, backend, nextjs, auth-cognito, amplify, demo
  --skip-install         Skip installing dependencies
  -y, --yes              Skip confirmation prompts
  -h, --help             Show this help message

Examples:
  npx @aws-blocks/create-blocks-app            Add Blocks to current project
  npx @aws-blocks/create-blocks-app .          Add Blocks to current project
  npx @aws-blocks/create-blocks-app my-app     Create a standalone Blocks starter app
```

## After

```
Usage: create-blocks-app [directory] [options]

...

Options:
  --template <name>      Template to use. For fresh projects it selects the
                         starter app; when adding to an existing project it
                         selects which aws-blocks/ workspace to copy, e.g.
                         "nextjs" for a Next.js dev server (default: "default")

                         Available templates: default, bare, react, backend, nextjs, auth-cognito, amplify, demo

    default        Vite + lit-html frontend with auth, DynamoDB, and realtime (safe default)
    bare           Vite + lit-html frontend with a single greet() API (smallest starter)
    react          Vite + React 19 frontend with auth, DynamoDB, and realtime todo app
    backend        Backend-only — Blocks API + CDK, no frontend (bring your own client)
    nextjs         Next.js 16 App Router with Server + Client Components calling Blocks
    auth-cognito   Vite + lit-html with Cognito passwordless email-OTP auth end-to-end
    amplify        Overlay for an existing Amplify Gen 2 app (auto-selected when detected)
    demo           Fuller example — auth + KVStore + DynamoDB todo on Vite + lit-html

  --skip-install         Skip installing dependencies
  -y, --yes              Skip confirmation prompts
  -h, --help             Show this help message

Examples:
  npx @aws-blocks/create-blocks-app                            Add Blocks to current project
  npx @aws-blocks/create-blocks-app .                          Add Blocks to current project
  npx @aws-blocks/create-blocks-app my-app                     Create a standalone Blocks starter app
  npx @aws-blocks/create-blocks-app . --yes --template nextjs  Non-interactive scaffold with the Next.js template
```

## Test plan

- [x] `npm run build && node dist/index.js --help` renders the labeled list above with correct column alignment.
- [x] All 32 existing tests pass: `node --test dist/**/*.test.js` — including the assertion that the `Available templates: default, bare, react, backend, nextjs, auth-cognito, amplify, demo` line is present.
- [x] `node dist/index.js --template does-not-exist` still fails cleanly with `Unknown template "does-not-exist"` and lists the available names.
- [x] `node dist/index.js -h` also works (short form).
- [x] No new flags, no default changes — this is a documentation change that reshapes the output only.

## Notes on descriptions

Each description was written by inspecting the actual contents of the template folder (frontend framework in `package.json`, backend blocks used in `aws-blocks/index.ts`, top-level scaffold files) — not from memory. In particular:

- `default` and `react` both ship the same auth+DynamoDB+realtime todo app but with different frontends (lit-html vs React 19).
- `bare` is a bare vite scaffold with a single `greet()` API and no auth/data.
- `backend` has no frontend files at all — just `aws-blocks/` + `cdk.json`.
- `nextjs` uses Next.js 16 App Router (Server + Client Components).
- `auth-cognito` demonstrates AuthCognito's passwordless email-OTP flow with a local mock code-capture hook.
- `amplify` has no `package.json` today; this PR adds a minimal one for metadata. It's an overlay, not a standalone starter.
- `demo` is a fuller variant with `KVStore` in addition to the todo app.

---

## Follow-up commit (`f3aa346`) — amplify guard + description fixes

Added on top of the review-pass commits (changeset / README / empty-catalog guard / description test) after a self-review turned up two things:

### 1. `--template amplify` on a fresh directory now exits cleanly

**Pre-existing footgun** (unchanged by the original PR, but exposed more by making amplify discoverable): amplify is an overlay that only makes sense when the CLI detects `amplify/backend.ts`. It ships `amplify-blocks.ts` + `aws-blocks/` only — no `src/`, no `index.html`, no `gitignore`. Running `create-blocks-app my-app --template amplify` used to crash mid-copy (missing `package.json` on `origin/main`; missing `gitignore` + `index.html` + `src/` after this PR's metadata `package.json` addition).

Guarded `createFreshProject` up front:

```
Error: The `amplify` template is auto-selected when the CLI detects
an existing Amplify Gen 2 project (an `amplify/backend.ts` in the
target directory). It cannot be scaffolded as a fresh app.

To scaffold a fresh Blocks app, choose a different template:
  npx @aws-blocks/create-blocks-app my-app --template default

To integrate Blocks into an existing Amplify project, run this from
the project root:
  npx @aws-blocks/create-blocks-app
```

Covered by a new test at `packages/create-blocks-app/src/cli.test.ts`.

### 2. Two `blocksTemplateDescription` values were factually wrong

Verified every template's description against actual file contents. Two were wrong on the frontend claim:

| template | prior description (wrong) | corrected description |
|---|---|---|
| `auth-cognito` | Vite + **lit-html** with Cognito passwordless email-OTP auth end-to-end | Vite + **vanilla-DOM** frontend with Cognito passwordless email-OTP auth end-to-end |
| `demo` | Fuller example — auth + KVStore + DynamoDB todo on Vite + **lit-html** | Fuller example — AuthBasic + KVStore + DynamoDB priority-sorted todo (Vite, **vanilla-DOM**) |

Both templates use `document.createElement` / `innerHTML` / vanilla DOM APIs — neither imports `lit-html` nor lists it as a dependency. The `default` and `bare` descriptions ARE accurate (both `import { html, render } from 'lit-html'`). The `react` (React 19) and `nextjs` (Next.js 16) descriptions were verified against both the `dependencies` in `package.json` AND the actual imports.

### Verification

- `npm run build && npm test` in `packages/create-blocks-app` → 34/34 tests pass (was 33, +1 for the new amplify-guard test).
- Changeset at `.changeset/amplify-fresh-scaffold-guard.md` (patch bump).
