### PR TITLE
feat(bench): redesign report + fix baseline (SUPERSEDED by #171 — closed, not merged)

### DIFF
--- a/.changeset/bench-report-redesign.md
+++ b/.changeset/bench-report-redesign.md
@@ -1,0 +1,21 @@
+---
+---
+
+feat(bench): redesign agent-bench PR-vs-`main` report + fix baseline selection
+
+Internal CI tooling — no published-package changes.
+
+- The report is now two tables built from the same rows: a colors-only
+  **Overview** (🟢/🟡/🔴 per metric) and a numbers **Detailed results**
+  (`baseline -> pr`, with a multi-line per-dimension judge cell + stop reason),
+  preceded by a collapsible glossary and followed by a short executive summary
+  (paragraph + bullets), a **Potential issues** section, and a collapsed
+  per-cell analysis. Dropped the old build/verdict/composite columns and the raw
+  per-dimension blurb.
+- New per-metric coloring vs the `main` baseline with a single tunable
+  `MARGIN_PCT` (±5%), and a new **SCORE = composite ÷ cost** (composite points
+  per dollar) priced from builder tokens at Bedrock Sonnet rates
+  (`PRICING`/`cellCost`/`scorePerDollar` in `scoring.mjs`).
+- Baseline-selection fix: a PR now always diffs against `latest-main.json` (the
+  current `main` tip), never the PR's stale recorded `base.sha`; a push to `main`
+  diffs against the preceding main commit (`github.event.before`) by exact sha.

--- a/.github/workflows/agent-bench.yml
+++ b/.github/workflows/agent-bench.yml
@@ -396,28 +396,46 @@ jobs:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: us-east-1
 
-      # Fetch the BASELINE aggregate for this PR's base commit so the overview
-      # can show per-cell deltas. Tries the exact base sha, then the stable
-      # latest-main pointer. Best-effort: a miss (or no creds) removes the file,
-      # so summary.mjs renders absolute composites with a "no baseline" note.
-      # Only on a PR (push/dispatch have no PR base to diff against).
+      # Fetch the BASELINE aggregate the overview diffs against. Best-effort: a
+      # miss (or no creds) removes the file, so summary.mjs renders absolute
+      # composites with a "no baseline" note.
+      #   - PR / manual dispatch → ALWAYS the latest-main pointer (the MOST RECENT
+      #     main-branch bench = current main tip). NEVER the PR's recorded base
+      #     commit: github.event.pull_request.base.sha is captured at PR open /
+      #     last-sync and goes stale as main advances, so an exact-base-sha lookup
+      #     can silently diff against an outdated or never-benched commit.
+      #   - push to main → the IMMEDIATELY PRECEDING main commit (github.event.
+      #     before) by exact sha — the ONLY place a commit-keyed baseline is read —
+      #     with the latest-main pointer (its pre-persist value) as fallback.
       - name: Fetch baseline from S3 (best-effort)
         id: baseline
-        if: steps.oidc.outcome == 'success' && github.event_name == 'pull_request'
+        if: steps.oidc.outcome == 'success'
         continue-on-error: true
         env:
           BUCKET: ${{ vars.S3_BUCKET }}
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          EVENT_NAME: ${{ github.event_name }}
+          BEFORE_SHA: ${{ github.event.before }}
           BASELINE_PATH: ${{ github.workspace }}/baseline.json
         run: |
           set -u
-          if aws s3 cp "s3://${BUCKET}/bench/runs/${BASE_SHA}/results.json" "$BASELINE_PATH" 2>/dev/null; then
-            echo "baseline: exact base ${BASE_SHA}"
-          elif aws s3 cp "s3://${BUCKET}/bench/runs/latest-main.json" "$BASELINE_PATH" 2>/dev/null; then
-            echo "baseline: latest-main fallback (exact base ${BASE_SHA} not benched)"
+          if [ "$EVENT_NAME" = "push" ]; then
+            if [ -n "${BEFORE_SHA:-}" ] \
+               && [ "$BEFORE_SHA" != "0000000000000000000000000000000000000000" ] \
+               && aws s3 cp "s3://${BUCKET}/bench/runs/${BEFORE_SHA}/results.json" "$BASELINE_PATH" 2>/dev/null; then
+              echo "baseline: previous main commit ${BEFORE_SHA} (exact)"
+            elif aws s3 cp "s3://${BUCKET}/bench/runs/latest-main.json" "$BASELINE_PATH" 2>/dev/null; then
+              echo "baseline: latest-main pointer (previous main bench)"
+            else
+              echo "baseline: none found — overview will show absolute numbers"
+              rm -f "$BASELINE_PATH"
+            fi
           else
-            echo "baseline: none found (exact base or latest-main) — overview will show absolute numbers"
-            rm -f "$BASELINE_PATH"
+            if aws s3 cp "s3://${BUCKET}/bench/runs/latest-main.json" "$BASELINE_PATH" 2>/dev/null; then
+              echo "baseline: latest-main (current main tip)"
+            else
+              echo "baseline: none found (latest-main) — overview will show absolute numbers"
+              rm -f "$BASELINE_PATH"
+            fi
           fi
 
       # This is the ONLY step in the whole workflow that is intentionally NOT

--- a/scripts/agent-bench/README.md
+++ b/scripts/agent-bench/README.md
@@ -29,8 +29,9 @@ Nine steps per cell, all on the GitHub runner (4b and 6b are best-effort auxilia
    shown to it.
    - **4b. Analyze cell** (best-effort) — asks the judge model for a concise
      2–4 sentence analysis of this cell's fresh `trace.json` + `metrics.json`
-     and writes it back into `result.json` (`analyze-cell.mjs`); the summary
-     job later rolls these up
+     plus a short list of potential issues, and writes both back into
+     `result.json` as `analysis` + `analysis_issues[]` (`analyze-cell.mjs`); the
+     summary job later rolls these up
 5. **Upload result** — JSON artifact + S3 archive (best-effort)
 6. **Upload source** — uploads the generated `bench-app` as
    `bench-source-<task>-<template>` for post-run auditing, excluding deps/build
@@ -122,6 +123,26 @@ whatever the judge said, and the judge term only reaches full weight once ≥25%
 of tests pass. A judge failure (`judge=0`) drops *only* its 40% — never the
 test-driven 60%. Bands: ≥80 🟢, ≥50 🟡, else 🔴.
 
+**Cost & Score (per cell).** COST is the **builder's** token spend priced at
+Bedrock Claude Sonnet rates — `$3` / 1M input, `$15` / 1M output
+(`PRICING` / `BUILDER_PRICING` in `lib/scoring.mjs`, the one place to edit when
+AWS pricing or the builder model changes). The judge and analysis run on Opus,
+but that spend is the harness's, not the agent's, so it is not counted. **SCORE**
+= `composite ÷ cost` — composite points per **dollar**, higher = better. Cost, not
+raw token volume, is the denominator, so token count can't *dominate* the metric,
+and a broken (composite 0) cell scores 0 no matter how cheap it was. A cell with
+no recorded tokens renders `—` (never a fake `$0`). Flip the single
+`SCORE_PER_DOLLAR` constant in `lib/scoring.mjs` for cost-per-point instead.
+
+**Colors vs baseline (per metric).** In the report every metric cell is colored
+against the baseline value for that metric: 🟢 same-or-better · 🟡 worse but
+within the margin · 🔴 worse beyond it · 🆕 no baseline value (new cell) · `—`
+nothing to diff · 🗑️ cell gone since the baseline. The margin is a SINGLE tunable,
+`MARGIN_PCT` (5% relative) in `lib/overview.mjs`; for integer metrics (test
+counts, 0–10 judge dims) it is floored to 1, so a single-point nudge reads 🟡,
+never 🔴. Directions: tests ↑, judge ↑, score ↑ are better (higher = 🟢); cost ↓,
+tokens ↓ are better (lower = 🟢).
+
 **Verdict tiers** are pure pass-rate — the judge plays no part, so an LLM
 failure can never flip a verdict:
 
@@ -182,10 +203,13 @@ data so identifiers stay collision-free across a spec's internal navigation.
 
 **Re-derivability.** Each `result.json` publishes `tests_passed`/`tests_total`,
 `test_rate`, the raw per-dimension judge scores (pre-cap `judge_dimensions_raw`
-and post-cap `judge_dimensions`), `judge_overall`, `composite`, `verdict` and
-`klass`; the summary also renders a collapsible **Raw per-dimension scores**
-table. A reader can re-derive — or re-weight — every composite from the
-published data without re-running anything.
+and post-cap `judge_dimensions`), `judge_overall`, `composite`, `verdict`,
+`klass`, the builder `tokens_in`/`tokens_out`, and `stop_reason`. The **Detailed
+results** table renders every post-cap dimension inline (one colored
+`baseline -> pr` line per dimension in its Judge cell), and the cost + score are
+derived from the published tokens via `lib/scoring.mjs`. A reader can re-derive —
+or re-weight — every composite, cost and score from the published data without
+re-running anything.
 
 **Gating.** Observational by default: with the repo/org variable
 `BENCH_MIN_SCORE` unset the summary only reports the mean composite. Set it to a
@@ -204,16 +228,37 @@ the run summary, not the check status, and the summary job is green too (unless
 `BENCH_MIN_SCORE` is set and trips). A new commit cancels the prior in-flight run
 via the workflow `concurrency` group.
 
-**PR-vs-baseline overview.** Each run writes a compact **aggregate** (per-cell
-composites + mean) to S3 at `bench/runs/<sha>/results.json`; a push-to-`main` run
-also updates `bench/runs/latest-main.json`. On a PR the summary job fetches the
-baseline for the PR's **base** commit (falling back to `latest-main`) and renders,
-at the **top** of the run summary, an at-a-glance per-cell composite **delta**
-(▲ better · ▼ worse · = unchanged · 🆕 new) plus the overall mean delta. With no
-baseline found it shows absolute composites and a "no baseline" note (never an
-error). Reading/writing the baseline uses the same OIDC role
-(`s3:GetObject` / `s3:PutObject` on `bench/*`); a missing grant just degrades to
-"no baseline".
+**The report — Overview + Detailed vs the `main` baseline.** Each run writes a
+compact **aggregate** (per cell: composite/verdict, test counts, per-dimension
+judge scores, builder tokens, cost, and score-per-$, plus the mean) to S3 at
+`bench/runs/<sha>/results.json`; a push-to-`main` run also updates the stable
+pointer `bench/runs/latest-main.json`. The summary job fetches a baseline and
+renders TWO tables from the SAME rows (`lib/overview.mjs`):
+
+- **Overview** — colors ONLY (🟢/🟡/🔴 per metric vs baseline), at-a-glance:
+  `TASK · TEMPLATE · TESTS · JUDGE · COST · TOKENS (in/out) · SCORE`.
+- **Detailed results** — the same rows widened WITH numbers (`baseline -> pr`),
+  including a multi-line per-dimension Judge cell and the cell's stop reason.
+
+A collapsible **Glossary** (scoring, colors, the ±5% margin) sits at the very
+top; a best-effort roll-up step (`analyze.mjs`) then appends an **Executive
+summary** (a short paragraph + bullets), a **Potential issues** section (fed by
+each cell's own analysis), and a collapsed **Per-cell analysis** (each cell also
+collapsed within it). The old `build` / `verdict` / `composite` columns and the
+raw per-dimension blurb are gone — folded into the two tables above.
+
+**Baseline selection.** The baseline a **PR** diffs against is ALWAYS the most
+recent `main`-branch bench, `bench/runs/latest-main.json` — the current tip of
+`main`, NOT the PR's recorded base commit. `github.event.pull_request.base.sha`
+is captured when the PR is opened / last synced and goes stale as `main` advances,
+so an exact-base-sha lookup can silently diff against an outdated or never-benched
+commit; `latest-main.json`, refreshed on every push to `main`, can't. A **push to
+`main`** instead diffs against the immediately preceding main commit
+(`github.event.before`) by exact sha — the ONLY place a commit-keyed baseline is
+read — with `latest-main` as the fallback. With no baseline found the tables show
+absolute values (every metric 🆕) and a "no baseline" note (never an error).
+Reading/writing the baseline uses the same OIDC role (`s3:GetObject` /
+`s3:PutObject` on `bench/*`); a missing grant just degrades to "no baseline".
 
 ## Files
 
@@ -228,13 +273,13 @@ error). Reading/writing the baseline uses the same OIDC role
 | `steps/3-build-and-test.sh` | `npm run build` + Playwright spec; writes build / dev-server / playwright / test signals to `$GITHUB_OUTPUT` |
 | `steps/4-judge.ts` | Judge agent (Strands + Bedrock); one vended `bash` tool over a spec-blinded, disposable source-only copy; grades on the fixed shared rubric (`COMMON_DIMENSIONS`) and applies hard caps |
 | `steps/lib/run-shell.ts` | Shared shell infrastructure for the builder + judge: the `WorkspaceSandbox` (host-execution Sandbox rooted at a fixed dir) + a backgrounded-process-safe runner. The containment fix lives here once; imported by `2-agent-run.ts` and `4-judge.ts` |
-| `steps/lib/scoring.mjs` | **Single source of truth** for scoring: `classifyCell`, `testStats`/`testRate`, `verdict`/`verdictOf`, `composite`/`compositeBand`, `isScoredCell`. Imported by both finalize + summary |
-| `steps/lib/overview.mjs` | Pure helpers for the PR-vs-baseline overview: `buildAggregate` (per-cell composites + mean), `diffAgainstBaseline`, `renderOverview`. Imported by summary |
-| `steps/lib/analysis.mjs` | Shared, mostly-pure helpers for the trace/metrics analysis feature; imported by `analyze-cell.mjs` (per-cell) and `analyze.mjs` (roll-up) |
-| `steps/analyze-cell.mjs` | Step 4b: per-cell trace/metrics analysis via the judge model; writes a concise `analysis` string back into the cell's `result.json` |
-| `steps/analyze.mjs` | Summary-job roll-up that synthesizes the per-cell `analysis` strings into one executive summary via a single Bedrock call |
+| `steps/lib/scoring.mjs` | **Single source of truth** for scoring: `classifyCell`, `testStats`/`testRate`, `verdict`/`verdictOf`, `composite`/`compositeBand`, `isScoredCell`, plus the cost/score model — `PRICING`/`BUILDER_PRICING`, `cellCost`, `scorePerDollar` (+ the `SCORE_PER_DOLLAR` knob). Imported by finalize, summary, and overview |
+| `steps/lib/overview.mjs` | Pure helpers for the two report tables: `buildAggregate` (schema-2 aggregate — per-cell composite/tests/judge-dims/tokens/cost/score/stop_reason + mean), `diffAgainstBaseline`, the color engine (`MARGIN_PCT`, `metricColor`), formatters, and `renderOverview` (colors) + `renderDetailed` (numbers). Imported by summary + analyze |
+| `steps/lib/analysis.mjs` | Shared, mostly-pure helpers for the trace/metrics analysis feature: trace trimming, prompt builders, and `parseCellAnalysis` (splits the per-cell model output into an analysis string + a bounded potential-issues list). Imported by `analyze-cell.mjs` (per-cell) and `analyze.mjs` (roll-up) |
+| `steps/analyze-cell.mjs` | Step 4b: per-cell trace/metrics analysis via the judge model; writes a concise `analysis` string **and** an `analysis_issues[]` (potential issues) back into the cell's `result.json` |
+| `steps/analyze.mjs` | Summary-job roll-up: synthesizes the per-cell analyses into a short **Executive summary** (paragraph + bullets) via one best-effort Bedrock call, aggregates a **Potential issues** section, and renders a collapsed **Per-cell analysis** (each cell also collapsed) |
 | `steps/finalize-result.mjs` | Run with `if: always()`; stamps `status` + `failed_at` from per-step outcomes, then `klass`, `test_rate`, `verdict`, `composite` via `lib/scoring.mjs` |
-| `steps/summary.mjs` | Render the PR-vs-baseline overview + scoreboard (+ collapsible raw per-dimension table, run-logs deep-link) to `$GITHUB_STEP_SUMMARY`; reads one `result.json` per cell (N=1); writes the run's aggregate (per-cell composites + mean) for the S3 baseline; optional `BENCH_MIN_SCORE` gate |
+| `steps/summary.mjs` | Render the report to `$GITHUB_STEP_SUMMARY`: a collapsible **Glossary**, the colors-only **Overview** + numbers **Detailed results** tables (vs the `main` baseline), and a deterministic caveats block; reads one `result.json` per cell (N=1); writes the run's schema-2 aggregate (+ Athena NDJSON) for the S3 baseline; optional `BENCH_MIN_SCORE` gate |
 | `package.json` | Workspace metadata; `private: true` |
 
 Failure handling: every cell starts with `0-init-result.mjs` writing a
@@ -245,13 +290,13 @@ runs with `if: always()` and stamps `status: scored` (all steps green),
 upload step also runs with `if: always()`, so the cell always shows up in the
 summary table — never silently missing.
 
-The scoreboard is written to the **GitHub Actions run summary**
-(`$GITHUB_STEP_SUMMARY`) and renders in the run UI, with the PR-vs-baseline
-overview prepended at the top. The bench posts **no PR comment** — the
-github-script commenting step in `agent-bench.yml` is intentionally left in place
-but commented out, so it can be restored if commenting is ever wanted again. When
-the bench matrix produces no results, `summary.mjs` renders a benign "no results"
-note and still exits 0.
+The report is written to the **GitHub Actions run summary**
+(`$GITHUB_STEP_SUMMARY`) and renders in the run UI — the Glossary, the Overview +
+Detailed tables, then the executive summary / potential issues / per-cell
+analysis. The bench posts **no PR comment** — the github-script commenting step in
+`agent-bench.yml` is intentionally left in place but commented out, so it can be
+restored if commenting is ever wanted again. When the bench matrix produces no
+results, `summary.mjs` renders a benign "no results" note and still exits 0.
 
 ## Local development
 

--- a/scripts/agent-bench/steps/analyze-cell.mjs
+++ b/scripts/agent-bench/steps/analyze-cell.mjs
@@ -4,20 +4,22 @@
 // metrics.json (both written locally by step 2 at /tmp), asks the judge Bedrock
 // model (Opus 4.8) for a CONCISE 2-4 sentence analysis of what the agent built +
 // any struggles visible in the data, and writes that back into result.json as an
-// `analysis` string. The top-level summary job later ROLLS UP these per-cell
-// analyses (steps/analyze.mjs) — it no longer re-reads raw traces centrally.
+// `analysis` string PLUS an `analysis_issues` string[] (potential issues worth a
+// maintainer's attention). The top-level summary job later ROLLS UP these per-cell
+// analyses and aggregates the issues (steps/analyze.mjs) — it no longer re-reads
+// raw traces centrally.
 //
 // ISOLATION CONTRACT — purely additive, must NEVER affect the green-regardless
 // bench:
 //   - The whole run is wrapped so it can NEVER throw; it always exits 0.
-//   - It only ADDS the `analysis` field — it never touches the score, verdict,
-//     klass, or any other field finalize-result stamped.
+//   - It only ADDS the `analysis`/`analysis_issues` fields — it never touches the
+//     score, verdict, klass, or any other field finalize-result stamped.
 //   - No trace/metrics, a harness/agent failure, or any Bedrock error → it
