### PR TITLE
fix(core): preserve void RPC responses in verbose mode

### DIFF
--- a/.changeset/calm-rpcs-log.md
+++ b/.changeset/calm-rpcs-log.md
@@ -1,0 +1,5 @@
+---
+'@aws-blocks/core': patch
+---
+
+Prevent verbose local RPC logging from turning successful void handlers into error responses.

--- a/packages/core/src/redact.test.ts
+++ b/packages/core/src/redact.test.ts
@@ -205,6 +205,14 @@ describe('redactToJson', () => {
     assert.equal(redactToJson(undefined), 'undefined');
   });
 
+  it('returns a string for function values', () => {
+    assert.equal(redactToJson(() => {}), 'undefined');
+  });
+
+  it('returns a string for symbol values', () => {
+    assert.equal(redactToJson(Symbol('x')), 'undefined');
+  });
+
   it('does not leak secrets even when truncation would apply downstream', () => {
     const json = redactToJson([{ action: 'signIn', username: 'u', password: 'p'.repeat(50) }]);
     assert.ok(!json.includes('pppp'));

--- a/packages/core/src/redact.test.ts
+++ b/packages/core/src/redact.test.ts
@@ -201,6 +201,10 @@ describe('redactToJson', () => {
     assert.equal(redactToJson({ big: 10n }), '[unserializable]');
   });
 
+  it('returns a string for undefined', () => {
+    assert.equal(redactToJson(undefined), 'undefined');
+  });
+
   it('does not leak secrets even when truncation would apply downstream', () => {
     const json = redactToJson([{ action: 'signIn', username: 'u', password: 'p'.repeat(50) }]);
     assert.ok(!json.includes('pppp'));

--- a/packages/core/src/redact.ts
+++ b/packages/core/src/redact.ts
@@ -131,12 +131,13 @@ export function redactForLogging(value: unknown, seen: WeakSet<object> = new Wea
 
 /**
  * Convenience for log call sites: redact `value` and serialize it to a JSON
- * string. Returns a safe placeholder instead of throwing if serialization
- * fails (e.g. a BigInt slips through), so logging can never crash a request.
+ * string. Returns `'undefined'` when JSON serialization produces no output,
+ * or a safe placeholder if serialization throws (e.g. a BigInt slips through),
+ * so logging can never crash a request.
  */
 export function redactToJson(value: unknown): string {
   try {
-    return JSON.stringify(redactForLogging(value));
+    return JSON.stringify(redactForLogging(value)) ?? 'undefined';
   } catch {
     return '[unserializable]';
   }

--- a/packages/core/src/scripts/dev-server-rpc.test.ts
+++ b/packages/core/src/scripts/dev-server-rpc.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, describe, it } from 'node:test';
+import assert from 'node:assert';
+import { spawn, type ChildProcess } from 'node:child_process';
+import { createServer } from 'node:http';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+async function getAvailablePort(): Promise<number> {
+  const server = createServer();
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', resolve);
+  });
+  const address = server.address();
+  assert.ok(address && typeof address === 'object');
+  const { port } = address;
+  await new Promise<void>((resolve, reject) => server.close(error => error ? reject(error) : resolve()));
+  return port;
+}
+
+describe('dev-server RPC integration', () => {
+  let devProcess: ChildProcess | null = null;
+  let tempDir: string | null = null;
+
+  afterEach(async () => {
+    if (devProcess && devProcess.exitCode === null) {
+      devProcess.kill('SIGTERM');
+      await new Promise<void>((resolve) => {
+        const timeout = setTimeout(() => {
+          devProcess?.kill('SIGKILL');
+          resolve();
+        }, 2_000);
+        devProcess?.once('exit', () => {
+          clearTimeout(timeout);
+          resolve();
+        });
+      });
+    }
+    if (tempDir) rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('returns success for a void handler in verbose mode', async () => {
+    const port = await getAvailablePort();
+    tempDir = join(tmpdir(), `dev-rpc-test-${process.pid}-${Date.now()}`);
+    mkdirSync(tempDir, { recursive: true });
+    writeFileSync(join(tempDir, 'backend.ts'), `
+export const testApi = {
+  pingVoid: async () => undefined,
+};
+`);
+    writeFileSync(join(tempDir, 'preload.mjs'), `
+if (!process.loadEnvFile) {
+  process.loadEnvFile = () => { throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' }); };
+}
+`);
+    writeFileSync(join(tempDir, 'run-dev.ts'), `
+import { startDevServer } from '${join(__dirname, 'dev-server.js').replace(/\\/g, '/')}';
+startDevServer({ backendPath: '${join(tempDir, 'backend.ts').replace(/\\/g, '/')}', port: ${port} });
+`);
+
+    const tsxBin = join(__dirname, '..', '..', '..', '..', 'node_modules', '.bin', 'tsx');
+    devProcess = spawn(tsxBin, ['--import', join(tempDir, 'preload.mjs'), join(tempDir, 'run-dev.ts')], {
+      cwd: tempDir,
+      env: {
+        ...process.env,
+        AWS_BLOCKS_DISABLE_TELEMETRY: '1',
+        BLOCKS_DEV_QUIET: '',
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    let stdout = '';
+    let stderr = '';
+    devProcess.stdout?.on('data', chunk => { stdout += chunk.toString(); });
+    devProcess.stderr?.on('data', chunk => { stderr += chunk.toString(); });
+
+    const deadline = Date.now() + 15_000;
+    let response: Response | undefined;
+    let lastError: unknown;
+    while (!response && Date.now() < deadline) {
+      try {
+        response = await fetch(`http://127.0.0.1:${port}/aws-blocks/api`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ jsonrpc: '2.0', method: 'testApi.pingVoid', params: [], id: 1 }),
+        });
+      } catch (error) {
+        lastError = error;
+        await new Promise(resolve => setTimeout(resolve, 100));
+      }
+    }
+
+    assert.ok(response, `Dev server did not respond: ${String(lastError)}\nstdout: ${stdout}\nstderr: ${stderr}`);
+    assert.strictEqual(response.status, 200);
+    const payload = await response.json() as Record<string, unknown>;
+    assert.strictEqual(payload.jsonrpc, '2.0');
+    assert.strictEqual(payload.id, 1);
+    assert.ok(!('error' in payload), `Unexpected RPC error: ${JSON.stringify(payload.error)}`);
+
+    const logDeadline = Date.now() + 1_000;
+    while (!stdout.includes('[rpc-ok] testApi.pingVoid') && Date.now() < logDeadline) {
+      await new Promise(resolve => setTimeout(resolve, 25));
+    }
+    assert.ok(stdout.includes('[rpc-ok] testApi.pingVoid'), `Missing verbose success log. stdout: ${stdout}`);
+    assert.ok(!stdout.includes('[rpc-err]'), `Unexpected RPC error log. stdout: ${stdout}`);
+  });
+});

--- a/packages/core/src/scripts/dev-server-rpc.test.ts
+++ b/packages/core/src/scripts/dev-server-rpc.test.ts
@@ -18,6 +18,8 @@ async function getAvailablePort(): Promise<number> {
   const address = server.address();
   assert.ok(address && typeof address === 'object');
   const { port } = address;
+  // TOCTOU: brief window between closing this probe and the dev server binding
+  // the port; port: 0 would require the dev server to expose its assigned port.
   await new Promise<void>((resolve, reject) => server.close(error => error ? reject(error) : resolve()));
   return port;
 }
@@ -52,6 +54,7 @@ export const testApi = {
   pingVoid: async () => undefined,
 };
 `);
+    // Polyfill process.loadEnvFile for Node <20.6; ENOENT means no .env file.
     writeFileSync(join(tempDir, 'preload.mjs'), `
 if (!process.loadEnvFile) {
   process.loadEnvFile = () => { throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' }); };
@@ -68,6 +71,7 @@ startDevServer({ backendPath: '${join(tempDir, 'backend.ts').replace(/\\/g, '/')
       env: {
         ...process.env,
         AWS_BLOCKS_DISABLE_TELEMETRY: '1',
+        // Empty is falsy, keeping verbose logging on even if the parent sets quiet mode.
         BLOCKS_DEV_QUIET: '',
       },
       stdio: ['ignore', 'pipe', 'pipe'],


### PR DESCRIPTION
## Problem

In verbose local development mode, an RPC handler that successfully returns `void` is converted into a JSON-RPC error response. `redactToJson(undefined)` returns `undefined` at runtime despite its declared `string` return type, so the success logger throws while reading `.length` before the prepared success response is sent.

This is especially problematic for side-effect-only methods such as delete, send, or publish: the operation completes, but the client receives an error and may retry it.

Closes #187.

## Changes

- Make `redactToJson()` return the string `undefined` when `JSON.stringify()` produces no output, preserving its string return contract.
- Add focused unit coverage for `undefined`, function, and symbol serialization.
- Add an integration test that starts the verbose dev server, invokes a void RPC handler, and verifies a success response and `[rpc-ok]` log.
- Add a patch changeset for `@aws-blocks/core`.

## Validation

- Reproduced before the fix: the integration test received a JSON-RPC error with code `500` and `Cannot read properties of undefined (reading 'length')`.
- `npm ci`
- `npm run build:packages`
- `npm run build -w @aws-blocks/core`
- `node --test packages/core/dist/redact.test.js packages/core/dist/scripts/dev-server-rpc.test.js` (26 passed, 0 failed)
- `node --test --test-concurrency=1 dist/*.test.js dist/**/*.test.js` from `packages/core` (584 passed, 0 failed)
- `npm run lint`
- `npm run lint:deps`
- `npm run check:exports-consistency`
- `npm run check:api`
- `npx @changesets/cli status --since=origin/main`
- `npx tsx scripts/verify-changeset-coverage.ts`
- `git diff origin/main...HEAD --check`

## Checklist

- [x] PR description included
- [x] Tests are changed or added
- [ ] Relevant documentation is changed or added (not applicable; this fixes an internal logging failure without changing the public API)

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
