### PR TITLE
fix(ci): blocks-integrity compares HEAD vs PR base; skip paid bench on CI/doc-only PRs

### DIFF
--- a/.github/workflows/pr-agent-bench.yml
+++ b/.github/workflows/pr-agent-bench.yml
@@ -23,15 +23,16 @@ on:
   # agent-timeout lands in the run summary, not the check status. Fork PRs get
   # no secrets/OIDC under `pull_request` and are blocked by the same-repo `if`.
   #
-  # paths-ignore skips the (paid) bench when EVERY changed file is CI/docs-only
-  # (a PR touching any real code — packages/**, scripts/agent-bench/**, etc. —
-  # still benches, since paths-ignore only skips when ALL files match).
+  # paths-ignore skips the (paid) bench when EVERY changed file is agent-inert:
+  # .github/** (CI/workflow config) and .changeset/** (release metadata). Docs
+  # and markdown are NOT ignored — the bench grades an agent that reads framework
+  # docs (packages/**/*.md, guides), so a docs change may be made to improve agent
+  # outcomes and should be benchable. A PR touching any real code still benches,
+  # since paths-ignore only skips when ALL files match.
   pull_request:
     types: [opened, synchronize, reopened]
     paths-ignore:
       - '.github/**'
-      - '**/*.md'
-      - 'docs/**'
       - '.changeset/**'
   push:
     branches: [main]

--- a/.github/workflows/pr-agent-bench.yml
+++ b/.github/workflows/pr-agent-bench.yml
@@ -17,25 +17,32 @@ name: PR Agent Bench
 #   S3_BUCKET     variable  Registry bucket (existing).
 
 on:
-  # Runs on same-repo PR open/update AND on every push to main (a main run
-  # records the merged commit's baseline for later PRs to diff against). There
-  # is NO label gate: the bench is green-regardless — a failed cell /
-  # agent-timeout lands in the run summary, not the check status. Fork PRs get
-  # no secrets/OIDC under `pull_request` and are blocked by the same-repo `if`.
+  # Runs on same-repo PR open/update AND on push to main (a main run records the
+  # merged commit's baseline for later PRs to diff against). NO label gate: the
+  # bench is green-regardless — a failed cell / agent-timeout lands in the run
+  # summary, not the check status. Fork PRs get no secrets/OIDC under
+  # `pull_request` and are blocked by the same-repo `if`.
   #
-  # paths-ignore skips the (paid) bench when EVERY changed file is agent-inert:
-  # .github/** (CI/workflow config) and .changeset/** (release metadata). Docs
-  # and markdown are NOT ignored — the bench grades an agent that reads framework
-  # docs (packages/**/*.md, guides), so a docs change may be made to improve agent
-  # outcomes and should be benchable. A PR touching any real code still benches,
-  # since paths-ignore only skips when ALL files match.
+  # ALLOWLIST: the bench only runs when something the building/grading agent
+  # actually consumes changes — the framework (packages/**, incl. agent-facing
+  # packages/**/*.md), the bench harness (scripts/agent-bench/**), or the task
+  # prompts + graded specs (tasks/**). Everything else is skipped as agent-inert:
+  # .github/** (CI/workflow config), docs/** and root prose, .changeset/**.
+  # NOTE: the task↔template matrix is defined INLINE in agent-bench.yml (under
+  # .github/**, intentionally NOT allowlisted so CI edits stay $0) — changes to
+  # those inline cell defs won't auto-trigger; use workflow_dispatch to bench them.
   pull_request:
     types: [opened, synchronize, reopened]
-    paths-ignore:
-      - '.github/**'
-      - '.changeset/**'
+    paths:
+      - 'packages/**'
+      - 'scripts/agent-bench/**'
+      - 'tasks/**'
   push:
     branches: [main]
+    paths:
+      - 'packages/**'
+      - 'scripts/agent-bench/**'
+      - 'tasks/**'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/pr-agent-bench.yml
+++ b/.github/workflows/pr-agent-bench.yml
@@ -25,9 +25,12 @@ on:
   #
   # ALLOWLIST: the bench only runs when something the building/grading agent
   # actually consumes changes — the framework (packages/**, incl. agent-facing
