### PR TITLE
fix(bb-distributed-data): reject index key sort order (ASC/DESC) for DSQL

### DIFF
--- a/.changeset/dsql-index-sort-order.md
+++ b/.changeset/dsql-index-sort-order.md
@@ -1,0 +1,5 @@
+---
+"@aws-blocks/bb-distributed-data": patch
+---
+
+Reject index key sort order (`ASC`/`DESC`, `NULLS FIRST/LAST`) in `CREATE INDEX` at dev time. DSQL rejects sort order on index keys ("specifying sort order not supported for index keys"), but the PGlite-based local mock previously accepted it, so the error only surfaced on deploy. Migration and mock validation now fail locally instead.

--- a/.changeset/dsql-index-sort-order.md
+++ b/.changeset/dsql-index-sort-order.md
@@ -2,4 +2,4 @@
 "@aws-blocks/bb-distributed-data": patch
 ---
 
-Reject index key sort order (`ASC`/`DESC`, `NULLS FIRST/LAST`) in `CREATE INDEX` at dev time. DSQL rejects sort order on index keys ("specifying sort order not supported for index keys"), but the PGlite-based local mock previously accepted it, so the error only surfaced on deploy. Migration and mock validation now fail locally instead.
+Reject index key sort direction (`ASC`/`DESC`) in `CREATE INDEX` at dev time. DSQL does not allow a sort direction on index keys ("specifying sort order not supported for index keys"), but the PGlite-based local mock previously accepted it, so the error only surfaced on deploy. Migration and mock validation now fail locally instead. (`NULLS FIRST/LAST` is supported by DSQL and is not rejected.)

--- a/packages/bb-distributed-data/DESIGN.md
+++ b/packages/bb-distributed-data/DESIGN.md
@@ -74,6 +74,7 @@ The core insight: PGlite supports everything DSQL doesn't. Without validation, c
 | `CREATE TEMP TABLE` | Temporary tables |
 | `SET TRANSACTION ISOLATION LEVEL` | Fixed Repeatable Read |
 | `COLLATE` | C collation only |
+| `CREATE INDEX ... ASC/DESC` | Sort direction on index keys (NULLS FIRST/LAST is allowed) |
 
 ### Transaction Tracking
 

--- a/packages/bb-distributed-data/README.md
+++ b/packages/bb-distributed-data/README.md
@@ -108,7 +108,7 @@ DSQL is a subset of PostgreSQL. The local mock enforces these restrictions so co
 | LISTEN / NOTIFY | AppSync Events, EventBridge, or polling |
 | Extensions | Not available |
 | ADD COLUMN with DEFAULT | Add column without default, handle nulls in app |
-| Index key sort order (`ASC`/`DESC`, `NULLS FIRST/LAST`) | Omit it; enforce ordering with `ORDER BY` in queries |
+| Index key sort direction (`ASC`/`DESC`) | Omit it; enforce ordering with `ORDER BY` in queries (`NULLS FIRST/LAST` is supported) |
 
 ### Transaction Constraints
 

--- a/packages/bb-distributed-data/README.md
+++ b/packages/bb-distributed-data/README.md
@@ -108,6 +108,7 @@ DSQL is a subset of PostgreSQL. The local mock enforces these restrictions so co
 | LISTEN / NOTIFY | AppSync Events, EventBridge, or polling |
 | Extensions | Not available |
 | ADD COLUMN with DEFAULT | Add column without default, handle nulls in app |
+| Index key sort order (`ASC`/`DESC`, `NULLS FIRST/LAST`) | Omit it; enforce ordering with `ORDER BY` in queries |
 
 ### Transaction Constraints
 

--- a/packages/bb-distributed-data/src/e2e-mock.test.ts
+++ b/packages/bb-distributed-data/src/e2e-mock.test.ts
@@ -207,6 +207,13 @@ describe('DsqlMockEngine — CREATE INDEX ASYNC parity', () => {
     );
   });
 
+  it('rejects CREATE INDEX ASYNC with a DESC sort order on a key', async () => {
+    await assert.rejects(
+      () => engine.withDdl(() => db.execute(sql`CREATE INDEX ASYNC idx_users_email_desc ON users (email DESC)`)),
+      /sort order/i,
+    );
+  });
+
   it('does not strip ASYNC outside of CREATE INDEX (column named "async")', async () => {
     await engine.withDdl(() => db.execute(sql`CREATE TABLE jobs (id TEXT PRIMARY KEY, async BOOLEAN)`));
     await db.execute(sql`INSERT INTO jobs (id, async) VALUES (${'j1'}, ${true})`);

--- a/packages/bb-distributed-data/src/validation.test.ts
+++ b/packages/bb-distributed-data/src/validation.test.ts
@@ -500,3 +500,44 @@ describe('validateStatement — unsupported features after bind parameters', () 
     assert.doesNotThrow(() => validateStatement("INSERT INTO audit (id, action) VALUES ($1, 'TRUNCATE')"));
   });
 });
