### PR TITLE
test(comprehensive): persist AuthBasic codes in KVStore

### DIFF
--- a/test-apps/comprehensive/aws-blocks/index.ts
+++ b/test-apps/comprehensive/aws-blocks/index.ts
@@ -52,13 +52,16 @@ const profileSchema = z.object({ name: z.string(), age: z.number(), tags: z.arra
 const validatedStore = new KVStore(scope, 'validated-store', { schema: profileSchema });
 
 // AuthBasic - Authentication
-// Store last delivered code so e2e tests can retrieve and use it.
-let lastDeliveredCode: { username: string; code: string } | null = null;
+// Store the last delivered code so e2e tests can retrieve and use it. This
+// must be shared storage: sandbox/production may read from a different Lambda
+// instance than the one that delivered the code.
+type DeliveredAuthBasicCode = { username: string; code: string };
+const authBasicLastCodeKey = 'auth-basic:last-code';
 const auth = new AuthBasic(scope, 'auth', {
   sessionDuration: 86400,
   passwordPolicy: { minLength: 6 },
   codeDelivery: async (username, code) => {
-    lastDeliveredCode = { username, code };
+    await store.put(authBasicLastCodeKey, JSON.stringify({ username, code }));
     // In a real app, connect this to email: await sendEmail(username, `Your code: ${code}`);
     logCodeLocally(`[AuthBasic] Verification code for "${username}": ${code}`);
   },
@@ -884,7 +887,8 @@ export const api = new ApiNamespace(scope, 'api', (context) => ({
   },
 
   async authGetLastCode() {
-    return lastDeliveredCode;
+    const lastDeliveredCode = await store.get(authBasicLastCodeKey);
+    return lastDeliveredCode ? JSON.parse(lastDeliveredCode) as DeliveredAuthBasicCode : null;
   },
 
   // Cookie-attribute convergence (D-007): sign up + sign in so the e2e can


### PR DESCRIPTION
## Problem

The comprehensive test app stores the latest AuthBasic verification code in a module-level variable. That is deterministic in the local single-process dev server, but it is not shared across Lambda instances in the sandbox runtime. As described in #131, `authGetLastCode()` can therefore poll an instance that never ran `codeDelivery` and return `null` until the test times out.

**Issue #, if available:** Partially addresses #131 (AuthBasic code-delivery state only)

## Changes

- Persist the latest delivered AuthBasic code through the comprehensive app's existing `KVStore` instead of a module global.
- Keep the change scoped to the test app harness and avoid adding another backend resource by reusing the existing store with a namespaced key.
- Leave the realtime flake and the workflow detect-changes gate from #131 for separate, focused follow-up changes.

## Validation

- `npx tsc --noEmit` from `test-apps/comprehensive`
- `npm run test:e2e:local` from `test-apps/comprehensive` (372 tests, 371 passed, 1 skipped)
- `npx @changesets/cli status --since=origin/main`
- `npx tsx scripts/verify-changeset-coverage.ts`
- `git diff --check`
- Focused AuthBasic smoke against the comprehensive backend on `localhost:3055`:
  - `authSignUp` -> `authGetLastCode` -> `authConfirmSignUp` -> `authSignIn`
  - `authResetPassword` -> `authGetLastCode` -> `authConfirmResetPassword` -> `authSignIn` with the new password

I did not add a new test file because the existing comprehensive AuthBasic E2E already covers this flow; this PR changes the test harness storage backing so that the existing sandbox E2E can read the code across Lambda invocations.

## Checklist

- [x] PR description included
- [ ] Tests are changed or added
- [ ] Relevant documentation is changed or added (and PR referenced)

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