-  # packages/**/*.md), the bench harness (scripts/agent-bench/**), or the task
-  # prompts + graded specs (tasks/**). Everything else is skipped as agent-inert:
-  # .github/** (CI/workflow config), docs/** and root prose, .changeset/**.
+  # packages/**/*.md), the bench harness (scripts/agent-bench/**), the task
+  # prompts + graded specs (tasks/**), or the root dependency manifests
+  # (package.json / package-lock.json — a transitive/dev-dep bump can shift what
+  # the agent builds against, so it's worth a bench). Everything else is skipped
+  # as agent-inert: .github/** (CI/workflow config), docs/** and root prose,
+  # .changeset/**.
   # NOTE: the task↔template matrix is defined INLINE in agent-bench.yml (under
   # .github/**, intentionally NOT allowlisted so CI edits stay $0) — changes to
   # those inline cell defs won't auto-trigger; use workflow_dispatch to bench them.
@@ -37,12 +40,16 @@ on:
       - 'packages/**'
       - 'scripts/agent-bench/**'
       - 'tasks/**'
+      - 'package.json'
+      - 'package-lock.json'
   push:
     branches: [main]
     paths:
       - 'packages/**'
       - 'scripts/agent-bench/**'
       - 'tasks/**'
+      - 'package.json'
+      - 'package-lock.json'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/pr-agent-bench.yml
+++ b/.github/workflows/pr-agent-bench.yml
@@ -17,14 +17,22 @@ name: PR Agent Bench
 #   S3_BUCKET     variable  Registry bucket (existing).
 
 on:
-  # Runs unconditionally on same-repo PR open/update AND on every push to main
-  # (a main run records the merged commit's baseline for later PRs to diff
-  # against). There is NO label gate: the bench is green-regardless — a failed
-  # cell / agent-timeout lands in the run summary, not the check status — so it
-  # is safe to run on every commit. Fork PRs get no secrets/OIDC under
-  # `pull_request` and are additionally blocked by the same-repo `if` below.
+  # Runs on same-repo PR open/update AND on every push to main (a main run
+  # records the merged commit's baseline for later PRs to diff against). There
+  # is NO label gate: the bench is green-regardless — a failed cell /
+  # agent-timeout lands in the run summary, not the check status. Fork PRs get
+  # no secrets/OIDC under `pull_request` and are blocked by the same-repo `if`.
+  #
+  # paths-ignore skips the (paid) bench when EVERY changed file is CI/docs-only
+  # (a PR touching any real code — packages/**, scripts/agent-bench/**, etc. —
+  # still benches, since paths-ignore only skips when ALL files match).
   pull_request:
     types: [opened, synchronize, reopened]
+    paths-ignore:
+      - '.github/**'
+      - '**/*.md'
+      - 'docs/**'
+      - '.changeset/**'
   push:
     branches: [main]
   workflow_dispatch:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -90,7 +90,9 @@ jobs:
             node scripts/sync-block-docs.mjs >/dev/null
             # --ignore-scripts intentionally packs source + synced docs, NOT a freshly built dist/ — this diffs shipped content, not the published build.
             ( cd packages/blocks && npm pack --ignore-scripts --pack-destination "$dest" >/dev/null 2>&1 )
