### PR TITLE
feat(core): add throttling and access logging to central API Gateway

### DIFF
--- a/.changeset/api-gateway-throttling-logging.md
+++ b/.changeset/api-gateway-throttling-logging.md
@@ -1,0 +1,5 @@
+---
+"@aws-blocks/core": minor
+---
+
+Add default throttling and structured access logging to the central API Gateway. The stage now enforces a steady-state limit of 100 requests/second with a burst ceiling of 200 (returning 429s beyond that), and emits JSON access logs (IP, method, resource path, status, response length, request time, caller, user, protocol) to a dedicated CloudWatch `ApiAccessLogs` log group with 1-month retention (`RemovalPolicy.DESTROY` so stack teardown stays clean). These are account-level stage defaults and can be overridden per-method if needed.

--- a/packages/core/src/cdk/blocks-backend.test.ts
+++ b/packages/core/src/cdk/blocks-backend.test.ts
@@ -6,7 +6,7 @@ import assert from 'node:assert';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import * as cdk from 'aws-cdk-lib';
-import { Template } from 'aws-cdk-lib/assertions';
+import { Template, Match } from 'aws-cdk-lib/assertions';
 import { BlocksBackend } from './blocks-backend.js';
 
 // Simulate the CDK condition being active (tests import CDK files directly)
@@ -86,6 +86,43 @@ describe('synth shape (drop into existing stack)', () => {
 
     const template = Template.fromStack(parent);
     template.resourceCountIs('AWS::ApiGateway::RestApi', 2);
+  });
+});
+
+describe('API Gateway throttling + access logging', () => {
+  test('stage enforces throttle limits and writes JSON access logs to a retained log group', async () => {
+    const app = new cdk.App();
+    const parent = new cdk.Stack(app, 'ThrottleStack');
+
+    await BlocksBackend.create(parent, 'Blocks', {
+      backendHandlerPath: handlerPath,
+      backendCDKPath: sideEffectBackendPath,
+    });
+
+    const template = Template.fromStack(parent);
+
+    // Stage carries the stage-wide throttle defaults (100 req/s steady, 200 burst)
+    // applied to all methods/resources ('*' / '/*').
+    template.hasResourceProperties('AWS::ApiGateway::Stage', {
+      MethodSettings: Match.arrayWith([
+        Match.objectLike({
+          HttpMethod: '*',
+          ResourcePath: '/*',
+          ThrottlingRateLimit: 100,
+          ThrottlingBurstLimit: 200,
+        }),
+      ]),
+      // Access logging is wired to a destination with a non-empty (JSON) format.
+      AccessLogSetting: Match.objectLike({
+        DestinationArn: Match.anyValue(),
+        Format: Match.anyValue(),
+      }),
+    });
+
+    // A dedicated access-log group exists with 1-month (30-day) retention.
+    template.hasResourceProperties('AWS::Logs::LogGroup', {
+      RetentionInDays: 30,
+    });
   });
 });
 

--- a/packages/core/src/cdk/blocks-backend.ts
+++ b/packages/core/src/cdk/blocks-backend.ts
@@ -4,6 +4,7 @@
 import * as cdk from 'aws-cdk-lib';
 import * as lambda from 'aws-cdk-lib/aws-lambda-nodejs';
 import * as apigateway from 'aws-cdk-lib/aws-apigateway';
+import * as logs from 'aws-cdk-lib/aws-logs';
 import { CfnGroup } from 'aws-cdk-lib/aws-resourcegroups';
 import { Construct } from 'constructs';
 import { pathToFileURL } from 'node:url';
@@ -82,9 +83,34 @@ export function setupBlocksInfra(scope: Construct, props: BlocksBackendProps, id
     handler.addEnvironment('CORS_ALLOWED_ORIGINS', '^https?://(localhost|127\\.0\\.0\\.1)(:\\d+)?$');
   }
 
+  const accessLogGroup = new logs.LogGroup(scope, 'ApiAccessLogs', {
+    retention: logs.RetentionDays.ONE_MONTH,
+    removalPolicy: cdk.RemovalPolicy.DESTROY,
+  });
+
   const api = new apigateway.RestApi(scope, 'API', {
     restApiName: 'Blocks API',
-    deployOptions: { cachingEnabled: false },
+    deployOptions: {
+      cachingEnabled: false,
+      // Steady-state cap: 100 requests/second sustained across the stage,
+      // enforced by API Gateway's token-bucket refill rate.
+      throttlingRateLimit: 100,
+      // Burst cap: token-bucket depth allowing up to 200 concurrent requests
+      // to absorb short spikes above the steady-state rate before throttling (429s).
+      throttlingBurstLimit: 200,
+      accessLogDestination: new apigateway.LogGroupLogDestination(accessLogGroup),
+      accessLogFormat: apigateway.AccessLogFormat.jsonWithStandardFields({
+        ip: true,
+        httpMethod: true,
+        resourcePath: true,
+        status: true,
+        responseLength: true,
+        requestTime: true,
+        caller: true,
+        user: true,
+        protocol: true,
+      }),
+    },
   });
 
   const integration = new apigateway.LambdaIntegration(handler);


### PR DESCRIPTION
## Problem

The central API Gateway (`setupBlocksInfra` in `@aws-blocks/core`) was created with no request throttling and no access logging. That leaves the Blocks API with unbounded request rates (no protection against traffic spikes / abuse) and no per-request audit trail for debugging or security review.

**Issue #, if available:** N/A

## Changes

Added stage-level defaults to the `RestApi` deployment in `packages/core/src/cdk/blocks-backend.ts`:

- **Throttling** — `throttlingRateLimit: 100` (steady-state req/s) and `throttlingBurstLimit: 200` (token-bucket burst ceiling; over-limit requests get 429s). Documented inline with the token-bucket semantics.
- **Access logging** — structured JSON logs (`AccessLogFormat.jsonWithStandardFields`: IP, method, resource path, status, response length, request time, caller, user, protocol) delivered to a dedicated `ApiAccessLogs` CloudWatch log group.
- **Log group** — 1-month retention with `RemovalPolicy.DESTROY` so stack teardown stays clean (matches the existing `bb-logger` convention).

These are account-level stage defaults and can be overridden per-method later if needed. Changeset included (`minor` bump for `@aws-blocks/core`).

## Validation

- Existing `blocks-backend` test suite: 7/8 pass. The one failure (`@aws-blocks/pipeline/dist/index.js` not found) is an unbuilt sibling-package artifact pulled in transitively via `src/cdk/index.ts`, unrelated to this change.
- Wrote a throwaway CDK synth check asserting the synthesized template: `AWS::ApiGateway::Stage` carries `ThrottlingRateLimit: 100` / `ThrottlingBurstLimit: 200` / `AccessLogSetting`, and `AWS::Logs::LogGroup` has `RetentionInDays: 30`. Passed.

## Checklist

- [x] PR description included
- [x] Tests are changed or added
- [x] Relevant documentation is changed or added (changeset)

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._