+
+describe('validateStatement — index key sort order', () => {
+  it('rejects DESC on an index key', () => {
+    assert.throws(
+      () => validateStatement('CREATE INDEX idx ON persons (user_id, last_encounter_at DESC)'),
+      /sort order/i,
+    );
+  });
+
+  it('rejects DESC on a CREATE INDEX ASYNC key', () => {
+    assert.throws(
+      () => validateStatement('CREATE INDEX ASYNC idx_persons_user_recent ON persons (user_id, last_encounter_at DESC)'),
+      /sort order/i,
+    );
+  });
+
+  it('rejects an explicit ASC on an index key', () => {
+    assert.throws(() => validateStatement('CREATE INDEX idx ON t (col ASC)'), /sort order/i);
+  });
+
+  it('rejects NULLS FIRST / NULLS LAST on an index key', () => {
+    assert.throws(() => validateStatement('CREATE INDEX idx ON t (col NULLS FIRST)'), /sort order/i);
+    assert.throws(() => validateStatement('CREATE INDEX idx ON t (col NULLS LAST)'), /sort order/i);
+  });
+
+  it('allows a plain CREATE INDEX without sort order', () => {
+    assert.doesNotThrow(() => validateStatement('CREATE INDEX idx ON persons (user_id, last_encounter_at)'));
+  });
+
+  it('allows a partial index whose WHERE mentions a column like "description"', () => {
+    assert.doesNotThrow(() => validateStatement('CREATE INDEX idx ON t (name) WHERE description IS NOT NULL'));
+  });
+
+  it('allows an expression index without sort order', () => {
+    assert.doesNotThrow(() => validateStatement('CREATE INDEX idx ON t ((lower(name)))'));
+  });
+
+  it('does not flag ORDER BY ... DESC in a SELECT (no false positive outside CREATE INDEX)', () => {
+    assert.doesNotThrow(() => validateStatement('SELECT * FROM persons ORDER BY last_encounter_at DESC'));
+  });
+});

--- a/packages/bb-distributed-data/src/validation.test.ts
+++ b/packages/bb-distributed-data/src/validation.test.ts
@@ -520,9 +520,9 @@ describe('validateStatement — index key sort order', () => {
     assert.throws(() => validateStatement('CREATE INDEX idx ON t (col ASC)'), /sort order/i);
   });
 