-            shasum -a 512 "$dest"/*.tgz | awk '{print $1}'
+            set -- "$dest"/*.tgz
+            [ $# -eq 1 ] || { echo "expected exactly one .tgz in $dest, found $#" >&2; exit 1; }
+            shasum -a 512 "$1" | awk '{print $1}'
           }
 
           mkdir -p /tmp/head-pack
@@ -103,7 +105,9 @@ jobs:
             cd /tmp/blocks-base
             node scripts/sync-block-docs.mjs >/dev/null
             ( cd packages/blocks && npm pack --ignore-scripts --pack-destination /tmp/base-pack >/dev/null 2>&1 )
-            shasum -a 512 /tmp/base-pack/*.tgz | awk '{print $1}'
+            set -- /tmp/base-pack/*.tgz
+            [ $# -eq 1 ] || { echo "expected exactly one .tgz in /tmp/base-pack, found $#" >&2; exit 1; }
+            shasum -a 512 "$1" | awk '{print $1}'
           )
           git worktree remove --force /tmp/blocks-base
 

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -89,7 +89,7 @@ jobs:
             local dest="$1"
             node scripts/sync-block-docs.mjs >/dev/null
             # --ignore-scripts intentionally packs source + synced docs, NOT a freshly built dist/ — this diffs shipped content, not the published build.
-            ( cd packages/blocks && npm pack --ignore-scripts --pack-destination "$dest" >/dev/null 2>&1 )
+            ( cd packages/blocks && npm pack --ignore-scripts --pack-destination "$dest" >/dev/null )
             set -- "$dest"/*.tgz
             [ $# -eq 1 ] || { echo "expected exactly one .tgz in $dest, found $#" >&2; exit 1; }
             shasum -a 512 "$1" | awk '{print $1}'
@@ -99,12 +99,12 @@ jobs:
           HEAD_INTEGRITY=$(pack_blocks /tmp/head-pack)
 
           # BASE_SHA is present locally (checkout uses fetch-depth: 0).
-          git worktree add --detach /tmp/blocks-base "$BASE_SHA" >/dev/null 2>&1
+          git worktree add --detach /tmp/blocks-base "$BASE_SHA" >/dev/null
           mkdir -p /tmp/base-pack
           BASE_INTEGRITY=$(
             cd /tmp/blocks-base
             node scripts/sync-block-docs.mjs >/dev/null
-            ( cd packages/blocks && npm pack --ignore-scripts --pack-destination /tmp/base-pack >/dev/null 2>&1 )
+            ( cd packages/blocks && npm pack --ignore-scripts --pack-destination /tmp/base-pack >/dev/null )
             set -- /tmp/base-pack/*.tgz
             [ $# -eq 1 ] || { echo "expected exactly one .tgz in /tmp/base-pack, found $#" >&2; exit 1; }
             shasum -a 512 "$1" | awk '{print $1}'
@@ -114,6 +114,7 @@ jobs:
           echo "Head packed shasum: $HEAD_INTEGRITY"
           echo "Base packed shasum: $BASE_INTEGRITY"
 
+          # Relies on npm's reproducible packing (fixed mtimes); head & base pack on the same runner, so identical content ⇒ identical tarball hash.
           if [ "$HEAD_INTEGRITY" = "$BASE_INTEGRITY" ]; then
             echo "✅ @aws-blocks/blocks packaged content is unchanged vs the base branch — no version bump required."
             exit 0

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -88,6 +88,7 @@ jobs:
           pack_blocks() {
             local dest="$1"
             node scripts/sync-block-docs.mjs >/dev/null
+            # --ignore-scripts intentionally packs source + synced docs, NOT a freshly built dist/ — this diffs shipped content, not the published build.
             ( cd packages/blocks && npm pack --ignore-scripts --pack-destination "$dest" >/dev/null 2>&1 )
             shasum -a 512 "$dest"/*.tgz | awk '{print $1}'
           }

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -74,44 +74,56 @@ jobs:
       - name: Sync block docs (prebuild step)
         run: node scripts/sync-block-docs.mjs
 
-      - name: Check blocks package integrity
+      - name: Check blocks docs-sync integrity
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
-          cd packages/blocks
+          set -euo pipefail
 
-          # Pack the local package to get its shasum
-          LOCAL_TARBALL=$(npm pack --pack-destination /tmp 2>/dev/null)
-          LOCAL_INTEGRITY=$(shasum -a 512 "/tmp/$LOCAL_TARBALL" | awk '{print $1}')
+          # sync-block-docs.mjs regenerates packages/blocks/docs/ from sibling READMEs
+          # (docs/ is gitignored, built at publish time). We compare the packed
+          # @aws-blocks/blocks tarball at THIS PR's head against the PR base branch —
+          # like-for-like (same algo, same build state), so only a change introduced by
+          # THIS PR trips the check. A PR that doesn't alter what ships needs no bump.
+          pack_blocks() {
+            local dest="$1"
+            node scripts/sync-block-docs.mjs >/dev/null
+            ( cd packages/blocks && npm pack --ignore-scripts --pack-destination "$dest" >/dev/null 2>&1 )
+            shasum -a 512 "$dest"/*.tgz | awk '{print $1}'
+          }
 
-          # Get the current published version
-          VERSION=$(node -p "require('./package.json').version")
+          mkdir -p /tmp/head-pack
+          HEAD_INTEGRITY=$(pack_blocks /tmp/head-pack)
 
-          # Fetch the published integrity hash — if the version isn't published yet, skip
-          PUBLISHED_INTEGRITY=$(npm view "@aws-blocks/blocks@$VERSION" dist.shasum 2>/dev/null || echo "")
+          # BASE_SHA is present locally (checkout uses fetch-depth: 0).
+          git worktree add --detach /tmp/blocks-base "$BASE_SHA" >/dev/null 2>&1
+          mkdir -p /tmp/base-pack
+          BASE_INTEGRITY=$(
+            cd /tmp/blocks-base
+            node scripts/sync-block-docs.mjs >/dev/null
+            ( cd packages/blocks && npm pack --ignore-scripts --pack-destination /tmp/base-pack >/dev/null 2>&1 )
+            shasum -a 512 /tmp/base-pack/*.tgz | awk '{print $1}'
+          )
+          git worktree remove --force /tmp/blocks-base
 
-          if [ -z "$PUBLISHED_INTEGRITY" ]; then
-            echo "✅ Version $VERSION is not yet published on npm — nothing to compare."
+          echo "Head packed shasum: $HEAD_INTEGRITY"
+          echo "Base packed shasum: $BASE_INTEGRITY"
+
+          if [ "$HEAD_INTEGRITY" = "$BASE_INTEGRITY" ]; then
+            echo "✅ @aws-blocks/blocks packaged content is unchanged vs the base branch — no version bump required."
             exit 0
           fi
 
-          echo "Local shasum:     $LOCAL_INTEGRITY"
-          echo "Published shasum: $PUBLISHED_INTEGRITY"
-
-          if [ "$LOCAL_INTEGRITY" = "$PUBLISHED_INTEGRITY" ]; then
-            echo "✅ Package content matches the published version."
-            exit 0
-          fi
-
-          # Content differs — check if a changeset already bumps @aws-blocks/blocks
-          cd "$GITHUB_WORKSPACE"
-          CHANGESET_BUMPS=$(find .changeset -name '*.md' ! -name 'README.md' -exec grep -l '"@aws-blocks/blocks"' {} \;)
+          # Content changed vs base — require a changeset that bumps @aws-blocks/blocks.
+          CHANGESET_BUMPS=$(find .changeset -name '*.md' ! -name 'README.md' -exec grep -l '"@aws-blocks/blocks"' {} \; || true)
 
           if [ -n "$CHANGESET_BUMPS" ]; then
-            echo "✅ Package content changed but a changeset already bumps @aws-blocks/blocks:"
+            echo "✅ Packaged content changed and a changeset already bumps @aws-blocks/blocks:"
             echo "$CHANGESET_BUMPS"
             exit 0
           fi
 
-          echo "❌ The @aws-blocks/blocks package content has changed (synced docs from sibling packages), but no changeset bumps it. Add \"@aws-blocks/blocks\": patch to your changeset file."
+          echo "❌ This PR changes @aws-blocks/blocks packaged content (e.g. synced docs from sibling READMEs) vs the base branch, but no changeset bumps it. Add \"@aws-blocks/blocks\": patch to a changeset."
           exit 1
 
   build-and-test-local:


### PR DESCRIPTION
## What & why

Two `.github/`-only fixes that unblock the `Blocks Package Integrity` / `Build and Test` required checks for **every** PR that doesn't change published packages (including #171), and stop **agent-inert** PRs from burning a paid bench run.

### 1. `blocks-integrity` compared the wrong things (root cause)

The check in `.github/workflows/pr-checks.yml` (added in #186 by @iambipedal) had two defects that made it fail on essentially every PR:

- **Hash-algorithm mismatch:** it compared a local `shasum -a 512` (SHA-512, 128 hex chars) against `npm view … dist.shasum` (npm's `dist.shasum` is **SHA-1**, 40 hex chars). `[ "$LOCAL" = "$PUBLISHED" ]` can never be true for any published version.
- **Wrong baseline (design flaw):** it diffed the freshly-synced package against the **published** tarball. `packages/blocks/docs/` is gitignored and regenerated from sibling READMEs at publish time. Once *any* sibling README changed on `main` without republishing `@aws-blocks/blocks`, every later PR regenerates docs that differ from the frozen published version → fails, regardless of what the PR touches.

**Fix:** pack `@aws-blocks/blocks` at the PR **head** and at the PR **base branch** and compare like-for-like (same hash algorithm, same build state). The check now fails only when a PR *itself* changes the packaged content (e.g. via synced sibling docs) without a changeset bump, and passes for PRs that don't touch it — with **no version bump or release required**. The existing changeset escape-hatch (`"@aws-blocks/blocks": patch`) is preserved.

`npm pack --ignore-scripts` is intentional and now carries an inline note: it packs source + synced docs, **not** a freshly built `dist/`, so the check diffs *shipped content*, not the published build.

### 2. Bench only on agent-relevant changes (paths allowlist)

`.github/workflows/pr-agent-bench.yml` triggered the (paid, Bedrock) bench on every same-repo PR with no path filter. Replaced that with a **`paths:` allowlist** — the bench runs **only** when something the building/grading agent actually consumes changes:

```yaml
paths:
  - 'packages/**'          # the framework the agent builds against (incl. agent-facing packages/**/*.md)
  - 'scripts/agent-bench/**'  # the bench harness itself
  - 'tasks/**'             # task prompts + graded specs
