### PR TITLE
feat(bb-agent): canned provider tool hints default values

### DIFF
--- a/.changeset/canned-provider-tool-hints.md
+++ b/.changeset/canned-provider-tool-hints.md
@@ -1,0 +1,9 @@
+---
+"@aws-blocks/bb-agent": patch
+---
+
+Improve the local-dev `canned` provider's tool support with two optional tool hints (ignored by real providers) and schema-default awareness:
+
+- `cannedExamples` — realistic tool input, shallow-merged over generated placeholders instead of the generic `sample` values.
+- `cannedTriggers` — extra keyword phrases that trigger a tool beyond its name (single words match on word boundaries; multi-word phrases match as substrings).
+- Generated placeholder input now respects schema `default` values (from Zod `.default()`).

--- a/.changeset/canned-provider-tool-hints.md
+++ b/.changeset/canned-provider-tool-hints.md
@@ -5,5 +5,5 @@
 Improve the local-dev `canned` provider's tool support with two optional tool hints (ignored by real providers) and schema-default awareness:
 
 - `cannedExamples` — realistic tool input, shallow-merged over generated placeholders instead of the generic `sample` values.
-- `cannedTriggers` — extra keyword phrases that trigger a tool beyond its name (single words match on word boundaries; multi-word phrases match as substrings).
+- `cannedTriggers` — extra keyword phrases that trigger a tool beyond its name (single- and multi-word phrases match on word boundaries, so `'log in'` won't fire on `"backlog in"`; internal whitespace is flexible).
 - Generated placeholder input now respects schema `default` values (from Zod `.default()`).

--- a/.changeset/canned-provider-tool-hints.md
+++ b/.changeset/canned-provider-tool-hints.md
@@ -7,3 +7,11 @@ Improve the local-dev `canned` provider's tool support with two optional tool hi
 - `cannedExamples` — realistic tool input, shallow-merged over generated placeholders instead of the generic `sample` values.
 - `cannedTriggers` — extra keyword phrases that trigger a tool beyond its name (single- and multi-word phrases match on word boundaries, so `'log in'` won't fire on `"backlog in"`; internal whitespace is flexible).
 - Generated placeholder input now respects schema `default` values (from Zod `.default()`).
+
+Also fixes three pre-existing rough edges in the same provider:
+
+- Generated input now resolves `const`, `enum`, and `anyOf`/`oneOf` (Zod union) properties. Previously a property that was a union, a const, or untyped and carried no `default` matched no branch and was dropped — and a *required* field of that shape made the emitted call fail schema validation before the tool ran. A required field of an otherwise unrecognized shape now falls back to a string; optional ones stay omitted, since absence is valid there.
+- The canned *text* responses (`weather`/`order`/`help`) now match on word boundaries like tool matching does, so `"reorder"` no longer returns the order response and `"helper"` no longer returns the help response.
+- A `cannedExamples` key that isn't a field of the tool's schema now logs a one-time warning naming the tool and field, since it is almost always a typo. It never throws and the value is still sent — a bad hint must not break local dev.
+
+Patch (not minor) per the pre-1.0 caret convention — the change is additive and backward-compatible.

--- a/packages/bb-agent/API.md
+++ b/packages/bb-agent/API.md
@@ -284,6 +284,8 @@ export interface ToolCallRecord {
 
 // @public (undocumented)
 export interface ToolDefinition<TContext = DefaultToolContext, TParams extends z.ZodType = z.ZodType<any>> {
+    cannedExamples?: Record<string, JSONValue>;
+    cannedTriggers?: string[];
     // (undocumented)
     description: string;
     handler: (args: ToolHandlerArgs<z.infer<TParams>, TContext>) => Promise<JSONValue>;

--- a/packages/bb-agent/DESIGN.md
+++ b/packages/bb-agent/DESIGN.md
@@ -72,6 +72,7 @@ Custom Strands model provider for local development. No network, no API keys, no
 
 - Returns instant keyword-based responses (e.g., prompt contains "weather" → weather response, otherwise a default canned response)
 - Streams word by word, matching the same `ModelStreamEvent` protocol as Bedrock/OpenAI
-- Triggers tool calls when the prompt mentions a tool name — splits camelCase names into words (e.g., "weather" matches `getWeather`) and emits Strands `toolUse` events
+- Triggers tool calls when the prompt mentions a tool name (or a `cannedTriggers` keyword) — splits camelCase names into words (e.g., "weather" matches `getWeather`) and emits Strands `toolUse` events. Matching is on word boundaries, not substrings, so "category" does not fire `getCat`.
+- Derives tool input from, in order of preference: the tool's `cannedExamples`, the schema `default` (from Zod `.default()`), the first `enum` value (for enum fields), then a generic placeholder by type (`'sample'` / `1` / `true` / `[]`)
 - After Strands executes the tool and sends the result back, returns a fixed acknowledgment (`"I called the tool and got a result."`)
 - Token usage reports zeros (no real model call)

--- a/packages/bb-agent/README.md
+++ b/packages/bb-agent/README.md
@@ -674,8 +674,31 @@ The CannedProvider is a custom Strands model provider that requires no network o
 
 - Returns simple mock responses
 - Triggers tool calls when the prompt mentions a tool name (e.g., "get order" triggers `getOrderStatus`)
-- Generates valid tool inputs from Zod schemas using type-based placeholders
+- Generates valid tool inputs from Zod schemas, respecting schema `default` values (from `.default()`) before falling back to type-based placeholders (`'sample'`, `1`, `true`, `[]`)
 - Streams responses word by word, matching the same protocol as real providers
+
+#### Canned Hints — `cannedExamples` and `cannedTriggers`
+
+Two optional tool fields make the canned provider more useful for local prototyping. Both are **ignored by the real bedrock/openai providers**, so they're safe to leave on production tools:
+
+| Field | Type | Effect (canned provider only) |
+| --- | --- | --- |
+| `cannedExamples` | `Record<string, JSONValue>` | Realistic tool input, shallow-merged over the generated placeholder — your fields win, unspecified fields fall back to schema defaults / placeholders. |
+| `cannedTriggers` | `string[]` | Extra keyword phrases that make the provider select this tool, beyond its name and camelCase words. Single and multi-word phrases match on word boundaries (so `'log in'` won't fire on `"backlog in"`); internal whitespace is flexible. |
+
+```typescript
+tools: (tool) => ({
+  searchDocs: tool({
+    description: 'Search documentation',
+    parameters: z.object({ query: z.string() }),
+    handler: async ({ input }) => search(input.query),
+
+    // Canned provider hints (ignored by real models):
+    cannedExamples: { query: 'how do I get started' },      // used instead of the generic 'sample'
+    cannedTriggers: ['search', 'find', 'look up'],           // "help me find X" now triggers searchDocs
+  }),
+}),
+```
 
 
 ## Client Hook — `useChat`

--- a/packages/bb-agent/README.md
+++ b/packages/bb-agent/README.md
@@ -686,16 +686,24 @@ Two optional tool fields make the canned provider more useful for local prototyp
 | `cannedExamples` | `Record<string, JSONValue>` | Realistic tool input, shallow-merged over the generated placeholder — your fields win, unspecified fields fall back to schema defaults / placeholders. The merge is one level deep: a nested-object example replaces that whole generated sub-object rather than deep-merging into it. |
 | `cannedTriggers` | `string[]` | Extra keyword phrases that make the provider select this tool, beyond its name and camelCase words. Single and multi-word phrases match on word boundaries (so `'log in'` won't fire on `"backlog in"`); internal whitespace is flexible. |
 
+Building on the [KnowledgeBase tool](#using-knowledgebase-with-the-agent) above: without hints the mock calls `searchDocs` with `{ query: 'sample' }`, which matches nothing in your documents, so local testing returns empty results. A `cannedExamples` query that actually appears in *your* docs makes the mock return real hits, and `cannedTriggers` lets natural phrasings fire the tool:
+
 ```typescript
 tools: (tool) => ({
   searchDocs: tool({
-    description: 'Search documentation',
-    parameters: z.object({ query: z.string() }),
-    handler: async ({ input }) => search(input.query),
+    description: 'Search product documentation for relevant information',
+    parameters: z.object({
+      query: z.string().describe('The search query'),
+      maxResults: z.number().optional().describe('Max results to return (default: 5)'),
+    }),
+    handler: async ({ input }) => kb.retrieve(input.query, { maxResults: input.maxResults ?? 5 }),
 
     // Canned provider hints (ignored by real models):
-    cannedExamples: { query: 'how do I get started' },      // used instead of the generic 'sample'
-    cannedTriggers: ['search', 'find', 'look up'],           // "help me find X" now triggers searchDocs
+    // Without this the mock would search for the literal 'sample' and match nothing —
+    // use a query that hits YOUR documents so local runs return meaningful results.
+    cannedExamples: { query: 'how do I reset my password' },
+    // "help me find the login docs" now triggers searchDocs, not just the word "searchDocs".
+    cannedTriggers: ['search', 'find', 'look up'],
   }),
 }),
 ```

--- a/packages/bb-agent/README.md
+++ b/packages/bb-agent/README.md
@@ -702,8 +702,9 @@ tools: (tool) => ({
     // Without this the mock would search for the literal 'sample' and match nothing —
     // use a query that hits YOUR documents so local runs return meaningful results.
     cannedExamples: { query: 'how do I reset my password' },
-    // "help me find the login docs" now triggers searchDocs, not just the word "searchDocs".
-    cannedTriggers: ['search', 'find', 'look up'],
+    // The name already matches "search"/"docs"/"searchDocs"; these add phrasings that don't
+    // contain the name, so "help me find the manual" or "look up the guide" also fire the tool.
+    cannedTriggers: ['find', 'look up'],
   }),
 }),
 ```

--- a/packages/bb-agent/README.md
+++ b/packages/bb-agent/README.md
@@ -683,7 +683,7 @@ Two optional tool fields make the canned provider more useful for local prototyp
 
 | Field | Type | Effect (canned provider only) |
 | --- | --- | --- |
-| `cannedExamples` | `Record<string, JSONValue>` | Realistic tool input, shallow-merged over the generated placeholder — your fields win, unspecified fields fall back to schema defaults / placeholders. |
+| `cannedExamples` | `Record<string, JSONValue>` | Realistic tool input, shallow-merged over the generated placeholder — your fields win, unspecified fields fall back to schema defaults / placeholders. The merge is one level deep: a nested-object example replaces that whole generated sub-object rather than deep-merging into it. |
 | `cannedTriggers` | `string[]` | Extra keyword phrases that make the provider select this tool, beyond its name and camelCase words. Single and multi-word phrases match on word boundaries (so `'log in'` won't fire on `"backlog in"`); internal whitespace is flexible. |
 
 ```typescript

--- a/packages/bb-agent/src/agent.ts
+++ b/packages/bb-agent/src/agent.ts
@@ -15,7 +15,7 @@ import type { Agent as StrandsAgent, SnapshotStorage } from '@strands-agents/sdk
 import { z } from 'zod';
 import { createStrandsModel, checkModelHealth } from './model-factory.js';
 import { messageSchema, conversationSchema, agentStreamChunkSchema } from './schemas.js';
-import type { AgentConfig, AgentStreamChunk, AgentStreamResult, StreamOptions, Message, Conversation, TokenUsage, ConversationManagerConfig, ModelConfig, JSONValue, InterruptResponse, DefaultToolContext, AgentTool, ToolDefinition } from './types.js';
+import type { AgentConfig, AgentStreamChunk, AgentStreamResult, StreamOptions, Message, Conversation, TokenUsage, ConversationManagerConfig, ModelConfig, JSONValue, InterruptResponse, DefaultToolContext, AgentTool, ToolDefinition, CannedToolHints } from './types.js';
 import { AgentErrors, blocksAgentError, InterruptError } from './errors.js';
 import { INTERACTIVE_JOB_EVENT_SOURCE } from './job-event-source.js';
 import { BB_NAME, BB_VERSION } from './version.js';
@@ -477,6 +477,17 @@ export class AgentBase<TContext = DefaultToolContext> extends Scope {
 			}),
 		}));
 
+		// Collect local-dev hints for the canned provider (Strands strips these fields from
+		// tools, so plumb them explicitly). Built only when a tool declares one — otherwise
+		// undefined, so real providers and the common no-hint case carry zero overhead.
+		let cannedHints: Map<string, CannedToolHints> | undefined;
+		for (const t of toolDefs) {
+			if (t.cannedExamples || t.cannedTriggers) {
+				cannedHints ??= new Map();
+				cannedHints.set(t.name!, { examples: t.cannedExamples, triggers: t.cannedTriggers });
+			}
+		}
+
 		const configs = Array.isArray(this.modelConfig) ? this.modelConfig : this.modelConfig ? [this.modelConfig] : [];
 		let resolvedConfig: ModelConfig | undefined;
 		for (const config of configs) {
@@ -486,7 +497,7 @@ export class AgentBase<TContext = DefaultToolContext> extends Scope {
 			const tried = configs.map(c => `${c.provider}${c.modelId ? ` (${c.modelId})` : ''}`).join(', ');
 			throw blocksAgentError(AgentErrors.ModelUnavailable, `No model available. Tried: ${tried}. Check logs for details.`);
 		}
-		const model = await createStrandsModel(resolvedConfig, this.log);
+		const model = await createStrandsModel(resolvedConfig, this.log, cannedHints);
 
 		// SessionManager restores/saves agent state across invocations.
 		// undefined when no conversationId (inference-only calls — no state to persist).

--- a/packages/bb-agent/src/index.test.ts
+++ b/packages/bb-agent/src/index.test.ts
@@ -382,6 +382,80 @@ describe('CannedProvider', () => {
 		assert.deepStrictEqual(started, ['getOrder']);
 	});
 
+	// Collect the parsed tool input from the first tool call in a stream.
+	const collectToolInput = async (provider: CannedProvider, prompt: string, toolSpecs: any[]): Promise<any> => {
+		let input: any;
+		for await (const event of provider.stream([{ role: 'user', content: [{ text: prompt }] }] as any, { toolSpecs } as any)) {
+			if (event.type === 'modelContentBlockDeltaEvent' && event.delta.type === 'toolUseInputDelta') {
+				input = JSON.parse(event.delta.input);
+			}
+		}
+		return input;
+	};
+
+	// Collect the names of every tool call started in a stream.
+	const collectToolStarts = async (provider: CannedProvider, prompt: string, toolSpecs: any[]): Promise<string[]> => {
+		const started: string[] = [];
+		for await (const event of provider.stream([{ role: 'user', content: [{ text: prompt }] }] as any, { toolSpecs } as any)) {
+			if (event.type === 'modelContentBlockStartEvent' && event.start?.type === 'toolUseStart') started.push(event.start.name);
+		}
+		return started;
+	};
+
+	test('cannedExamples are shallow-merged over generated placeholder input', async () => {
+		const hints = new Map([['searchDocs', { examples: { query: 'how do I get started' } }]]);
+		const provider = new CannedProvider({ hints });
+		const toolSpecs = [{ name: 'searchDocs', description: '', inputSchema: { type: 'object', properties: { query: { type: 'string' }, limit: { type: 'integer' } } } }];
+		const input = await collectToolInput(provider, 'searchDocs please', toolSpecs);
+		// Example query wins; unspecified `limit` falls back to the generic integer placeholder.
+		assert.deepStrictEqual(input, { query: 'how do I get started', limit: 1 });
+	});
+
+	test('respects schema default values over generic placeholders', async () => {
+		const provider = new CannedProvider();
+		const toolSpecs = [{ name: 'listItems', description: '', inputSchema: { type: 'object', properties: { limit: { type: 'integer', default: 10 } } } }];
+		const input = await collectToolInput(provider, 'listItems now', toolSpecs);
+		assert.deepStrictEqual(input, { limit: 10 });
+	});
+
+	test('mixes schema defaults with generic placeholders per field', async () => {
+		const provider = new CannedProvider();
+		const toolSpecs = [{ name: 'listItems', description: '', inputSchema: { type: 'object', properties: { limit: { type: 'integer', default: 10 }, query: { type: 'string' } } } }];
+		const input = await collectToolInput(provider, 'listItems now', toolSpecs);
+		assert.deepStrictEqual(input, { limit: 10, query: 'sample' });
+	});
+
+	test('cannedTriggers fire a tool for a single-word keyword beyond its name', async () => {
+		const hints = new Map([['searchDocs', { triggers: ['find'] }]]);
+		const provider = new CannedProvider({ hints });
+		const toolSpecs = [{ name: 'searchDocs', description: '', inputSchema: {} }];
+		const started = await collectToolStarts(provider, 'help me find the answer', toolSpecs);
+		assert.deepStrictEqual(started, ['searchDocs']);
+	});
+
+	test('cannedTriggers fire a tool for a multi-word phrase', async () => {
+		const hints = new Map([['searchDocs', { triggers: ['look up'] }]]);
+		const provider = new CannedProvider({ hints });
+		const toolSpecs = [{ name: 'searchDocs', description: '', inputSchema: {} }];
+		const started = await collectToolStarts(provider, 'can you look up the manual', toolSpecs);
+		assert.deepStrictEqual(started, ['searchDocs']);
+	});
+
+	test('single-word cannedTriggers respect word boundaries', async () => {
+		const hints = new Map([['searchDocs', { triggers: ['cat'] }]]);
+		const provider = new CannedProvider({ hints });
+		const toolSpecs = [{ name: 'searchDocs', description: '', inputSchema: {} }];
+		const started = await collectToolStarts(provider, 'what category is this', toolSpecs);
+		assert.deepStrictEqual(started, [], 'trigger "cat" must not fire on "category"');
+	});
+
+	test('generates generic placeholder when no example or default is given', async () => {
+		const provider = new CannedProvider();
+		const toolSpecs = [{ name: 'searchDocs', description: '', inputSchema: { type: 'object', properties: { query: { type: 'string' } } } }];
+		const input = await collectToolInput(provider, 'searchDocs please', toolSpecs);
+		assert.deepStrictEqual(input, { query: 'sample' });
+	});
+
 	test('responds to tool result with acknowledgment', async () => {
 		const provider = new CannedProvider();
 		const chunks: string[] = [];
@@ -414,6 +488,35 @@ describe('CannedProvider', () => {
 		const done = await result.complete();
 		assert.strictEqual(done.type, 'done');
 		assert.ok(done.text && done.text.length > 0, 'should have response text');
+	});
+
+	// End-to-end: exercises the full createStrandsAgent -> createStrandsModel -> CannedProvider
+	// plumbing. A prompt that only matches a `cannedTriggers` keyword must fire the tool, and the
+	// emitted call must carry the `cannedExamples` input.
+	test('canned hints plumb through the Agent end-to-end', async () => {
+		const scope = new Scope('test-canned-hints');
+		const agent = new Agent(scope, 'hints', {
+			inferenceOnly: false,
+			systemPrompt: 'test',
+			model: { deployed: { provider: 'canned' }, local: { provider: 'canned' } },
+			tools: (tool) => ({
+				searchDocs: tool({
+					description: 'Search documentation',
+					parameters: z.object({ query: z.string() }),
+					handler: async ({ input }) => ({ echoed: input.query }),
+					cannedExamples: { query: 'how do I get started' },
+					cannedTriggers: ['find'],
+				}),
+			}),
+		});
+		const convId = await agent.createConversationId('test-user');
+		const result = await agent.stream('help me find the answer', { conversationId: convId, userId: 'test-user' });
+		await result.complete();
+		const messages = await agent.getConversation(convId);
+		const toolCall = messages.find(m => m.role === 'tool-call');
+		assert.ok(toolCall, 'trigger keyword should have fired a tool call');
+		assert.strictEqual(toolCall.metadata.toolName, 'searchDocs');
+		assert.deepStrictEqual(toolCall.metadata.toolInput, { query: 'how do I get started' });
 	});
 
 	test("getConversation with limit returns most recent messages", async () => {

--- a/packages/bb-agent/src/index.test.ts
+++ b/packages/bb-agent/src/index.test.ts
@@ -449,6 +449,22 @@ describe('CannedProvider', () => {
 		assert.deepStrictEqual(started, [], 'trigger "cat" must not fire on "category"');
 	});
 
+	test('multi-word cannedTriggers respect word boundaries', async () => {
+		const hints = new Map([['searchDocs', { triggers: ['log in'] }]]);
+		const provider = new CannedProvider({ hints });
+		const toolSpecs = [{ name: 'searchDocs', description: '', inputSchema: {} }];
+		const started = await collectToolStarts(provider, 'check the backlog in the queue', toolSpecs);
+		assert.deepStrictEqual(started, [], 'trigger "log in" must not fire on "backlog in"');
+	});
+
+	test('multi-word cannedTriggers tolerate flexible internal whitespace', async () => {
+		const hints = new Map([['searchDocs', { triggers: ['look up'] }]]);
+		const provider = new CannedProvider({ hints });
+		const toolSpecs = [{ name: 'searchDocs', description: '', inputSchema: {} }];
+		const started = await collectToolStarts(provider, 'can you look   up the manual', toolSpecs);
+		assert.deepStrictEqual(started, ['searchDocs'], 'multiple spaces between words should still match');
+	});
+
 	test('generates generic placeholder when no example or default is given', async () => {
 		const provider = new CannedProvider();
 		const toolSpecs = [{ name: 'searchDocs', description: '', inputSchema: { type: 'object', properties: { query: { type: 'string' } } } }];

--- a/packages/bb-agent/src/index.test.ts
+++ b/packages/bb-agent/src/index.test.ts
@@ -425,6 +425,37 @@ describe('CannedProvider', () => {
 		assert.deepStrictEqual(input, { limit: 10, query: 'sample' });
 	});
 
+	test('cannedExamples win over a schema default on the same field', async () => {
+		const hints = new Map([['listItems', { examples: { limit: 5 } }]]);
+		const provider = new CannedProvider({ hints });
+		const toolSpecs = [{ name: 'listItems', description: '', inputSchema: { type: 'object', properties: { limit: { type: 'integer', default: 10 } } } }];
+		const input = await collectToolInput(provider, 'listItems now', toolSpecs);
+		// Full precedence chain is cannedExamples > schema default > generic placeholder;
+		// this pins the top link, where a field carries both an example and a default.
+		assert.deepStrictEqual(input, { limit: 5 }, 'the cannedExamples value must beat the schema default');
+	});
+
+	test('warns on a cannedExamples field missing from the tool schema, but still sends it', async () => {
+		const hints = new Map([['fetchPage', { examples: { rul: 'https://example.com' } }]]);
+		const provider = new CannedProvider({ hints });
+		const toolSpecs = [{ name: 'fetchPage', description: '', inputSchema: { type: 'object', properties: { url: { type: 'string' } } } }];
+		const originalWarn = console.warn;
+		const warnings: string[] = [];
+		console.warn = (msg: unknown) => { warnings.push(String(msg)); };
+		let input: any;
+		try {
+			input = await collectToolInput(provider, 'fetchPage now', toolSpecs);
+		} finally {
+			console.warn = originalWarn;
+		}
+		assert.ok(
+			warnings.some(w => w.includes('fetchPage') && w.includes('"rul"')),
+			`the typo'd field should be reported, got ${JSON.stringify(warnings)}`,
+		);
+		// A bad hint is surfaced, never enforced: nothing throws and the value still ships.
+		assert.deepStrictEqual(input, { url: 'sample', rul: 'https://example.com' });
+	});
+
 	test('cannedTriggers fire a tool for a single-word keyword beyond its name', async () => {
 		const hints = new Map([['searchDocs', { triggers: ['find'] }]]);
 		const provider = new CannedProvider({ hints });

--- a/packages/bb-agent/src/index.test.ts
+++ b/packages/bb-agent/src/index.test.ts
@@ -334,6 +334,19 @@ describe('CannedProvider', () => {
 		assert.ok(text.includes('22°C'), 'should contain weather data');
 	});
 
+	// Keyword text matching must respect word boundaries for the same reason tool matching
+	// does, or "reorder" returns the order response and "helper" returns the help response.
+	test('does not return a keyword response when the keyword is only a substring', async () => {
+		const provider = new CannedProvider();
+		const chunks: string[] = [];
+		for await (const event of provider.stream([{ role: 'user', content: [{ text: 'please reorder the list alphabetically' }] }] as any)) {
+			if (event.type === 'modelContentBlockDeltaEvent' && event.delta.type === 'textDelta') chunks.push(event.delta.text);
+		}
+		const text = chunks.join('');
+		assert.ok(!text.includes('#12345'), `"reorder" must not return the order response, got: ${text}`);
+		assert.ok(text.includes('No real model was called'), 'should fall through to the default response');
+	});
+
 	test('triggers tool call when prompt matches tool name', async () => {
 		const provider = new CannedProvider();
 		let toolName: string | undefined;
@@ -501,6 +514,36 @@ describe('CannedProvider', () => {
 		const toolSpecs = [{ name: 'searchDocs', description: '', inputSchema: { type: 'object', properties: { query: { type: 'string' } } } }];
 		const input = await collectToolInput(provider, 'searchDocs please', toolSpecs);
 		assert.deepStrictEqual(input, { query: 'sample' });
+	});
+
+	test('resolves a union (anyOf) field from its first usable variant', async () => {
+		const provider = new CannedProvider();
+		const toolSpecs = [{ name: 'listItems', description: '', inputSchema: { type: 'object', properties: { limit: { anyOf: [{ type: 'integer' }, { type: 'string' }] } } } }];
+		const input = await collectToolInput(provider, 'listItems now', toolSpecs);
+		assert.deepStrictEqual(input, { limit: 1 });
+	});
+
+	test('resolves a const field to its fixed value', async () => {
+		const provider = new CannedProvider();
+		const toolSpecs = [{ name: 'listItems', description: '', inputSchema: { type: 'object', properties: { kind: { const: 'archive' } } } }];
+		const input = await collectToolInput(provider, 'listItems now', toolSpecs);
+		assert.deepStrictEqual(input, { kind: 'archive' });
+	});
+
+	// A required field of an unrecognized shape used to be dropped entirely, so the emitted
+	// call failed schema validation before the tool ever ran.
+	test('fills a required field whose shape yields no placeholder', async () => {
+		const provider = new CannedProvider();
+		const toolSpecs = [{ name: 'listItems', description: '', inputSchema: { type: 'object', properties: { mystery: {} }, required: ['mystery'] } }];
+		const input = await collectToolInput(provider, 'listItems now', toolSpecs);
+		assert.deepStrictEqual(input, { mystery: 'sample' });
+	});
+
+	test('leaves an optional field whose shape yields no placeholder omitted', async () => {
+		const provider = new CannedProvider();
+		const toolSpecs = [{ name: 'listItems', description: '', inputSchema: { type: 'object', properties: { mystery: {} } } }];
+		const input = await collectToolInput(provider, 'listItems now', toolSpecs);
+		assert.deepStrictEqual(input, {}, 'absence is valid for an optional field; do not invent a wrong-typed value');
 	});
 
 	test('responds to tool result with acknowledgment', async () => {

--- a/packages/bb-agent/src/model-factory.ts
+++ b/packages/bb-agent/src/model-factory.ts
@@ -8,7 +8,7 @@ import type { ChildLogger } from '@aws-blocks/bb-logger';
 // `./providers/canned` and `./providers/throwing` extend Strands' `Model`, so importing
 // them would evaluate `@strands-agents/sdk` at load time — hence they're also loaded
 // lazily inside createStrandsModel(). See issue #153.
-import type { ModelConfig } from './types.js';
+import type { CannedToolHints, ModelConfig } from './types.js';
 import { AgentErrors, blocksAgentError } from './errors.js';
 
 // TODO: validate model-specific inference config (e.g., some models don't support topP with temperature)
@@ -152,10 +152,10 @@ export async function checkModelHealth(config: ModelConfig, log: ChildLogger, _t
  *
  * @see https://strandsagents.com/docs/user-guide/concepts/model-providers/
  */
-export async function createStrandsModel(config?: ModelConfig, log?: ChildLogger): Promise<Model<BaseModelConfig>> {
+export async function createStrandsModel(config?: ModelConfig, log?: ChildLogger, cannedHints?: Map<string, CannedToolHints>): Promise<Model<BaseModelConfig>> {
 	if (!config || config.provider === 'canned') {
 		const { CannedProvider } = await import('./providers/canned.js');
-		return new CannedProvider();
+		return new CannedProvider({ hints: cannedHints });
 	}
 
 	// Test-only provider — throws mid-stream to verify error handling

--- a/packages/bb-agent/src/providers/canned.ts
+++ b/packages/bb-agent/src/providers/canned.ts
@@ -68,13 +68,15 @@ function findAllToolMatches(prompt: string, toolSpecs?: { name: string }[], hint
 		// on word boundaries. Skip short words (<=2 chars) to avoid noise.
 		const words = t.name.replace(/([a-z])([A-Z])/g, '$1 $2').toLowerCase().split(' ');
 		if (words.some(w => w.length > 2 && promptMentionsWord(lower, w))) return true;
-		// Extra trigger keywords declared via `cannedTriggers`. Single words use word
-		// boundaries (consistent with tool-name matching); multi-word phrases use substrings.
+		// Extra trigger keywords declared via `cannedTriggers`. Single and multi-word triggers
+		// both match on word boundaries (consistent with tool-name matching), so "log in" is not
+		// triggered by "backlog in" and internal whitespace is flexible (matches one-or-more spaces).
 		const triggers = hints?.get(t.name)?.triggers;
 		return triggers?.some(tr => {
 			const low = tr.trim().toLowerCase();
 			if (!low) return false;
-			return low.includes(' ') ? lower.includes(low) : promptMentionsWord(lower, low);
+			const escaped = low.replace(/[.*+?^${}()|[\]\\]/g, '\\$&').replace(/\s+/g, '\\s+');
+			return new RegExp(`\\b${escaped}\\b`).test(lower);
 		}) ?? false;
 	}).map(t => t.name);
 }

--- a/packages/bb-agent/src/providers/canned.ts
+++ b/packages/bb-agent/src/providers/canned.ts
@@ -17,9 +17,16 @@
 import { Model } from '@strands-agents/sdk';
 import type { Message, ModelStreamEvent, StreamOptions } from '@strands-agents/sdk';
 import { ToolResultBlock } from '@strands-agents/sdk';
+import type { CannedToolHints } from '../types.js';
 
 interface CannedConfig {
 	modelId: string;
+}
+
+interface CannedProviderOptions {
+	modelId?: string;
+	/** Per-tool hints (examples, triggers) keyed by tool name. */
+	hints?: Map<string, CannedToolHints>;
 }
 
 const CANNED_RESPONSES: Record<string, string> = {
@@ -51,7 +58,7 @@ function promptMentionsWord(lowerPrompt: string, word: string): boolean {
 }
 
 /** Find ALL tools mentioned in the prompt (for parallel tool calls). */
-function findAllToolMatches(prompt: string, toolSpecs?: { name: string }[]): string[] {
+function findAllToolMatches(prompt: string, toolSpecs?: { name: string }[], hints?: Map<string, CannedToolHints>): string[] {
 	if (!toolSpecs?.length) return [];
 	const lower = prompt.toLowerCase();
 	return toolSpecs.filter(t => {
@@ -60,7 +67,15 @@ function findAllToolMatches(prompt: string, toolSpecs?: { name: string }[]): str
 		// Split camelCase into words (getWeather -> "get weather") and match each
 		// on word boundaries. Skip short words (<=2 chars) to avoid noise.
 		const words = t.name.replace(/([a-z])([A-Z])/g, '$1 $2').toLowerCase().split(' ');
-		return words.some(w => w.length > 2 && promptMentionsWord(lower, w));
+		if (words.some(w => w.length > 2 && promptMentionsWord(lower, w))) return true;
+		// Extra trigger keywords declared via `cannedTriggers`. Single words use word
+		// boundaries (consistent with tool-name matching); multi-word phrases use substrings.
+		const triggers = hints?.get(t.name)?.triggers;
+		return triggers?.some(tr => {
+			const low = tr.trim().toLowerCase();
+			if (!low) return false;
+			return low.includes(' ') ? lower.includes(low) : promptMentionsWord(lower, low);
+		}) ?? false;
 	}).map(t => t.name);
 }
 
@@ -93,7 +108,11 @@ function generatePlaceholderInput(schema: any): any {
 	if (schema.type === 'object' && schema.properties) {
 		const result: Record<string, any> = {};
 		for (const [key, prop] of Object.entries(schema.properties) as [string, any][]) {
-			if (prop.type === 'string') {
+			// Schema default (from Zod `.default()`) is the most realistic value — prefer it,
+			// and populate fields whose only signal is a default with no recognized `type`.
+			if (prop.default !== undefined) {
+				result[key] = prop.default;
+			} else if (prop.type === 'string') {
 				if (prop.enum?.length) result[key] = prop.enum[0];
 				else result[key] = 'sample';
 			} else if (prop.type === 'number' || prop.type === 'integer') {
@@ -111,21 +130,27 @@ function generatePlaceholderInput(schema: any): any {
 	return {};
 }
 
-/** Look up a tool's inputSchema from toolSpecs and generate placeholder input. */
-function getToolInput(toolName: string, toolSpecs?: { name: string; inputSchema?: any }[]): string {
+/**
+ * Look up a tool's inputSchema from toolSpecs and generate placeholder input, shallow-merging
+ * any `cannedExamples` (from hints) on top so realistic values win over generated placeholders.
+ */
+function getToolInput(toolName: string, toolSpecs?: { name: string; inputSchema?: any }[], hints?: Map<string, CannedToolHints>): string {
 	const spec = toolSpecs?.find(t => t.name === toolName);
-	if (!spec?.inputSchema) return '{}';
-	return JSON.stringify(generatePlaceholderInput(spec.inputSchema));
+	const base = spec?.inputSchema ? generatePlaceholderInput(spec.inputSchema) : {};
+	const examples = hints?.get(toolName)?.examples;
+	return JSON.stringify(examples ? { ...base, ...examples } : base);
 }
 
 let toolCallCounter = 0;
 
 export class CannedProvider extends Model<CannedConfig> {
 	private config: CannedConfig;
+	private hints: Map<string, CannedToolHints>;
 
-	constructor(config?: Partial<CannedConfig>) {
+	constructor(options?: CannedProviderOptions) {
 		super();
-		this.config = { modelId: config?.modelId ?? 'canned-mock' };
+		this.config = { modelId: options?.modelId ?? 'canned-mock' };
+		this.hints = options?.hints ?? new Map();
 	}
 
 	updateConfig(config: Partial<CannedConfig>): void {
@@ -150,7 +175,7 @@ export class CannedProvider extends Model<CannedConfig> {
 		}
 
 		// Check if prompt mentions tool names — trigger tool call(s)
-		const toolMatches = findAllToolMatches(prompt, options?.toolSpecs);
+		const toolMatches = findAllToolMatches(prompt, options?.toolSpecs, this.hints);
 		if (toolMatches.length > 1) {
 			yield* this.emitParallelToolCalls(toolMatches, options?.toolSpecs);
 			return;
@@ -160,8 +185,6 @@ export class CannedProvider extends Model<CannedConfig> {
 			yield* this.emitToolCall(toolName, options?.toolSpecs);
 			return;
 		}
-
-		// Default: keyword-based text response
 
 		// Default: keyword-based text response
 		yield* this.emitText(matchResponse(prompt));
@@ -185,7 +208,7 @@ export class CannedProvider extends Model<CannedConfig> {
 		for (const toolName of toolNames) {
 			const toolUseId = `canned-tool-${++toolCallCounter}`;
 			yield { type: 'modelContentBlockStartEvent', start: { type: 'toolUseStart', name: toolName, toolUseId } };
-			yield { type: 'modelContentBlockDeltaEvent', delta: { type: 'toolUseInputDelta', input: getToolInput(toolName, toolSpecs) } };
+			yield { type: 'modelContentBlockDeltaEvent', delta: { type: 'toolUseInputDelta', input: getToolInput(toolName, toolSpecs, this.hints) } };
 			yield { type: 'modelContentBlockStopEvent' };
 		}
 		yield { type: 'modelMessageStopEvent', stopReason: 'toolUse' };
@@ -197,7 +220,7 @@ export class CannedProvider extends Model<CannedConfig> {
 		const toolUseId = `canned-tool-${++toolCallCounter}`;
 		yield { type: 'modelMessageStartEvent', role: 'assistant' };
 		yield { type: 'modelContentBlockStartEvent', start: { type: 'toolUseStart', name: toolName, toolUseId } };
-		yield { type: 'modelContentBlockDeltaEvent', delta: { type: 'toolUseInputDelta', input: getToolInput(toolName, toolSpecs) } };
+		yield { type: 'modelContentBlockDeltaEvent', delta: { type: 'toolUseInputDelta', input: getToolInput(toolName, toolSpecs, this.hints) } };
 		yield { type: 'modelContentBlockStopEvent' };
 		yield { type: 'modelMessageStopEvent', stopReason: 'toolUse' };
 		yield { type: 'modelMetadataEvent', usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 }, metrics: { latencyMs: 0 } };

--- a/packages/bb-agent/src/providers/canned.ts
+++ b/packages/bb-agent/src/providers/canned.ts
@@ -37,10 +37,15 @@ const CANNED_RESPONSES: Record<string, string> = {
 
 const DEFAULT_RESPONSE = 'This is a canned mock response. No real model was called. [canned]';
 
+/**
+ * Pick a canned text response by keyword, matched on word boundaries for the same reason
+ * tool matching is: substring matching fired `order` inside "reorder" and `help` inside
+ * "helper", the same false-positive class the tool matcher avoids.
+ */
 function matchResponse(prompt: string): string {
 	const lower = prompt.toLowerCase();
 	for (const [keyword, response] of Object.entries(CANNED_RESPONSES)) {
-		if (lower.includes(keyword)) return response;
+		if (promptMentionsWord(lower, keyword)) return response;
 	}
 	return DEFAULT_RESPONSE;
 }
@@ -117,32 +122,58 @@ function getToolResultText(messages: Message[]): string {
 	return results.join(' | ');
 }
 
+/** Sentinel for a property whose shape carries no usable signal (distinct from a legitimate `null`/`0`/`false`). */
+const NO_PLACEHOLDER = Symbol('no-placeholder');
+
+/**
+ * Resolve one property's placeholder value, or `NO_PLACEHOLDER` if its shape gives no signal.
+ * Order matters: an authored `default` (from Zod `.default()`) is the most realistic value, then
+ * a fixed `const`/`enum` member, then a union variant, then a per-type placeholder. `!== undefined`
+ * rather than truthiness so a `default` of `0`, `false`, or `''` is honored.
+ */
+function placeholderForProperty(prop: any): any {
+	if (prop?.default !== undefined) return prop.default;
+	if (prop?.const !== undefined) return prop.const;
+	if (prop?.enum?.length) return prop.enum[0];
+	// Zod unions (`z.union`, `z.discriminatedUnion`) surface as anyOf/oneOf; any one
+	// satisfying variant is enough for a mock, so take the first that resolves.
+	const variants = prop?.anyOf ?? prop?.oneOf;
+	if (Array.isArray(variants)) {
+		for (const variant of variants) {
+			const resolved = placeholderForProperty(variant);
+			if (resolved !== NO_PLACEHOLDER) return resolved;
+		}
+	}
+	switch (prop?.type) {
+		case 'string': return 'sample';
+		case 'number':
+		case 'integer': return 1;
+		case 'boolean': return true;
+		case 'array': return [];
+		case 'object': return generatePlaceholderInput(prop);
+		default: return NO_PLACEHOLDER;
+	}
+}
+
 /** Generate placeholder input from a JSON Schema. Produces values that pass validation. */
 function generatePlaceholderInput(schema: any): any {
 	if (!schema || typeof schema !== 'object') return {};
-	if (schema.type === 'object' && schema.properties) {
-		const result: Record<string, any> = {};
-		for (const [key, prop] of Object.entries(schema.properties) as [string, any][]) {
-			// Schema default (from Zod `.default()`) is the most realistic value — prefer it,
-			// and populate fields whose only signal is a default with no recognized `type`.
-			if (prop.default !== undefined) {
-				result[key] = prop.default;
-			} else if (prop.type === 'string') {
-				if (prop.enum?.length) result[key] = prop.enum[0];
-				else result[key] = 'sample';
-			} else if (prop.type === 'number' || prop.type === 'integer') {
-				result[key] = 1;
-			} else if (prop.type === 'boolean') {
-				result[key] = true;
-			} else if (prop.type === 'array') {
-				result[key] = [];
-			} else if (prop.type === 'object') {
-				result[key] = generatePlaceholderInput(prop);
-			}
+	if (schema.type !== 'object' || !schema.properties) return {};
+	const required: unknown[] = Array.isArray(schema.required) ? schema.required : [];
+	const result: Record<string, any> = {};
+	for (const [key, prop] of Object.entries(schema.properties) as [string, any][]) {
+		const value = placeholderForProperty(prop);
+		if (value !== NO_PLACEHOLDER) {
+			result[key] = value;
+		} else if (required.includes(key)) {
+			// An unrecognized shape (untyped, or a union of only unrecognized variants) yields no
+			// placeholder. Omitting a *required* field makes the emitted call fail validation before
+			// the tool ever runs, so fall back to a string. Optional fields stay omitted: absence is
+			// valid there, and inventing a wrong-typed value would break calls that used to work.
+			result[key] = 'sample';
 		}
-		return result;
 	}
-	return {};
+	return result;
 }
 
 const warnedExampleKeys = new Set<string>();

--- a/packages/bb-agent/src/providers/canned.ts
+++ b/packages/bb-agent/src/providers/canned.ts
@@ -45,16 +45,31 @@ function matchResponse(prompt: string): string {
 	return DEFAULT_RESPONSE;
 }
 
+const wordPatternCache = new Map<string, RegExp>();
+
 /**
- * Match a single word against the prompt on word boundaries (case-insensitive).
+ * Compile a word-boundary matcher for a word or phrase, cached by phrase.
  * Uses `\b...\b` rather than substring `includes()` so a tool word like "cat"
  * (from `getCat`) is NOT triggered by an unrelated word like "category", and
- * "pass" (from `getPass`) is not triggered by "password". The word is regex-
- * escaped so punctuation in tool names can't break the pattern.
+ * "pass" (from `getPass`) is not triggered by "password". Regex metacharacters are
+ * escaped so punctuation in tool names can't break the pattern, and internal
+ * whitespace becomes `\s+` so a multi-word phrase tolerates irregular spacing.
+ * Compiled patterns are cached because matching re-runs for every tool on every
+ * `stream()` call, and the key space is bounded by the agent's tool and trigger set.
  */
+function wordBoundaryPattern(phrase: string): RegExp {
+	let pattern = wordPatternCache.get(phrase);
+	if (!pattern) {
+		const escaped = phrase.replace(/[.*+?^${}()|[\]\\]/g, '\\$&').replace(/\s+/g, '\\s+');
+		pattern = new RegExp(`\\b${escaped}\\b`);
+		wordPatternCache.set(phrase, pattern);
+	}
+	return pattern;
+}
+
+/** Match a word against an already-lowercased prompt on word boundaries. */
 function promptMentionsWord(lowerPrompt: string, word: string): boolean {
-	const escaped = word.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-	return new RegExp(`\\b${escaped}\\b`).test(lowerPrompt);
+	return wordBoundaryPattern(word).test(lowerPrompt);
 }
 
 /** Find ALL tools mentioned in the prompt (for parallel tool calls). */
@@ -74,9 +89,7 @@ function findAllToolMatches(prompt: string, toolSpecs?: { name: string }[], hint
 		const triggers = hints?.get(t.name)?.triggers;
 		return triggers?.some(tr => {
 			const low = tr.trim().toLowerCase();
-			if (!low) return false;
-			const escaped = low.replace(/[.*+?^${}()|[\]\\]/g, '\\$&').replace(/\s+/g, '\\s+');
-			return new RegExp(`\\b${escaped}\\b`).test(lower);
+			return low ? wordBoundaryPattern(low).test(lower) : false;
 		}) ?? false;
 	}).map(t => t.name);
 }
@@ -132,6 +145,30 @@ function generatePlaceholderInput(schema: any): any {
 	return {};
 }
 
+const warnedExampleKeys = new Set<string>();
+
+/**
+ * Warn (once per tool+field) when a `cannedExamples` key isn't a field of the tool's
+ * inputSchema — almost always a typo in the hint. Only ever reached through the canned
+ * provider, which is local-dev-only, so this never warns in a deployed agent. The value
+ * is still merged through and nothing throws: a bad hint must not break local dev.
+ * Skipped when the schema exposes no `properties`, where unknown keys are unknowable.
+ */
+function warnUnknownExampleKeys(toolName: string, examples: Record<string, unknown>, inputSchema?: any): void {
+	const properties = inputSchema?.properties;
+	if (!properties) return;
+	for (const key of Object.keys(examples)) {
+		if (key in properties) continue;
+		const seen = `${toolName}.${key}`;
+		if (warnedExampleKeys.has(seen)) continue;
+		warnedExampleKeys.add(seen);
+		console.warn(
+			`[canned] cannedExamples for tool "${toolName}" sets "${key}", which is not a field of its ` +
+			`parameters schema (${Object.keys(properties).join(', ') || 'none'}). Check for a typo — the value is still sent.`,
+		);
+	}
+}
+
 /**
  * Look up a tool's inputSchema from toolSpecs and generate placeholder input, shallow-merging
  * any `cannedExamples` (from hints) on top so realistic values win over generated placeholders.
@@ -140,7 +177,9 @@ function getToolInput(toolName: string, toolSpecs?: { name: string; inputSchema?
 	const spec = toolSpecs?.find(t => t.name === toolName);
 	const base = spec?.inputSchema ? generatePlaceholderInput(spec.inputSchema) : {};
 	const examples = hints?.get(toolName)?.examples;
-	return JSON.stringify(examples ? { ...base, ...examples } : base);
+	if (!examples) return JSON.stringify(base);
+	warnUnknownExampleKeys(toolName, examples, spec?.inputSchema);
+	return JSON.stringify({ ...base, ...examples });
 }
 
 let toolCallCounter = 0;

--- a/packages/bb-agent/src/types.ts
+++ b/packages/bb-agent/src/types.ts
@@ -216,8 +216,9 @@ export interface ToolDefinition<TContext = DefaultToolContext, TParams extends z
 	cannedExamples?: Record<string, JSONValue>;
 	/**
 	 * Local-dev only. Extra keyword phrases that make the `canned` mock provider select this
-	 * tool, in addition to the tool name and its camelCase words. Single words match on word
-	 * boundaries; multi-word phrases match as substrings. Ignored by the bedrock/openai providers.
+	 * tool, in addition to the tool name and its camelCase words. Single and multi-word phrases
+	 * match on word boundaries (so "log in" is not triggered by "backlog in"). Ignored by the
+	 * bedrock/openai providers.
 	 */
 	cannedTriggers?: string[];
 }

--- a/packages/bb-agent/src/types.ts
+++ b/packages/bb-agent/src/types.ts
@@ -208,6 +208,28 @@ export interface ToolDefinition<TContext = DefaultToolContext, TParams extends z
 	 * - `interrupt` — pause the agent for human input
 	 */
 	handler: (args: ToolHandlerArgs<z.infer<TParams>, TContext>) => Promise<JSONValue>;
+	/**
+	 * Local-dev only. Realistic tool input for the `canned` mock provider. Shallow-merged
+	 * over the generated placeholder input (your fields win; unspecified fields fall back to
+	 * schema defaults / generic placeholders). Ignored by the bedrock/openai providers.
+	 */
+	cannedExamples?: Record<string, JSONValue>;
+	/**
+	 * Local-dev only. Extra keyword phrases that make the `canned` mock provider select this
+	 * tool, in addition to the tool name and its camelCase words. Single words match on word
+	 * boundaries; multi-word phrases match as substrings. Ignored by the bedrock/openai providers.
+	 */
+	cannedTriggers?: string[];
+}
+
+/**
+ * Local-dev hints for the `canned` mock provider, keyed by tool name and threaded from
+ * `ToolDefinition.cannedExamples`/`cannedTriggers` into the provider (Strands strips these
+ * fields when converting tools, so they're plumbed explicitly). Ignored by real providers.
+ */
+export interface CannedToolHints {
+	examples?: Record<string, JSONValue>;
+	triggers?: string[];
 }
 
 /**

--- a/packages/bb-agent/src/types.ts
+++ b/packages/bb-agent/src/types.ts
@@ -211,7 +211,9 @@ export interface ToolDefinition<TContext = DefaultToolContext, TParams extends z
 	/**
 	 * Local-dev only. Realistic tool input for the `canned` mock provider. Shallow-merged
 	 * over the generated placeholder input (your fields win; unspecified fields fall back to
-	 * schema defaults / generic placeholders). Ignored by the bedrock/openai providers.
+	 * schema defaults / generic placeholders). The merge is one level deep — a nested-object
+	 * example replaces that whole generated sub-object rather than deep-merging into it.
+	 * Ignored by the bedrock/openai providers.
 	 */
 	cannedExamples?: Record<string, JSONValue>;
 	/**


### PR DESCRIPTION
merge **before** #90 
## Problem

<!--
Describe the issue this PR is solving. For trivial changes, a short one-liner is fine.
-->

The local-dev `canned` provider (the fake LLM used when no real model is configured) has only limited tool support that made prototyping against it less useful:

- Tool inputs were generic placeholders (`'sample'`, `1`, `true`, `[]`) that ignored schema `default` values and didn't reflect realistic usage.
- A tool only fired when the prompt mentioned the tool name (or its camelCase words), so natural phrasings like "find the docs" wouldn't trigger the obvious tool.

## Changes

<!--
Summarize the changes introduced in this PR. Call out critical or potentially problematic parts of the change.
-->
Adds two optional, local-dev-only hint fields to `ToolDefinition` (both **ignored by the real bedrock/openai providers**) plus schema-default awareness in the canned provider:

- **`cannedExamples`** — realistic tool input, shallow-merged over generated placeholders (your fields win; unspecified fields fall back to schema defaults / generic placeholders). The merge is one level
deep — a nested-object example replaces the whole generated sub-object rather than deep-merging.
- **`cannedTriggers`** — extra keyword phrases that make the canned provider select a tool beyond its name. Single and multi-word phrases match on word boundaries (so `cat` won't fire on `category`, and
  `log in` won't fire on `backlog in`); internal whitespace is flexible; blank triggers are skipped.
- **Schema defaults** — placeholder generation now respects `default` values (from Zod `.default()`) before falling back to generic placeholders.

**Implementation note (potentially non-obvious):** Strands strips these fields when it converts tools (`tool()` only copies `name`/`description`/`inputSchema`/`callback`), so `CannedProvider.stream()`
never sees the original `ToolDefinition`. The hints are therefore plumbed explicitly, keyed by tool name: `createStrandsAgent` builds a hints map from the tool defs (only when a tool declares one) →
`createStrandsModel(config, log, cannedHints)` → `new CannedProvider({ hints })`. The extra `createStrandsModel` param is consumed only in the canned branch; bedrock/openai construction is untouched.

No `index.mock/aws/cdk/browser` changes were needed — the canned provider is a pure runtime concern with no CDK/synthGuard surface (same as the sibling `throwing.ts` provider).

```typescript
tools: (tool) => ({
  searchDocs: tool({
    description: 'Search product documentation for relevant information',
    parameters: z.object({
      query: z.string().describe('The search query'),
      maxResults: z.number().optional().describe('Max results to return (default: 5)'),
    }),
    handler: async ({ input }) => kb.retrieve(input.query, { maxResults: input.maxResults ?? 5 }),

    // Canned provider hints (ignored by real models):
    // Without this the mock would search for the literal 'sample' and match nothing —
    // use a query that hits YOUR documents so local runs return meaningful results.
    cannedExamples: { query: 'how do I reset my password' },
    // "help me find the login docs" now triggers the tool searchDocs
    cannedTriggers: ['find', 'look up'],
  }),
}),
```
## Validation

<!--
Describe how changes have been validated — added/updated unit, integration, or E2E tests, manual verification, etc.
If no automated tests were added, explain why.
-->
- **10 new tests** in `packages/bb-agent/src/index.test.ts`:
  - 9 provider-level tests (direct `new CannedProvider({ hints })` + `stream`): `cannedExamples` merge, schema-default precedence, default+placeholder mix, single-word trigger, multi-word phrase trigger,
trigger word-boundary regression, and a no-hints regression guard.
  - 1 end-to-end test exercising the full `Agent → createStrandsAgent → createStrandsModel → CannedProvider` plumbing (a trigger-only prompt fires the tool and the persisted `tool-call` carries the example
input).
- Full suite passes: **88/88 tests** (including all 10 new).
- Build clean (`tsc --build`); Biome lint reports 0 errors on the changed files.
## Checklist

- [x] PR description included
- [x] Tests are changed or added
- [x] Relevant documentation is changed or added (and PR referenced)

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