-//     writes a benign fallback string and still exits 0 (never blocks upload).
+//     writes a benign fallback string (and no issues) and still exits 0.
 // Runs under bare `node` in the cell (which DID `npm ci`, but this uses only
 // Node built-ins + the runner's AWS CLI via lib/analysis.mjs — no SDK import).
 import { readFileSync, writeFileSync } from 'node:fs';
-import { CELL_MAX_TOKENS, CELL_SYSTEM, DEFAULT_MODEL_ID, FALLBACK_ANALYSIS, bedrockConverse, buildCellUserText, oneLine } from './lib/analysis.mjs';
+import { CELL_MAX_TOKENS, CELL_SYSTEM, DEFAULT_MODEL_ID, FALLBACK_ANALYSIS, bedrockConverse, buildCellUserText, parseCellAnalysis } from './lib/analysis.mjs';
 
 const RESULT_PATH = process.env.RESULT_PATH ?? '/tmp/result.json';
 const TRACE_PATH = process.env.TRACE ?? '/tmp/trace.json';
@@ -33,18 +35,23 @@ function readJson(path) {
 	}
 }
 
-// Decide the per-cell analysis text. Returns a string — never throws. Only calls
-// Bedrock when there is actual data to analyze; a harness/agent failure with no
-// trace gets a benign, self-describing note without spending a model call.
+// Decide the per-cell analysis. Returns `{ analysis, issues }` — never throws.
+// Only calls Bedrock when there is actual data to analyze; a harness/agent
+// failure with no trace gets a benign, self-describing note (and no issues)
+// without spending a model call.
 function analyze(result, trace, metrics) {
 	const klass = result?.klass ?? null;
 	if (klass === 'harness_error') {
-		return 'Cell failed before producing a gradeable app (harness error) — no agent trace to analyze.';
+		return { analysis: 'Cell failed before producing a gradeable app (harness error) — no agent trace to analyze.', issues: [] };
 	}
 	if (!trace && !metrics) {
-		return klass === 'agent_fail'
-			? 'Agent timed out / produced no app within budget — no trace was emitted, so there is nothing to analyze.'
-			: 'No trace/metrics artifact available for this cell — nothing to analyze.';
+		return {
+			analysis:
+				klass === 'agent_fail'
+					? 'Agent timed out / produced no app within budget — no trace was emitted, so there is nothing to analyze.'
+					: 'No trace/metrics artifact available for this cell — nothing to analyze.',
+			issues: [],
+		};
 	}
 
 	const userText = buildCellUserText({
@@ -65,8 +72,9 @@ function analyze(result, trace, metrics) {
 		region: REGION,
 		maxTokens: CELL_MAX_TOKENS,
 	});
-	if (error) return `${FALLBACK_ANALYSIS}: ${error}`;
-	return oneLine(text) || FALLBACK_ANALYSIS;
+	if (error) return { analysis: `${FALLBACK_ANALYSIS}: ${error}`, issues: [] };
+	const parsed = parseCellAnalysis(text);
+	return { analysis: parsed.analysis || FALLBACK_ANALYSIS, issues: parsed.issues };
 }
 
 function main() {
@@ -80,17 +88,21 @@ function main() {
 	const metrics = readJson(METRICS_PATH);
 
 	let analysis;
+	let issues = [];
 	try {
-		analysis = analyze(result, trace, metrics);
+		const out = analyze(result, trace, metrics);
+		analysis = out.analysis;
+		issues = Array.isArray(out.issues) ? out.issues : [];
 	} catch (err) {
 		analysis = `${FALLBACK_ANALYSIS}: ${err?.message ?? err}`;
 	}
 
-	// Add ONLY the analysis field — never touch score/verdict/klass/etc.
+	// Add ONLY the analysis fields — never touch score/verdict/klass/etc.
 	result.analysis = analysis;
+	result.analysis_issues = issues;
 	try {
 		writeFileSync(RESULT_PATH, JSON.stringify(result, null, 2));
-		process.stderr.write(`[analyze-cell] wrote analysis (${analysis.length} chars) to ${RESULT_PATH}\n`);
+		process.stderr.write(`[analyze-cell] wrote analysis (${analysis.length} chars, ${issues.length} issue(s)) to ${RESULT_PATH}\n`);
 	} catch (err) {
 		process.stderr.write(`[analyze-cell] failed to write analysis to ${RESULT_PATH} (ignored): ${err?.message ?? err}\n`);
 	}

--- a/scripts/agent-bench/steps/analyze.mjs
+++ b/scripts/agent-bench/steps/analyze.mjs
@@ -1,13 +1,18 @@
 // Top-level ROLL-UP of the per-cell analyses. This runs ONCE in the summary job
-// and is BOTTOM-UP: it CONSUMES the `analysis` string each cell already wrote
-// into its own result.json (steps/analyze-cell.mjs, right after that cell's
-// judge) — it no longer re-reads raw traces centrally. It produces:
-//   - an `## Executive summary` that SYNTHESIZES the per-cell analyses via ONE
-//     Bedrock call (Opus 4.8) over the collected analyses + the run aggregate
-//     (mean, verdict mix, low/regressed flags), and
-//   - a per-cell one-liner list (cell → composite/verdict → its analysis),
-// appended to $GITHUB_STEP_SUMMARY, plus a run-level bench-analysis.json
-// artifact assembled from the per-cell analyses.
+// and is BOTTOM-UP: it CONSUMES the `analysis` string + `analysis_issues` array
+// each cell already wrote into its own result.json (steps/analyze-cell.mjs, right
+// after that cell's judge) — it no longer re-reads raw traces centrally. It
+// appends THREE sections to $GITHUB_STEP_SUMMARY, after the Glossary/Overview/
+// Detailed tables that steps/summary.mjs renders:
+//   - `## Executive summary` — a SHORT paragraph + bullets, synthesized via ONE
+//     best-effort Bedrock call (Opus 4.8) over the per-cell analyses + the run
+//     aggregate (mean, verdict mix, low/regressed flags);
+//   - `## ⚠️ Potential issues` — deterministic severity flags (harness/agent
+//     failures, low/regressed composites) plus every issue the per-cell analyses
+//     emitted, each attributed to its cell;
+//   - `## Per-cell analysis` — the whole section collapsed, and EACH cell also
+//     collapsed within it (compact analysis + its potential issues).
+// It also writes a run-level bench-analysis.json artifact.
 //
 // The scoreboard table + PR-vs-baseline overview are rendered separately by
 // steps/summary.mjs and are unchanged.
@@ -31,7 +36,7 @@ import {
 	buildRollupUserText,
 	fmt,
 } from './lib/analysis.mjs';
-import { verdictOf } from './lib/scoring.mjs';
+import { compositeBand, verdictOf } from './lib/scoring.mjs';
 import { buildAggregate, diffAgainstBaseline } from './lib/overview.mjs';
 
 const RESULTS_DIR = process.env.RESULTS_DIR ?? 'results';
@@ -57,8 +62,8 @@ function main() {
 		}
 	}
 	if (cells.length === 0) {
-		emit(['## Agent analysis', '', '_No cell results to roll up._', '']);
-		writeAnalysis({ executive_summary: null, cells: [], note: 'no cell results' });
+		emit(['## Executive summary', '', '_No cell results to roll up._', '']);
+		writeAnalysis({ executive_summary: null, potential_issues: [], cells: [], note: 'no cell results' });
 		return;
 	}
 
@@ -91,28 +96,58 @@ function main() {
 			template: c.template ?? '—',
 			composite,
 			verdict,
+			klass: c.klass ?? null,
 			delta,
 			low: composite !== null && composite < LOW_THRESHOLD,
 			regressed: delta !== null && delta < REGRESSION_DELTA,
 			analysis: c.analysis || null,
+			issues: Array.isArray(c.analysis_issues) ? c.analysis_issues.filter((s) => typeof s === 'string' && s.trim()) : [],
 		};
 	});
 
 	// ── Executive summary: ONE best-effort Bedrock synthesis over the analyses ─
 	const execSummary = synthesize(aggregate, verdictCounts, rows);
 
-	// ── Render ────────────────────────────────────────────────────────────────
-	const out = ['## Agent analysis', ''];
-	out.push('### Executive summary', '');
+	// ── Potential issues: deterministic flags + each cell's emitted issues ─────
+	const potential = collectPotentialIssues(rows);
+
+	// ── Render: Executive summary → Potential issues → collapsible per-cell ────
+	const out = [];
+	out.push('## Executive summary', '');
 	out.push(execSummary.text, '');