```

Applied to **both** the `pull_request` trigger and the `push: main` trigger (a main run records the merged commit's baseline; doc/CI-only merges don't need a fresh paid baseline — the last code baseline stays valid, and PR-vs-baseline gracefully degrades to "no baseline", never an error).

Everything else is treated as **agent-inert** and skipped: `.github/**` (CI/workflow config), `docs/**` + root prose, `.changeset/**` (release metadata). Note this is an allowlist (`paths:`), not a denylist — the run fires when **at least one** changed file matches a pattern.

> ⚠️ **Caveat — inline cell matrix.** The task↔template matrix (the 10 bench cells) is defined **inline** in `.github/workflows/agent-bench.yml`, which lives under `.github/**` and is **intentionally not allowlisted** (so ordinary CI edits stay `$0`). Consequence: **editing the inline cell definitions** (adding/removing a task, changing a template) **won't auto-trigger the bench** — use **`workflow_dispatch`** to bench such a change. If we later want cell edits to auto-bench, the matrix would need to move into an allowlisted path (e.g. `tasks/**`).

This also makes *this* PR cost `$0`: it changes only `.github/**`, which matches none of the allowlist patterns, so for `pull_request` (GitHub evaluates the workflow file + paths filter from the PR head branch) the bench self-skips on every open/sync.

## Impact
- Unblocks #171 and every other PR that doesn't change `@aws-blocks/blocks` packaged content — no release needed.
- Still correctly requires a changeset when a PR really changes blocks packaged content.
- Bench now runs **only** on `packages/**`, `scripts/agent-bench/**`, or `tasks/**` changes — CI-config, docs, and changeset-only PRs no longer start a paid run.

## Validation (local + live)
- `npm pack` verified path-independent; HEAD-vs-BASE end-to-end run of the fixed step → identical shasum → exit 0 (green).
- Negative case: a simulated sibling-README change → differs from base → correctly fails without a changeset, passes with one.
- `changeset status` + `verify-changeset-coverage.ts` (Node 22) → pass (no changeset required; change is CI-only).
- Allowlist behavior (simulated): a PR touching `packages/**/README.md`, `scripts/agent-bench/**`, or `tasks/**` **would** bench; a PR touching only `.github/**`, `docs/**`, or root `*.md` **skips**.
- **Live: every push to this branch (only `.github/**`) self-skips the bench — confirmed no `PR Agent Bench` run on any push (`$0`).**

Root cause introduced in #186 (cc @iambipedal). No package release required.
