### PR TITLE
feat(core): add compute target seam for pluggable container runtimes

### DIFF
--- a/.changeset/container-compute-seam.md
+++ b/.changeset/container-compute-seam.md
@@ -1,0 +1,15 @@
+---
+"@aws-blocks/core": minor
+---
+
+Add the container compute-target seam: `BlocksStackProps.compute` /
+`BlocksBackendProps.compute` accept a `ComputeTarget` (the contract ECS/EKS
+targets implement). When set, the HTTP front door is provided by the target
+instead of API Gateway, the Lambda remains as the event-source companion, and
+both share one execution role so every Building Block grant applies to
+containers unchanged. Adds `@aws-blocks/core/http-server` — a production HTTP
+server wrapping the Lambda dispatch for container entrypoints (health gating,
+graceful drain, `BLOCKS_PUBLIC_ORIGIN`, `BLOCKS_HTTP_TIMEOUT_MS`) — and a
+structural `apiOrigin` on `BlocksStackApi` so Hosting proxies stage-less
+container URLs correctly. No `compute` prop → synthesized template unchanged.
+For container-mode stacks, `gateway` now throws (no REST API exists).

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,6 +25,10 @@
     },
     "./client": "./dist/client/index.js",
     "./lambda-handler": "./dist/lambda-handler.js",
+    "./http-server": {
+      "types": "./dist/http-server.d.ts",
+      "default": "./dist/http-server.js"
+    },
     "./bb-utils": {
       "types": "./dist/bb-utils.d.ts",
       "default": "./dist/bb-utils.js"

--- a/packages/core/src/cdk/blocks-backend.ts
+++ b/packages/core/src/cdk/blocks-backend.ts
@@ -4,6 +4,7 @@
 import * as cdk from 'aws-cdk-lib';
 import * as lambda from 'aws-cdk-lib/aws-lambda-nodejs';
 import * as apigateway from 'aws-cdk-lib/aws-apigateway';
+import * as iam from 'aws-cdk-lib/aws-iam';
 import { CfnGroup } from 'aws-cdk-lib/aws-resourcegroups';
 import { Construct } from 'constructs';
 import { pathToFileURL } from 'node:url';
@@ -12,6 +13,12 @@ import { addBlocksStackMetadata } from './stack-metadata.js';
 import { finalizeConfigRegistry, registerConfig } from './config-registry.js';
 import { BLOCKS_NAMESPACE, BLOCKS_RPC_PREFIX } from '../constants.js';
 import { registerBuiltinRoutes } from '../builtin-routes.js';
+import type {
+  ComputeApiOrigin,
+  ComputeBindContext,
+  ComputePrincipal,
+  ComputeTarget,
+} from './compute-target.js';
 
 /**
  * Validate that the Node.js process was started with `--conditions=cdk`.
@@ -44,16 +51,56 @@ export function assertCdkConditionActive(): void {
 export interface BlocksBackendProps {
   backendHandlerPath: string;
   backendCDKPath: string;
+  /**
+   * Optional container compute target (e.g. ECS Fargate, EKS). When set, the
+   * HTTP front door is served by load-balanced containers running the same
+   * bundle instead of API Gateway + Lambda; the Lambda is still created as a
+   * companion for event-source triggers (SQS, EventBridge Scheduler,
+   * WebSocket) and remains the attachment point for Building Block grants.
+   * When omitted, the synthesized template is unchanged from previous releases.
+   */
+  compute?: ComputeTarget;
 }
 