-	out.push('### Per-cell analysis', '');
-	out.push(`_Each cell's analysis was generated in-cell right after its judge. Model: \`${MODEL_ID}\`._`, '');
-	for (const r of rows) {
-		const flags = [r.low ? '🔴 low' : '', r.regressed ? `▼ regressed Δ${fmt(r.delta)}` : ''].filter(Boolean).join(', ');
-		const head = `\`${r.task}/${r.template}\` — composite ${fmt(r.composite)} (${r.verdict})${flags ? ` [${flags}]` : ''}`;
-		out.push(`- ${head}: ${r.analysis ?? '_no per-cell analysis_'}`);
+
+	out.push('## ⚠️ Potential issues', '');
+	if (potential.length === 0) {
+		out.push('_None surfaced — no low or regressed cells, and no per-cell analysis flagged an issue._', '');
+	} else {
+		for (const line of potential) out.push(`- ${line}`);
+		out.push('');
 	}
+
+	// Whole section collapsed; EACH cell also collapsed within it.
+	out.push('## Per-cell analysis', '');
+	out.push('<details>');
+	out.push(
+		`<summary>Per-cell analysis — ${rows.length} cell(s), generated in-cell right after each judge · model <code>${MODEL_ID}</code> (click to expand)</summary>`,
+	);
 	out.push('');
+	for (const r of rows) {
+		const band = typeof r.composite === 'number' ? compositeBand(r.composite) : '⚪';
+		const flags = [r.low ? '🔴 low' : '', r.regressed ? `▼ regressed Δ${fmt(r.delta)}` : ''].filter(Boolean).join(', ');
+		const head = `${band} \`${r.task}/${r.template}\` — composite ${fmt(r.composite)} (${r.verdict})${flags ? ` [${flags}]` : ''}`;
+		out.push('<details>');
+		out.push(`<summary>${head}</summary>`);
+		out.push('');
+		out.push(`- ${r.analysis ?? '_no per-cell analysis_'}`);
+		if (r.issues.length > 0) {
+			out.push('- **Potential issues:**');
+			for (const iss of r.issues) out.push(`  - ${iss}`);
+		}
+		out.push('');
+		out.push('</details>');
+		out.push('');
+	}
+	out.push('</details>', '');
 	emit(out);
 
 	writeAnalysis({
@@ -121,8 +156,37 @@ function main() {
 		verdict_counts: verdictCounts,
 		executive_summary: execSummary.text,
 		executive_summary_error: execSummary.error ?? null,
+		potential_issues: potential,
 		cells: rows,
 	});
+}
+
+// Deterministic "Potential issues" list, synthesized from the per-cell rows:
+// harness/agent failures and low/regressed composites first (severity-flagged),
+// then every issue the per-cell analyses emitted, each attributed to its cell.
+function collectPotentialIssues(rows) {
+	const out = [];
+	for (const r of rows) {
+		const cell = `\`${r.task}/${r.template}\``;
+		if (r.verdict === 'harness_error') {
+			out.push(`🧰 ${cell} — harness error (no gradeable app; excluded from the mean)`);
+			continue;
+		}
+		if (r.klass === 'agent_fail') {
+			out.push(`🔴 ${cell} — agent produced no app within budget (scored composite 0)`);
+			continue;
+		}
+		const flags = [];
+		if (r.low) flags.push(`low composite ${fmt(r.composite)}`);
+		if (r.regressed) flags.push(`regressed Δ${fmt(r.delta)} vs \`main\``);
+		if (flags.length) out.push(`🔴 ${cell} — ${flags.join('; ')}`);
+	}
+	for (const r of rows) {
+		if (r.issues.length === 0) continue;
+		const cell = `\`${r.task}/${r.template}\``;
+		for (const iss of r.issues) out.push(`${cell} — ${iss}`);
+	}
+	return out;
 }
 
 // One Bedrock call synthesizing the per-cell analyses into an executive summary.
@@ -169,7 +233,7 @@ function writeAnalysis(extra) {
 			ANALYSIS_PATH,
 			`${JSON.stringify(
 				{
-					schema: 2,
+					schema: 3,
 					generated_at: new Date().toISOString().replace(/\.\d{3}Z$/, 'Z'),
 					model: MODEL_ID,
 					low_threshold: LOW_THRESHOLD,

--- a/scripts/agent-bench/steps/lib/analysis.mjs
+++ b/scripts/agent-bench/steps/lib/analysis.mjs
@@ -36,10 +36,15 @@ export const MAX_TAIL_CHARS = 1500;
 // it can't dominate the per-cell prompt.
 export const MAX_JUDGE_EXPLANATION_CHARS = 500;
 
-// Small output budgets — the per-cell analysis is 2-4 sentences, the rollup a
-// short paragraph. maxTokens keeps both tight.
-export const CELL_MAX_TOKENS = 320;
+// Small output budgets — the per-cell analysis is 2-4 sentences + a short issue
+// list, the rollup a short paragraph + bullets. maxTokens keeps both tight.
+export const CELL_MAX_TOKENS = 420;
 export const ROLLUP_MAX_TOKENS = 700;
+
+// Caps on the per-cell POTENTIAL ISSUES the analysis emits (fed into the report's
+// "Potential issues" section) so one cell can't flood it.
+export const MAX_CELL_ISSUES = 5;
+export const MAX_ISSUE_LEN = 200;
 
 // Composite < this is "low"; a drop of more than this many points vs the
 // baseline is a "regression" — the same ±5 band the overview uses to separate a
@@ -61,25 +66,64 @@ const TRANSIENT_RE =
 
 // Per-cell analysis system prompt. Per the owner (Jon): what the agent built +
 // score context, and the STRUGGLES visible in the data — never a task restatement
-// or a code re-grade. Clean cells are allowed to say so.
-export const CELL_SYSTEM = `You are analyzing ONE benchmark cell where an AI coding agent built an app from a task prompt. Using the score context, the metrics, and the trimmed tool-call trace provided, write a CONCISE 2-4 sentence analysis:
-(1) one short clause on WHAT the agent built and its score context;
-(2) any STRUGGLES visible in the data — failed or errored tool calls (name the tool and the error), time spent hunting for missing or undocumented APIs/docs, or non-inherent trial-and-error such as dev-server wrangling or build-error loops, and any disproportionate token/turn cost.
-Cite concrete tool names or short error snippets. Do NOT restate the task, propose fixes, or re-grade the code. If the data shows a clean run with no notable struggle, say so in one sentence (e.g. "Clean run — no notable struggle in the trace.").`;
+// or a code re-grade. It ALSO emits a short POTENTIAL ISSUES list that feeds the
+// report's "Potential issues" section, in a strict two-part format the harness
+// parses (see parseCellAnalysis).
+export const CELL_SYSTEM = `You are analyzing ONE benchmark cell where an AI coding agent built an app from a task prompt. Using the score context, the metrics, and the trimmed tool-call trace provided, respond in EXACTLY this two-part format and nothing else:
 
-// Top-level roll-up system prompt: synthesize the per-cell analyses bottom-up.
-export const ROLLUP_SYSTEM = `You are writing the EXECUTIVE SUMMARY of an AI coding-agent benchmark run, synthesizing BOTTOM-UP from the PER-CELL analyses provided (each already diagnoses one cell). In 4-8 sentences:
-- state the overall outcome (mean composite and the pass/partial/fail mix);
-- surface CROSS-CELL patterns that recur across multiple cells — e.g. dev-server wrangling, shared build friction, missing-docs hunting, or repeated failed tool calls;
-- call out which cells regressed or are low and the likely why;
-- name the obvious areas to improve (failed tool calls / missing docs / non-inherent trial-and-error).
-Be concrete and cite cells by name. Do NOT restate the task list or write detailed code fixes — surface patterns and problem areas.`;
+ANALYSIS: <2-4 sentences: (1) one short clause on WHAT the agent built and its score context; (2) any STRUGGLES visible in the data — failed or errored tool calls (name the tool and the error), time hunting for missing/undocumented APIs, non-inherent trial-and-error such as dev-server wrangling or build-error loops, or disproportionate token/turn cost. Cite concrete tool names or short error snippets. Do NOT restate the task, propose fixes, or re-grade the code. If the trace shows a clean run, say so.>
+ISSUES:
+- <one concise potential issue worth a maintainer's attention (a recurring failure mode, a missing doc/API, a cost/efficiency concern), max ~15 words>
+- <another, if any>
+
+List at most a few issues, most-important first. If there are no notable issues, write exactly "ISSUES: none".`;
+
+// Top-level roll-up system prompt: synthesize the per-cell analyses bottom-up
+// into a SHORT executive summary — a lead paragraph, then bullets.
+export const ROLLUP_SYSTEM = `You are writing the EXECUTIVE SUMMARY of an AI coding-agent benchmark run, synthesizing BOTTOM-UP from the PER-CELL analyses provided (each already diagnoses one cell). Format your answer as:
+- FIRST, a SHORT lead paragraph (2-3 sentences): the overall outcome — the mean composite and the pass/partial/fail mix — and the single most important takeaway.
+- THEN 3-6 concise bullet points (start each line with "- "): CROSS-CELL patterns recurring across multiple cells (dev-server wrangling, shared build friction, missing-docs hunting, repeated failed tool calls), which cells regressed or are low and the likely why, and the obvious areas to improve.
+Be concrete and cite cells by name. Do NOT restate the task list or write detailed code fixes — surface patterns and problem areas. Keep it tight.`;
 
 export const fmt = (n) => (n === null || n === undefined || Number.isNaN(n) ? '—' : Number(n).toFixed(1));
 
 /** Collapse whitespace to a single line. Safe on non-strings (→ ''). */
 export function oneLine(text) {
 	return typeof text === 'string' ? text.replace(/\s+/g, ' ').trim() : '';
+}
+
+/**
+ * Parse the per-cell model output (the strict `ANALYSIS: … ISSUES: …` format
+ * from {@link CELL_SYSTEM}) into a one-line analysis string plus a bounded list
+ * of potential-issue strings. Robust to a missing ISSUES section (→ no issues),
+ * to "ISSUES: none", to bulleted or single-line issue lists, and to a plain
+ * fallback string with no labels at all (the whole thing becomes the analysis).
+ * Never throws.
+ * @param {unknown} text raw model completion (or a fallback sentence)
+ * @returns {{analysis: string, issues: string[]}}
+ */
+export function parseCellAnalysis(text) {
+	if (typeof text !== 'string') return { analysis: '', issues: [] };
+	// Split on the FIRST "ISSUES:" section header (line-anchored, case-insensitive).
+	const m = text.match(/(^|\n)\s*ISSUES:\s*/i);
+	let analysisPart = text;
+	let issuesPart = '';
+	if (m) {
+		analysisPart = text.slice(0, m.index);
+		issuesPart = text.slice(m.index + m[0].length);
+	}
+	const analysis = oneLine(analysisPart.replace(/^\s*ANALYSIS:\s*/i, ''));
+	let issues = [];
+	const trimmed = issuesPart.trim();
+	if (trimmed && !/^none\b/i.test(trimmed)) {
+		issues = trimmed
+			.split('\n')
+			.map((l) => oneLine(l.replace(/^\s*[-*•]\s*/, '')))
+			.filter((l) => l.length > 0 && !/^none$/i.test(l))
+			.slice(0, MAX_CELL_ISSUES)
+			.map((l) => l.slice(0, MAX_ISSUE_LEN));
+	}
+	return { analysis, issues };
 }
 
 // Error-like lines to lift out of the trace for the model.

--- a/scripts/agent-bench/steps/lib/analysis.test.mjs
+++ b/scripts/agent-bench/steps/lib/analysis.test.mjs
@@ -10,13 +10,16 @@ import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import {
 	LOW_THRESHOLD,
+	MAX_CELL_ISSUES,
 	MAX_ERROR_LINES,
+	MAX_ISSUE_LEN,
 	MAX_TAIL_CHARS,
 	MAX_TOOL_NAMES,
 	REGRESSION_DELTA,
 	buildCellUserText,
 	buildRollupUserText,
 	oneLine,
+	parseCellAnalysis,
 	summarizeMetrics,
 	trimTrace,
 } from './analysis.mjs';
@@ -139,6 +142,52 @@ describe('buildCellUserText(input)', () => {
 		const text = buildCellUserText({ task: 't', template: 'x', judgeExplanation: long });
 		const noteLine = text.split('\n').find((l) => l.startsWith('Judge notes'));
 		assert.ok(noteLine.length < 700, `judge notes line should be trimmed, got ${noteLine.length}`);
+	});
+});
+
+describe('parseCellAnalysis(text)', () => {
+	it('splits the ANALYSIS + ISSUES contract into a one-line analysis and bullet issues', () => {
+		const raw = [
+			'ANALYSIS: Built a working notes app with AuthBasic + KVStore; clean pass.',
+			'A couple of bash retries early on.',
+			'ISSUES:',
+			'- Repeated fileEditor errors before finding the KVStore API',
+			'- Dev server took 3 restarts to bind a port',
+		].join('\n');
+		const { analysis, issues } = parseCellAnalysis(raw);
+		assert.equal(analysis, 'Built a working notes app with AuthBasic + KVStore; clean pass. A couple of bash retries early on.');
+		assert.deepEqual(issues, [
+			'Repeated fileEditor errors before finding the KVStore API',
+			'Dev server took 3 restarts to bind a port',
+		]);
+	});
+
+	it('treats "ISSUES: none" as no issues and strips the ANALYSIS label', () => {
+		const { analysis, issues } = parseCellAnalysis('ANALYSIS: Clean run — no notable struggle.\nISSUES: none');
+		assert.equal(analysis, 'Clean run — no notable struggle.');
+		assert.deepEqual(issues, []);
+	});
+
+	it('returns the whole text as analysis when there is no ISSUES section', () => {
+		const { analysis, issues } = parseCellAnalysis('Agent timed out — no trace to analyze.');
+		assert.equal(analysis, 'Agent timed out — no trace to analyze.');
+		assert.deepEqual(issues, []);
+	});
+
+	it('caps the issue count and the per-issue length', () => {
+		const many = ['ANALYSIS: x', 'ISSUES:'];
+		for (let i = 0; i < 20; i++) many.push(`- issue ${i} ${'y'.repeat(500)}`);
+		const { issues } = parseCellAnalysis(many.join('\n'));
+		assert.equal(issues.length, MAX_CELL_ISSUES);
+		for (const iss of issues) assert.ok(iss.length <= MAX_ISSUE_LEN);
+	});
+
+	it('is defensive about non-strings and empty issue lists', () => {
+		assert.deepEqual(parseCellAnalysis(null), { analysis: '', issues: [] });
+		assert.deepEqual(parseCellAnalysis(42), { analysis: '', issues: [] });
+		const { analysis, issues } = parseCellAnalysis('ANALYSIS: only analysis, blank issues.\nISSUES:\n\n');
+		assert.equal(analysis, 'only analysis, blank issues.');
+		assert.deepEqual(issues, []);
 	});
 });
 

--- a/scripts/agent-bench/steps/lib/overview.mjs
+++ b/scripts/agent-bench/steps/lib/overview.mjs
@@ -1,19 +1,36 @@
-// PR-vs-baseline overview helpers, kept as PURE functions (no fs / env / process
-// side effects) so the diff math is unit-testable under bare `node --test`, the
-// same way lib/scoring.mjs is. summary.mjs does the I/O (read the downloaded
-// baseline, write the new aggregate, append markdown to $GITHUB_STEP_SUMMARY)
-// and calls these to build the at-a-glance overview rendered at the TOP of the
-// run summary.
+// PR-vs-baseline overview + detailed-results helpers, kept as PURE functions (no
+// fs / env / process side effects) so the diff math + coloring are unit-testable
+// under bare `node --test`, the same way lib/scoring.mjs is. summary.mjs does the
+// I/O (read the downloaded baseline, write the new aggregate, append markdown to
+// $GITHUB_STEP_SUMMARY) and calls these to render the two report tables.
 //
 // The baseline is a small commit-keyed aggregate (built by buildAggregate and
-// persisted to S3 under bench/runs/<sha>/results.json): per-cell composites
-// plus the mean. A PR run fetches the aggregate for its base commit and renders
-// the delta so the PR's effect is obvious at first glance. No baseline → the
-// overview falls back to absolute composites with a note (never an error).
+// persisted to S3 as bench/runs/latest-main.json — the MOST RECENT main-branch
+// bench). A PR run fetches that pointer and renders the delta so the PR's effect
+// vs the current state of `main` is obvious. No baseline → the tables render the
+// PR's absolute numbers, every cell flagged 🆕 (never an error).
 //
-// Composite + inclusion rules come from lib/scoring.mjs — the ONE source of
-// truth — so the aggregate's numbers can't drift from the rendered table.
-import { composite, isScoredCell, testRate, testStats, verdictOf } from './scoring.mjs';
+// TWO tables from the SAME rows:
+//   - renderOverview  — colors ONLY (🟢/🟡/🔴), at-a-glance.
+//   - renderDetailed  — the same rows widened WITH numbers (baseline -> pr).
+//
+// COLOR SEMANTICS (per metric, vs baseline): 🟢 same-or-better · 🟡 worse but
+// within the margin · 🔴 worse beyond it. The margin is a SINGLE tunable,
+// MARGIN_PCT (5%). Directions: tests↑ judge↑ score↑ are better; cost↓ tokens↓
+// are better. See metricColor + the glossary in summary.mjs.
+//
+// Composite, cost, and score-per-$ all come from lib/scoring.mjs — the ONE
+// source of truth — so the aggregate's numbers can't drift from the tables.
+import {
+	SCORE_PER_DOLLAR,
+	cellCost,
+	composite,
+	isScoredCell,
+	scorePerDollar,
+	testRate,
+	testStats,
+	verdictOf,
+} from './scoring.mjs';
 
 // Stable identity for a cell across runs: a baseline cell is matched to the
 // current cell by this key. Both task + template are part of it because a task
@@ -21,11 +38,71 @@ import { composite, isScoredCell, testRate, testStats, verdictOf } from './scori
 export const cellKey = (c) => `${c?.task ?? ''}/${c?.template ?? ''}`;
 
 const round1 = (n) => Math.round(n * 10) / 10;
+const numOrNull = (v) => (typeof v === 'number' && Number.isFinite(v) ? v : null);
+
+// ── Color engine ─────────────────────────────────────────────────────────────
+export const GREEN = '🟢';
+export const YELLOW = '🟡';
+export const RED = '🔴';
+export const NEW = '🆕';
+export const GONE = '🗑️';
+export const NONE = '—';
+
+// The SINGLE tunable that separates 🟡 (worse, but within noise) from 🔴 (worse
+// beyond it): a relative margin of 5%. Change ONLY this line to widen/narrow the
+// tolerance for EVERY metric.
+export const MARGIN_PCT = 0.05;
+
+// DEFAULT boundary policy: a metric that is worse-but-within-margin renders 🟡.
+// Set true to treat within-margin as 🟢 (equal-or-better-OR-within-margin = 🟢).
+export const MARGIN_IS_GREEN = false;
+
+// SCORE is higher-better iff scoring.mjs computes it as composite-per-$ (the
+// default). Imported so the ONE knob in scoring.mjs also drives the color here.
+export const SCORE_HIGHER_BETTER = SCORE_PER_DOLLAR;
 
 /**
+ * The absolute tolerance around a baseline value below which a WORSE move is
+ * still 🟡 (noise) rather than 🔴. `MARGIN_PCT` of |baseline|; for INTEGER
+ * metrics (test counts, 0-10 judge dims) it is floored to 1, so a ±1 nudge on a
+ * small integer metric always reads as within-margin — 5% of 8 is 0.4, which
+ * would otherwise round to 0 and make every single-point drop red.
+ * @param {number} baseline
+ * @param {boolean} integer
+ * @returns {number}
+ */
+export function marginAbs(baseline, integer) {
+	const raw = Math.abs(baseline) * MARGIN_PCT;
+	return integer ? Math.max(1, Math.round(raw)) : raw;
+}
+
+/**
+ * Color one metric vs its baseline. Returns 🟢/🟡/🔴, or `null` when either side
+ * is missing (the caller then renders 🆕 for a new cell / — for nothing to diff).
+ *   - `direction` 'up'   → higher is better (tests, judge, score)
+ *   - `direction` 'down' → lower is better  (cost, tokens)
+ * Equal counts as better (🟢). A worse move within {@link marginAbs} is 🟡 (or
+ * 🟢 when MARGIN_IS_GREEN); beyond it, 🔴.
+ * @param {number|null|undefined} baseline
+ * @param {number|null|undefined} pr
+ * @param {{direction?: 'up'|'down', integer?: boolean}} [opts]
+ * @returns {'🟢'|'🟡'|'🔴'|null}
+ */
+export function metricColor(baseline, pr, opts = {}) {
+	const direction = opts.direction ?? 'up';
+	const integer = opts.integer ?? false;
+	if (baseline === null || baseline === undefined || Number.isNaN(baseline)) return null;
+	if (pr === null || pr === undefined || Number.isNaN(pr)) return null;
+	const better = direction === 'up' ? pr >= baseline : pr <= baseline;
+	if (better) return GREEN;
+	const worseBy = direction === 'up' ? baseline - pr : pr - baseline; // > 0
+	return worseBy <= marginAbs(baseline, integer) ? (MARGIN_IS_GREEN ? GREEN : YELLOW) : RED;
+}
+
+// ── Cell scoring (shared with the mean/headline) ─────────────────────────────
+/**
  * Composite (0..100) for a cell from the shared scoring formula, or `null` when
- * the cell isn't a scored cell (a harness_error, or a gradeable cell that ran
- * no tests). A `null` composite is rendered as "—" and excluded from the mean.
+ * the cell isn't scored (a harness_error, or a gradeable cell that ran no tests).
  * @param {object} r a finalized result.json cell
  * @returns {number|null}
  */
@@ -43,18 +120,22 @@ export function cellComposite(r) {
 export function meanComposite(cells) {
 	const scored = (cells ?? []).filter((c) => isScoredCell(c));
 	if (scored.length === 0) return null;
-	// cellComposite re-checks isScoredCell, but every `c` here already passed the
-	// filter above, so that guard is a defensive no-op on this path (never null).
 	const sum = scored.reduce((acc, c) => acc + cellComposite(c), 0);
 	return round1(sum / scored.length);
 }
 
+// ── Aggregate (schema 2) ─────────────────────────────────────────────────────
 /**
- * Build the compact, self-describing aggregate that is persisted to S3 as the
- * commit-keyed baseline. Holds exactly what the overview diff needs: per-cell
- * composites + the mean, plus provenance (sha / base_sha / event) for auditing.
- * Artifact-unreadable cells (those carrying an `error` field) are dropped — they
- * have no gradeable signal to baseline against.
+ * Build the compact, self-describing aggregate persisted to S3 as the
+ * commit-keyed baseline. Schema 2 holds everything the two report tables diff
+ * against — per cell: the base composite + verdict/klass, the test counts, the
+ * judge overall + per-dimension scores, the builder token spend, its $ cost, and
+ * the score-per-$ — plus the mean and provenance (sha / event) for auditing.
+ * Artifact-unreadable cells (carrying an `error` field) are dropped.
+ *
+ * Back-compat: a schema-1 baseline (composite/judge_score/test_rate only) still
+ * diffs — the fields it lacks simply render 🆕/— on the baseline side until a
+ * `main` bench records a schema-2 baseline.
  * @param {object[]} cells finalized result.json cells for this run
  * @param {{sha?: string, base_sha?: string, pr_number?: string, event?: string, generated_at?: string}} [meta]
  * @returns {object}
@@ -62,7 +143,7 @@ export function meanComposite(cells) {
 export function buildAggregate(cells, meta = {}) {
 	const data = (cells ?? []).filter((c) => c && !c.error);
 	return {
-		schema: 1,
+		schema: 2,
 		sha: meta.sha ?? null,
 		base_sha: meta.base_sha ?? null,
 		pr_number: meta.pr_number ?? null,
@@ -71,25 +152,37 @@ export function buildAggregate(cells, meta = {}) {
 		mean_composite: meanComposite(data),
 		scored_cells: data.filter((c) => isScoredCell(c)).length,
 		cells: data
-			.map((c) => ({
-				task: c.task ?? null,
-				template: c.template ?? null,
-				composite: cellComposite(c),
-				verdict: verdictOf(c),
-				klass: c.klass ?? null,
-				judge_score: typeof c.judge_score === 'number' ? c.judge_score : null,
-				test_rate: round1(testRate(testStats(c)) * 100) / 100,
-			}))
+			.map((c) => {
+				const comp = cellComposite(c);
+				const cost = cellCost(c);
+				const { passed, denom } = testStats(c);
+				return {
+					task: c.task ?? null,
+					template: c.template ?? null,
+					composite: comp,
+					verdict: verdictOf(c),
+					klass: c.klass ?? null,
+					judge_score: numOrNull(c.judge_score),
+					test_rate: round1(testRate(testStats(c)) * 100) / 100,
+					tests_passed: passed,
+					tests_denom: denom,
+					judge_dimensions:
+						c.judge_dimensions && typeof c.judge_dimensions === 'object' ? c.judge_dimensions : null,
+					tokens_in: numOrNull(c.tokens_in),
+					tokens_out: numOrNull(c.tokens_out),
+					cost,
+					score: scorePerDollar(comp, cost),
+					stop_reason: typeof c.stop_reason === 'string' && c.stop_reason ? c.stop_reason : null,
+				};
+			})
 			.sort((a, b) => cellKey(a).localeCompare(cellKey(b))),
 	};
 }
 
 /**
- * Direction marker for a composite delta. The near-equal band is ±5 (wide on
- * purpose): the bench is N=1 per cell, so a small delta is as likely to be
- * model variance as a real change. Within ±5 we render `≈` (still showing the
- * signed number) rather than a confident ▲/▼, reserving the arrows for moves
- * large enough to plausibly be real. `''` for a missing/NaN delta.
+ * Direction marker for a COMPOSITE delta (used by the headline + the roll-up).
+ * ±5 near-equal band (wide on purpose: N=1, so a small delta is as likely model
+ * variance as a real change). `''` for a missing/NaN delta.
  * @param {number|null} delta
  * @returns {'▲'|'▼'|'≈'|''}
  */
@@ -100,11 +193,29 @@ export function deltaArrow(delta) {
 	return '≈';
 }
 
+// The metric fields the two tables read, defaulted to null so a schema-1 (or
+// partial) baseline cell degrades gracefully to 🆕/— instead of throwing.
+function cellMetrics(c) {
+	return {
+		composite: numOrNull(c?.composite),
+		tests_passed: numOrNull(c?.tests_passed),
+		tests_denom: numOrNull(c?.tests_denom),
+		judge_score: numOrNull(c?.judge_score),
+		judge_dimensions: c?.judge_dimensions && typeof c.judge_dimensions === 'object' ? c.judge_dimensions : null,
+		tokens_in: numOrNull(c?.tokens_in),
+		tokens_out: numOrNull(c?.tokens_out),
+		cost: numOrNull(c?.cost),
+		score: numOrNull(c?.score),
+		stop_reason: typeof c?.stop_reason === 'string' && c.stop_reason ? c.stop_reason : null,
+	};
+}
+
 /**
- * Diff the current run's aggregate against a baseline aggregate (or `null` when
- * none was found). Cells are matched by {@link cellKey}; a cell present in only
- * one side gets a `null` on the missing side and a `null` delta. The mean delta
- * is computed only when BOTH means exist.
+ * Diff the current run's aggregate against a baseline aggregate (or `null`).
+ * Cells are matched by {@link cellKey}. Each row carries the COMPOSITE delta
+ * (`current`/`baseline`/`delta`, kept for the headline + the analysis roll-up)
+ * PLUS `pr` and `base` metric objects (from {@link cellMetrics}) the two tables
+ * color and render. A baseline-only cell surfaces as a `removed` row.
  * @param {object} current aggregate from {@link buildAggregate} for this run
  * @param {object|null} baseline aggregate fetched for the base commit, or null
  * @returns {{rows: object[], meanCurrent: number|null, meanBaseline: number|null, meanDelta: number|null, hasBaseline: boolean}}
@@ -115,15 +226,24 @@ export function diffAgainstBaseline(current, baseline) {
 	const rows = (current?.cells ?? []).map((c) => {
 		const key = cellKey(c);
 		const base = baseCells.get(key);
-		const cur = typeof c.composite === 'number' ? c.composite : null;
-		const bas = base && typeof base.composite === 'number' ? base.composite : null;
+		const cur = numOrNull(c.composite);
+		const bas = base ? numOrNull(base.composite) : null;
 		const delta = cur !== null && bas !== null ? round1(cur - bas) : null;
-		return { key, task: c.task ?? null, template: c.template ?? null, current: cur, baseline: bas, delta, hasBaselineCell: !!base, removed: false };
+		return {
+			key,
+			task: c.task ?? null,
+			template: c.template ?? null,
+			current: cur,
+			baseline: bas,
+			delta,
+			hasBaselineCell: !!base,
+			removed: false,
+			pr: cellMetrics(c),
+			base: base ? cellMetrics(base) : null,
+		};
 	});
-	// Baseline-only cells (removed or renamed since the baseline — e.g. a task
-	// folder rename) get their OWN row so a dropped cell is VISIBLE in the diff
-	// instead of silently vanishing. current + delta are null and `removed` flags
-	// it for the 'removed' marker; a null current keeps it out of the mean.
+	// Baseline-only cells (removed/renamed since the baseline) get their OWN row
+	// so a dropped cell is VISIBLE instead of silently vanishing.
 	for (const [key, base] of baseCells) {
 		if (curKeys.has(key)) continue;
 		rows.push({
@@ -131,26 +251,96 @@ export function diffAgainstBaseline(current, baseline) {
 			task: base.task ?? null,
 			template: base.template ?? null,
 			current: null,
-			baseline: typeof base.composite === 'number' ? base.composite : null,
+			baseline: numOrNull(base.composite),
 			delta: null,
 			hasBaselineCell: true,
 			removed: true,
+			pr: null,
+			base: cellMetrics(base),
 		});
 	}
 	rows.sort((a, b) => a.key.localeCompare(b.key));
-	const meanCurrent = typeof current?.mean_composite === 'number' ? current.mean_composite : null;
-	const meanBaseline = baseline && typeof baseline.mean_composite === 'number' ? baseline.mean_composite : null;
+	const meanCurrent = numOrNull(current?.mean_composite);
+	const meanBaseline = baseline ? numOrNull(baseline.mean_composite) : null;
 	const meanDelta = meanCurrent !== null && meanBaseline !== null ? round1(meanCurrent - meanBaseline) : null;
 	return { rows, meanCurrent, meanBaseline, meanDelta, hasBaseline: !!baseline };
 }
 
-const fmt = (n) => (n === null || n === undefined || Number.isNaN(n) ? '—' : n.toFixed(1));
-const signed = (n) => (n === null || n === undefined ? '' : n > 0 ? `+${n.toFixed(1)}` : n.toFixed(1));
+// ── Formatters ───────────────────────────────────────────────────────────────
+/** Compact token count: 3456 → "3.5K", 3000 → "3K", 800 → "800", null → "—". */
+export function humanTokens(n) {
+	if (n === null || n === undefined || Number.isNaN(n)) return NONE;
+	if (n < 1000) return String(Math.round(n));
+	return `${+(n / 1000).toFixed(1)}K`;
+}
 
+/** USD, trailing zeros trimmed: 3.5 → "$3.5", 2 → "$2", 1.05 → "$1.05", null → "—". */
+export function fmtCost(c) {
+	if (c === null || c === undefined || Number.isNaN(c)) return NONE;
+	return `$${+c.toFixed(2)}`;
+}
+
+/** Score-per-$ to 1 decimal: 66.7 → "66.7", null → "—". */
+export function fmtScore(s) {
+	if (s === null || s === undefined || Number.isNaN(s)) return NONE;
+	return String(+s.toFixed(1));
+}
+
+// The metric spec shared by BOTH renderers so a metric is colored/directed
+// identically in the Overview and the Detailed table. `pick` reads the value
+// off a cellMetrics object; `format` renders it for the Detailed table.
+const SCORE_DIR = SCORE_HIGHER_BETTER ? 'up' : 'down';
+
+// Glyph for the colors-only Overview: the metric color, else 🆕 (scored now, no
+// baseline value) / — (nothing to diff this run).
+function overviewGlyph(baseVal, prVal, opts) {
+	if (prVal === null || prVal === undefined) return NONE;
+	const col = metricColor(baseVal, prVal, opts);
+	if (col) return col;
+	return baseVal === null || baseVal === undefined ? NEW : NONE;
+}
+
+// "baseline -> pr" for the Detailed table, colored. `fmtVal` formats each side.
+function detailPair(baseVal, prVal, fmtVal, opts) {
+	if (prVal === null || prVal === undefined) return NONE;
+	const col = metricColor(baseVal, prVal, opts);
+	if (col === null) return `${NEW} ${fmtVal(prVal)}`; // scored now, no baseline
+	return `${col} ${fmtVal(baseVal)} -> ${fmtVal(prVal)}`;
+}
+
+// Union of judge-dimension keys across baseline + pr, in a stable order (pr
+// first, then any baseline-only dims), so the multi-line judge cell is consistent.
+function dimKeys(baseDims, prDims) {
+	const keys = [];
+	for (const k of Object.keys(prDims ?? {})) if (!keys.includes(k)) keys.push(k);
+	for (const k of Object.keys(baseDims ?? {})) if (!keys.includes(k)) keys.push(k);
+	return keys;
+}
+
+// Multi-line judge cell for the Detailed table: one "<color> <dim> base -> pr"
+// line per dimension, joined with <br> (GitHub renders it as a line break in a
+// table cell).
+function judgeDetailCell(base, pr) {
+	const baseDims = base?.judge_dimensions ?? null;
+	const prDims = pr?.judge_dimensions ?? null;
+	const keys = dimKeys(baseDims, prDims);
+	if (keys.length === 0) return NONE;
+	const lines = keys.map((k) => {
+		const bv = baseDims ? numOrNull(baseDims[k]) : null;
+		const pv = prDims ? numOrNull(prDims[k]) : null;
+		if (pv === null) return `${NONE} ${k} ${bv ?? NONE} -> ${NONE}`;
+		const col = metricColor(bv, pv, { direction: 'up', integer: true });
+		if (col === null) return `${NEW} ${k} ${pv}`;
+		return `${col} ${k} ${bv} -> ${pv}`;
+	});
+	return lines.join('<br>');
+}
+
+// ── Render: Overview (colors only) ───────────────────────────────────────────
 /**
- * Render the overview as an array of markdown lines for the TOP of the run
- * summary. With a baseline it's a Baseline | PR | Δ table (▲/▼/= + signed
- * numbers, mean row in bold); without one it's an absolute Composite table.
+ * Colors-only, at-a-glance overview: TASK | TEMPLATE | TESTS | JUDGE | COST |
+ * TOKENS (in/out) | SCORE, one 🟢/🟡/🔴 glyph per metric vs baseline (🆕 new,
+ * — nothing to diff). No numbers — see {@link renderDetailed} for those.
  * @param {ReturnType<typeof diffAgainstBaseline>} diff
  * @param {{heading?: string, note?: string}} [opts]
  * @returns {string[]}
@@ -158,28 +348,80 @@ const signed = (n) => (n === null || n === undefined ? '' : n > 0 ? `+${n.toFixe
 export function renderOverview(diff, opts = {}) {
 	const lines = [opts.heading ?? '## Overview', ''];
 	if (opts.note) lines.push(opts.note, '');
-
-	if (diff.hasBaseline) {
-		lines.push('| Task | Template | Baseline | PR | Δ |', '|------|----------|----------|----|----|');
-		for (const r of diff.rows) {
-			let deltaCell;
-			if (r.removed) deltaCell = '🗑️ removed'; // baseline-only cell — dropped/renamed since the baseline
-			else if (r.delta !== null) deltaCell = `${deltaArrow(r.delta)} ${signed(r.delta)}`;
-			else if (r.current === null) deltaCell = '—'; // not scored this run (harness / no-tests) — nothing to diff
-			else if (!r.hasBaselineCell) deltaCell = '🆕 new'; // scored now, absent from the baseline
-			else deltaCell = '—'; // baseline cell exists but had no composite
-			lines.push(`| ${r.task ?? '—'} | ${r.template ?? '—'} | ${fmt(r.baseline)} | ${fmt(r.current)} | ${deltaCell} |`);
+	lines.push(
+		'| Task | Template | Tests | Judge | Cost | Tokens (in/out) | Score |',
+		'|------|----------|:-----:|:-----:|:----:|:---------------:|:-----:|',
+	);
+	for (const r of diff.rows) {
+		if (r.removed) {
+			lines.push(`| ${r.task ?? NONE} | ${r.template ?? NONE} | ${GONE} | ${GONE} | ${GONE} | ${GONE} | ${GONE} |`);
+			continue;
 		}
-		const meanDeltaCell = diff.meanDelta === null ? '—' : `${deltaArrow(diff.meanDelta)} ${signed(diff.meanDelta)}`;
-		lines.push(`| **Mean** | | **${fmt(diff.meanBaseline)}** | **${fmt(diff.meanCurrent)}** | **${meanDeltaCell}** |`);
-	} else {
-		lines.push('| Task | Template | Composite |', '|------|----------|-----------|');
-		for (const r of diff.rows) lines.push(`| ${r.task ?? '—'} | ${r.template ?? '—'} | ${fmt(r.current)} |`);
-		lines.push(`| **Mean** | | **${fmt(diff.meanCurrent)}** |`);
+		const b = r.base;
+		const p = r.pr ?? {};
+		const tests = overviewGlyph(b?.tests_passed, p.tests_passed, { direction: 'up', integer: true });
+		const judge = overviewGlyph(b?.judge_score, p.judge_score, { direction: 'up' });
+		const cost = overviewGlyph(b?.cost, p.cost, { direction: 'down' });
+		const tin = overviewGlyph(b?.tokens_in, p.tokens_in, { direction: 'down' });
+		const tout = overviewGlyph(b?.tokens_out, p.tokens_out, { direction: 'down' });
+		const score = overviewGlyph(b?.score, p.score, { direction: SCORE_DIR });
+		lines.push(
+			`| ${r.task ?? NONE} | ${r.template ?? NONE} | ${tests} | ${judge} | ${cost} | ${tin}/${tout} | ${score} |`,
+		);
 	}
 	lines.push('');
-	// N=1 caveat: with a single rep per cell, small deltas are indistinguishable
-	// from model variance — hence the ±5 ≈ band above.
-	lines.push('_N=1 per cell. Deltas within ±5 may reflect model variance, not a real change — re-run for certainty._', '');
+	return lines;
+}
+
+// ── Render: Detailed results (numbers) ───────────────────────────────────────
+/**
+ * The same rows as {@link renderOverview}, widened WITH numbers: TASK | TEMPLATE
+ * | TESTS (🟡 10/14 -> 9/14) | JUDGE (one colored dim per line) | COST (🟢 $3.5
+ * -> $2) | TOKENS (in/out, each colored) | SCORE (colored base -> pr) | STOP
+ * REASON. Colors + directions are identical to the Overview.
+ * @param {ReturnType<typeof diffAgainstBaseline>} diff
+ * @param {{heading?: string, note?: string}} [opts]
+ * @returns {string[]}
+ */
+export function renderDetailed(diff, opts = {}) {
+	const lines = [opts.heading ?? '## Detailed results', ''];
+	if (opts.note) lines.push(opts.note, '');
+	lines.push(
+		'| Task | Template | Tests | Judge | Cost | Tokens | Score | Stop reason |',
+		'|------|----------|-------|-------|------|--------|-------|-------------|',
+	);
+	for (const r of diff.rows) {
+		if (r.removed) {
+			const was = r.base && r.base.tests_passed !== null ? ` (was ${r.base.tests_passed}/${r.base.tests_denom})` : '';
+			lines.push(`| ${r.task ?? NONE} | ${r.template ?? NONE} | ${GONE} removed${was} | ${NONE} | ${NONE} | ${NONE} | ${NONE} | ${NONE} |`);
+			continue;
+		}
+		const b = r.base;
+		const p = r.pr ?? {};
+		// TESTS is a "passed/denom" string colored by the passed COUNT (not a
+		// scalar), so it's built explicitly rather than via detailPair.
+		const fmtTests = (m) => `${m.tests_passed ?? NONE}/${m.tests_denom ?? NONE}`;
+		let testsCell;
+		if (p.tests_passed === null || p.tests_passed === undefined || p.tests_denom === 0) {
+			testsCell = NONE;
+		} else if (!b || b.tests_passed === null) {
+			testsCell = `${NEW} ${fmtTests(p)}`;
+		} else {
+			const col = metricColor(b.tests_passed, p.tests_passed, { direction: 'up', integer: true });
+			testsCell = `${col} ${fmtTests(b)} -> ${fmtTests(p)}`;
+		}
+		const judge = judgeDetailCell(b, p);
+		const cost = detailPair(b?.cost ?? null, p.cost, fmtCost, { direction: 'down' });
+		const tinCell = detailPair(b?.tokens_in ?? null, p.tokens_in, humanTokens, { direction: 'down' });
+		const toutCell = detailPair(b?.tokens_out ?? null, p.tokens_out, humanTokens, { direction: 'down' });
+		const tokens =
+			p.tokens_in === null && p.tokens_out === null ? NONE : `in ${tinCell}<br>out ${toutCell}`;
+		const score = detailPair(b?.score ?? null, p.score, fmtScore, { direction: SCORE_DIR });
+		const stop = p.stop_reason || NONE;
+		lines.push(
+			`| ${r.task ?? NONE} | ${r.template ?? NONE} | ${testsCell} | ${judge} | ${cost} | ${tokens} | ${score} | ${stop} |`,
+		);
+	}
+	lines.push('');
 	return lines;
 }

--- a/scripts/agent-bench/steps/lib/overview.mjs
+++ b/scripts/agent-bench/steps/lib/overview.mjs
@@ -211,16 +211,42 @@ function cellMetrics(c) {
 }
 
 /**
+ * True iff the baseline aggregate can supply the schema-2 PER-METRIC set the two
+ * tables diff (tests pass-counts, per-dimension judge, tokens, cost, score) —
+ * i.e. it is schema 2+.
+ *
+ * WHY THIS GATE EXISTS: a schema-1 (pre-redesign) baseline persisted only
+ * `composite`, `judge_score`, and `test_rate` per cell. Coloring each metric
+ * independently against it lights up ONLY the fields it happens to carry
+ * (`judge_score` → Judge colors) while every other column has no baseline value
+ * (→ 🆕). That produced the inconsistent "Judge colored, Tests/Cost/Tokens/Score
+ * all 🆕" row. So Judge must gate on baseline-COMPLETENESS exactly like the other
+ * metrics: a partial (schema-1) baseline is treated as "no per-metric baseline"
+ * — every column, Judge included, renders 🆕 — until a `main` bench records a
+ * schema-2 baseline. The composite mean/delta still uses `composite` (present in
+ * schema 1) for the headline + analysis roll-up.
+ * @param {object|null|undefined} baseline
+ * @returns {boolean}
+ */
+export function baselineHasMetrics(baseline) {
+	return !!baseline && (numOrNull(baseline.schema) ?? 0) >= 2;
+}
+
+/**
  * Diff the current run's aggregate against a baseline aggregate (or `null`).
  * Cells are matched by {@link cellKey}. Each row carries the COMPOSITE delta
  * (`current`/`baseline`/`delta`, kept for the headline + the analysis roll-up)
  * PLUS `pr` and `base` metric objects (from {@link cellMetrics}) the two tables
- * color and render. A baseline-only cell surfaces as a `removed` row.
+ * color and render. `base` is populated ONLY when the baseline carries the
+ * schema-2 per-metric set ({@link baselineHasMetrics}); against a schema-1
+ * baseline every metric — Judge included — renders 🆕 for consistency. A
+ * baseline-only cell surfaces as a `removed` row.
  * @param {object} current aggregate from {@link buildAggregate} for this run
  * @param {object|null} baseline aggregate fetched for the base commit, or null
- * @returns {{rows: object[], meanCurrent: number|null, meanBaseline: number|null, meanDelta: number|null, hasBaseline: boolean}}
+ * @returns {{rows: object[], meanCurrent: number|null, meanBaseline: number|null, meanDelta: number|null, hasBaseline: boolean, perMetricBaseline: boolean}}
  */
 export function diffAgainstBaseline(current, baseline) {
+	const perMetricBaseline = baselineHasMetrics(baseline);
 	const baseCells = new Map((baseline?.cells ?? []).map((c) => [cellKey(c), c]));
 	const curKeys = new Set((current?.cells ?? []).map((c) => cellKey(c)));
 	const rows = (current?.cells ?? []).map((c) => {
@@ -239,7 +265,10 @@ export function diffAgainstBaseline(current, baseline) {
 			hasBaselineCell: !!base,
 			removed: false,
 			pr: cellMetrics(c),
-			base: base ? cellMetrics(base) : null,
+			// Only diff per-metric against a schema-2 baseline; a schema-1 baseline
+			// (composite/judge_score only) is NOT per-metric-comparable, so every
+			// column renders 🆕 rather than lighting up Judge alone.
+			base: base && perMetricBaseline ? cellMetrics(base) : null,
 		};
 	});
 	// Baseline-only cells (removed/renamed since the baseline) get their OWN row
@@ -256,14 +285,14 @@ export function diffAgainstBaseline(current, baseline) {
 			hasBaselineCell: true,
 			removed: true,
 			pr: null,
-			base: cellMetrics(base),
+			base: perMetricBaseline ? cellMetrics(base) : null,
 		});
 	}
 	rows.sort((a, b) => a.key.localeCompare(b.key));
 	const meanCurrent = numOrNull(current?.mean_composite);
 	const meanBaseline = baseline ? numOrNull(baseline.mean_composite) : null;
 	const meanDelta = meanCurrent !== null && meanBaseline !== null ? round1(meanCurrent - meanBaseline) : null;
-	return { rows, meanCurrent, meanBaseline, meanDelta, hasBaseline: !!baseline };
+	return { rows, meanCurrent, meanBaseline, meanDelta, hasBaseline: !!baseline, perMetricBaseline };
 }
 
 // ── Formatters ───────────────────────────────────────────────────────────────

--- a/scripts/agent-bench/steps/lib/overview.test.mjs
+++ b/scripts/agent-bench/steps/lib/overview.test.mjs
@@ -1,26 +1,35 @@
-// Unit tests for the PR-vs-baseline overview helpers (overview.mjs).
+// Unit tests for the PR-vs-baseline report helpers (overview.mjs).
 //
-// These pin the diff math and the two render modes (with / without a baseline)
-// so the at-a-glance overview at the top of the run summary stays correct and
-// can't silently drift from lib/scoring.mjs. Run under bare `node --test` (no
-// build step): plain .mjs, same as the module under test.
+// These pin the diff math, the margin/color engine, the formatters, and the two
+// render modes (Overview = colors only, Detailed = numbers) so the report stays
+// correct and can't silently drift from lib/scoring.mjs. Run under bare
+// `node --test` (no build step): plain .mjs, same as the module under test.
 
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import {
+	MARGIN_PCT,
 	buildAggregate,
 	cellComposite,
 	cellKey,
 	deltaArrow,
 	diffAgainstBaseline,
+	fmtCost,
+	fmtScore,
+	humanTokens,
+	marginAbs,
 	meanComposite,
+	metricColor,
+	renderDetailed,
 	renderOverview,
 } from './overview.mjs';
 
+const DIMS = { functional_completeness: 8, selector_contract: 8, persistence: 8, code_quality: 8, blocks_fidelity: 8 };
 // composite(tr, j) = round(60*tr + 4*j*min(1, 4*tr), 1) — see scoring.mjs.
-const PASS = { task: 'auth-notes', template: 'demo', tests_passed: 4, tests_failed: 0, judge_score: 8 }; // tr=1 → 60 + 32 = 92
-const PARTIAL = { task: 'file-gallery', template: 'bare', tests_passed: 3, tests_failed: 1, judge_score: 5 }; // tr=.75 → 45 + 20 = 65
-const AGENT_FAIL = { task: 'sql-kb', template: 'nextjs', klass: 'agent_fail', tests_passed: 0, tests_failed: 0 }; // included, composite 0
+// cost = (in*3 + out*15)/1e6 ; score = composite/cost (score per $).
+const PASS = { task: 'auth-notes', template: 'demo', tests_passed: 4, tests_failed: 0, judge_score: 8, judge_dimensions: DIMS, tokens_in: 200000, tokens_out: 30000, stop_reason: 'end_turn' }; // comp 92 · cost 1.05 · score 87.6
+const PARTIAL = { task: 'file-gallery', template: 'bare', tests_passed: 3, tests_failed: 1, judge_score: 5, tokens_in: 100000, tokens_out: 20000, stop_reason: 'end_turn' }; // comp 65 · cost 0.6 · score 108.3
+const AGENT_FAIL = { task: 'sql-kb', template: 'nextjs', klass: 'agent_fail', tests_passed: 0, tests_failed: 0 }; // comp 0 · no tokens → cost/score null
 const HARNESS = { task: 'oidc-dsql', template: 'react', klass: 'harness_error' }; // excluded → null
 const UNKNOWN = { task: 'email-digest', template: 'demo', tests_passed: 0, tests_failed: 0 }; // gradeable, no tests → null
 
@@ -29,214 +38,246 @@ describe('cellComposite(r)', () => {
 		assert.equal(cellComposite(PASS), 92);
 		assert.equal(cellComposite(PARTIAL), 65);
 	});
-
-	it('an agent_fail is scored as composite 0 (included)', () => {
+	it('an agent_fail is scored 0 (included); harness/unknown are null (excluded)', () => {
 		assert.equal(cellComposite(AGENT_FAIL), 0);
-	});
-
-	it('a harness_error is null (excluded)', () => {
 		assert.equal(cellComposite(HARNESS), null);
-	});
-
-	it('a gradeable cell that ran no tests (unknown) is null (excluded)', () => {
 		assert.equal(cellComposite(UNKNOWN), null);
 	});
 });
 
 describe('meanComposite(cells)', () => {
-	it('averages only the scored cells (agent_fail counts as 0; harness/unknown excluded)', () => {
-		// (92 + 65 + 0) / 3 = 52.333… → 52.3
-		assert.equal(meanComposite([PASS, PARTIAL, AGENT_FAIL, HARNESS, UNKNOWN]), 52.3);
+	it('averages only the scored cells (agent_fail 0; harness/unknown excluded)', () => {
+		assert.equal(meanComposite([PASS, PARTIAL, AGENT_FAIL, HARNESS, UNKNOWN]), 52.3); // (92+65+0)/3
+		assert.equal(meanComposite([PASS, PARTIAL]), 78.5);
 	});
-
 	it('is null when no cell was scored', () => {
 		assert.equal(meanComposite([HARNESS, UNKNOWN]), null);
 		assert.equal(meanComposite([]), null);
 	});
+});
 
-	it('rounds to one decimal', () => {
-		// (92 + 65) / 2 = 78.5
-		assert.equal(meanComposite([PASS, PARTIAL]), 78.5);
+describe('marginAbs(baseline, integer) — one tunable, MARGIN_PCT', () => {
+	it('MARGIN_PCT is the documented 5%', () => {
+		assert.equal(MARGIN_PCT, 0.05);
+	});
+	it('integer metrics floor the margin to 1 (a ±1 nudge is always within-margin)', () => {
+		assert.equal(marginAbs(8, true), 1); // round(0.4)=0 → floored to 1
+		assert.equal(marginAbs(11, true), 1); // round(0.55)=1
+		assert.equal(marginAbs(40, true), 2); // round(2.0)=2
+		assert.equal(marginAbs(0, true), 1);
+	});
+	it('continuous metrics use exact 5% of |baseline| (no floor)', () => {
+		assert.equal(marginAbs(100, false), 5);
+		assert.equal(marginAbs(2, false), 0.1);
+		assert.equal(marginAbs(0, false), 0);
 	});
 });
 
-describe('buildAggregate(cells, meta)', () => {
+describe('metricColor(baseline, pr, {direction, integer})', () => {
+	it('equal or better is 🟢 (both directions)', () => {
+		assert.equal(metricColor(8, 8, { direction: 'up' }), '🟢');
+		assert.equal(metricColor(8, 9, { direction: 'up' }), '🟢');
+		assert.equal(metricColor(2, 2, { direction: 'down' }), '🟢');
+		assert.equal(metricColor(2, 1, { direction: 'down' }), '🟢');
+	});
+	it('worse within the (integer) margin is 🟡, beyond is 🔴 — matches the judge-dim example', () => {
+		assert.equal(metricColor(8, 7, { direction: 'up', integer: true }), '🟡'); // 8→7 within 1
+		assert.equal(metricColor(9, 5, { direction: 'up', integer: true }), '🔴'); // 9→5 beyond 1
+		assert.equal(metricColor(11, 10, { direction: 'up', integer: true }), '🟡'); // 11→10
+		assert.equal(metricColor(11, 9, { direction: 'up', integer: true }), '🔴'); // 11→9
+	});
+	it('worse within/beyond the (continuous) margin for a lower-is-better metric (cost/tokens)', () => {
+		assert.equal(metricColor(100, 103, { direction: 'down' }), '🟡'); // +3 within 5
+		assert.equal(metricColor(100, 110, { direction: 'down' }), '🔴'); // +10 beyond 5
+	});
+	it('null when either side is missing (caller renders 🆕 / —)', () => {
+		assert.equal(metricColor(null, 5, { direction: 'up' }), null);
+		assert.equal(metricColor(5, null, { direction: 'up' }), null);
+		assert.equal(metricColor(undefined, undefined), null);
+	});
+});
+
+describe('formatters', () => {
+	it('humanTokens compacts to K', () => {
+		assert.equal(humanTokens(3456), '3.5K');
+		assert.equal(humanTokens(3000), '3K');
+		assert.equal(humanTokens(800), '800');
+		assert.equal(humanTokens(null), '—');
+	});
+	it('fmtCost trims trailing zeros', () => {
+		assert.equal(fmtCost(3.5), '$3.5');
+		assert.equal(fmtCost(2), '$2');
+		assert.equal(fmtCost(1.05), '$1.05');
+		assert.equal(fmtCost(null), '—');
+	});
+	it('fmtScore to 1 decimal', () => {
+		assert.equal(fmtScore(66.7), '66.7');
+		assert.equal(fmtScore(108.3), '108.3');
+		assert.equal(fmtScore(null), '—');
+	});
+});
+
+describe('buildAggregate(cells, meta) — schema 2', () => {
 	const agg = buildAggregate([PARTIAL, PASS, AGENT_FAIL, HARNESS, UNKNOWN, { task: 'x', error: 'unreadable' }], {
 		sha: 'abc123',
-		base_sha: 'base999',
-		pr_number: '31',
 		event: 'pull_request',
 		generated_at: '2026-06-29T00:00:00Z',
 	});
+	const byKey = Object.fromEntries(agg.cells.map((c) => [cellKey(c), c]));
 
-	it('carries provenance + headline numbers', () => {
-		assert.equal(agg.schema, 1);
+	it('is schema 2 with headline numbers + provenance', () => {
+		assert.equal(agg.schema, 2);
 		assert.equal(agg.sha, 'abc123');
-		assert.equal(agg.base_sha, 'base999');
-		assert.equal(agg.pr_number, '31');
-		assert.equal(agg.event, 'pull_request');
 		assert.equal(agg.mean_composite, 52.3);
-		assert.equal(agg.scored_cells, 3); // PASS, PARTIAL, AGENT_FAIL
+		assert.equal(agg.scored_cells, 3);
 	});
-
-	it('drops artifact-unreadable (error) cells, keeps every gradeable/harness cell', () => {
-		// 5 real cells in, the {error} cell dropped.
+	it('drops artifact-unreadable cells, keeps every gradeable/harness cell', () => {
 		assert.equal(agg.cells.length, 5);
 		assert.ok(!agg.cells.some((c) => c.task === 'x'));
 	});
-
-	it('per-cell composites: scored numeric, excluded null', () => {
-		const byKey = Object.fromEntries(agg.cells.map((c) => [cellKey(c), c]));
-		assert.equal(byKey['auth-notes/demo'].composite, 92);
-		assert.equal(byKey['file-gallery/bare'].composite, 65);
-		assert.equal(byKey['sql-kb/nextjs'].composite, 0);
-		assert.equal(byKey['oidc-dsql/react'].composite, null);
-		assert.equal(byKey['email-digest/demo'].composite, null);
+	it('carries the new per-cell metric fields (tokens, cost, score, tests, dims, stop_reason)', () => {
+		const p = byKey['auth-notes/demo'];
+		assert.equal(p.composite, 92);
+		assert.equal(p.tests_passed, 4);
+		assert.equal(p.tests_denom, 4);
+		assert.equal(p.tokens_in, 200000);
+		assert.equal(p.tokens_out, 30000);
+		assert.equal(p.cost, 1.05); // (200000*3 + 30000*15)/1e6
+		assert.equal(p.score, 87.6); // 92 / 1.05
+		assert.equal(p.stop_reason, 'end_turn');
+		assert.deepEqual(p.judge_dimensions, DIMS);
 	});
-
-	it('cells are sorted by task/template for stable output', () => {
+	it('a cell with no tokens has cost + score null (never a fake $0)', () => {
+		assert.equal(byKey['sql-kb/nextjs'].composite, 0);
+		assert.equal(byKey['sql-kb/nextjs'].cost, null);
+		assert.equal(byKey['sql-kb/nextjs'].score, null);
+	});
+	it('cells are sorted by task/template', () => {
 		const keys = agg.cells.map(cellKey);
 		assert.deepEqual(keys, [...keys].sort((a, b) => a.localeCompare(b)));
-	});
-
-	it('tolerates empty / missing input', () => {
-		const empty = buildAggregate([], {});
-		assert.equal(empty.mean_composite, null);
-		assert.equal(empty.scored_cells, 0);
-		assert.deepEqual(empty.cells, []);
 	});
 });
 
 describe('deltaArrow(delta)', () => {
-	it('▲ for a move larger than the ±5 band, ▼ for a large decrease', () => {
+	it('▲ / ▼ beyond ±5, ≈ within (inclusive), empty for null', () => {
 		assert.equal(deltaArrow(5.2), '▲');
 		assert.equal(deltaArrow(-6.4), '▼');
-	});
-
-	it('≈ for |delta| within the ±5 noise band (incl. zero and the boundary)', () => {
 		assert.equal(deltaArrow(0), '≈');
-		assert.equal(deltaArrow(3.1), '≈');
-		assert.equal(deltaArrow(-4.9), '≈');
-		assert.equal(deltaArrow(5), '≈'); // boundary is inclusive: |5| is not > 5
-		assert.equal(deltaArrow(-5), '≈');
-	});
-
-	it('empty string for a null/NaN delta (no baseline cell)', () => {
+		assert.equal(deltaArrow(5), '≈');
 		assert.equal(deltaArrow(null), '');
-		assert.equal(deltaArrow(undefined), '');
-		assert.equal(deltaArrow(Number.NaN), '');
 	});
 });
 
 describe('diffAgainstBaseline(current, baseline)', () => {
-	const current = buildAggregate([PASS, PARTIAL, { task: 'brand-new', template: 'demo', tests_passed: 2, tests_failed: 0, judge_score: 10 }], {});
-	// Baseline: auth lower (80), file higher (70), plus a cell that's gone now.
+	const current = buildAggregate([PASS, PARTIAL, { task: 'brand-new', template: 'demo', tests_passed: 2, tests_failed: 0, judge_score: 10, tokens_in: 50000, tokens_out: 5000 }], {});
 	const baseline = {
+		schema: 2,
 		mean_composite: 70,
 		cells: [
-			{ task: 'auth-notes', template: 'demo', composite: 80 },
-			{ task: 'file-gallery', template: 'bare', composite: 70 },
-			{ task: 'removed', template: 'x', composite: 50 },
+			{ task: 'auth-notes', template: 'demo', composite: 80, judge_score: 7, tests_passed: 4, tests_denom: 4, judge_dimensions: { functional_completeness: 9, selector_contract: 8, persistence: 8, code_quality: 7, blocks_fidelity: 8 }, cost: 2.0, score: 40, tokens_in: 190000, tokens_out: 28000 },
+			{ task: 'file-gallery', template: 'bare', composite: 70, tests_passed: 3, tests_denom: 4, cost: 0.6, score: 116.7, tokens_in: 100000, tokens_out: 20000 },
+			{ task: 'removed', template: 'x', composite: 50, tests_passed: 5, tests_denom: 5 },
 		],
 	};
 	const diff = diffAgainstBaseline(current, baseline);
+	const byKey = Object.fromEntries(diff.rows.map((r) => [r.key, r]));
 
-	it('matches cells by task/template and computes signed deltas', () => {
-		const byKey = Object.fromEntries(diff.rows.map((r) => [r.key, r]));
+	it('keeps the COMPOSITE delta on each row (used by the headline + analysis roll-up)', () => {
 		assert.equal(byKey['auth-notes/demo'].delta, 12); // 92 - 80
 		assert.equal(byKey['file-gallery/bare'].delta, -5); // 65 - 70
+		assert.equal(diff.meanDelta, round1Delta(diff.meanCurrent, 70));
 	});
-
-	it('a cell with no baseline match has a null delta + hasBaselineCell=false (rendered 🆕)', () => {
-		const row = diff.rows.find((r) => r.key === 'brand-new/demo');
-		assert.equal(row.baseline, null);
-		assert.equal(row.delta, null);
-		assert.equal(row.hasBaselineCell, false);
+	it('attaches pr + base metric objects for the tables', () => {
+		const r = byKey['auth-notes/demo'];
+		assert.equal(r.pr.cost, 1.05);
+		assert.equal(r.base.cost, 2.0);
+		assert.equal(r.pr.tests_passed, 4);
+		assert.equal(r.base.judge_score, 7);
+		assert.deepEqual(r.base.judge_dimensions.functional_completeness, 9);
 	});
-
-	it('a baseline-only cell (removed/renamed) surfaces as its own row: current+delta null, removed=true', () => {
-		// The baseline has `removed/x` (composite 50), absent from `current`. It
-		// must NOT silently vanish — it appears as a row flagged `removed`, with a
-		// null current + delta so it stays out of the mean, keeping its baseline value.
-		const row = diff.rows.find((r) => r.key === 'removed/x');
-		assert.ok(row, 'baseline-only cell must appear as a row');
-		assert.equal(row.removed, true);
-		assert.equal(row.current, null);
-		assert.equal(row.delta, null);
-		assert.equal(row.baseline, 50);
-		assert.equal(row.hasBaselineCell, true);
-		// A present-both cell is never flagged removed.
-		assert.equal(diff.rows.find((r) => r.key === 'auth-notes/demo').removed, false);
+	it('a new cell has base=null; a removed cell surfaces with pr=null', () => {
+		assert.equal(byKey['brand-new/demo'].base, null);
+		assert.equal(byKey['brand-new/demo'].hasBaselineCell, false);
+		const gone = byKey['removed/x'];
+		assert.equal(gone.removed, true);
+		assert.equal(gone.pr, null);
+		assert.equal(gone.baseline, 50);
 	});
-
-	it('computes the mean delta when both means exist', () => {
-		// current mean = (92 + 65 + 100)/3 = 85.7 ; baseline mean = 70 → +15.7
-		assert.equal(diff.meanCurrent, 85.7);
-		assert.equal(diff.meanBaseline, 70);
-		assert.equal(diff.meanDelta, 15.7);
-		assert.equal(diff.hasBaseline, true);
-	});
-
-	it('rows are sorted by key', () => {
-		const keys = diff.rows.map((r) => r.key);
-		assert.deepEqual(keys, [...keys].sort((a, b) => a.localeCompare(b)));
-	});
-
-	it('null baseline → hasBaseline false, no mean delta, current values intact', () => {
+	it('null baseline → hasBaseline false, every base null', () => {
 		const noBase = diffAgainstBaseline(current, null);
 		assert.equal(noBase.hasBaseline, false);
-		assert.equal(noBase.meanBaseline, null);
-		assert.equal(noBase.meanDelta, null);
-		assert.equal(noBase.meanCurrent, 85.7);
-		assert.equal(noBase.rows.every((r) => r.baseline === null && r.delta === null), true);
+		assert.equal(noBase.rows.every((r) => r.base === null), true);
 	});
 });
 
-describe('renderOverview(diff, opts)', () => {
-	const current = buildAggregate([PASS, PARTIAL], {});
+function round1Delta(a, b) {
+	return Math.round((a - b) * 10) / 10;
+}
 
-	it('baseline mode renders a Baseline | PR | Δ table with arrows + a bold mean row', () => {
-		const baseline = { mean_composite: 70, cells: [{ task: 'auth-notes', template: 'demo', composite: 80 }] };
-		const md = renderOverview(diffAgainstBaseline(current, baseline), { heading: '## Overview — PR vs baseline' }).join('\n');
-		assert.match(md, /## Overview — PR vs baseline/);
-		assert.match(md, /\| Task \| Template \| Baseline \| PR \| Δ \|/);
-		assert.match(md, /auth-notes \| demo \| 80\.0 \| 92\.0 \| ▲ \+12\.0/);
-		// file-gallery has no baseline cell → 🆕 new
-		assert.match(md, /file-gallery \| bare \| — \| 65\.0 \| 🆕 new/);
-		assert.match(md, /\*\*Mean\*\* \| \| \*\*70\.0\*\* \| \*\*78\.5\*\*/);
+describe('renderOverview(diff) — colors only', () => {
+	const current = buildAggregate([PASS], {});
+	const baseline = {
+		schema: 2,
+		mean_composite: 92,
+		cells: [{ task: 'auth-notes', template: 'demo', composite: 92, judge_score: 8, tests_passed: 4, tests_denom: 4, cost: 2.0, score: 46, tokens_in: 190000, tokens_out: 28000 }],
+	};
+	const md = renderOverview(diffAgainstBaseline(current, baseline), { heading: '## Overview' }).join('\n');
+
+	it('has the colors-only column header and no baseline->pr numbers', () => {
+		assert.match(md, /\| Task \| Template \| Tests \| Judge \| Cost \| Tokens \(in\/out\) \| Score \|/);
+		assert.doesNotMatch(md, /->/); // Overview is glyphs only
 	});
-
-	it('no-baseline mode renders an absolute Composite table + the note', () => {
-		const md = renderOverview(diffAgainstBaseline(current, null), { note: '_No baseline found._' }).join('\n');
-		assert.match(md, /_No baseline found\._/);
-		assert.match(md, /\| Task \| Template \| Composite \|/);
-		assert.match(md, /auth-notes \| demo \| 92\.0/);
-		assert.match(md, /\*\*Mean\*\* \| \| \*\*78\.5\*\*/);
-		// no Δ column when there's no baseline
-		assert.doesNotMatch(md, /Baseline \| PR \| Δ/);
+	it('colors each metric vs baseline', () => {
+		// tests 4/4 vs 4/4 → 🟢 ; judge 8 vs 8 → 🟢 ; cost $1.05 vs $2.0 (lower) → 🟢 ;
+		// tokens_in 200k vs 190k (higher=worse, beyond 5%) → 🔴 ; score 87.6 vs 46 (higher) → 🟢
+		const row = md.split('\n').find((l) => l.includes('auth-notes'));
+		assert.match(row, /\| auth-notes \| demo \| 🟢 \| 🟢 \| 🟢 \| 🔴\/🔴 \| 🟢 \|/);
 	});
-
-	it('a cell not scored THIS run (harness/unknown) renders Δ "—", not "🆕 new"', () => {
-		// HARNESS has a null composite this run and is absent from the baseline:
-		// it must read as "—" (nothing to diff), never as a new cell.
-		const withHarness = buildAggregate([PASS, HARNESS], {});
-		const baseline = { mean_composite: 80, cells: [{ task: 'auth-notes', template: 'demo', composite: 80 }] };
-		const md = renderOverview(diffAgainstBaseline(withHarness, baseline), {}).join('\n');
-		assert.match(md, /oidc-dsql \| react \| — \| — \| — \|/);
-		assert.doesNotMatch(md, /oidc-dsql \| react \| — \| — \| 🆕 new \|/);
+	it('no-baseline mode flags every metric 🆕', () => {
+		const noBase = renderOverview(diffAgainstBaseline(current, null), {}).join('\n');
+		const row = noBase.split('\n').find((l) => l.includes('auth-notes'));
+		assert.match(row, /\| auth-notes \| demo \| 🆕 \| 🆕 \| 🆕 \| 🆕\/🆕 \| 🆕 \|/);
 	});
+});
 
-	it('a baseline-only (removed) cell renders a "removed" marker with a "—" PR column', () => {
-		// current has only auth-notes; the baseline additionally has a gone cell.
-		const baseline = {
-			mean_composite: 75,
+describe('renderDetailed(diff) — numbers', () => {
+	const current = buildAggregate([PASS], {});
+	const baseline = {
+		schema: 2,
+		mean_composite: 92,
+		cells: [{ task: 'auth-notes', template: 'demo', composite: 92, judge_score: 8, tests_passed: 4, tests_denom: 4, judge_dimensions: { functional_completeness: 9, selector_contract: 8, persistence: 8, code_quality: 7, blocks_fidelity: 8 }, cost: 2.0, score: 46, tokens_in: 190000, tokens_out: 28000 }],
+	};
+	const md = renderDetailed(diffAgainstBaseline(current, baseline), {}).join('\n');
+	const row = md.split('\n').find((l) => l.includes('auth-notes'));
+
+	it('has the detailed column header incl. Stop reason', () => {
+		assert.match(md, /\| Task \| Template \| Tests \| Judge \| Cost \| Tokens \| Score \| Stop reason \|/);
+	});
+	it('renders tests as colored baseline->pr counts', () => {
+		assert.match(row, /🟢 4\/4 -> 4\/4/);
+	});
+	it('renders the judge cell multi-line per dimension with color + baseline->pr', () => {
+		// functional_completeness 9→8 (down 1, within margin 1) → 🟡 ; code_quality 7→8 (better) → 🟢
+		assert.match(row, /🟡 functional_completeness 9 -> 8/);
+		assert.match(row, /🟢 code_quality 7 -> 8/);
+		assert.match(row, /<br>/); // dimensions on separate lines
+	});
+	it('renders cost, tokens (in/out), score, and stop reason with numbers', () => {
+		assert.match(row, /🟢 \$2 -> \$1\.05/); // cost lower = better
+		assert.match(row, /in 🔴 190K -> 200K<br>out 🔴 28K -> 30K/);
+		assert.match(row, /🟢 46 -> 87\.6/); // score higher = better
+		assert.match(row, /\| end_turn \|/);
+	});
+	it('a removed cell shows a 🗑️ marker', () => {
+		const withRemoved = diffAgainstBaseline(current, {
+			schema: 2,
+			mean_composite: 80,
 			cells: [
-				{ task: 'auth-notes', template: 'demo', composite: 80 },
-				{ task: 'gone-task', template: 'demo', composite: 40 },
+				{ task: 'auth-notes', template: 'demo', composite: 92, tests_passed: 4, tests_denom: 4 },
+				{ task: 'gone', template: 'demo', composite: 40, tests_passed: 2, tests_denom: 5 },
 			],
-		};
-		const md = renderOverview(diffAgainstBaseline(current, baseline), {}).join('\n');
-		// baseline 40.0, PR "—", Δ removed marker.
-		assert.match(md, /gone-task \| demo \| 40\.0 \| — \| 🗑️ removed \|/);
+		});
+		const dmd = renderDetailed(withRemoved, {}).join('\n');
+		assert.match(dmd, /\| gone \| demo \| 🗑️ removed \(was 2\/5\)/);
 	});
 });

--- a/scripts/agent-bench/steps/lib/overview.test.mjs
+++ b/scripts/agent-bench/steps/lib/overview.test.mjs
@@ -9,6 +9,7 @@ import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import {
 	MARGIN_PCT,
+	baselineHasMetrics,
 	buildAggregate,
 	cellComposite,
 	cellKey,
@@ -279,5 +280,55 @@ describe('renderDetailed(diff) — numbers', () => {
 		});
 		const dmd = renderDetailed(withRemoved, {}).join('\n');
 		assert.match(dmd, /\| gone \| demo \| 🗑️ removed \(was 2\/5\)/);
+	});
+});
+
+describe('baselineHasMetrics(baseline) — the per-metric gate', () => {
+	it('true only for a schema-2+ baseline (carries the per-metric set)', () => {
+		assert.equal(baselineHasMetrics({ schema: 2, cells: [] }), true);
+		assert.equal(baselineHasMetrics({ schema: 3, cells: [] }), true);
+	});
+	it('false for schema-1, a missing schema, or null (NOT per-metric comparable)', () => {
+		assert.equal(baselineHasMetrics({ schema: 1, cells: [] }), false);
+		assert.equal(baselineHasMetrics({ cells: [] }), false);
+		assert.equal(baselineHasMetrics(null), false);
+		assert.equal(baselineHasMetrics(undefined), false);
+	});
+});
+
+// REGRESSION GUARD for the "Judge colored while Tests/Cost/Tokens/Score are all
+// 🆕" bug: a schema-1 baseline (the pre-redesign aggregate) persisted composite +
+// judge_score but NONE of the schema-2 per-metric fields. Coloring each metric
+// off its own baseline field lit up Judge alone. The fix gates ALL per-metric
+// coloring on baseline COMPLETENESS, so a schema-1 baseline renders every column
+// — Judge included — as 🆕, while the composite mean/delta stays comparable.
+describe('schema-1 baseline → every column (Judge included) is 🆕', () => {
+	// Exactly what the OLD buildAggregate wrote: composite/judge_score/test_rate only.
+	const SCHEMA1 = {
+		schema: 1,
+		mean_composite: 80,
+		cells: [{ task: 'auth-notes', template: 'demo', composite: 80, verdict: 'pass', klass: null, judge_score: 7, test_rate: 1 }],
+	};
+	const diff = diffAgainstBaseline(buildAggregate([PASS], {}), SCHEMA1);
+
+	it('is recognized as a baseline, but NOT a per-metric one', () => {
+		assert.equal(diff.hasBaseline, true); // a baseline WAS found in S3…
+		assert.equal(diff.perMetricBaseline, false); // …but it can't diff per-metric
+		assert.equal(diff.rows.every((r) => r.base === null), true); // so no base metrics
+	});
+	it('keeps the composite mean/delta comparable (the headline still works)', () => {
+		assert.equal(diff.rows.find((r) => r.key === 'auth-notes/demo').delta, 12); // 92 - 80
+		assert.equal(diff.meanDelta, round1Delta(diff.meanCurrent, 80));
+	});
+	it('Overview: Judge renders 🆕 like the rest — NOT a color (the exact bug)', () => {
+		const row = renderOverview(diff, {}).find((l) => l.includes('auth-notes'));
+		assert.match(row, /\| auth-notes \| demo \| 🆕 \| 🆕 \| 🆕 \| 🆕\/🆕 \| 🆕 \|/);
+		assert.doesNotMatch(row, /🟢|🟡|🔴/); // no metric may color against a schema-1 baseline
+	});
+	it('Detailed: the whole row is 🆕 + numbers, Judge included — no colors', () => {
+		const row = renderDetailed(diff, {}).find((l) => l.includes('auth-notes'));
+		assert.doesNotMatch(row, /🟢|🟡|🔴/);
+		assert.doesNotMatch(row, /->/); // 🆕 cells show the pr value only, no baseline->pr
+		assert.match(row, /🆕 functional_completeness 8/); // judge dims are 🆕, not colored
 	});
 });

--- a/scripts/agent-bench/steps/lib/scoring.mjs
+++ b/scripts/agent-bench/steps/lib/scoring.mjs
@@ -303,3 +303,69 @@ export function hardCapPlan(ev) {
 	}
 	return { caps, notes };
 }
+
+// ── Cost & score-per-dollar ──────────────────────────────────────────────────
+// Amazon Bedrock on-demand pricing, USD per 1,000,000 tokens. This is the SINGLE
+// place to edit when AWS changes Bedrock pricing or the benchmarked model. The
+// COST/SCORE columns in the report are derived from BUILDER_PRICING below.
+// Source: https://aws.amazon.com/bedrock/pricing/ (Anthropic Claude).
+export const PRICING = {
+	// $/1M tokens (input, output).
+	'claude-sonnet': { input: 3.0, output: 15.0 },
+	'claude-opus': { input: 15.0, output: 75.0 },
+};
+
+// The BUILDER (the agent under test in 2-agent-run.ts) runs on Claude Sonnet 4.6,
+// so a cell's cost is its builder token spend priced at Sonnet rates. result.json's
+// tokens_in/tokens_out are the BUILDER's accumulated usage — the judge and the
+// analysis run on Opus but that spend is the harness's, not the agent's, and is
+// NOT counted here. Point this at PRICING['claude-opus'] if the builder model
+// ever changes.
+export const BUILDER_PRICING = PRICING['claude-sonnet'];
+
+/**
+ * USD cost of a cell's BUILDER token spend at {@link BUILDER_PRICING}. Returns
+ * `null` — never a fake `$0` — when the cell recorded no usable token counts
+ * (e.g. a harness_error that died before the agent ran, so tokens are 0/0), so
+ * the report renders "—" for it. Rounded to 1/100th of a cent.
+ * @param {{tokens_in?: number, tokens_out?: number}} r a finalized result.json cell
+ * @param {{input: number, output: number}} [pricing]
+ * @returns {number|null}
+ */
+export function cellCost(r, pricing = BUILDER_PRICING) {
+	const tin = typeof r?.tokens_in === 'number' && Number.isFinite(r.tokens_in) ? r.tokens_in : 0;
+	const tout = typeof r?.tokens_out === 'number' && Number.isFinite(r.tokens_out) ? r.tokens_out : 0;
+	if (tin + tout <= 0) return null;
+	const cost = (tin * pricing.input + tout * pricing.output) / 1_000_000;
+	return Math.round(cost * 1e4) / 1e4;
+}
+
+// SCORE direction, the SINGLE knob for the headline SCORE metric:
+//   true  → SCORE = composite per dollar (higher = better) — the default.
+//   false → SCORE = dollars per composite point (lower = better).
+// Flipping this ONE constant swaps the ratio in scorePerDollar below AND the
+// green/red direction in overview.mjs (which imports it), keeping the number and
+// its coloring in sync.
+export const SCORE_PER_DOLLAR = true;
+
+/**
+ * The headline SCORE for a cell: the 0..100 composite (quality) normalized by its
+ * $ cost (efficiency) — "composite points per dollar", higher = better, by
+ * default. Cost, NOT raw token volume, is the denominator, so token count can
+ * never DOMINATE the score: a cheap-and-good cell beats an expensive-and-good
+ * one, while a broken (composite 0) cell scores 0 no matter how cheap it was.
+ * `null` when the composite or the cost is unavailable (rendered "—"). Rounded
+ * to 1 decimal.
+ * @param {number|null} baseComposite the 0..100 composite from {@link composite}
+ * @param {number|null} cost USD from {@link cellCost}
+ * @returns {number|null}
+ */
+export function scorePerDollar(baseComposite, cost) {
+	if (typeof baseComposite !== 'number' || !Number.isFinite(baseComposite)) return null;
+	if (typeof cost !== 'number' || !Number.isFinite(cost) || cost <= 0) return null;
+	// Default (SCORE_PER_DOLLAR): points per $. Inverted: $ per point — undefined
+	// at composite 0 (a free-but-worthless cell), so return null there.
+	const s = SCORE_PER_DOLLAR ? baseComposite / cost : baseComposite > 0 ? cost / baseComposite : null;
+	if (s === null || !Number.isFinite(s)) return null;
+	return Math.round(s * 10) / 10;
+}

--- a/scripts/agent-bench/steps/lib/scoring.test.mjs
+++ b/scripts/agent-bench/steps/lib/scoring.test.mjs
@@ -11,7 +11,10 @@ import { describe, it } from 'node:test';
 import {
 	AGENT_FAIL_AT,
 	AGENT_FAIL_REASON,
+	BUILDER_PRICING,
+	PRICING,
 	buildCapDecision,
+	cellCost,
 	classifyCell,
 	COMMON_DIMENSIONS,
 	composite,
@@ -19,6 +22,7 @@ import {
 	HARNESS_FAIL_REASONS,
 	hardCapPlan,
 	isScoredCell,
+	scorePerDollar,
 	testRate,
 	testStats,
 	verdict,
@@ -441,5 +445,41 @@ describe('scored-cell integrity across the judge/build-test failure modes', () =
 		assert.equal(verdictOf(cell), 'partial');
 		// Judge skipped ⇒ judge term gated to 0 ⇒ composite is the test portion: 60*(2/3) = 40.
 		assert.equal(composite(testRate(testStats(cell)), 0), 40);
+	});
+});
+
+describe('cellCost(r) — builder token spend priced at BUILDER_PRICING', () => {
+	it('BUILDER_PRICING is Sonnet ($3/$15 per 1M) — the one place to edit for pricing', () => {
+		assert.deepEqual(PRICING['claude-sonnet'], { input: 3.0, output: 15.0 });
+		assert.deepEqual(PRICING['claude-opus'], { input: 15.0, output: 75.0 });
+		assert.equal(BUILDER_PRICING, PRICING['claude-sonnet']);
+	});
+	it('prices in + out tokens at $/1M', () => {
+		// (200000*3 + 30000*15)/1e6 = (600000 + 450000)/1e6 = 1.05
+		assert.equal(cellCost({ tokens_in: 200000, tokens_out: 30000 }), 1.05);
+		// (100000*3 + 20000*15)/1e6 = 0.6
+		assert.equal(cellCost({ tokens_in: 100000, tokens_out: 20000 }), 0.6);
+	});
+	it('returns null (never a fake $0) when there are no usable token counts', () => {
+		assert.equal(cellCost({}), null);
+		assert.equal(cellCost({ tokens_in: 0, tokens_out: 0 }), null);
+		assert.equal(cellCost({ tokens_in: undefined, tokens_out: null }), null);
+	});
+	it('accepts a custom pricing table', () => {
+		// Opus rates: (1e6*15 + 1e6*75)/1e6 = 90
+		assert.equal(cellCost({ tokens_in: 1_000_000, tokens_out: 1_000_000 }, PRICING['claude-opus']), 90);
+	});
+});
+
+describe('scorePerDollar(composite, cost) — the headline SCORE (points per $)', () => {
+	it('is composite / cost, rounded to 1 decimal', () => {
+		assert.equal(scorePerDollar(92, 1.05), 87.6); // 92/1.05 = 87.619…
+		assert.equal(scorePerDollar(65, 0.6), 108.3); // 65/0.6 = 108.33…
+		assert.equal(scorePerDollar(0, 1.05), 0); // a broken cell scores 0 no matter how cheap
+	});
+	it('is null when composite or cost is missing / non-positive', () => {
+		assert.equal(scorePerDollar(null, 1.05), null);
+		assert.equal(scorePerDollar(92, null), null);
+		assert.equal(scorePerDollar(92, 0), null);
 	});
 });

--- a/scripts/agent-bench/steps/summary.mjs
+++ b/scripts/agent-bench/steps/summary.mjs
@@ -162,7 +162,7 @@ md.push('<summary>📖 Glossary &amp; notes — scoring, colors, the ±5% margin
 md.push('');
 md.push('- **N = 1** — one rep per cell, so a small delta may be model variance, not a real change; re-run for certainty.');
 md.push(
-	'- **Colors (vs baseline, per metric):** 🟢 same-or-better · 🟡 worse but within the margin · 🔴 worse beyond it · 🆕 no baseline value (new cell) · — nothing to diff this run · 🗑️ cell gone since the baseline.',
+	'- **Colors (vs baseline, per metric):** 🟢 same-or-better · 🟡 worse but within the margin · 🔴 worse beyond it · 🆕 no comparable baseline value (a new cell, or a baseline that predates this metric) · — nothing to diff this run · 🗑️ cell gone since the baseline.',
 );
 md.push(
 	'- **Margin = ±5%** (`MARGIN_PCT` in `overview.mjs`) — relative to the baseline value; for integer metrics (test counts, 0-10 judge dims) it is floored to 1, so a single-point nudge is 🟡, never 🔴. Edit that one constant to widen/narrow it.',
@@ -190,18 +190,27 @@ md.push('');
 if (cells.length > 0) {
 	let heading = '## Overview — PR vs `main` baseline';
 	let note;
-	const legend = '🟢 better/equal · 🟡 worse within ±5% · 🔴 worse beyond · 🆕 new cell.';
+	const legend = '🟢 better/equal · 🟡 worse within ±5% · 🔴 worse beyond · 🆕 new/uncomparable.';
+	const perMetric = diff.perMetricBaseline;
 	const baseLabel = baseline?.sha ? `\`${String(baseline.sha).slice(0, 7)}\`` : 'the recorded baseline';
+	// A baseline that predates the per-metric (schema-2) aggregate can compare
+	// only the composite mean; every per-metric cell shows 🆕 until the next
+	// `main` bench records the new schema. Say so explicitly rather than implying
+	// a full per-metric diff ran (that mismatch was the "Judge colored, rest 🆕"
+	// bug's symptom).
+	const staleNote = `A \`main\` baseline exists (${baseLabel}) but predates the per-metric schema, so per-metric cells show 🆕 — only the composite mean (in the headline) is comparable. Full per-metric coloring returns once a \`main\` bench records the new schema.`;
 	if (benchEvent === 'push') {
 		// A push-to-main run IS the new baseline; it diffs against the PREVIOUS
 		// main bench (fetched pre-persist), or shows absolute values if none.
 		heading = '## Overview — baseline run';
 		const rec = `Baseline run (push to \`main\`): recorded as the new \`main\` baseline for \`${benchSha.slice(0, 7) || '(unknown)'}\`.`;
-		note = baseline
-			? `${rec} Colored vs the PREVIOUS \`main\` baseline ${baseLabel}. ${legend}`
-			: `${rec} No earlier baseline to diff — absolute values (all 🆕).`;
-	} else if (baseline) {
+		if (!baseline) note = `${rec} No earlier baseline to diff — absolute values (all 🆕).`;
+		else if (perMetric) note = `${rec} Colored vs the PREVIOUS \`main\` baseline ${baseLabel}. ${legend}`;
+		else note = `${rec} ${staleNote}`;
+	} else if (perMetric) {
 		note = `Each metric colored vs the latest \`main\` baseline ${baseLabel}. ${legend}`;
+	} else if (baseline) {
+		note = staleNote;
 	} else {
 		note = 'No `main` baseline recorded yet — showing absolute values (every metric 🆕). PR-vs-`main` deltas appear once a `main` bench has stored one.';
 	}

--- a/scripts/agent-bench/steps/summary.mjs
+++ b/scripts/agent-bench/steps/summary.mjs
@@ -1,41 +1,42 @@
 // Step "Render summary": read every bench-result-*/result.json downloaded as
-// artifacts and render a markdown scoreboard to $GITHUB_STEP_SUMMARY — the
-// result lives in the Actions run summary, NOT a PR comment (the commenting
-// step is intentionally disabled; see agent-bench.yml). On a PR it also renders
-// an at-a-glance PR-vs-baseline OVERVIEW at the TOP (per-cell composite delta +
-// mean delta) from the baseline aggregate the job fetched from S3 for the PR's
-// base commit; with no baseline it falls back to absolute composites.
+// artifacts and render a markdown report to $GITHUB_STEP_SUMMARY — the result
+// lives in the Actions run summary, NOT a PR comment (the commenting step is
+// intentionally disabled; see agent-bench.yml).
+//
+// The report has TWO tables built from the SAME rows (lib/overview.mjs):
+//   1. Overview — colors ONLY (🟢/🟡/🔴 per metric vs baseline), at-a-glance.
+//   2. Detailed results — the same rows widened WITH numbers (baseline -> pr).
+// A collapsible Glossary (scoring, colors, the ±5% margin) sits at the very top;
+// the executive summary, potential issues, and per-cell analysis are appended
+// AFTER these by the separate best-effort roll-up step (steps/analyze.mjs).
 //
 // The bench runs N=1 (a single rep) per cell: each cell artifact holds exactly
 // one result.json, read directly here.
 //
-// Scoring model (gradient, not binary) — the formulas live in ONE place,
-// ./lib/scoring.mjs, and are also stamped onto each result.json by
-// finalize-result.mjs, so the published artifact and this table can't diverge:
-//   - VERDICT is pure pass-rate — the judge plays NO part. A judge/LLM failure
-//     can never flip a verdict or zero the test_rate (judge & test harness
-//     errors are tracked as SEPARATE signals). Tests are the source of truth.
-//       harness_error  pre-grade step failed / cancelled — no gradeable artifact (excluded)
-//       agent_fail     agent timed out / produced no app at 2-agent — verdict 'fail', composite 0 (INCLUDED)
-//       unknown        gradeable but produced no test results (denom 0; excluded)
-//       pass           pass_rate >= 0.999
-//       partial        0 < pass_rate < 0.999
-//       fail           pass_rate == 0 (tests ran)
-//   - COMPOSITE (0..100) blends the test rate with the judge score:
-//       composite = round(60*tr + 4*j*min(1, 4*tr), 1)
-//     A judge error drops only the judge term (composite = 60*tr) — it never
-//     zeroes the test-driven portion. Bands: >=80 🟢, >=50 🟡, else 🔴.
+// Scoring model — the formulas live in ONE place, ./lib/scoring.mjs, and are
+// also stamped onto each result.json by finalize-result.mjs, so the published
+// artifact and this report can't diverge:
+//   - COMPOSITE (0..100) = round(60*tr + 4*j*min(1, 4*tr), 1) — 60% objective
+//     pass-rate + 40% judge (judge gated below a 25% pass-rate). A judge error
+//     drops only the judge term, never the test-driven portion.
+//   - COST = builder token spend priced at Bedrock Sonnet rates (BUILDER_PRICING).
+//   - SCORE = composite / cost — composite points per dollar (higher = better).
+//   - COLOR vs baseline, per metric: 🟢 same-or-better · 🟡 worse within ±5% ·
+//     🔴 worse beyond. Single tunable MARGIN_PCT; see the glossary + overview.mjs.
+//
+// The BASELINE a PR diffs against is the MOST RECENT main-branch bench
+// (bench/runs/latest-main.json), fetched by the job's "Fetch baseline" step —
+// never the PR's (possibly stale) base commit. With no baseline the tables show
+// absolute PR values (every metric 🆕), never an error.
 //
 // The headline is the MEAN composite over SCORED cells (harness_error AND
-// no-test-result cells excluded), with the judge mean shown alongside.
-//
-// Scoring is OBSERVATIONAL by default. Set the optional `BENCH_MIN_SCORE` env
-// (wired to the repo/org variable of the same name) to gate: the job exits
-// non-zero when the mean composite (0..100) across scored cells falls below it.
+// no-test-result cells excluded). Scoring is OBSERVATIONAL by default; set
+// `BENCH_MIN_SCORE` to gate: the job exits non-zero when the mean composite
+// falls below it.
 import { appendFileSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { compositeBand, isScoredCell, testRate, testStats, verdictOf } from './lib/scoring.mjs';
-import { buildAggregate, cellComposite, diffAgainstBaseline, renderOverview } from './lib/overview.mjs';
+import { cellCost, compositeBand, isScoredCell, scorePerDollar, testRate, testStats, verdictOf } from './lib/scoring.mjs';
+import { buildAggregate, cellComposite, deltaArrow, diffAgainstBaseline, renderDetailed, renderOverview } from './lib/overview.mjs';
 
 const RESULTS_DIR = process.env.RESULTS_DIR ?? 'results';
 
@@ -48,16 +49,6 @@ try {
 } catch (err) {
 	if (err?.code !== 'ENOENT') throw err;
 }
-
-// Composite for a cell (0..100) comes from overview.mjs's shared `cellComposite`
-// (null for non-scored cells — coerced to 0 at the call sites here).
-
-// EVIDENCE boolean signals (build_succeeded, …) are QUOTED in the workflow's
-// EVIDENCE JSON (so a non-bool step output can't yield invalid JSON), then
-// spread verbatim onto result.json. They reach here as either a real bool or
-// its string form, so coerce both — a bare `"false"` string is truthy in JS and
-// would otherwise read as a passing build. Mirrors 4-judge.ts's `truthy`.
-const truthy = (v) => v === true || v === 'true';
 
 // One row per cell, read from the single result.json the cell artifact holds.
 const cells = dirs.map((d) => {
@@ -73,25 +64,17 @@ const cells = dirs.map((d) => {
 
 // ── Buckets ──────────────────────────────────────────────────────────────────
 const dataCells = cells.filter((c) => !c.error);
+const errorCells = cells.filter((c) => c.error);
 // A cell enters the composite mean iff gradeable (not harness_error) AND it
 // produced test results — single-sourced via isScoredCell.
 const compositeCells = dataCells.filter((c) => isScoredCell(c));
 const judgeScoredCells = dataCells.filter((c) => c.klass !== 'harness_error' && typeof c.judge_score === 'number');
 const harnessErrors = dataCells.filter((c) => c.klass === 'harness_error');
 
-// Judge error on an otherwise-gradeable cell: tracked SEPARATELY from test
-// signals so it can never flip the verdict or zero the test_rate. An agent_fail
-// (timeout / no app) ran neither the judge nor the tests, so it is NEITHER a
-// judge error NOR a test-harness error — it shows as ❌ fail / composite 0 in
-// the table; exclude it from both isolation notes below.
-//
-// A judge error means the judge actually RAN and failed to yield a numeric
-// score (invoke error, schema-validation error, timeout, or missing structured
-// output). A cell that failed at 3-build-test SKIPS the judge entirely (step 4
-// is gated on step 3 success), so it has no judge_score even though the judge
-// never ran — excluding failed_at==='3-build-test' (and testErr cells, whose
-// no-test-signal bucket already owns them) prevents miscounting those here and
-// double-counting them with the test-harness note below.
+// Judge/test harness errors, tracked SEPARATELY from test signals so they can
+// never flip a verdict or zero a test_rate (see the long-form note that used to
+// live in the removed scoreboard table). An agent_fail ran neither, so it is
+// neither — excluded from both.
 const testErr = (r) => r.klass !== 'harness_error' && r.klass !== 'agent_fail' && testStats(r).denom === 0;
 const judgeErr = (r) =>
 	r.klass !== 'harness_error' &&
@@ -100,122 +83,17 @@ const judgeErr = (r) =>
 	r.failed_at !== '3-build-test' &&
 	typeof r.judge_score !== 'number';
 
-const VERDICT_LABEL = {
-	pass: '✅ pass',
-	partial: '🟡 partial',
-	fail: '❌ fail',
-	unknown: '❔ unknown',
-	harness_error: '🧰 harness',
-};
 const sortKey = (r) => `${r.task ?? ''}/${r.template ?? ''}`;
 const byTask = (a, b) => sortKey(a).localeCompare(sortKey(b));
+const cellRef = (r) => `\`${r.task ?? '—'}/${r.template ?? '—'}\``;
 
-// ── Table ───────────────────────────────────────────────────────────────────
-// Run-logs deep-link, hoisted ABOVE the table so the artifacts pointer can sit
-// right under it (the footer's "last run" line reuses these same vars). GitHub
-// Actions exposes no per-artifact deep link, so we name the deterministic
-// artifacts and link the run page where they're listed.
+// ── Run-logs deep link (for the glossary + Athena/aggregate provenance) ───────
 const serverUrl = process.env.GITHUB_SERVER_URL;
 const repoSlug = process.env.GITHUB_REPOSITORY;
 const runId = process.env.GITHUB_RUN_ID;
 const logsUrl = serverUrl && repoSlug && runId ? `${serverUrl}/${repoSlug}/actions/runs/${runId}` : null;
 
-const out = ['## Bench results', ''];
-out.push(
-	'| Task | Template | Verdict | Tests | Build | Judge | Composite | Stop reason |',
-	'|------|----------|---------|-------|-------|-------|-----------|-------------|',
-);
-for (const r of cells.slice().sort(byTask)) {
-	if (r.error) {
-		out.push(`| ${r.task} | — | (artifact ${r.error}) | — | — | — | — | — |`);
-		continue;
-	}
-	const { passed, denom } = testStats(r);
-	const tests = denom > 0 ? `${passed}/${denom}` : '—';
-	const build =
-		r.build_status === 'na'
-			? '∅'
-			: r.build_status === 'ok'
-				? '✅'
-				: r.build_status === 'failed'
-					? '❌'
-					: truthy(r.build_succeeded)
-						? '✅'
-						: '❌';
-	const judge =
-		typeof r.judge_score === 'number'
-			? String(r.judge_score)
-			: r.klass === 'harness_error' || r.klass === 'agent_fail'
-				? '—'
-				: 'err';
-	let compositeCell = '—';
-	if (isScoredCell(r)) {
-		const c = cellComposite(r) ?? 0;
-		compositeCell = `${c.toFixed(1)} ${compositeBand(c)}`;
-	}
-	out.push(
-		`| ${r.task ?? '—'} | ${r.template ?? '—'} | ${VERDICT_LABEL[verdictOf(r)]} | ${tests} | ${build} | ${judge} | ${compositeCell} | ${r.stop_reason || '—'} |`,
-	);
-}
-out.push('');
-if (logsUrl) {
-	out.push(
-		`📦 Per-cell source & full agent traces (tool calls, tokens): see this run's Artifacts — \`bench-source-<task>-<template>\`, \`bench-trace-<task>-<template>\` → [run artifacts](${logsUrl})`,
-		'',
-	);
-}
-
-// ── Harness-error section (excluded from the headline & the gate) ────────────
-if (harnessErrors.length > 0) {
-	const counts = {};
-	for (const r of harnessErrors) {
-		const reason = r.klass_reason ?? r.failed_at ?? 'unknown';
-		counts[reason] = (counts[reason] ?? 0) + 1;
-	}
-	const reasonSummary = Object.entries(counts)
-		.sort((a, b) => b[1] - a[1])
-		.map(([reason, n]) => `${n}× ${reason}`)
-		.join(', ');
-	out.push(`### Excluded as harness_error (${harnessErrors.length}: ${reasonSummary})`);
-	out.push('');
-	out.push('_These cells never produced a gradeable artifact and are NOT in the headline below._');
-	out.push('');
-	for (const r of harnessErrors.slice().sort(byTask)) {
-		const where = r.failed_at ? ` — failed at \`${r.failed_at}\`` : '';
-		out.push(`- \`${r.task ?? '—'}/${r.template ?? '—'}\`: ${r.klass_reason ?? 'harness_error'}${where}`);
-	}
-	out.push('');
-}
-
-// ── Judge/test harness-error isolation note ──────────────────────────────────
-// Surfaced as SEPARATE signals so it's clear a judge failure left the verdict
-// and test_rate intact, and a missing test run only produced an `unknown`.
-const judgeErrs = dataCells.filter(judgeErr);
-const testErrs = dataCells.filter(testErr);
-if (judgeErrs.length > 0 || testErrs.length > 0) {
-	const parts = [];
-	if (judgeErrs.length > 0) {
-		parts.push(
-			`${judgeErrs.length} cell(s) had a **judge error** (composite uses the test rate only; verdict unaffected): ${judgeErrs
-				.map((r) => `\`${r.task}/${r.template}\``)
-				.join(', ')}`,
-		);
-	}
-	if (testErrs.length > 0) {
-		parts.push(
-			`${testErrs.length} cell(s) produced **no test results** (verdict \`unknown\`, excluded from the headline): ${testErrs
-				.map((r) => `\`${r.task}/${r.template}\``)
-				.join(', ')}`,
-		);
-	}
-	out.push(`> **Harness isolation:** ${parts.join('; ')}.`);
-	out.push('');
-}
-
-// Build this run's compact aggregate (per-cell composites + mean) up-front from
-// the shared scoring source of truth. The gate headline below reuses its
-// `mean_composite`, and the PR-vs-baseline overview (rendered at the TOP of the
-// run summary) diffs it against the baseline the job fetched from S3.
+// ── Aggregate + baseline diff ─────────────────────────────────────────────────
 const benchSha = (process.env.BENCH_SHA ?? '').trim();
 const baseSha = (process.env.BENCH_BASE_SHA ?? '').trim();
 const benchEvent = (process.env.BENCH_EVENT ?? '').trim();
@@ -227,115 +105,6 @@ const aggregate = buildAggregate(cells, {
 	generated_at: new Date().toISOString().replace(/\.\d{3}Z$/, 'Z'),
 });
 
-// ── Headline + optional gate over the composite mean (scored cells only) ──────
-const minScoreRaw = (process.env.BENCH_MIN_SCORE ?? '').trim();
-const min = Number(minScoreRaw);
-const gateEnabled = minScoreRaw !== '' && Number.isFinite(min);
-let gateFailed = false;
-
-if (minScoreRaw !== '' && !Number.isFinite(min)) {
-	out.push(`⚠️ \`BENCH_MIN_SCORE\` is set but not a number (\`${minScoreRaw}\`) — ignoring; not gating.`);
-}
-
-const judgeMean = judgeScoredCells.length
-	? judgeScoredCells.reduce((acc, r) => acc + r.judge_score, 0) / judgeScoredCells.length
-	: null;
-
-if (compositeCells.length === 0) {
-	// Distinguish "every cell was a harness error" from "no results at all" so a
-	// systemic infra failure reads differently from an empty run.
-	if (cells.length > 0 && harnessErrors.length === cells.length) {
-		out.push(`⚠️ All ${cells.length} cell(s) were harness_error — no composite to report (nothing was scored).`);
-	} else {
-		out.push('_No cells produced test results — no composite headline to report._');
-	}
-	if (gateEnabled) {
-		out.push(`(\`BENCH_MIN_SCORE=${min}\` is set, but with no scored cells the gate is skipped — conservative.)`);
-	}
-} else {
-	const compositeMean = aggregate.mean_composite;
-	const judgeNote = judgeMean !== null ? ` (judge mean **${judgeMean.toFixed(2)}**/10)` : '';
-	if (!gateEnabled) {
-		out.push(
-			`Mean composite **${compositeMean.toFixed(1)}**/100 ${compositeBand(compositeMean)} across ${compositeCells.length} scored cell(s)${judgeNote}. _Observational — \`BENCH_MIN_SCORE\` is unset, so it does not gate the merge._`,
-		);
-	} else {
-		const pass = compositeMean >= min;
-		gateFailed = !pass;
-		out.push(
-			`${pass ? '✅' : '❌'} Mean composite **${compositeMean.toFixed(1)}**/100 ${compositeBand(compositeMean)} across ${compositeCells.length} scored cell(s)${judgeNote} vs threshold **${min}** — ${pass ? 'pass' : 'FAIL'}.`,
-		);
-	}
-}
-
-// ── Raw per-dimension scores (collapsible; composite re-derivable from here) ──
-// Publishes each scored cell's per-dimension judge scores (capped, with the
-// pre-cap raw shown as `capped←raw` when a hard cap fired) alongside the
-// pass-rate and overall, so a reader can re-derive — or re-weight — the
-// composite without re-running anything. Dimension keys are read from the data
-// (they vary per task) rather than imported, since this .mjs runs under bare
-// `node` and can't import the .ts rubric.
-const dimsCell = (r) => {
-	const capped = r.judge_dimensions && typeof r.judge_dimensions === 'object' ? r.judge_dimensions : {};
-	const raw = r.judge_dimensions_raw && typeof r.judge_dimensions_raw === 'object' ? r.judge_dimensions_raw : {};
-	const keys = Object.keys(capped).length ? Object.keys(capped) : Object.keys(raw);
-	if (keys.length === 0) return '_none_';
-	return keys
-		.map((k) => {
-			const c = capped[k];
-			const rw = raw[k];
-			if (typeof c === 'number' && typeof rw === 'number' && c !== rw) return `${k} ${c}←${rw}`;
-			const v = typeof c === 'number' ? c : typeof rw === 'number' ? rw : '—';
-			return `${k} ${v}`;
-		})
-		.join('; ');
-};
-if (compositeCells.length > 0) {
-	out.push('');
-	out.push('<details>');
-	out.push('<summary>Raw per-dimension scores (judge dims shown <code>capped←raw</code> when a hard cap fired)</summary>');
-	out.push('');
-	out.push(
-		'Composite = `round(60·test_rate + 4·judge·min(1, 4·test_rate), 1)`. Judge dims are 0–10, averaged equally into the overall; objective caps (build/dev-server/scaffold) may lower a dim after the judge. Everything below the composite is re-derivable from these columns.',
-	);
-	out.push('');
-	out.push('| Task | Template | Pass-rate | Judge dims | Judge overall | Composite |');
-	out.push('|------|----------|-----------|------------|---------------|-----------|');
-	for (const r of compositeCells.slice().sort(byTask)) {
-		const { passed, denom } = testStats(r);
-		const rate = `${passed}/${denom} (${Math.round(testRate(testStats(r)) * 100)}%)`;
-		const overall =
-			typeof r.judge_score === 'number' ? r.judge_score.toFixed(2) : r.klass === 'agent_fail' ? '—' : 'err';
-		const compCell = (cellComposite(r) ?? 0).toFixed(1);
-		out.push(`| ${r.task} | ${r.template} | ${rate} | ${dimsCell(r)} | ${overall} | ${compCell} |`);
-	}
-	out.push('');
-	out.push('</details>');
-}
-
-// ── Footer: when the bench last ran + a deep-link back to the workflow run ────
-// Uses the default GitHub Actions env vars (always set inside a workflow step)
-// so the run summary shows the last-run time and links straight to these logs.
-// serverUrl / repoSlug / runId / logsUrl are hoisted above the table (the
-// artifacts pointer reuses them). The timestamp prefers GitHub's run start time
-// when exported, else falls back to render time (both UTC, ISO 8601).
-if (logsUrl) {
-	const lastRun = (process.env.GITHUB_RUN_STARTED_AT || new Date().toISOString()).replace(/\.\d{3}Z$/, 'Z');
-	out.push('');
-	out.push(`🕒 Last run: ${lastRun} · [run #${runId}](${logsUrl})`);
-}
-
-// ── PR-vs-baseline overview (rendered at the TOP of the run summary) ─────────
-// `aggregate` was built up-front (before the gate). It is diffed against the
-// baseline aggregate the job fetched from S3 for the PR's base commit, and is
-// also written to AGGREGATE_PATH so the job can persist it under
-// bench/runs/<sha>/results.json as the baseline a future PR (or this commit,
-// once merged to main) will diff against.
-// The baseline is whatever the job's "Fetch baseline" step downloaded (the
-// exact base commit's aggregate, or the latest-main fallback). It is ABSENT on
-// the first runs, on push-to-main (there's nothing earlier to diff), and when
-// the OIDC role can't read S3 — every one of those is a benign "no baseline",
-// never an error.
 let baseline = null;
 const baselinePath = process.env.BASELINE_PATH;
 if (baselinePath) {
@@ -347,34 +116,147 @@ if (baselinePath) {
 		}
 	}
 }
+const diff = diffAgainstBaseline(aggregate, baseline);
 
-const overviewLines = [];
-if (cells.length > 0) {
-	const diff = diffAgainstBaseline(aggregate, baseline);
-	let heading = '## Overview — PR vs baseline';
-	let note;
-	if (baseline) {
-		const baseLabel = baseline.sha ? `\`${String(baseline.sha).slice(0, 7)}\`` : 'the base commit';
-		// The fetch step falls back to latest-main when the exact base isn't
-		// benched; detect that by comparing the baseline's own sha to the PR base.
-		const exact =
-			baseline.sha && baseSha && (baseline.sha === baseSha || baseline.sha.startsWith(baseSha) || baseSha.startsWith(baseline.sha));
-		const src = exact ? `base ${baseLabel}` : `latest \`main\` ${baseLabel} (PR base not benched)`;
-		note = `Per-cell composite **delta** vs ${src}. ▲ better · ▼ worse · ≈ within ±5 (likely noise) · 🆕 new cell.`;
-	} else if (benchEvent === 'push') {
-		heading = '## Overview — baseline run';
-		note = `Baseline run (push to \`main\`): these composites are recorded as the baseline for \`${benchSha.slice(0, 7) || '(unknown)'}\`. No earlier baseline to diff against.`;
-	} else {
-		note = baseSha
-			? `_No baseline found for base \`${baseSha.slice(0, 7)}\` (and no latest-\`main\` baseline). Showing absolute composites — the PR-vs-baseline delta appears once a \`main\` bench run has stored one._`
-			: '_No baseline available. Showing absolute composites._';
+// ── Headline + optional gate over the composite mean (scored cells only) ──────
+const minScoreRaw = (process.env.BENCH_MIN_SCORE ?? '').trim();
+const min = Number(minScoreRaw);
+const gateEnabled = minScoreRaw !== '' && Number.isFinite(min);
+let gateFailed = false;
+
+const judgeMean = judgeScoredCells.length
+	? judgeScoredCells.reduce((acc, r) => acc + r.judge_score, 0) / judgeScoredCells.length
+	: null;
+
+// The deterministic headline line rendered under the Overview heading. (The
+// LLM-written executive summary is a SEPARATE section appended by analyze.mjs.)
+function headlineLine() {
+	if (compositeCells.length === 0) {
+		if (cells.length > 0 && harnessErrors.length === cells.length) {
+			return `⚠️ All ${cells.length} cell(s) were harness_error — nothing was scored, no composite headline.`;
+		}
+		const g = gateEnabled ? ` (\`BENCH_MIN_SCORE=${min}\` set, but with no scored cells the gate is skipped — conservative.)` : '';
+		return `_No cells produced test results — no composite headline to report._${g}`;
 	}
-	overviewLines.push(...renderOverview(diff, { heading, note }));
+	const mean = aggregate.mean_composite;
+	const judgeNote = judgeMean !== null ? ` · judge mean **${judgeMean.toFixed(2)}**/10` : '';
+	// Composite mean delta vs the baseline (▲/▼/≈ over the ±5 band), when present.
+	const deltaNote =
+		diff.hasBaseline && diff.meanDelta !== null
+			? ` · ${deltaArrow(diff.meanDelta)} ${diff.meanDelta > 0 ? '+' : ''}${diff.meanDelta.toFixed(1)} vs \`main\``
+			: '';
+	const head = `Mean composite **${mean.toFixed(1)}**/100 ${compositeBand(mean)} across ${compositeCells.length} scored cell(s)${judgeNote}${deltaNote}.`;
+	if (!gateEnabled) return `${head} _Observational — \`BENCH_MIN_SCORE\` unset, so it does not gate the merge._`;
+	const pass = mean >= min;
+	gateFailed = !pass;
+	return `${pass ? '✅' : '❌'} ${head} Threshold **${min}** — ${pass ? 'pass' : 'FAIL'}.`;
 }
 
-// Persist the aggregate so the job can archive it to S3 as the commit-keyed
-// baseline. Only when ≥1 cell produced a result, so an empty run never clobbers
-// a real baseline for this commit with an empty one.
+// ── Assemble the report ───────────────────────────────────────────────────────
+const md = [];
+
+// 1) Glossary & notes — collapsed, at the very top.
+const lastRun = (process.env.GITHUB_RUN_STARTED_AT || new Date().toISOString()).replace(/\.\d{3}Z$/, 'Z');
+md.push('<details>');
+md.push('<summary>📖 Glossary &amp; notes — scoring, colors, the ±5% margin (click to expand)</summary>');
+md.push('');
+md.push('- **N = 1** — one rep per cell, so a small delta may be model variance, not a real change; re-run for certainty.');
+md.push(
+	'- **Colors (vs baseline, per metric):** 🟢 same-or-better · 🟡 worse but within the margin · 🔴 worse beyond it · 🆕 no baseline value (new cell) · — nothing to diff this run · 🗑️ cell gone since the baseline.',
+);
+md.push(
+	'- **Margin = ±5%** (`MARGIN_PCT` in `overview.mjs`) — relative to the baseline value; for integer metrics (test counts, 0-10 judge dims) it is floored to 1, so a single-point nudge is 🟡, never 🔴. Edit that one constant to widen/narrow it.',
+);
+md.push('- **Directions:** tests ↑, judge ↑, score ↑ are better (higher = 🟢); cost ↓, tokens ↓ are better (lower = 🟢).');
+md.push(
+	'- **Composite (0-100)** = `round(60·test_rate + 4·judge·min(1, 4·test_rate), 1)` — 60% objective pass-rate + 40% judge, the judge term gated below a 25% pass-rate.',
+);
+md.push('- **Cost** = builder token spend at Bedrock Claude Sonnet rates ($3 in / $15 out per 1M tokens; `BUILDER_PRICING` in `scoring.mjs`).');
+md.push(
+	'- **SCORE = composite ÷ cost** — composite points per dollar (higher = better). Cost, not raw token volume, is the denominator, so tokens can\'t dominate; a broken (composite 0) cell scores 0 no matter how cheap. Flip `SCORE_PER_DOLLAR` in `scoring.mjs` for cost-per-point (lower = better).',
+);
+md.push(
+	'- **Baseline** = the most recent `main`-branch bench (`bench/runs/latest-main.json`), NOT the PR base commit — the PR always diffs against the current state of `main`.',
+);
+md.push(
+	'- **Excluded from the mean:** `harness_error` cells (infra failures) and gradeable cells that ran no tests. `agent_fail` (agent produced no app in budget) IS included, as composite 0.',
+);
+if (logsUrl) md.push(`- [Run artifacts — per-cell source + full agent traces](${logsUrl}) · 🕒 Last run: ${lastRun} · run #${runId}`);
+md.push('');
+md.push('</details>');
+md.push('');
+
+// 2) Overview — colors only.
+if (cells.length > 0) {
+	let heading = '## Overview — PR vs `main` baseline';
+	let note;
+	const legend = '🟢 better/equal · 🟡 worse within ±5% · 🔴 worse beyond · 🆕 new cell.';
+	const baseLabel = baseline?.sha ? `\`${String(baseline.sha).slice(0, 7)}\`` : 'the recorded baseline';
+	if (benchEvent === 'push') {
+		// A push-to-main run IS the new baseline; it diffs against the PREVIOUS
+		// main bench (fetched pre-persist), or shows absolute values if none.
+		heading = '## Overview — baseline run';
+		const rec = `Baseline run (push to \`main\`): recorded as the new \`main\` baseline for \`${benchSha.slice(0, 7) || '(unknown)'}\`.`;
+		note = baseline
+			? `${rec} Colored vs the PREVIOUS \`main\` baseline ${baseLabel}. ${legend}`
+			: `${rec} No earlier baseline to diff — absolute values (all 🆕).`;
+	} else if (baseline) {
+		note = `Each metric colored vs the latest \`main\` baseline ${baseLabel}. ${legend}`;
+	} else {
+		note = 'No `main` baseline recorded yet — showing absolute values (every metric 🆕). PR-vs-`main` deltas appear once a `main` bench has stored one.';
+	}
+	md.push(...renderOverview(diff, { heading, note }));
+	// Deterministic headline directly under the Overview.
+	md.push(headlineLine(), '');
+}
+
+// 3) Detailed results — numbers.
+if (cells.length > 0) {
+	md.push(...renderDetailed(diff, { heading: '## Detailed results', note: 'Same rows, colored `baseline -> pr`.' }));
+}
+
+// 4) Compact caveats (deterministic) — excluded / harness / judge-error cells.
+const caveats = [];
+if (harnessErrors.length > 0) {
+	const counts = {};
+	for (const r of harnessErrors) {
+		const reason = r.klass_reason ?? r.failed_at ?? 'unknown';
+		counts[reason] = (counts[reason] ?? 0) + 1;
+	}
+	const summary = Object.entries(counts)
+		.sort((a, b) => b[1] - a[1])
+		.map(([reason, n]) => `${n}× ${reason}`)
+		.join(', ');
+	caveats.push(
+		`- 🧰 **Excluded (harness_error, not scored)** — ${harnessErrors.length}: ${summary}. Cells: ${harnessErrors
+			.slice()
+			.sort(byTask)
+			.map(cellRef)
+			.join(', ')}`,
+	);
+}
+const judgeErrs = dataCells.filter(judgeErr);
+if (judgeErrs.length > 0) {
+	caveats.push(
+		`- ⚠️ **Judge error** (composite used the test-rate only; verdict intact) — ${judgeErrs.map(cellRef).join(', ')}`,
+	);
+}
+const testErrs = dataCells.filter(testErr);
+if (testErrs.length > 0) {
+	caveats.push(
+		`- ❔ **No test results** (verdict \`unknown\`, excluded from the headline) — ${testErrs.map(cellRef).join(', ')}`,
+	);
+}
+if (errorCells.length > 0) {
+	caveats.push(`- 🗂️ **Artifact unreadable** — ${errorCells.map((r) => `\`${r.task}\``).join(', ')}`);
+}
+if (caveats.length > 0) {
+	md.push('### Caveats & exclusions', '', ...caveats, '');
+}
+
+// ── Persist the aggregate (S3 baseline) + Athena NDJSON ───────────────────────
+// Only when ≥1 cell produced a result, so an empty run never clobbers a real
+// baseline for this commit with an empty one.
 if (process.env.AGGREGATE_PATH && cells.length > 0) {
 	try {
 		writeFileSync(process.env.AGGREGATE_PATH, `${JSON.stringify(aggregate, null, 2)}\n`);
@@ -383,58 +265,55 @@ if (process.env.AGGREGATE_PATH && cells.length > 0) {
 	}
 }
 
-// ── Athena NDJSON (one flat line per SCORED cell) ────────────────────────────
-// Emit a newline-delimited-JSON file the workflow uploads to a date-partitioned
-// Athena prefix (bench/athena/year=YYYY/month=MM/<sha-short>.json), so bench
-// history is queryable without parsing per-cell result.json blobs. One line per
-// scored cell (same inclusion rule as the headline mean); each line is a FLAT
-// record — no nested objects — so it maps cleanly to Athena columns. Best-effort:
-// warn and carry on if the write fails, never fail the summary job. The S3 upload
-// (and the partition key) live in the workflow step; here we only write the file.
+// One flat NDJSON line per SCORED cell for the date-partitioned Athena prefix,
+// so bench history (incl. cost + score-per-$) is queryable without parsing
+// per-cell result.json. Best-effort: warn and carry on, never fail the job.
 if (process.env.ATHENA_NDJSON_PATH) {
 	try {
 		const scored = dataCells.filter((c) => isScoredCell(c));
 		const ndjson = scored
-			.map((r) =>
-				JSON.stringify({
+			.map((r) => {
+				const comp = cellComposite(r) ?? 0;
+				const cost = cellCost(r);
+				return JSON.stringify({
 					sha: benchSha || null,
 					timestamp: aggregate.generated_at,
 					event: benchEvent || null,
 					pr_number: (process.env.PR_NUMBER ?? '').trim() || null,
 					task: r.task ?? null,
 					template: r.template ?? null,
-					composite: cellComposite(r) ?? 0,
+					composite: comp,
 					test_rate: Math.round(testRate(testStats(r)) * 1000) / 1000,
 					judge_score: typeof r.judge_score === 'number' ? r.judge_score : null,
 					verdict: verdictOf(r),
 					klass: r.klass ?? null,
 					tokens_in: typeof r.tokens_in === 'number' ? r.tokens_in : null,
 					tokens_out: typeof r.tokens_out === 'number' ? r.tokens_out : null,
+					cost,
+					score: scorePerDollar(comp, cost),
 					duration_sec: typeof r.duration_sec === 'number' ? r.duration_sec : null,
-				}),
-			)
+				});
+			})
 			.join('\n');
-		// Only write when there's at least one scored cell — an empty NDJSON file
-		// would upload a 0-row partition object for no reason.
 		if (scored.length > 0) writeFileSync(process.env.ATHENA_NDJSON_PATH, `${ndjson}\n`);
 	} catch (err) {
 		process.stderr.write(`[summary] failed to write Athena NDJSON to ${process.env.ATHENA_NDJSON_PATH}: ${err?.message ?? err}\n`);
 	}
 }
 
-// Overview first (at-a-glance), then the full scoreboard.
-const md = [...overviewLines, ...out].join('\n') + '\n';
+// ── Emit ──────────────────────────────────────────────────────────────────────
+const out = `${md.join('\n')}\n`;
 if (process.env.GITHUB_STEP_SUMMARY) {
 	// A >1MB step summary (GitHub's per-step limit) or any IO error here must NOT
 	// turn the check red — fall back to stdout so the summary is still visible.
 	try {
-		appendFileSync(process.env.GITHUB_STEP_SUMMARY, md);
+		appendFileSync(process.env.GITHUB_STEP_SUMMARY, out);
 	} catch (err) {
 		process.stderr.write(`[summary] failed to append GITHUB_STEP_SUMMARY (${err?.message ?? err}); writing to stdout instead\n`);
-		process.stdout.write(md);
+		process.stdout.write(out);
 	}
 } else {
-	process.stdout.write(md);
+	process.stdout.write(out);
 }
 
 if (gateFailed) {


### PR DESCRIPTION
## ⛔ Superseded by #171 — closed (not merged)

**This PR's changes were consolidated into #171 and this PR was closed without merging.** Nothing here is lost: the report redesign, the PR-vs-`main` baseline-selection fix, and the Judge-coloring fix were merged (normal `--no-ff`, no force-push) onto `#171`'s `fix/bench-throttling-retry` branch so a single PR carries **both** the throttling/retry + build-once work **and** this report/baseline/coloring work.

➡️ **Track the consolidated work in #171.**

_Original description below (for reference only)._

---

## What

Redesign the agent-bench PR-vs-`main` report and fix a baseline-selection bug. Bench-only CI tooling — **no published-package changes** (empty changeset).

## Why

The old report leaned on a single composite column + a raw per-dimension blurb and was hard to scan; it also had no cost/efficiency signal. More importantly, PR runs were diffing against the wrong baseline (see fix below), so deltas could be computed against a stale or never-benched commit.

## Baseline-selection fix (`.github/workflows/agent-bench.yml`)

The "Fetch baseline from S3 (best-effort)" step used to try `bench/runs/<pull_request.base.sha>/results.json` first. `pull_request.base.sha` is captured at PR-open / last-sync and **goes stale as `main` advances**, so the exact-sha lookup could silently diff against an outdated (or never-benched) commit.

- **PR / `workflow_dispatch`** → now **always** uses `latest-main.json` (the current `main` tip). No exact-base-sha lookup.
- **push to `main`** → uses `github.event.before` (the immediately preceding main commit) by exact sha, with `latest-main.json` as fallback. This is the only place a commit-keyed baseline is read.

## Report redesign

Two tables built from the same rows, rendered to `$GITHUB_STEP_SUMMARY` (never a PR comment):

1. **Overview** — colors only, no numbers: `TASK | TEMPLATE | TESTS | JUDGE | COST | TOKENS (in/out) | SCORE`.
2. **Detailed results** — the same rows widened with numbers (`baseline -> pr`), a multi-line per-dimension **judge** cell, and a **stop reason** column.

Plus: a collapsed **Glossary & notes** at the top (N=1, score formula, margin, color legend, pricing), a short **Executive summary** (paragraph + bullets), a **Potential issues** section (sourced from per-cell analysis), and a collapsed **Per-cell analysis** (each cell also collapsed).

Dropped: the build column, verdict, composite column, and the extra raw per-dimension score blurb.

### Coloring + score

- Per-metric color vs baseline: 🟢 same-or-better · 🟡 worse within margin · 🔴 worse beyond margin. Margin is a single tunable `MARGIN_PCT = 0.05` (±5% relative). Directions: tests↑ / judge↑ / score↑ better; cost↓ / tokens↓ better.
- New **SCORE = composite ÷ cost** ("composite points per dollar", higher = better). Cost is priced from builder tokens at Bedrock Claude Sonnet rates (`PRICING` / `cellCost` / `scorePerDollar` in `scoring.mjs`; one place to edit for pricing). Cost is `null` (never fake `$0`) when tokens are missing.

### Analysis pipeline

`analyze-cell.mjs` now emits a structured `{ analysis, analysis_issues[] }` per cell (`parseCellAnalysis` in `analysis.mjs`); `analyze.mjs` rolls these into the Executive summary + Potential issues + collapsed Per-cell analysis. Aggregate bumped to schema 2 (per-cell tokens / judge dims / tests / cost / score / stop_reason).

## Verification

- `tsc --noEmit` → clean (exit 0)
- `node --test steps/lib/*.test.mjs` → **114/114 pass** (overview + scoring + analysis + run-shell suites)
- Rendered the full report against a local fixture covering 🟢 improve / 🔴 regress / 🟡 within-margin / 🆕 new / 🗑️ removed / 🧰 harness-error cells and confirmed: glossary collapsed, Overview colors-only, Detailed numbers + multi-line judge + stop reason, executive-summary fallback, potential-issues section, per-cell analysis collapsed.

## Notes

- Do **not** merge — this is a review-only redesign PR; separate from #171 (`fix/bench-throttling-retry`).
- No `scripts/agent-bench/tasks/**/test.spec.ts` or scoring-band logic changed; framework behavior is unchanged.