-  it('rejects NULLS FIRST / NULLS LAST on an index key', () => {
-    assert.throws(() => validateStatement('CREATE INDEX idx ON t (col NULLS FIRST)'), /sort order/i);
-    assert.throws(() => validateStatement('CREATE INDEX idx ON t (col NULLS LAST)'), /sort order/i);
+  it('allows NULLS FIRST / NULLS LAST on an index key (supported by DSQL)', () => {
+    assert.doesNotThrow(() => validateStatement('CREATE INDEX ASYNC idx ON t (col NULLS FIRST)'));
+    assert.doesNotThrow(() => validateStatement('CREATE INDEX ASYNC idx ON t (col NULLS LAST)'));
   });
 
   it('allows a plain CREATE INDEX without sort order', () => {

--- a/packages/bb-distributed-data/src/validation.ts
+++ b/packages/bb-distributed-data/src/validation.ts
@@ -85,7 +85,13 @@ const RULES: ValidationRule[] = [
   { pattern: /\bCOLLATE\b/i, message: 'DSQL only supports C collation.', severity: 'error' },
   { pattern: /(?<!::)\bJSONB\b/i, message: 'DSQL does not support JSONB columns. Use JSON instead (JSONB is available as a query runtime cast via ::jsonb).', severity: 'error' },
   { pattern: /(@>|<@|\?\||\?&)/, message: 'JSONB operators lack GIN index acceleration in DSQL.', severity: 'warn' },
-  { pattern: /\bCREATE\s+(?:UNIQUE\s+)?INDEX\b[\s\S]*\b(?:ASC|DESC|NULLS\s+(?:FIRST|LAST))\b/i, message: 'DSQL does not support sort order (ASC/DESC/NULLS FIRST/LAST) on index keys. Remove it — ordering is enforced by ORDER BY in queries. (DSQL: "specifying sort order not supported for index keys")', severity: 'error' },
+  // DSQL rejects a sort direction (ASC/DESC) on index keys — it isn't in the
+  // CREATE INDEX ASYNC grammar (only `NULLS FIRST|LAST`, which IS supported, is).
+  // `[^;]*` keeps the match inside a single statement; ASC/DESC cannot otherwise
+  // appear in a CREATE INDEX. Caveat: stripLiteralsAndComments doesn't strip
+  // double-quoted identifiers, so a column literally named "desc"/"asc" would
+  // false-positive — niche, and shared with other single-keyword rules here.
+  { pattern: /\bCREATE\s+(?:UNIQUE\s+)?INDEX\b[^;]*\b(?:ASC|DESC)\b/i, message: 'DSQL does not support sort order (ASC/DESC) on index keys. Remove it — ordering is enforced by ORDER BY in queries (NULLS FIRST/LAST is allowed). (DSQL: "specifying sort order not supported for index keys")', severity: 'error' },
 ];
 
 /** Validate a SQL statement for DSQL compatibility. Throws on unsupported features. */

--- a/packages/bb-distributed-data/src/validation.ts
+++ b/packages/bb-distributed-data/src/validation.ts
@@ -85,6 +85,7 @@ const RULES: ValidationRule[] = [
   { pattern: /\bCOLLATE\b/i, message: 'DSQL only supports C collation.', severity: 'error' },
   { pattern: /(?<!::)\bJSONB\b/i, message: 'DSQL does not support JSONB columns. Use JSON instead (JSONB is available as a query runtime cast via ::jsonb).', severity: 'error' },
   { pattern: /(@>|<@|\?\||\?&)/, message: 'JSONB operators lack GIN index acceleration in DSQL.', severity: 'warn' },
+  { pattern: /\bCREATE\s+(?:UNIQUE\s+)?INDEX\b[\s\S]*\b(?:ASC|DESC|NULLS\s+(?:FIRST|LAST))\b/i, message: 'DSQL does not support sort order (ASC/DESC/NULLS FIRST/LAST) on index keys. Remove it — ordering is enforced by ORDER BY in queries. (DSQL: "specifying sort order not supported for index keys")', severity: 'error' },
 ];
 
 /** Validate a SQL statement for DSQL compatibility. Throws on unsupported features. */


### PR DESCRIPTION
## Problem

Aurora DSQL does not support a sort direction (`ASC`/`DESC`) on index keys. Deploying such a migration fails with `specifying sort order not supported for index keys`. (`NULLS FIRST`/`NULLS LAST` **is** supported by DSQL and is not affected.)

The local mock runs on PGlite (full PostgreSQL), which accepts `ASC`/`DESC` on index keys, so a migration like `CREATE INDEX ASYNC ... (col DESC)` passes locally and only fails on the first real DSQL deploy — exactly the class of divergence the mock is meant to close.

**Issue #, if available:** N/A

## Changes

- **Validation rule** (`packages/bb-distributed-data/src/validation.ts`): add one entry to the existing `RULES` array that rejects a sort direction (`ASC`/`DESC`) on `CREATE [UNIQUE] INDEX` keys, while leaving `NULLS FIRST/LAST` allowed. Because `validateStatement` runs from both the migration validator and the mock engine's query path (before the engine strips `ASYNC`), the failure now surfaces at dev time — during `npm run dev` migration execution — instead of on deploy.
- **Docs** (`packages/bb-distributed-data/README.md`, `packages/bb-distributed-data/DESIGN.md`): add a row to the DSQL limitations / statement-validation tables, with the alternative (omit the direction; enforce ordering with `ORDER BY` in queries).
- **Changeset**: patch bump for `@aws-blocks/bb-distributed-data`.

The rule matches within a single statement (`[^;]*`) and is false-positive-safe: `validateStatement` is called per statement (statements are split upstream), a `CREATE INDEX` grammar has no `ORDER BY` clause, and string literals are stripped before matching.

## Validation

- **Unit tests** (`validation.test.ts`): reject `ASC`/`DESC`; confirm `NULLS FIRST`/`NULLS LAST` are allowed; regression cases confirm no false positive on `SELECT ... ORDER BY x DESC`, on a partial index whose `WHERE` mentions a `description` column, or on an expression index.
- **End-to-end mock test** (`e2e-mock.test.ts`): the `DsqlMockEngine` rejects `CREATE INDEX ASYNC ... (col DESC)` — proving the reproduction case is now caught locally before any deploy.
- Full `bb-distributed-data` suite: **146/146 passing**.

**Known limitation:** a column literally named `"desc"`/`"asc"` (double-quoted identifier) can false-positive, since `stripLiteralsAndComments` does not strip double-quoted identifiers. This is the same class as the existing single-keyword rules (`COLLATE`, `TRUNCATE`) and affects no current migration, so it is treated as non-blocking.

## Checklist

- [x] PR description included
- [x] Tests are changed or added
- [x] Relevant documentation is changed or added (and PR referenced)

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