-/** Shared infra setup — creates Lambda + API Gateway on the given scope. */
+/**
+ * Map a compute principal to its IAM principal for the shared role's trust
+ * policy. EKS Pod Identity requires `sts:TagSession` alongside `sts:AssumeRole`.
+ */
+function toIamPrincipal(principal: ComputePrincipal): iam.IPrincipal {
+  const servicePrincipal = new iam.ServicePrincipal(principal);
+  return principal === 'pods.eks.amazonaws.com'
+    ? servicePrincipal.withSessionTags()
+    : servicePrincipal;
+}
+
+/** Shared infra setup — creates the Lambda plus the HTTP front door (API Gateway by default, or a container compute target). */
 export function setupBlocksInfra(scope: Construct, props: BlocksBackendProps, id?: string) {
+  const compute = props.compute;
+
+  // The shared execution role only exists in container-compute mode. Creating
+  // it unconditionally would replace the Lambda's implicit role in every
+  // existing deployment; gating it keeps the default template byte-identical.
+  let sharedRole: iam.Role | undefined;
+  if (compute) {
+    sharedRole = new iam.Role(scope, 'BackendSharedRole', {
+      assumedBy: new iam.CompositePrincipal(
+        new iam.ServicePrincipal('lambda.amazonaws.com'),
+        ...compute.requiredPrincipals.map(toIamPrincipal),
+      ),
+      description: 'Shared execution role for the Blocks backend Lambda and container compute',
+      managedPolicies: [
+        iam.ManagedPolicy.fromAwsManagedPolicyName('service-role/AWSLambdaBasicExecutionRole'),
+      ],
+    });
+  }
+
   const handler = new lambda.NodejsFunction(scope, 'Handler', {
     entry: props.backendHandlerPath,
     runtime: DEFAULT_NODE_RUNTIME,
     handler: 'handler',
     memorySize: 2048,
     timeout: cdk.Duration.seconds(60 * 15),
+    role: sharedRole,
     environment: {
       NODE_ENV: 'production',
       /**
@@ -82,23 +129,45 @@ export function setupBlocksInfra(scope: Construct, props: BlocksBackendProps, id
     handler.addEnvironment('CORS_ALLOWED_ORIGINS', '^https?://(localhost|127\\.0\\.0\\.1)(:\\d+)?$');
   }
 
-  const api = new apigateway.RestApi(scope, 'API', {
-    restApiName: 'Blocks API',
-    deployOptions: { cachingEnabled: false },
-  });
+  let gateway: apigateway.RestApi | undefined;
+  let apiUrl: string;
+  let apiOrigin: ComputeApiOrigin | undefined;
+  let computeCtx: ComputeBindContext | undefined;
 
-  const integration = new apigateway.LambdaIntegration(handler);
+  if (compute && sharedRole) {
+    computeCtx = {
+      scope,
+      id: id ?? cdk.Stack.of(scope).stackName,
+      handler,
+      sharedRole,
+      backendHandlerPath: props.backendHandlerPath,
+      isSandbox,
+    };
+    const bound = compute.bind(computeCtx);
+    apiUrl = bound.apiUrl;
+    apiOrigin = bound.apiOrigin;
+  } else {
+    const api = new apigateway.RestApi(scope, 'API', {
+      restApiName: 'Blocks API',
+      deployOptions: { cachingEnabled: false },
+    });
 
-  // Build the nested resource tree for /aws-blocks/api.
-  // Intermediate resource gets a proxy so sub-paths (RawRoutes) still reach Lambda.
-  const awsBlocksResource = api.root.addResource(BLOCKS_NAMESPACE.slice(1));
-  awsBlocksResource.addProxy({ defaultIntegration: integration, anyMethod: true });
-  
-  const apiResource = awsBlocksResource.addResource('api');
-  apiResource.addMethod('POST', integration);
-  apiResource.addMethod('OPTIONS', integration);
+    const integration = new apigateway.LambdaIntegration(handler);
 
-  api.root.addProxy({ defaultIntegration: integration, anyMethod: true });
+    // Build the nested resource tree for /aws-blocks/api.
+    // Intermediate resource gets a proxy so sub-paths (RawRoutes) still reach Lambda.
+    const awsBlocksResource = api.root.addResource(BLOCKS_NAMESPACE.slice(1));
+    awsBlocksResource.addProxy({ defaultIntegration: integration, anyMethod: true });
+
+    const apiResource = awsBlocksResource.addResource('api');
+    apiResource.addMethod('POST', integration);
+    apiResource.addMethod('OPTIONS', integration);
+
+    api.root.addProxy({ defaultIntegration: integration, anyMethod: true });
+
+    gateway = api;
+    apiUrl = `${api.url}${BLOCKS_RPC_PREFIX.slice(1)}`;
+  }
 
   // ── Resource Groups ────────────────────────────────────────────────────
   let rootStack = cdk.Stack.of(scope);
@@ -152,7 +221,7 @@ export function setupBlocksInfra(scope: Construct, props: BlocksBackendProps, id
 
   registerBuiltinRoutes();
 
-  return { handler, gateway: api, apiUrl: `${api.url}${BLOCKS_RPC_PREFIX.slice(1)}` };
+  return { handler, gateway, apiUrl, apiOrigin, computeCtx };
 }
 
 /**
@@ -174,9 +243,31 @@ export function setupBlocksInfra(scope: Construct, props: BlocksBackendProps, id
  */
 export class BlocksBackend extends Construct {
   public readonly apiUrl: string;
-  public readonly gateway: apigateway.RestApi;
   public readonly handler: cdk.aws_lambda_nodejs.NodejsFunction;
   public readonly backendHandlerPath: string;
+  /**
+   * Structured HTTP origin for the API. Only set in container-compute mode,
+   * where `apiUrl` has no API Gateway stage segment for consumers to parse.
+   */
+  public readonly apiOrigin?: ComputeApiOrigin;
+  private readonly _gateway?: apigateway.RestApi;
+  private readonly _compute?: ComputeTarget;
+  private readonly _computeCtx?: ComputeBindContext;
+
+  /**
+   * The API Gateway REST API fronting the Lambda. Not available when a
+   * container compute target is configured — the container's load balancer
+   * is the front door and no REST API is created.
+   */
+  public get gateway(): apigateway.RestApi {
+    if (!this._gateway) {
+      throw new Error(
+        'BlocksBackend.gateway is not available: this backend uses a container compute target, ' +
+        'so no API Gateway is created. Use `apiUrl` / `apiOrigin` for the HTTP front door.',
+      );
+    }
+    return this._gateway;
+  }
 
   /**
    * The fullId used by child Scopes to compute their env var names,
@@ -219,8 +310,11 @@ export class BlocksBackend extends Construct {
 
     const infra = setupBlocksInfra(this, props, id);
     this.handler = infra.handler;
-    this.gateway = infra.gateway;
+    this._gateway = infra.gateway;
     this.apiUrl = infra.apiUrl;
+    this.apiOrigin = infra.apiOrigin;
+    this._compute = props.compute;
+    this._computeCtx = infra.computeCtx;
 
     // Override BLOCKS_STACK_NAME to include the parent stack name so runtime
     // resource lookups (DynamoDB table names) match the CDK-time fullId
@@ -247,6 +341,13 @@ export class BlocksBackend extends Construct {
 
     // Finalize BB config → S3 (after all BBs have registered their config)
     finalizeConfigRegistry(backend, backend.handler);
+
+    // Late hook: every Building Block has attached env vars and grants by now,
+    // so the compute target can mirror the handler environment into its
+    // container definition and sequence container boot after the config upload.
+    if (backend._compute && backend._computeCtx) {
+      backend._compute.finalize(backend._computeCtx);
+    }
 
     return backend;
   }

--- a/packages/core/src/cdk/compute-target.test.ts
+++ b/packages/core/src/cdk/compute-target.test.ts
@@ -1,0 +1,227 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { test, describe, before } from 'node:test';
+import assert from 'node:assert';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import * as cdk from 'aws-cdk-lib';
+import { Template } from 'aws-cdk-lib/assertions';
+import { BlocksBackend } from './blocks-backend.js';
+import { BlocksStack } from './index.js';
+import { getConfigDeployment } from './config-registry.js';
+import type { ComputeBindContext, ComputeBindResult, ComputeTarget } from './compute-target.js';
+
+// Simulate the CDK condition being active (tests import CDK files directly)
+before(() => {
+  process.env.NODE_OPTIONS = `${process.env.NODE_OPTIONS ?? ''} --conditions=cdk`;
+});
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const handlerPath = join(__dirname, '__fixtures__', 'handler.js');
+const sideEffectBackendPath = join(__dirname, '__fixtures__', 'side-effect-backend.js');
+
+/** Minimal recording compute target for exercising the seam. */
+class FakeCompute implements ComputeTarget {
+  readonly requiredPrincipals: ComputeTarget['requiredPrincipals'];
+  bindCtx?: ComputeBindContext;
+  finalizeCtx?: ComputeBindContext;
+  finalizeObservations: { configDeployment: boolean; sideEffectMarker: boolean } = {
+    configDeployment: false,
+    sideEffectMarker: false,
+  };
+
+  constructor(principals: ComputeTarget['requiredPrincipals'] = ['ecs-tasks.amazonaws.com']) {
+    this.requiredPrincipals = principals;
+  }
+
+  bind(ctx: ComputeBindContext): ComputeBindResult {
+    this.bindCtx = ctx;
+    return {
+      apiUrl: 'https://d111111abcdef8.cloudfront.net/aws-blocks/api',
+      apiOrigin: { hostname: 'd111111abcdef8.cloudfront.net', originPath: '' },
+    };
+  }
+
+  finalize(ctx: ComputeBindContext): void {
+    this.finalizeCtx = ctx;
+    this.finalizeObservations = {
+      // finalizeConfigRegistry must have run: the config deployment exists.
+      configDeployment: getConfigDeployment(ctx.scope) !== undefined,
+      // The app's backendCDKPath module must have been imported already.
+      sideEffectMarker: ctx.scope.node.tryFindChild('SideEffectMarker') !== undefined,
+    };
+  }
+}
+
+describe('default mode (no compute target) — template stability', () => {
+  test('synthesizes the exact Lambda + API Gateway shape with no shared role', async () => {
+    const app = new cdk.App();
+
+    const stack = await BlocksStack.create(app, 'DefaultModeStack', {
+      backendHandlerPath: handlerPath,
+      backendCDKPath: sideEffectBackendPath,
+    });
+
+    const template = Template.fromStack(stack);
+
+    // Front door unchanged: one REST API with the RPC route tree.
+    template.resourceCountIs('AWS::ApiGateway::RestApi', 1);
+
+    // The shared execution role must NOT exist — creating it unconditionally
+    // would replace the Lambda role in every existing deployment.
+    const roles = template.findResources('AWS::IAM::Role');
+    for (const role of Object.values(roles)) {
+      assert.notStrictEqual(
+        (role as any).Properties?.Description,
+        'Shared execution role for the Blocks backend Lambda and container compute',
+        'default mode must not create the shared compute role',
+      );
+    }
+
+    // Public surface unchanged.
+    assert.ok(stack.gateway, 'gateway accessor works in default mode');
+    assert.ok(stack.apiUrl.includes('/aws-blocks/api'));
+    assert.strictEqual(stack.apiOrigin, undefined, 'apiOrigin is compute-mode only');
+  });
+});
+
+describe('container-compute mode — BlocksStack', () => {
+  test('replaces API Gateway with the target front door and shares one role', async () => {
+    const app = new cdk.App();
+    const compute = new FakeCompute();
+
+    const stack = await BlocksStack.create(app, 'ComputeModeStack', {
+      backendHandlerPath: handlerPath,
+      backendCDKPath: sideEffectBackendPath,
+      compute,
+    });
+
+    const template = Template.fromStack(stack);
+
+    // No REST API in container mode — one front door only.
+    template.resourceCountIs('AWS::ApiGateway::RestApi', 0);
+
+    // The Lambda assumes the shared role (not an implicit NodejsFunction role).
+    const sharedRoleIds = Object.entries(template.findResources('AWS::IAM::Role'))
+      .filter(([, role]) =>
+        (role as any).Properties?.Description ===
+        'Shared execution role for the Blocks backend Lambda and container compute')
+      .map(([logicalId]) => logicalId);
+    assert.strictEqual(sharedRoleIds.length, 1, 'exactly one shared role');
+
+    const trust = (template.findResources('AWS::IAM::Role')[sharedRoleIds[0]] as any)
+      .Properties.AssumeRolePolicyDocument.Statement;
+    const services = trust.flatMap((s: any) => [s.Principal?.Service].flat());
+    assert.ok(services.includes('lambda.amazonaws.com'), 'role trusts lambda');
+    assert.ok(services.includes('ecs-tasks.amazonaws.com'), 'role trusts ecs-tasks');
+
+    const fns = Object.values(template.findResources('AWS::Lambda::Function'))
+      .filter((fn: any) => fn.Properties?.Environment?.Variables?.BLOCKS_STACK_NAME);
+    assert.strictEqual(fns.length, 1, 'companion Lambda still exists');
+    assert.deepStrictEqual(
+      (fns[0] as any).Properties.Role,
+      { 'Fn::GetAtt': [sharedRoleIds[0], 'Arn'] },
+      'Lambda uses the shared role',
+    );
+
+    // Front door comes from the target.
+    assert.strictEqual(stack.apiUrl, 'https://d111111abcdef8.cloudfront.net/aws-blocks/api');
+    assert.deepStrictEqual(stack.apiOrigin, {
+      hostname: 'd111111abcdef8.cloudfront.net',
+      originPath: '',
+    });
+    template.hasOutput('ApiUrl', { Value: 'https://d111111abcdef8.cloudfront.net/aws-blocks/api' });
+
+    // gateway is a hard error, not a silent undefined.
+    assert.throws(() => stack.gateway, /container compute target/);
+  });
+
+  test('bind() receives the handler, shared role, and token-free id', async () => {
+    const app = new cdk.App();
+    const compute = new FakeCompute();
+
+    const stack = await BlocksStack.create(app, 'BindCtxStack', {
+      backendHandlerPath: handlerPath,
+      backendCDKPath: sideEffectBackendPath,
+      compute,
+    });
+
+    assert.ok(compute.bindCtx, 'bind was called');
+    assert.strictEqual(compute.bindCtx.id, 'BindCtxStack');
+    assert.ok(!cdk.Token.isUnresolved(compute.bindCtx.id), 'ctx.id must be token-free');
+    assert.strictEqual(compute.bindCtx.handler, stack.handler);
+    assert.strictEqual(compute.bindCtx.backendHandlerPath, handlerPath);
+    assert.strictEqual(compute.bindCtx.isSandbox, false);
+  });
+
+  test('finalize() runs after the app CDK module import and config finalization', async () => {
+    const app = new cdk.App();
+    const compute = new FakeCompute();
+
+    await BlocksStack.create(app, 'FinalizeOrderStack', {
+      backendHandlerPath: handlerPath,
+      backendCDKPath: sideEffectBackendPath,
+      compute,
+    });
+
+    assert.ok(compute.finalizeCtx, 'finalize was called');
+    assert.ok(
+      compute.finalizeObservations.sideEffectMarker,
+      'finalize must run after the backendCDKPath import (blocks all constructed)',
+    );
+    assert.ok(
+      compute.finalizeObservations.configDeployment,
+      'finalize must run after finalizeConfigRegistry (config deployment exists)',
+    );
+  });
+
+  test('EKS Pod Identity principal gets sts:TagSession on the trust policy', async () => {
+    const app = new cdk.App();
+    const compute = new FakeCompute(['pods.eks.amazonaws.com']);
+
+    const stack = await BlocksStack.create(app, 'EksTrustStack', {
+      backendHandlerPath: handlerPath,
+      backendCDKPath: sideEffectBackendPath,
+      compute,
+    });
+
+    const template = Template.fromStack(stack);
+    const roles = Object.values(template.findResources('AWS::IAM::Role')).filter(
+      (role: any) =>
+        role.Properties?.Description ===
+        'Shared execution role for the Blocks backend Lambda and container compute',
+    );
+    assert.strictEqual(roles.length, 1);
+
+    const statements = (roles[0] as any).Properties.AssumeRolePolicyDocument.Statement;
+    const eksStatement = statements.find(
+      (s: any) => [s.Principal?.Service].flat().includes('pods.eks.amazonaws.com'),
+    );
+    assert.ok(eksStatement, 'trust statement for pods.eks.amazonaws.com exists');
+    const actions = [eksStatement.Action].flat();
+    assert.ok(actions.includes('sts:AssumeRole'), 'sts:AssumeRole present');
+    assert.ok(actions.includes('sts:TagSession'), 'sts:TagSession present for Pod Identity');
+  });
+});
+
+describe('container-compute mode — BlocksBackend', () => {
+  test('works inside an existing stack with the same seam semantics', async () => {
+    const app = new cdk.App();
+    const parent = new cdk.Stack(app, 'ParentStack');
+    const compute = new FakeCompute();
+
+    const backend = await BlocksBackend.create(parent, 'Blocks', {
+      backendHandlerPath: handlerPath,
+      backendCDKPath: sideEffectBackendPath,
+      compute,
+    });
+
+    const template = Template.fromStack(parent);
+    template.resourceCountIs('AWS::ApiGateway::RestApi', 0);
+
+    assert.strictEqual(backend.apiUrl, 'https://d111111abcdef8.cloudfront.net/aws-blocks/api');
+    assert.throws(() => backend.gateway, /container compute target/);
+    assert.ok(compute.finalizeCtx, 'finalize was called for BlocksBackend');
+  });
+});

--- a/packages/core/src/cdk/compute-target.ts
+++ b/packages/core/src/cdk/compute-target.ts
@@ -1,0 +1,100 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type * as cdk from 'aws-cdk-lib';
+import type * as iam from 'aws-cdk-lib/aws-iam';
+import type { Construct } from 'constructs';
+
+/**
+ * Service principals a container compute target needs on the shared backend
+ * execution role, in addition to `lambda.amazonaws.com`.
+ *
+ * - `ecs-tasks.amazonaws.com` — ECS task role
+ * - `pods.eks.amazonaws.com` — EKS Pod Identity (also requires `sts:TagSession`,
+ *   which the role factory adds automatically for this principal)
+ */
+export type ComputePrincipal = 'ecs-tasks.amazonaws.com' | 'pods.eks.amazonaws.com';
+
+/**
+ * Structured CloudFront/HTTP origin for the Blocks API.
+ *
+ * Container compute targets produce URLs without an API Gateway stage segment,
+ * so consumers (e.g. Hosting) must not parse the stage out of {@link ComputeBindResult.apiUrl}.
+ * This carries the origin parts explicitly instead.
+ */
+export interface ComputeApiOrigin {
+  /** Origin hostname (no scheme), e.g. `d111111abcdef8.cloudfront.net`. May be a CDK token. */
+  readonly hostname: string;
+  /** Origin path prefix including leading slash, or `''` when the origin serves from root. */
+  readonly originPath: string;
+}
+
+/**
+ * Everything a compute target needs to provision container infrastructure for
+ * a Blocks backend. Handed to {@link ComputeTarget.bind} during
+ * `BlocksStack.create()` / `BlocksBackend.create()`.
+ */
+export interface ComputeBindContext {
+  /** Construct scope to create container resources under (the BlocksStack or BlocksBackend). */
+  readonly scope: Construct;
+  /**
+   * Logical id of the Blocks backend (the BlocksStack id / BlocksBackend construct id).
+   * Token-free; safe to embed in construct ids and physical resource names.
+   */
+  readonly id: string;
+  /**
+   * The companion Lambda. In container mode it keeps serving event sources
+   * (SQS, EventBridge Scheduler, WebSocket, CloudFormation custom resources)
+   * and remains the construct Building Blocks attach grants and env vars to.
+   */
+  readonly handler: cdk.aws_lambda_nodejs.NodejsFunction;
+  /**
+   * The shared execution role. Assumed by the Lambda AND the container
+   * principal(s) from {@link ComputeTarget.requiredPrincipals}, so every IAM
+   * grant a Building Block makes against the handler applies to containers too.
+   */
+  readonly sharedRole: iam.Role;
+  /** Absolute path to the app's backend handler entry (same entry the Lambda bundles). */
+  readonly backendHandlerPath: string;
+  /** Whether the app is being deployed via `npm run sandbox` (dev sandbox context). */
+  readonly isSandbox: boolean;
+}
+
+/** Result of {@link ComputeTarget.bind}: the front door the container serves. */
+export interface ComputeBindResult {
+  /**
+   * Full RPC URL ending in `/aws-blocks/api` — same semantic as the API
+   * Gateway `apiUrl` today. Surfaced as the `ApiUrl` stack output and consumed
+   * by deploy/sandbox tooling and generated clients. May contain CDK tokens.
+   */
+  readonly apiUrl: string;
+  /** Structured origin for CloudFront consumers; see {@link ComputeApiOrigin}. */
+  readonly apiOrigin: ComputeApiOrigin;
+}
+
+/**
+ * A pluggable production compute target for the Blocks backend.
+ *
+ * By default the backend runs on Lambda behind API Gateway. Passing a
+ * `ComputeTarget` via `BlocksStackProps.compute` replaces the HTTP front door
+ * with load-balanced containers (ECS, EKS, …) running the same bundle, while
+ * the companion Lambda keeps handling event-source triggers.
+ *
+ * Lifecycle within `BlocksStack.create()` / `BlocksBackend.create()`:
+ * 1. `requiredPrincipals` is read before any resource exists, to build the shared role.
+ * 2. `bind()` runs where API Gateway would otherwise be created — before the
+ *    app's `backendCDKPath` module is imported, so `apiUrl` is available to
+ *    Building Blocks during construction.
+ * 3. `finalize()` runs after `finalizeConfigRegistry()`, once every Building
+ *    Block has attached its env vars and grants — the point where a target can
+ *    mirror the handler's environment into the container definition and add
+ *    deploy-ordering dependencies (e.g. on the config bucket deployment).
+ */
+export interface ComputeTarget {
+  /** Container service principals to trust on the shared execution role. */
+  readonly requiredPrincipals: ReadonlyArray<ComputePrincipal>;
+  /** Provision container infrastructure and return the HTTP front door. */
+  bind(ctx: ComputeBindContext): ComputeBindResult;
+  /** Late hook after all Building Blocks registered config/env/grants. */
+  finalize(ctx: ComputeBindContext): void;
+}

--- a/packages/core/src/cdk/config-registry.ts
+++ b/packages/core/src/cdk/config-registry.ts
@@ -12,6 +12,7 @@ const REGISTRY_KEY = Symbol.for('BLOCKS_CONFIG_REGISTRY');
 interface ConfigRegistryState {
 	entries: Map<string, unknown>;
 	finalized: boolean;
+	deployment?: s3deploy.BucketDeployment;
 }
 
 /**
@@ -88,6 +89,7 @@ export function finalizeConfigRegistry(
 		destinationBucket: configBucket,
 		prune: false,
 	});
+	registry.deployment = deployment;
 
 	(handler as cdk.aws_lambda.Function).addEnvironment(
 		'BLOCKS_CONFIG_BUCKET',
@@ -103,4 +105,18 @@ export function finalizeConfigRegistry(
 		actions: ['s3:GetObject'],
 		resources: [`${configBucket.bucketArn}/${configKey}`],
 	}));
+}
+
+/**
+ * The config-file BucketDeployment for a stack, if one was created by
+ * {@link finalizeConfigRegistry}. Container compute targets depend on it so
+ * tasks never boot before `blocks-config.json` exists in S3.
+ *
+ * Only meaningful after `finalizeConfigRegistry` ran (i.e. inside a compute
+ * target's `finalize()` hook); returns `undefined` before that or when no
+ * Building Block registered any config.
+ */
+export function getConfigDeployment(scope: Construct): s3deploy.BucketDeployment | undefined {
+	const stack = cdk.Stack.of(scope);
+	return ((stack as any)[REGISTRY_KEY] as ConfigRegistryState | undefined)?.deployment;
 }

--- a/packages/core/src/cdk/index.ts
+++ b/packages/core/src/cdk/index.ts
@@ -15,11 +15,19 @@ import {
 import { setupBlocksInfra, BlocksBackend, assertCdkConditionActive } from './blocks-backend.js';
 import { addBlocksStackMetadata } from './stack-metadata.js';
 import { finalizeConfigRegistry } from './config-registry.js';
+import type { ComputeApiOrigin, ComputeBindContext, ComputeTarget } from './compute-target.js';
 
 export { BlocksBackend, type BlocksBackendProps } from './blocks-backend.js';
+export type {
+  ComputeTarget,
+  ComputeBindContext,
+  ComputeBindResult,
+  ComputeApiOrigin,
+  ComputePrincipal,
+} from './compute-target.js';
 export { DEFAULT_NODE_RUNTIME } from './node-version.js';
 export { SandboxDisableDeletionProtection } from './mixins.js';
-export { registerConfig, finalizeConfigRegistry } from './config-registry.js';
+export { registerConfig, finalizeConfigRegistry, getConfigDeployment } from './config-registry.js';
 export { synthGuard } from './synth-guard.js';
 export type { ScopeOptions } from '../index.js';
 export { ApiError, isBlocksError, hasAuthError, DEFAULT_API_ERROR_NAME } from '../errors.js';
@@ -27,9 +35,31 @@ export { ApiError, isBlocksError, hasAuthError, DEFAULT_API_ERROR_NAME } from '.
 export class BlocksStack extends cdk.Stack implements BaseBlocksStack {
   public readonly id: string;
   public readonly apiUrl: string;
-  public readonly gateway: cdk.aws_apigateway.RestApi;
   public readonly handler: cdk.aws_lambda_nodejs.NodejsFunction;
   public readonly backendHandlerPath: string;
+  /**
+   * Structured HTTP origin for the API. Only set in container-compute mode,
+   * where `apiUrl` has no API Gateway stage segment for consumers to parse.
+   */
+  public readonly apiOrigin?: ComputeApiOrigin;
+  private readonly _gateway?: cdk.aws_apigateway.RestApi;
+  private readonly _compute?: ComputeTarget;
+  private readonly _computeCtx?: ComputeBindContext;
+
+  /**
+   * The API Gateway REST API fronting the Lambda. Not available when a
+   * container compute target is configured — the container's load balancer
+   * is the front door and no REST API is created.
+   */
+  public get gateway(): cdk.aws_apigateway.RestApi {
+    if (!this._gateway) {
+      throw new Error(
+        'BlocksStack.gateway is not available: this stack uses a container compute target, ' +
+        'so no API Gateway is created. Use `apiUrl` / `apiOrigin` for the HTTP front door.',
+      );
+    }
+    return this._gateway;
+  }
 
   private constructor(scope: Construct, id: string, props: BlocksStackProps) {
     super(scope, id, props);
@@ -41,8 +71,11 @@ export class BlocksStack extends cdk.Stack implements BaseBlocksStack {
 
     const infra = setupBlocksInfra(this, props, id);
     this.handler = infra.handler;
-    this.gateway = infra.gateway;
+    this._gateway = infra.gateway;
     this.apiUrl = infra.apiUrl;
+    this.apiOrigin = infra.apiOrigin;
+    this._compute = props.compute;
+    this._computeCtx = infra.computeCtx;
   }
 
   static async create(scope: Construct, id: string, props: BlocksStackProps) {
@@ -67,6 +100,13 @@ export class BlocksStack extends cdk.Stack implements BaseBlocksStack {
     }
     // Finalize BB config → S3 (after all BBs have registered their config)
     finalizeConfigRegistry(stack, stack.handler);
+
+    // Late hook: every Building Block has attached env vars and grants by now,
+    // so the compute target can mirror the handler environment into its
+    // container definition and sequence container boot after the config upload.
+    if (stack._compute && stack._computeCtx) {
+      stack._compute.finalize(stack._computeCtx);
+    }
 
     new cdk.CfnOutput(stack, 'ApiUrl', { value: stack.apiUrl });
 

--- a/packages/core/src/common/index.ts
+++ b/packages/core/src/common/index.ts
@@ -325,6 +325,14 @@ export function computeScopeFullId(scope: { id: string; parent?: any }) {
 export interface BlocksStackProps extends StackProps {
   backendHandlerPath: string;
   backendCDKPath: string;
+  /**
+   * Optional container compute target (e.g. ECS Fargate, EKS). When set, the
+   * HTTP front door is served by load-balanced containers running the same
+   * bundle instead of API Gateway + Lambda; the Lambda is still created as a
+   * companion for event-source triggers and Building Block attachments.
+   * Only consumed at CDK synth time — local dev and mock layers ignore it.
+   */
+  compute?: import('../cdk/compute-target.js').ComputeTarget;
 }
 
 export class BlocksStack {

--- a/packages/core/src/hosting.ts
+++ b/packages/core/src/hosting.ts
@@ -110,6 +110,15 @@ export type { FrameworkType, HostingDomainConfig, HostingWafConfig, SkewProtecti
 export interface BlocksStackApi {
   /** Fully-qualified API Gateway URL (e.g. `https://{id}.execute-api.{region}.amazonaws.com/{stage}/aws-blocks`). */
   readonly apiUrl: string;
+  /**
+   * Structured origin for the API. Container compute targets set this because
+   * their `apiUrl` has no API Gateway stage segment — parsing a stage out of
+   * it would mangle the origin. When present, Hosting uses it directly.
+   */
+  readonly apiOrigin?: {
+    readonly hostname: string;
+    readonly originPath: string;
+  };
 }
 
 /**
@@ -558,7 +567,7 @@ export class Hosting extends Construct {
 
     // ── 7. Add CloudFront behaviors for API proxy ────────────────
     if (props.api) {
-      this.addApiBehaviors(hosting, props.api.apiUrl);
+      this.addApiBehaviors(hosting, props.api.apiUrl, props.api.apiOrigin);
     }
 
     // ── 7a. Inject Blocks env vars into compute functions ───────────
@@ -679,17 +688,33 @@ export class Hosting extends Construct {
   }
 
   /**
-   * Add CloudFront behaviors that proxy API traffic to the API Gateway origin.
+   * Add CloudFront behaviors that proxy API traffic to the API origin.
+   *
+   * With a structured `apiOrigin` (container compute targets) the origin is
+   * used as-is. Otherwise the API Gateway stage is parsed out of `apiUrl`,
+   * which assumes the `https://{host}/{stage}/aws-blocks/api` shape.
    */
-  private addApiBehaviors(hosting: HostingConstruct, apiUrl: string): void {
-    const baseUrl = cdk.Fn.select(0, cdk.Fn.split(BLOCKS_RPC_PREFIX, apiUrl));
-    const withoutScheme = cdk.Fn.select(1, cdk.Fn.split('https://', baseUrl));
-    const hostname = cdk.Fn.select(0, cdk.Fn.split('/', withoutScheme));
-    const stage = cdk.Fn.select(1, cdk.Fn.split('/', withoutScheme));
+  private addApiBehaviors(
+    hosting: HostingConstruct,
+    apiUrl: string,
+    apiOrigin?: BlocksStackApi['apiOrigin'],
+  ): void {
+    let apiGatewayOrigin: HttpOrigin;
+    if (apiOrigin) {
+      apiGatewayOrigin = new HttpOrigin(
+        apiOrigin.hostname,
+        apiOrigin.originPath ? { originPath: apiOrigin.originPath } : {},
+      );
+    } else {
+      const baseUrl = cdk.Fn.select(0, cdk.Fn.split(BLOCKS_RPC_PREFIX, apiUrl));
+      const withoutScheme = cdk.Fn.select(1, cdk.Fn.split('https://', baseUrl));
+      const hostname = cdk.Fn.select(0, cdk.Fn.split('/', withoutScheme));
+      const stage = cdk.Fn.select(1, cdk.Fn.split('/', withoutScheme));
 
-    const apiGatewayOrigin = new HttpOrigin(hostname, {
-      originPath: `/${stage}`,
-    });
+      apiGatewayOrigin = new HttpOrigin(hostname, {
+        originPath: `/${stage}`,
+      });
+    }
 
     const behaviorDefaults = {
       allowedMethods: AllowedMethods.ALLOW_ALL,

--- a/packages/core/src/http-server.test.ts
+++ b/packages/core/src/http-server.test.ts
@@ -1,0 +1,373 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Conformance tests for the container HTTP server: the same dispatch
+// behaviors covered by lambda-handler.test.ts, exercised through a real
+// Node HTTP server and fetch — proving Lambda/container parity.
+
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert';
+import type * as http from 'node:http';
+import {
+  startBlocksHttpServer,
+  createNodeRequestListener,
+  toLambdaEvent,
+  BLOCKS_HEALTH_PATH,
+} from './http-server.js';
+import { createLambdaHandler, defaultHttpDeadlineCapMs } from './lambda-handler.js';
+import { registerRoute, clearRouteRegistry } from './raw-route.js';
+import { _resetCorsPatterns } from './cors.js';
+import type { BlocksContext } from './api.js';
+
+const servers: http.Server[] = [];
+
+beforeEach(() => {
+  clearRouteRegistry();
+  delete process.env.CORS_ALLOWED_ORIGINS;
+  delete process.env.BLOCKS_HTTP_TIMEOUT_MS;
+  delete process.env.BLOCKS_PUBLIC_ORIGIN;
+  _resetCorsPatterns();
+});
+
+afterEach(async () => {
+  for (const server of servers.splice(0)) {
+    server.closeAllConnections?.();
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+  delete process.env.CORS_ALLOWED_ORIGINS;
+  delete process.env.BLOCKS_HTTP_TIMEOUT_MS;
+  delete process.env.BLOCKS_PUBLIC_ORIGIN;
+  _resetCorsPatterns();
+});
+
+/** Start a server on an ephemeral port for the given backend; returns its base URL. */
+async function serve(backend: any, options: Record<string, any> = {}): Promise<string> {
+  const handler = createLambdaHandler(async () => backend);
+  const server = await startBlocksHttpServer(handler, {
+    port: 0,
+    handleSignals: false,
+    ...options,
+  });
+  servers.push(server);
+  const address = server.address();
+  assert.ok(address && typeof address === 'object', 'server should be bound to a port');
+  return `http://127.0.0.1:${address.port}`;
+}
+
+function rpcBody(method: string, params: unknown[] = [], id = 1): string {
+  return JSON.stringify({ jsonrpc: '2.0', method, params, id });
+}
+
+const echoBackend = {
+  api: (_ctx: BlocksContext) => ({
+    async echo(msg: string) {
+      return { msg };
+    },
+  }),
+};
+
+// ── RPC over real HTTP ──────────────────────────────────────────────────────
+
+describe('http-server — RPC dispatch parity', () => {
+  it('returns a JSON-RPC success envelope for a valid call', async () => {
+    const baseUrl = await serve(echoBackend);
+
+    const res = await fetch(`${baseUrl}/aws-blocks/api`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: rpcBody('api.echo', ['hello']),
+    });
+
+    assert.strictEqual(res.status, 200);
+    const body = await res.json();
+    assert.strictEqual(body.jsonrpc, '2.0');
+    assert.strictEqual(body.id, 1);
+    assert.deepStrictEqual(body.result, { msg: 'hello' });
+  });
+
+  it('returns a method-not-found envelope for an unknown API', async () => {
+    const baseUrl = await serve(echoBackend);
+
+    const res = await fetch(`${baseUrl}/aws-blocks/api`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: rpcBody('nope.missing'),
+    });
+
+    assert.strictEqual(res.status, 200);
+    const body = await res.json();
+    assert.ok(body.error, 'expected a JSON-RPC error');
+    assert.strictEqual(body.error.code, -32601);
+  });
+
+  it('returns an invalid-request envelope for a malformed body', async () => {
+    const baseUrl = await serve(echoBackend);
+
+    const res = await fetch(`${baseUrl}/aws-blocks/api`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: 'not json',
+    });
+
+    assert.strictEqual(res.status, 200);
+    const body = await res.json();
+    assert.ok(body.error, 'expected a JSON-RPC error');
+  });
+});
+
+// ── RawRoutes over real HTTP ────────────────────────────────────────────────
+
+describe('http-server — RawRoute dispatch parity', () => {
+  it('dispatches path params and query string', async () => {
+    let seenParams: Record<string, string> = {};
+    let seenUrl: URL | undefined;
+    registerRoute({
+      method: 'GET',
+      path: '/things/{id}',
+      handler: async (ctx) => {
+        seenParams = ctx.request.params;
+        seenUrl = ctx.request.url;
+        ctx.response.send({ ok: true });
+      },
+    });
+    const baseUrl = await serve(echoBackend);
+
+    const res = await fetch(`${baseUrl}/things/42?tag=a&tag=b`);
+
+    assert.strictEqual(res.status, 200);
+    assert.deepStrictEqual(await res.json(), { ok: true });
+    assert.strictEqual(seenParams.id, '42');
+    assert.ok(seenUrl, 'route should observe ctx.request.url');
+    assert.deepStrictEqual(seenUrl.searchParams.getAll('tag'), ['a', 'b']);
+  });
+
+  it('delivers every Set-Cookie header separately', async () => {
+    registerRoute({
+      method: 'GET',
+      path: '/login',
+      handler: async (ctx) => {
+        ctx.response.headers.append('Set-Cookie', 'a=1; Path=/');
+        ctx.response.headers.append('Set-Cookie', 'b=2; Path=/; HttpOnly');
+        ctx.response.send({ ok: true });
+      },
+    });
+    const baseUrl = await serve(echoBackend);
+
+    const res = await fetch(`${baseUrl}/login`);
+
+    assert.strictEqual(res.status, 200);
+    const cookies = res.headers.getSetCookie();
+    assert.deepStrictEqual(cookies, ['a=1; Path=/', 'b=2; Path=/; HttpOnly']);
+  });
+
+  it('round-trips the request body byte-for-byte (base64 event encoding)', async () => {
+    let seenText = '';
+    registerRoute({
+      method: 'POST',
+      path: '/ingest',
+      handler: async (ctx) => {
+        seenText = await ctx.request.text();
+        ctx.response.send({ ok: true });
+      },
+    });
+    const baseUrl = await serve(echoBackend);
+    const payload = JSON.stringify({ emoji: '🚀', newline: 'a\nb' });
+
+    const res = await fetch(`${baseUrl}/ingest`, { method: 'POST', body: payload });
+
+    assert.strictEqual(res.status, 200);
+    assert.strictEqual(seenText, payload);
+  });
+
+  it('propagates error status and error name (D-003)', async () => {
+    registerRoute({
+      method: 'GET',
+      path: '/boom',
+      handler: async () => {
+        const err = new Error('nope');
+        err.name = 'CustomBlockError';
+        throw err;
+      },
+    });
+    const baseUrl = await serve(echoBackend);
+
+    const res = await fetch(`${baseUrl}/boom`);
+
+    assert.strictEqual(res.status, 500);
+    const body = await res.json();
+    assert.strictEqual(body.name, 'CustomBlockError');
+  });
+
+  it('returns 404 for unmatched non-RPC paths', async () => {
+    const baseUrl = await serve(echoBackend);
+
+    const res = await fetch(`${baseUrl}/definitely/not/registered`);
+
+    assert.strictEqual(res.status, 404);
+  });
+});
+
+// ── CORS over real HTTP ─────────────────────────────────────────────────────
+
+describe('http-server — CORS parity', () => {
+  it('answers OPTIONS preflight with CORS headers for an allowed origin', async () => {
+    process.env.CORS_ALLOWED_ORIGINS = '^https://allowed\\.example$';
+    _resetCorsPatterns();
+    const baseUrl = await serve(echoBackend);
+
+    const res = await fetch(`${baseUrl}/aws-blocks/api`, {
+      method: 'OPTIONS',
+      headers: { Origin: 'https://allowed.example' },
+    });
+
+    assert.strictEqual(res.status, 200);
+    assert.strictEqual(res.headers.get('access-control-allow-origin'), 'https://allowed.example');
+    assert.strictEqual(res.headers.get('access-control-allow-credentials'), 'true');
+  });
+
+  it('rejects a disallowed origin with 403', async () => {
+    process.env.CORS_ALLOWED_ORIGINS = '^https://allowed\\.example$';
+    _resetCorsPatterns();
+    const baseUrl = await serve(echoBackend);
+
+    const res = await fetch(`${baseUrl}/aws-blocks/api`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Origin: 'https://evil.example' },
+      body: rpcBody('api.echo', ['x']),
+    });
+
+    assert.strictEqual(res.status, 403);
+  });
+});
+
+// ── Timeout guard ───────────────────────────────────────────────────────────
+
+describe('http-server — timeout guard', () => {
+  it('returns 504 with the JSON-RPC timeout envelope when the cap elapses', async () => {
+    process.env.BLOCKS_HTTP_TIMEOUT_MS = '150';
+    const hangingBackend = {
+      api: (_ctx: BlocksContext) => ({
+        async hang() {
+          await new Promise(() => {}); // never resolves
+        },
+      }),
+    };
+    const baseUrl = await serve(hangingBackend);
+
+    const res = await fetch(`${baseUrl}/aws-blocks/api`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: rpcBody('api.hang'),
+    });
+
+    assert.strictEqual(res.status, 504);
+    const body = await res.json();
+    assert.ok(body.error, 'expected a JSON-RPC error envelope');
+    assert.strictEqual(body.error.data?.name, 'HandlerTimeoutError');
+  });
+
+  it('defaultHttpDeadlineCapMs reads BLOCKS_HTTP_TIMEOUT_MS with a 28s fallback', () => {
+    delete process.env.BLOCKS_HTTP_TIMEOUT_MS;
+    assert.strictEqual(defaultHttpDeadlineCapMs(), 28_000);
+
+    process.env.BLOCKS_HTTP_TIMEOUT_MS = '55000';
+    assert.strictEqual(defaultHttpDeadlineCapMs(), 55_000);
+
+    process.env.BLOCKS_HTTP_TIMEOUT_MS = 'garbage';
+    assert.strictEqual(defaultHttpDeadlineCapMs(), 28_000);
+
+    process.env.BLOCKS_HTTP_TIMEOUT_MS = '-5';
+    assert.strictEqual(defaultHttpDeadlineCapMs(), 28_000);
+  });
+});
+
+// ── Health and lifecycle ────────────────────────────────────────────────────
+
+describe('http-server — health endpoint', () => {
+  it('reports 200 on the health path once the backend is warm', async () => {
+    const baseUrl = await serve(echoBackend);
+
+    const res = await fetch(`${baseUrl}${BLOCKS_HEALTH_PATH}`);
+
+    assert.strictEqual(res.status, 200);
+    assert.deepStrictEqual(await res.json(), { status: 'ok' });
+  });
+
+  it('reports 503 while not ready (listener-level readiness gate)', async () => {
+    const handler = createLambdaHandler(async () => echoBackend);
+    let ready = false;
+    const listener = createNodeRequestListener(handler, { isReady: () => ready });
+
+    const { createServer } = await import('node:http');
+    const server = createServer(listener);
+    servers.push(server);
+    await new Promise<void>((resolve) => server.listen(0, () => resolve()));
+    const port = (server.address() as any).port;
+
+    const before = await fetch(`http://127.0.0.1:${port}${BLOCKS_HEALTH_PATH}`);
+    assert.strictEqual(before.status, 503);
+
+    ready = true;
+    const after = await fetch(`http://127.0.0.1:${port}${BLOCKS_HEALTH_PATH}`);
+    assert.strictEqual(after.status, 200);
+  });
+
+  it('exposes the health path to load balancers even with no matching route', async () => {
+    // BLOCKS_HEALTH_PATH lives under the reserved /aws-blocks namespace but is
+    // served by the server itself — dispatch (which would 404) never sees it.
+    const baseUrl = await serve(echoBackend);
+    const res = await fetch(`${baseUrl}${BLOCKS_HEALTH_PATH}`);
+    assert.strictEqual(res.status, 200);
+  });
+});
+
+// ── Public origin (front-door URL correctness) ──────────────────────────────
+
+describe('http-server — public origin', () => {
+  it('builds backend-visible URLs from BLOCKS_PUBLIC_ORIGIN, not the Host header', async () => {
+    let seenHref = '';
+    registerRoute({
+      method: 'GET',
+      path: '/whoami',
+      handler: async (ctx) => {
+        seenHref = ctx.request.url.href;
+        ctx.response.send({ ok: true });
+      },
+    });
+    const baseUrl = await serve(echoBackend, {
+      publicOrigin: 'https://d111111abcdef8.cloudfront.net',
+    });
+
+    const res = await fetch(`${baseUrl}/whoami?x=1`);
+
+    assert.strictEqual(res.status, 200);
+    assert.strictEqual(seenHref, 'https://d111111abcdef8.cloudfront.net/whoami?x=1');
+  });
+
+  it('toLambdaEvent leaves Host untouched when no public origin is set', () => {
+    const event = toLambdaEvent(
+      { method: 'GET', url: '/a?b=c', headers: { host: 'internal-alb.local' } } as any,
+      Buffer.alloc(0),
+    );
+    assert.strictEqual(event.headers.host, 'internal-alb.local');
+    assert.strictEqual(event.path, '/a');
+    assert.strictEqual(event.rawQueryString, 'b=c');
+    assert.strictEqual(event.body, null);
+    assert.strictEqual(event.isBase64Encoded, false);
+  });
+
+  it('toLambdaEvent strips a stale x-forwarded-host when rewriting to the public origin', () => {
+    const event = toLambdaEvent(
+      {
+        method: 'GET',
+        url: '/a',
+        headers: { host: 'alb.internal', 'x-forwarded-host': 'localhost:3000', 'x-forwarded-proto': 'http' },
+      } as any,
+      Buffer.alloc(0),
+      'https://public.example',
+    );
+    assert.strictEqual(event.headers.host, 'public.example');
+    assert.strictEqual(event.headers['x-forwarded-proto'], 'https');
+    assert.strictEqual('x-forwarded-host' in event.headers, false);
+  });
+});

--- a/packages/core/src/http-server.ts
+++ b/packages/core/src/http-server.ts
@@ -1,0 +1,281 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Production HTTP server for container compute targets (ECS, EKS).
+//
+// Wraps the exact same dispatch as the Lambda handler: an incoming Node
+// request is translated to an API-Gateway-v1-shaped event, run through
+// `createLambdaHandler()`'s returned function, and the result is written back.
+// Reusing the Lambda dispatch (rather than re-implementing routing) keeps
+// JSON-RPC envelopes, RawRoutes, CORS, cookies, and the 504 timeout guard
+// byte-identical between Lambda and container deployments.
+
+import * as http from 'node:http';
+import { BLOCKS_NAMESPACE, BLOCKS_RPC_PREFIX } from './constants.js';
+
+/**
+ * Health-check path served by the container HTTP server itself (never
+ * dispatched to the backend). Load balancer target groups and Kubernetes
+ * probes point here: 200 once the backend finished initializing, 503 before.
+ */
+export const BLOCKS_HEALTH_PATH = `${BLOCKS_NAMESPACE}/health`;
+
+/** The Lambda-shaped handler produced by `createLambdaHandler()`. */
+export type BlocksEventHandler = (event: any, context?: any) => Promise<any>;
+
+export interface BlocksHttpServerOptions {
+  /** Port to listen on. Default: `PORT` env var, else 8080. */
+  port?: number;
+  /** Health-check path answered by the server itself. Default: `/aws-blocks/health`. */
+  healthPath?: string;
+  /**
+   * Public origin the backend is reachable at (e.g. the CloudFront URL,
+   * `https://d111111abcdef8.cloudfront.net`). Behind CloudFront → internal ALB
+   * the request's `Host` header carries the load balancer's hostname, which is
+   * not externally reachable — absolute URLs built from it (OIDC redirect
+   * URIs, callback URLs) would break. When set, `Host` and `x-forwarded-proto`
+   * in the synthesized event are rewritten to this origin.
+   * Default: `BLOCKS_PUBLIC_ORIGIN` env var, else no rewrite.
+   */
+  publicOrigin?: string;
+  /**
+   * Grace period after SIGTERM/SIGINT before in-flight connections are
+   * force-closed. Load balancer deregistration delays and Kubernetes
+   * `terminationGracePeriodSeconds` should exceed this. Default: 25_000.
+   */
+  shutdownGraceMs?: number;
+  /**
+   * Register SIGTERM/SIGINT handlers that drain and `process.exit(0)`.
+   * Default: true (this is a container entrypoint helper).
+   */
+  handleSignals?: boolean;
+}
+
+interface ResolvedOptions {
+  port: number;
+  healthPath: string;
+  publicOrigin?: string;
+  shutdownGraceMs: number;
+  handleSignals: boolean;
+}
+
+function resolveOptions(options?: BlocksHttpServerOptions): ResolvedOptions {
+  const envPort = Number(process.env.PORT);
+  return {
+    port: options?.port ?? (Number.isFinite(envPort) && envPort > 0 ? envPort : 8080),
+    healthPath: options?.healthPath ?? BLOCKS_HEALTH_PATH,
+    publicOrigin: options?.publicOrigin ?? process.env.BLOCKS_PUBLIC_ORIGIN ?? undefined,
+    shutdownGraceMs: options?.shutdownGraceMs ?? 25_000,
+    handleSignals: options?.handleSignals ?? true,
+  };
+}
+
+/**
+ * Flatten Node's request headers (string | string[] | undefined values) into
+ * the single-valued record shape of an API Gateway v1 event. Node already
+ * lower-cases names and joins duplicate `Cookie` headers with `'; '`;
+ * remaining duplicates are comma-joined per RFC 9110.
+ */
+function toEventHeaders(req: http.IncomingMessage): Record<string, string> {
+  const headers: Record<string, string> = {};
+  for (const [name, value] of Object.entries(req.headers)) {
+    if (value === undefined) continue;
+    headers[name] = Array.isArray(value) ? value.join(', ') : value;
+  }
+  return headers;
+}
+
+/**
+ * Translate a Node request into an API-Gateway-v1-shaped event.
+ *
+ * The body is always base64-encoded (`isBase64Encoded: true`): the dispatch's
+ * `decodeEventBody` handles base64 for any payload, and encoding
+ * unconditionally avoids content-type sniffing. No `requestContext.stage` is
+ * set, so URLs built by the backend have no stage prefix — container front
+ * doors serve from the origin root.
+ *
+ * @internal Exported for testing only.
+ */
+export function toLambdaEvent(
+  req: http.IncomingMessage,
+  body: Buffer,
+  publicOrigin?: string,
+): any {
+  const headers = toEventHeaders(req);
+
+  if (publicOrigin) {
+    const origin = new URL(publicOrigin);
+    headers.host = origin.host;
+    headers['x-forwarded-proto'] = origin.protocol.replace(':', '');
+    // A stale forwarded host (e.g. stamped by the load balancer) must not
+    // shadow the canonical public origin in buildEventUrl's loopback gate.
+    delete headers['x-forwarded-host'];
+  }
+
+  const url = new URL(req.url ?? '/', 'http://localhost');
+
+  const event: any = {
+    httpMethod: req.method ?? 'GET',
+    path: url.pathname,
+    headers,
+    body: body.length > 0 ? body.toString('base64') : null,
+    isBase64Encoded: body.length > 0,
+  };
+  if (url.search.length > 1) {
+    event.rawQueryString = url.search.slice(1);
+  }
+  return event;
+}
+
+/**
+ * Write a Lambda-shaped result ({ statusCode, headers, multiValueHeaders,
+ * body, isBase64Encoded }) to the Node response.
+ *
+ * @internal Exported for testing only.
+ */
+export function writeLambdaResult(res: http.ServerResponse, result: any): void {
+  res.statusCode = result?.statusCode ?? 200;
+  for (const [name, value] of Object.entries(result?.headers ?? {})) {
+    res.setHeader(name, String(value));
+  }
+  // The dispatch emits Set-Cookie exclusively via multiValueHeaders (filtered
+  // out of `headers`), so setting arrays here never clobbers a single value.
+  for (const [name, values] of Object.entries(result?.multiValueHeaders ?? {})) {
+    if (Array.isArray(values) && values.length > 0) {
+      res.setHeader(name, values.map(String));
+    }
+  }
+  const body = result?.body ?? '';
+  res.end(result?.isBase64Encoded ? Buffer.from(body, 'base64') : body);
+}
+
+/**
+ * Build a Node request listener that serves the health endpoint and forwards
+ * everything else through the Blocks event dispatch.
+ *
+ * @internal Exported for testing; use {@link startBlocksHttpServer} in entrypoints.
+ */
+export function createNodeRequestListener(
+  handler: BlocksEventHandler,
+  options?: BlocksHttpServerOptions & { isReady?: () => boolean },
+): http.RequestListener {
+  const resolved = resolveOptions(options);
+  const isReady = options?.isReady ?? (() => true);
+
+  return (req, res) => {
+    const path = (req.url ?? '/').split('?')[0];
+
+    // Health is a server concern: answered before dispatch so probes get a
+    // deterministic response independent of routes and CORS config.
+    if (path === resolved.healthPath) {
+      const ready = isReady();
+      res.statusCode = ready ? 200 : 503;
+      res.setHeader('Content-Type', 'application/json');
+      res.end(JSON.stringify({ status: ready ? 'ok' : 'initializing' }));
+      return;
+    }
+
+    const chunks: Buffer[] = [];
+    req.on('data', (chunk) => chunks.push(chunk));
+    req.on('error', (err) => {
+      console.error('Request stream error:', err);
+      if (!res.headersSent) {
+        res.statusCode = 400;
+        res.end(JSON.stringify({ error: 'Bad Request' }));
+      } else {
+        res.destroy();
+      }
+    });
+    req.on('end', () => {
+      const event = toLambdaEvent(req, Buffer.concat(chunks), resolved.publicOrigin);
+      // No Lambda context is passed: the deadline guard then uses the
+      // BLOCKS_HTTP_TIMEOUT_MS-driven cap (see defaultHttpDeadlineCapMs) and
+      // still returns a proper 504 through the normal result path.
+      handler(event)
+        .then((result) => writeLambdaResult(res, result))
+        .catch((err) => {
+          console.error('Unhandled dispatch error:', err);
+          if (!res.headersSent) {
+            res.statusCode = 500;
+            res.setHeader('Content-Type', 'application/json');
+            res.end(JSON.stringify({ error: 'Internal Server Error' }));
+          } else {
+            res.destroy();
+          }
+        });
+    });
+  };
+}
+
+/**
+ * Start the production HTTP server for a Blocks backend container.
+ *
+ * ```ts
+ * import { handler } from './index.handler.js';
+ * import { startBlocksHttpServer } from '@aws-blocks/core/http-server';
+ * await startBlocksHttpServer(handler);
+ * ```
+ *
+ * Startup performs a warmup dispatch (an OPTIONS preflight to the RPC
+ * endpoint) so config loading and the backend import complete before the
+ * health endpoint reports ready — giving load balancers and Kubernetes
+ * readiness probes correct semantics without a separate init protocol.
+ * If warmup fails the process exits non-zero so the orchestrator restarts it.
+ */
+export async function startBlocksHttpServer(
+  handler: BlocksEventHandler,
+  options?: BlocksHttpServerOptions,
+): Promise<http.Server> {
+  const resolved = resolveOptions(options);
+  let ready = false;
+
+  const server = http.createServer(
+    createNodeRequestListener(handler, { ...options, isReady: () => ready }),
+  );
+
+  // Behind an ALB, Node's default keepAliveTimeout (5s) is shorter than the
+  // load balancer's idle timeout (60s): the server closes a kept-alive socket
+  // the ALB still considers usable, and the next proxied request gets a 502.
+  // Keep-alive must outlive the ALB idle timeout; headersTimeout must exceed
+  // keepAliveTimeout so header parsing on a reused socket isn't cut short.
+  server.keepAliveTimeout = 65_000;
+  server.headersTimeout = 66_000;
+
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(resolved.port, () => resolve());
+  });
+
+  try {
+    await handler({ httpMethod: 'OPTIONS', path: BLOCKS_RPC_PREFIX, headers: {} });
+    ready = true;
+    const address = server.address();
+    const boundPort = address && typeof address === 'object' ? address.port : resolved.port;
+    console.log(`Blocks backend listening on :${boundPort} (health: ${resolved.healthPath})`);
+  } catch (err) {
+    console.error('Backend initialization failed:', err);
+    server.close();
+    if (resolved.handleSignals) {
+      process.exit(1);
+    }
+    throw err;
+  }
+
+  if (resolved.handleSignals) {
+    const shutdown = (signal: string) => {
+      console.log(`Received ${signal}, draining connections…`);
+      ready = false; // fail health checks so the LB stops routing new work
+      server.close(() => process.exit(0));
+      server.closeIdleConnections();
+      const killTimer = setTimeout(() => {
+        server.closeAllConnections();
+        process.exit(0);
+      }, resolved.shutdownGraceMs);
+      killTimer.unref();
+    };
+    process.once('SIGTERM', () => shutdown('SIGTERM'));
+    process.once('SIGINT', () => shutdown('SIGINT'));
+  }
+
+  return server;
+}

--- a/packages/core/src/index.cdk.ts
+++ b/packages/core/src/index.cdk.ts
@@ -8,7 +8,14 @@ export { EventSourceMapping } from './lambda-handler.js';
 export { BlocksStackProps } from './common/index.js';
 export { registerSdkIdentifiers, getSdkIdentifiers, getAllSdkIdentifiers, _resetSdkRegistry } from './common/sdk-registry.js';
 export { getConfig, getConfigSync, preloadConfig, loadConfigToProcessEnv, _resetConfigCache } from './common/config.js';
-export { BlocksStack, Scope, SandboxDisableDeletionProtection, BlocksBackend, registerConfig, finalizeConfigRegistry, synthGuard, DEFAULT_NODE_RUNTIME, type BlocksBackendProps } from './cdk/index.js';
+export { BlocksStack, Scope, SandboxDisableDeletionProtection, BlocksBackend, registerConfig, finalizeConfigRegistry, getConfigDeployment, synthGuard, DEFAULT_NODE_RUNTIME, type BlocksBackendProps } from './cdk/index.js';
+export type {
+  ComputeTarget,
+  ComputeBindContext,
+  ComputeBindResult,
+  ComputeApiOrigin,
+  ComputePrincipal,
+} from './cdk/index.js';
 export {
   Hosting,
   type HostingProps,

--- a/packages/core/src/lambda-handler.ts
+++ b/packages/core/src/lambda-handler.ts
@@ -256,20 +256,35 @@ export function isApiGatewayHttpEvent(event: any): boolean {
 }
 
 /**
+ * Default cap for the HTTP deadline guard.
+ *
+ * On Lambda behind API Gateway this is the fixed 28s guard. Container
+ * deployments have no API Gateway 29s cutoff and can raise it via the
+ * `BLOCKS_HTTP_TIMEOUT_MS` env var — the same bundle serves both
+ * environments, so the cap must come from the environment, not a code path.
+ *
+ * @internal Exported for testing only.
+ */
+export function defaultHttpDeadlineCapMs(): number {
+  const raw = Number(process.env.BLOCKS_HTTP_TIMEOUT_MS);
+  return Number.isFinite(raw) && raw > 0 ? raw : APIGW_TIMEOUT_MS;
+}
+
+/**
  * Compute the HTTP deadline in milliseconds.
  *
  * Uses the minimum of:
- * - `APIGW_TIMEOUT_MS` (28s fixed guard)
+ * - `capMs` (28s fixed guard by default; see {@link defaultHttpDeadlineCapMs})
  * - `context.getRemainingTimeInMillis() - REMAINING_TIME_BUFFER_MS` (actual remaining Lambda time)
  *
  * This handles the edge case where a warm Lambda has less than 29s remaining.
  *
  * @internal Exported for testing only.
  */
-export function computeHttpDeadlineMs(context?: LambdaContext): number {
-  if (!context?.getRemainingTimeInMillis) return APIGW_TIMEOUT_MS;
+export function computeHttpDeadlineMs(context?: LambdaContext, capMs = defaultHttpDeadlineCapMs()): number {
+  if (!context?.getRemainingTimeInMillis) return capMs;
   const remaining = context.getRemainingTimeInMillis() - REMAINING_TIME_BUFFER_MS;
-  return Math.min(APIGW_TIMEOUT_MS, Math.max(remaining, 0));
+  return Math.min(capMs, Math.max(remaining, 0));
 }
 
 /**


### PR DESCRIPTION
> Part 1 of 3 (Refs #156). Self-contained; no new infrastructure. Part 2 (ECS) and Part 3 (EKS) build on this seam and follow as drafts.

## Problem

A Blocks backend can only run on Lambda + API Gateway: `BlocksStack.create()` hardcodes both. There is no way to run the backend on load-balanced container compute (long-running requests, steady-load cost profiles, EKS-standardized platforms) without forking core. RFC #156 proposes container compute targets; this PR adds the seam they plug into.

**Issue #, if available:** Refs #156

## Changes

- `ComputeTarget` contract (`core/cdk`): `requiredPrincipals`, `bind()` (provides the HTTP front door in place of API Gateway), `finalize()` (runs after the config registry is sealed). `BlocksStackProps`/`BlocksBackendProps` gain an optional `compute`.
- Shared execution role: with `compute` set, one role trusts `lambda` plus the target's principals (`ecs-tasks`, `pods.eks` with session tags), so every Building Block grant applies to containers with zero block changes.
- Hybrid model: the Lambda remains as the event-source companion (SQS, EventBridge, WebSocket, migrations); containers serve HTTP; both run the same esbuild bundle.
- `@aws-blocks/core/http-server` (new export): production HTTP server wrapping the existing Lambda dispatch — APIGW event translation, health gating on `/aws-blocks/health`, SIGTERM drain, ALB-safe keep-alive timeouts, `BLOCKS_HTTP_TIMEOUT_MS` deadline cap.
- Hosting: `BlocksStackApi` gains a structural `apiOrigin` so `addApiBehaviors` proxies stage-less container URLs (falls back to the existing stage parsing).

**Breaking changes:** none. Without `compute`, the synthesized template is byte-identical (pinned by a template-stability test). For container-mode stacks only, `gateway` throws (no REST API exists) — called out in the changeset.

**Review guide:** start with `packages/core/src/cdk/compute-target.ts` (the contract), then `blocks-backend.ts` (the split), then `http-server.ts`.

## Validation

- Request-conformance parity suite: the lambda-handler test table runs over real HTTP against the server (RPC envelopes, RawRoute params, multi-value Set-Cookie, CORS, base64 bodies, 404/timeout, health gating, drain).
- Template-stability test pins the no-compute default synth unchanged.
- All gates pass: build, unit tests, `lint:deps`, `check:exports-consistency`, `check:api` (report updated). Changeset: `@aws-blocks/core` minor.
- End-to-end consumption is exercised by the ECS/EKS smoke apps in Parts 2-3, both verified with real AWS deployments (evidence in those PRs).

## Checklist

- [x] PR description included
- [x] Tests are changed or added
- [x] Relevant documentation is changed or added (and PR referenced)

Authored with AI assistance (Claude Code); all code human-reviewed and verified end-to-end against real AWS deployments (see Parts 2-3).

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
