### PR TITLE
feat(bench): deep root-cause analysis pass on failing cells

### DIFF
--- a/.github/workflows/agent-bench.yml
+++ b/.github/workflows/agent-bench.yml
@@ -262,6 +262,11 @@ jobs:
           RESULT_PATH: /tmp/result.json
           TRACE: /tmp/trace.json
           METRICS: /tmp/metrics.json
+          # Deep-failure evidence, staged to stable /tmp paths by step "3. Build and test". Missing files
+          # degrade to null in analyze-cell.mjs (the deep pass simply has less to work with).
+          PW_RESULTS: /tmp/pw-results.json
+          DEV_LOG: /tmp/dev.log
+          BUILD_LOG: /tmp/build.log
           # BENCH_JUDGE_MODEL and AWS_REGION are inherited from the job-level env.
 
       - name: 5. Upload result

--- a/scripts/agent-bench/steps/3-build-and-test.sh
+++ b/scripts/agent-bench/steps/3-build-and-test.sh
@@ -253,6 +253,14 @@ else
   echo "::warning::Playwright produced no ${PW_RESULTS_JSON} (probably never ran); defaults retained"
 fi
 
+# Stage the deep-failure evidence to STABLE /tmp paths for the later "analyze cell" step. CELL_TMP is
+# keyed on this script's PID, so it's gone by the time analyze-cell.mjs runs — mirror how the
+# trace/metrics already land at /tmp. Best-effort: a missing source or copy failure must never break
+# the green-regardless exit (analyze-cell degrades to null when a file is absent).
+cp "$PW_RESULTS_JSON" /tmp/pw-results.json 2>/dev/null || true
+cp "${CELL_TMP}/dev.log" /tmp/dev.log 2>/dev/null || true
+cp "${CELL_TMP}/build.log" /tmp/build.log 2>/dev/null || true
+
 # Always exit 0: real failures are already captured as $GITHUB_OUTPUT signals for the judge, and a
 # non-zero exit would break green-regardless.
 exit 0

--- a/scripts/agent-bench/steps/analyze-cell.mjs
+++ b/scripts/agent-bench/steps/analyze-cell.mjs
@@ -1,15 +1,37 @@
 // Per-cell analysis: runs INSIDE each matrix cell right after the judge, colocated with that cell's
 // fresh trace/metrics. Reads this cell's result.json + trace.json + metrics.json, asks the judge model
 // (Opus 4.8) for a concise analysis, and writes it back as `analysis` + `analysis_issues[]`
-// (analyze.mjs rolls these up later). Additive & isolated: wrapped so it can NEVER throw (always exits
-// 0), only ADDS those two fields, and falls back to a benign string on any error. Runs under bare
+// (analyze.mjs rolls these up later). For cells that actually FAILED (see isFailureCell) it then runs
+// a second, DEEPER pass that ingests the quoted failing-test output + dev/build log tails and writes a
+// structured `failure_analysis` root cause. Additive & isolated: wrapped so it can NEVER throw (always
+// exits 0), only ADDS those fields, and falls back to a benign string on any error. Runs under bare
 // `node`: Node built-ins + AWS CLI via lib/analysis.mjs, no SDK.
 import { readFileSync, writeFileSync } from 'node:fs';
-import { CELL_MAX_TOKENS, CELL_SYSTEM, DEFAULT_MODEL_ID, FALLBACK_ANALYSIS, bedrockConverse, buildCellUserText, parseCellAnalysis } from './lib/analysis.mjs';
+import {
+	CELL_MAX_TOKENS,
+	CELL_SYSTEM,
+	DEFAULT_MODEL_ID,
+	FALLBACK_ANALYSIS,
+	FAILURE_MAX_TOKENS,
+	FAILURE_SYSTEM,
+	bedrockConverse,
+	buildCellUserText,
+	buildFailureUserText,
+	extractFailingTests,
+	isFailureCell,
+	parseCellAnalysis,
+	parseFailureAnalysis,
+	trimTrace,
+} from './lib/analysis.mjs';
 
 const RESULT_PATH = process.env.RESULT_PATH ?? '/tmp/result.json';
 const TRACE_PATH = process.env.TRACE ?? '/tmp/trace.json';
 const METRICS_PATH = process.env.METRICS ?? '/tmp/metrics.json';
+// Deep-failure evidence, staged to STABLE paths by 3-build-and-test.sh (its own CELL_TMP uses $$ and is
+// gone by the time this step runs). Missing files degrade to null — the deep pass simply has less data.
+const PW_RESULTS_PATH = process.env.PW_RESULTS ?? '/tmp/pw-results.json';
+const DEV_LOG_PATH = process.env.DEV_LOG ?? '/tmp/dev.log';
+const BUILD_LOG_PATH = process.env.BUILD_LOG ?? '/tmp/build.log';
 const MODEL_ID = process.env.BENCH_JUDGE_MODEL ?? DEFAULT_MODEL_ID;
 const REGION = process.env.AWS_REGION ?? 'us-east-1';
 
@@ -18,6 +40,14 @@ function readJson(path) {
 		return JSON.parse(readFileSync(path, 'utf-8'));
 	} catch {
 		return null;
+	}
+}
+
+function readText(path) {
+	try {
+		return readFileSync(path, 'utf-8');
+	} catch {
+		return '';
 	}
 }
 
@@ -61,6 +91,43 @@ function analyze(result, trace, metrics) {
 	return { analysis: parsed.analysis || FALLBACK_ANALYSIS, issues: parsed.issues };
 }
 
+// Deeper, structured root-cause pass — ONLY for failing cells. Reads the quoted failing tests + dev/
+// build log tails and asks the model for strict JSON. Returns a normalized object or null (no usable
+// diagnosis / model error / no evidence). Never throws — the caller also guards it.
+function analyzeFailure(result, trace) {
+	const failingTests = extractFailingTests(readJson(PW_RESULTS_PATH));
+	const buildFailed = result?.build_succeeded === false;
+	// If there's genuinely nothing to look at (no failing tests, no logs), skip the model call.
+	const devLogTail = readText(DEV_LOG_PATH);
+	const buildLogTail = buildFailed ? readText(BUILD_LOG_PATH) : '';
+	if (failingTests.totalFailing === 0 && !devLogTail && !buildLogTail) return null;
+
+	const userText = buildFailureUserText({
+		task: result?.task,
+		template: result?.template,
+		verdict: result?.verdict,
+		klass: result?.klass ?? null,
+		testsFailed: typeof result?.tests_failed === 'number' ? result.tests_failed : null,
+		testsTotal: typeof result?.tests_total === 'number' ? result.tests_total : null,
+		buildSucceeded: typeof result?.build_succeeded === 'boolean' ? result.build_succeeded : null,
+		devServerStarted: typeof result?.dev_server_started === 'boolean' ? result.dev_server_started : null,
+		judgeExplanation: result?.judge_explanation,
+		failingTests,
+		devLogTail,
+		buildLogTail,
+		traceTail: trace ? trimTrace(trace).tail : '',
+	});
+	const { text, error } = bedrockConverse({
+		system: FAILURE_SYSTEM,
+		userText,
+		modelId: MODEL_ID,
+		region: REGION,
+		maxTokens: FAILURE_MAX_TOKENS,
+	});
+	if (error) return null;
+	return parseFailureAnalysis(text);
+}
+
 function main() {
 	const result = readJson(RESULT_PATH);
 	if (!result || typeof result !== 'object') {
@@ -84,9 +151,26 @@ function main() {
 	// Add ONLY the analysis fields — never touch score/verdict/klass/etc.
 	result.analysis = analysis;
 	result.analysis_issues = issues;
+
+	// Deeper root-cause pass for failing cells only — passing/partial-clean cells stay on the cheap
+	// path above (no extra model call). Fully guarded: any error → no failure_analysis, cell unaffected.
+	if (isFailureCell(result)) {
+		try {
+			const fa = analyzeFailure(result, trace);
+			if (fa) {
+				result.failure_analysis = fa;
+				process.stderr.write(`[analyze-cell] deep failure analysis: category=${fa.category ?? '?'} owner=${fa.owner ?? '?'}\n`);
+			} else {
+				process.stderr.write('[analyze-cell] deep failure analysis produced no usable diagnosis (skipped/ignored)\n');
+			}
+		} catch (err) {
+			process.stderr.write(`[analyze-cell] deep failure analysis failed (ignored): ${err?.message ?? err}\n`);
+		}
+	}
+
 	try {
 		writeFileSync(RESULT_PATH, JSON.stringify(result, null, 2));
-		process.stderr.write(`[analyze-cell] wrote analysis (${analysis.length} chars, ${issues.length} issue(s)) to ${RESULT_PATH}\n`);
+		process.stderr.write(`[analyze-cell] wrote analysis (${analysis.length} chars, ${issues.length} issue(s)${result.failure_analysis ? ', +failure_analysis' : ''}) to ${RESULT_PATH}\n`);
 	} catch (err) {
 		process.stderr.write(`[analyze-cell] failed to write analysis to ${RESULT_PATH} (ignored): ${err?.message ?? err}\n`);
 	}

--- a/scripts/agent-bench/steps/analyze.mjs
+++ b/scripts/agent-bench/steps/analyze.mjs
@@ -83,19 +83,31 @@ function main() {
 			regressed: delta !== null && delta < REGRESSION_DELTA,
 			analysis: c.analysis || null,
 			issues: Array.isArray(c.analysis_issues) ? c.analysis_issues.filter((s) => typeof s === 'string' && s.trim()) : [],
+			failure_analysis: c.failure_analysis && typeof c.failure_analysis === 'object' ? c.failure_analysis : null,
 		};
 	});
 
 	// ── Executive summary: ONE best-effort Bedrock synthesis over the analyses ─
 	const execSummary = synthesize(aggregate, verdictCounts, rows);
 
+	// ── Failure root-cause: deterministic roll-up line + per-cell structured diagnosis ─
+	const failureRows = rows.filter((r) => r.failure_analysis);
+	const failureRollup = summarizeFailures(failureRows);
+
 	// ── Potential issues: deterministic flags + each cell's emitted issues ─────
 	const potential = collectPotentialIssues(rows);
 
-	// ── Render: Executive summary → Potential issues → collapsible per-cell ────
+	// ── Render: Executive summary → Failure root-cause → Potential issues → collapsible per-cell ────
 	const out = [];
 	out.push('## Executive summary', '');
+	if (failureRollup) out.push(failureRollup, '');
 	out.push(execSummary.text, '');
+
+	if (failureRows.length > 0) {
+		out.push('## 🔴 Failure root-cause', '');
+		out.push(`_Deep per-cell diagnosis of ${failureRows.length} failing cell(s) from quoted test/log evidence · model \`${MODEL_ID}\`._`, '');
+		for (const line of renderFailureAnalyses(failureRows)) out.push(line);
+	}
 
 	out.push('## ⚠️ Potential issues', '');
 	if (potential.length === 0) {
@@ -139,7 +151,69 @@ function main() {
 		executive_summary_error: execSummary.error ?? null,
 		potential_issues: potential,
 		cells: rows,
+		failure_analyses: failureRows.map((r) => ({ task: r.task, template: r.template, ...r.failure_analysis })),
 	});
+}
+
+// Badge per failure category (falls back to a generic marker for unknown categories).
+const FAILURE_CATEGORY_BADGE = {
+	build: '🏗️',
+	'dev-server': '🖥️',
+	'api-shape': '🔌',
+	auth: '🔑',
+	persistence: '💾',
+	timeout: '⏱️',
+	flake: '🎲',
+	'agent-logic': '🧠',
+};
+const MAX_EVIDENCE_CHARS = 500;
+
+function fdisp(v, fallback = '—') {
+	return typeof v === 'string' && v.trim() ? v.trim() : fallback;
+}
+
+// One deterministic sentence folding the structured failures by category + owner into the exec summary
+// (rendered even if the Bedrock roll-up call failed). Returns null when there are no structured failures.
+function summarizeFailures(failureRows) {
+	if (failureRows.length === 0) return null;
+	const byCat = new Map();
+	const byOwner = new Map();
+	for (const r of failureRows) {
+		const cat = fdisp(r.failure_analysis?.category, 'uncategorized');
+		const owner = fdisp(r.failure_analysis?.owner, 'unknown');
+		byCat.set(cat, (byCat.get(cat) ?? 0) + 1);
+		byOwner.set(owner, (byOwner.get(owner) ?? 0) + 1);
+	}
+	const catParts = [...byCat.entries()].sort((a, b) => b[1] - a[1]).map(([c, n]) => `${n} ${c}`);
+	const ownerParts = [...byOwner.entries()].sort((a, b) => b[1] - a[1]).map(([o, n]) => `${n} ${o}`);
+	const n = failureRows.length;
+	return `**${n} failing cell(s) diagnosed:** ${catParts.join(', ')} · owners: ${ownerParts.join(', ')}.`;
+}
+
+// Per-cell structured root-cause blocks. Each: category badge + owner header, root cause, quoted
+// evidence (as a blockquote, clipped), and likely fix. Defensive against missing fields.
+function renderFailureAnalyses(failureRows) {
+	const out = [];
+	for (const r of failureRows) {
+		const fa = r.failure_analysis ?? {};
+		const cat = fdisp(fa.category, 'uncategorized');
+		const badge = FAILURE_CATEGORY_BADGE[cat] ?? '🔴';
+		const owner = fdisp(fa.owner, 'unknown');
+		out.push(`### ${badge} \`${r.task}/${r.template}\` — ${cat} · owner: ${owner}`, '');
+		out.push(`- **Root cause:** ${fdisp(fa.root_cause)}`);
+		const evidence = fdisp(fa.evidence, '');
+		if (evidence) {
+			const clipped = (evidence.length > MAX_EVIDENCE_CHARS ? `${evidence.slice(0, MAX_EVIDENCE_CHARS)}…` : evidence)
+				.split('\n')
+				.map((l) => `  > ${l}`)
+				.join('\n');
+			out.push('- **Evidence:**');
+			out.push(clipped);
+		}
+		out.push(`- **Likely fix:** ${fdisp(fa.likely_fix)}`);
+		out.push('');
+	}
+	return out;
 }
 
 // Deterministic "Potential issues": harness/agent failures + low/regressed composites first, then

--- a/scripts/agent-bench/steps/lib/analysis.mjs
+++ b/scripts/agent-bench/steps/lib/analysis.mjs
@@ -245,6 +245,227 @@ export function buildRollupUserText(input) {
 	].join('\n');
 }
 
+// ---------------------------------------------------------------------------
+// DEEP FAILURE ANALYSIS — a second, richer pass that runs ONLY on failing cells
+// (see isFailureCell). Motivated by the shallow per-cell pass misdiagnosing an
+// auth-notes 0/11 as a "scoring/harness mismatch" because it never saw the
+// actual failing-test output. This pass ingests the quoted test failures + dev/
+// build logs and emits a STRUCTURED root cause. Best-effort: never gates a cell.
+// ---------------------------------------------------------------------------
+
+// Output budget for the deeper pass (a touch larger than CELL_MAX_TOKENS — it emits a small JSON object).
+export const FAILURE_MAX_TOKENS = 600;
+// Bound the failure evidence fed to the model so a log storm can't blow up the prompt.
+export const MAX_FAILING_TESTS = 8; // distinct error groups (after dedup)
+export const MAX_FAILURE_ERR_LEN = 300; // per grouped error line
+export const MAX_FAILURE_TITLES = 4; // example spec titles listed per error group
+export const MAX_LOG_TAIL_CHARS = 1500; // dev.log / build.log tail
+export const MAX_FAILURE_JUDGE_CHARS = 1500; // full-ish judge explanation (vs the 500 the cheap pass uses)
+
+// Closed vocabularies the model must pick from; parseFailureAnalysis coerces to these (unknowns → null).
+export const FAILURE_CATEGORIES = ['build', 'dev-server', 'api-shape', 'auth', 'persistence', 'timeout', 'flake', 'agent-logic'];
+export const FAILURE_OWNERS = ['agent', 'framework', 'harness'];
+
+/**
+ * Should this cell get the deep failure pass? True for any cell that actually failed at some layer:
+ * a fail verdict, an agent_fail, any failed test, or a build / dev-server that never came up. A clean
+ * pass / partial with all-green tests is left on the cheap path (no extra model call).
+ * @param {unknown} result parsed result.json
+ * @returns {boolean}
+ */
+export function isFailureCell(result) {
+	if (!result || typeof result !== 'object') return false;
+	const r = /** @type {Record<string, unknown>} */ (result);
+	if (r.verdict === 'fail') return true;
+	if (r.klass === 'agent_fail') return true;
+	if (typeof r.tests_failed === 'number' && r.tests_failed > 0) return true;
+	if (r.dev_server_started === false) return true;
+	if (r.build_succeeded === false) return true;
+	return false;
+}
+
+// Strip ANSI color codes Playwright embeds in error messages (they wreck dedup + waste chars).
+function stripAnsi(s) {
+	// eslint-disable-next-line no-control-regex
+	return typeof s === 'string' ? s.replace(/\u001b\[[0-9;]*m/g, '') : '';
+}
+
+// Collapse an error message to a single trimmed line, capped — the dedup key.
+function normalizeError(msg) {
+	return oneLine(stripAnsi(msg)).slice(0, MAX_FAILURE_ERR_LEN);
+}
+
+/**
+ * Pure parser for the Playwright JSON reporter output. Walks the (recursively nested) suites, finds
+ * FAILING specs, lifts each one's first error message, and DEDUPES by identical normalized error so a
+ * single root cause hitting all N specs collapses to one group (e.g. auth-notes' 11 identical
+ * `getByTestId('auth-username')` failures → one group, count 11). Never throws.
+ * @param {unknown} pwResults parsed pw-results.json (any shape) or null
+ * @returns {{totalFailing: number, groups: Array<{error: string, count: number, titles: string[]}>}}
+ */
+export function extractFailingTests(pwResults) {
+	const empty = { totalFailing: 0, groups: [] };
+	if (!pwResults || typeof pwResults !== 'object') return empty;
+	/** @type {Array<{title: string, error: string}>} */
+	const failing = [];
+
+	const firstError = (spec) => {
+		for (const t of spec?.tests ?? []) {
+			for (const res of t?.results ?? []) {
+				const status = res?.status;
+				if (status && status !== 'passed' && status !== 'skipped') {
+					const msg = res?.error?.message ?? (Array.isArray(res?.errors) ? res.errors[0]?.message : '') ?? '';
+					if (msg) return normalizeError(msg);
+				}
+			}
+		}
+		return '';
+	};
+
+	const walk = (suite, prefix) => {
+		if (!suite || typeof suite !== 'object') return;
+		const title = suite.title ? `${prefix}${prefix ? ' › ' : ''}${suite.title}` : prefix;
+		for (const spec of suite.specs ?? []) {
+			// A spec is failing when ok===false OR any of its tests has a non-passed result.
+			const anyBad = spec?.ok === false || (spec?.tests ?? []).some((t) => (t?.results ?? []).some((r) => r?.status && r.status !== 'passed' && r.status !== 'skipped'));
+			if (anyBad) {
+				failing.push({ title: oneLine(spec?.title) || '(untitled spec)', error: firstError(spec) || '(no error message captured)' });
+			}
+		}
+		for (const child of suite.suites ?? []) walk(child, title);
+	};
+
+	try {
+		for (const s of pwResults.suites ?? []) walk(s, '');
+	} catch {
+		return empty;
+	}
+
+	// Dedup by identical normalized error, preserving first-seen order.
+	/** @type {Map<string, {error: string, count: number, titles: string[]}>} */
+	const byError = new Map();
+	for (const f of failing) {
+		const g = byError.get(f.error);
+		if (g) {
+			g.count += 1;
+			if (g.titles.length < MAX_FAILURE_TITLES) g.titles.push(f.title);
+		} else {
+			byError.set(f.error, { error: f.error, count: 1, titles: [f.title] });
+		}
+	}
+	return { totalFailing: failing.length, groups: [...byError.values()].slice(0, MAX_FAILING_TESTS) };
+}
+
+// Deep-failure system prompt: force a single, evidence-grounded root cause as STRICT JSON.
+export const FAILURE_SYSTEM = `You are the failure triager for ONE benchmark cell where an AI coding agent built an app that then FAILED (tests failed, or the build / dev-server never came up). You are given the failing test names + their error messages, the dev-server log tail, the build log tail (if the build failed), the judge's notes on what was built, and the tool-call trace tail.
+
+Diagnose the SINGLE most likely root cause from the QUOTED evidence. Prefer one shared cause when many tests fail identically. Output ONLY a JSON object (no prose, no markdown fence) with EXACTLY these keys:
+{
+  "category": one of ["build","dev-server","api-shape","auth","persistence","timeout","flake","agent-logic"],
+  "single_root_cause": boolean (true if one cause explains all/most failures),
+  "root_cause": string (<=2 sentences; cite the decisive evidence),
+  "evidence": string (a quoted failing test name + its error line, or the decisive log line),
+  "likely_fix": string (<=1 sentence, concrete and actionable),
+  "owner": one of ["agent","framework","harness"] (who must fix it)
+}
+Base every field on the provided evidence — do not invent file names or errors you were not shown.`;
+
+/**
+ * Build the deep-failure prompt user text from a failing cell's data + logs. Pure.
+ * @param {{task?: string, template?: string, verdict?: string, klass?: string|null,
+ *   testsFailed?: number|null, testsTotal?: number|null, buildSucceeded?: boolean|null,
+ *   devServerStarted?: boolean|null, judgeExplanation?: string,
+ *   failingTests?: {totalFailing: number, groups: Array<{error: string, count: number, titles: string[]}>},
+ *   devLogTail?: string, buildLogTail?: string, traceTail?: string}} input
+ * @returns {string}
+ */
+export function buildFailureUserText(input) {
+	const ft = input.failingTests ?? { totalFailing: 0, groups: [] };
+	const testLines = ft.groups.length
+		? ft.groups.map((g) => {
+				const titles = g.titles.join(' | ');
+				return `- [${g.count}× ] ${titles}${g.count > g.titles.length ? ' (+more)' : ''}\n    ↳ ${g.error}`;
+			})
+		: ['(no failing-test detail captured)'];
+	const signals = [
+		input.verdict ? `verdict ${input.verdict}` : null,
+		input.klass ? `klass ${input.klass}` : null,
+		typeof input.testsFailed === 'number' ? `tests_failed ${input.testsFailed}${typeof input.testsTotal === 'number' ? `/${input.testsTotal}` : ''}` : null,
+		input.buildSucceeded === false ? 'build FAILED' : input.buildSucceeded === true ? 'build ok' : null,
+		input.devServerStarted === false ? 'dev-server DID NOT START' : input.devServerStarted === true ? 'dev-server ok' : null,
+	]
+		.filter(Boolean)
+		.join(', ');
+	const judge = oneLine(input.judgeExplanation).slice(0, MAX_FAILURE_JUDGE_CHARS);
+	const devTail = (input.devLogTail ?? '').slice(-MAX_LOG_TAIL_CHARS);
+	const buildTail = (input.buildLogTail ?? '').slice(-MAX_LOG_TAIL_CHARS);
+	return [
+		`Cell: ${input.task ?? '—'}/${input.template ?? '—'}`,
+		`Signals: ${signals || '(none)'}`,
+		`Failing tests (${ft.totalFailing} total, deduped by error):`,
+		...testLines,
+		'',
+		'Dev-server log tail:',
+		devTail || '(none)',
+		...(input.buildSucceeded === false ? ['', 'Build log tail:', buildTail || '(none)'] : []),
+		'',
+		judge ? `Judge notes (what was built): ${judge}` : 'Judge notes: (none)',
+		'',
+		'Trace tail:',
+		(input.traceTail ?? '').slice(-MAX_TAIL_CHARS) || '(no trace tail)',
+	].join('\n');
+}
+
+/**
+ * Tolerantly parse the deep-failure model output into a normalized object. Accepts a bare JSON object,
+ * a ```json fenced block, or JSON embedded in surrounding prose (first `{` … last `}`). Coerces
+ * category/owner to their closed vocabularies (unknown → null) and caps string lengths. Returns null
+ * on anything unusable. NEVER throws.
+ * @param {unknown} text raw model completion
+ * @returns {{category: string|null, single_root_cause: boolean|null, root_cause: string, evidence: string, likely_fix: string, owner: string|null}|null}
+ */
+export function parseFailureAnalysis(text) {
+	if (typeof text !== 'string' || !text.trim()) return null;
+	let raw = text.trim();
+	// Strip a ```json … ``` fence if present.
+	const fence = raw.match(/```(?:json)?\s*([\s\S]*?)```/i);
+	if (fence) raw = fence[1].trim();
+	let obj = null;
+	try {
+		obj = JSON.parse(raw);
+	} catch {
+		// Fall back to the first {...} span embedded in prose.
+		const start = raw.indexOf('{');
+		const end = raw.lastIndexOf('}');
+		if (start !== -1 && end > start) {
+			try {
+				obj = JSON.parse(raw.slice(start, end + 1));
+			} catch {
+				return null;
+			}
+		} else {
+			return null;
+		}
+	}
+	if (!obj || typeof obj !== 'object' || Array.isArray(obj)) return null;
+	const str = (v, cap) => (typeof v === 'string' ? oneLine(v).slice(0, cap) : '');
+	const category = FAILURE_CATEGORIES.includes(obj.category) ? obj.category : null;
+	const owner = FAILURE_OWNERS.includes(obj.owner) ? obj.owner : null;
+	const root_cause = str(obj.root_cause, 600);
+	const evidence = str(obj.evidence, 600);
+	const likely_fix = str(obj.likely_fix, 400);
+	// Require at least a category or a root_cause — otherwise the object carried nothing usable.
+	if (!category && !root_cause) return null;
+	return {
+		category,
+		single_root_cause: typeof obj.single_root_cause === 'boolean' ? obj.single_root_cause : null,
+		root_cause,
+		evidence,
+		likely_fix,
+		owner,
+	};
+}
+
 // Block synchronously between retries (bare-node, no async loop to yield to).
 function sleepSync(ms) {
 	try {

--- a/scripts/agent-bench/steps/lib/analysis.test.mjs
+++ b/scripts/agent-bench/steps/lib/analysis.test.mjs
@@ -7,14 +7,21 @@ import {
 	LOW_THRESHOLD,
 	MAX_CELL_ISSUES,
 	MAX_ERROR_LINES,
+	MAX_FAILING_TESTS,
+	MAX_FAILURE_ERR_LEN,
+	MAX_FAILURE_TITLES,
 	MAX_ISSUE_LEN,
 	MAX_TAIL_CHARS,
 	MAX_TOOL_NAMES,
 	REGRESSION_DELTA,
 	buildCellUserText,
+	buildFailureUserText,
 	buildRollupUserText,
+	extractFailingTests,
+	isFailureCell,
 	oneLine,
 	parseCellAnalysis,
+	parseFailureAnalysis,
 	summarizeMetrics,
 	trimTrace,
 } from './analysis.mjs';
@@ -214,5 +221,203 @@ describe('buildRollupUserText(input)', () => {
 		assert.match(text, /mean composite —\/100 over 0 scored cell/);
 		assert.match(text, /\(no per-cell analyses available\)/);
 		assert.match(text, /\(none\)/);
+	});
+});
+
+describe('isFailureCell(result)', () => {
+	it('triggers on a fail verdict', () => {
+		assert.equal(isFailureCell({ verdict: 'fail' }), true);
+	});
+	it('triggers on an agent_fail klass', () => {
+		assert.equal(isFailureCell({ verdict: 'partial', klass: 'agent_fail' }), true);
+	});
+	it('triggers on any failed test', () => {
+		assert.equal(isFailureCell({ verdict: 'partial', tests_failed: 1 }), true);
+	});
+	it('triggers when the dev-server did not start', () => {
+		assert.equal(isFailureCell({ verdict: 'pass', dev_server_started: false }), true);
+	});
+	it('triggers when the build failed', () => {
+		assert.equal(isFailureCell({ verdict: 'pass', build_succeeded: false }), true);
+	});
+	it('does NOT trigger on a clean pass', () => {
+		assert.equal(isFailureCell({ verdict: 'pass', klass: null, tests_failed: 0, dev_server_started: true, build_succeeded: true }), false);
+	});
+	it('does NOT trigger on a partial with all-green tests', () => {
+		assert.equal(isFailureCell({ verdict: 'partial', tests_failed: 0, dev_server_started: true, build_succeeded: true }), false);
+	});
+	it('is null-safe', () => {
+		assert.equal(isFailureCell(null), false);
+		assert.equal(isFailureCell(undefined), false);
+		assert.equal(isFailureCell('nope'), false);
+		assert.equal(isFailureCell(42), false);
+	});
+});
+
+describe('extractFailingTests(pwResults)', () => {
+	// Build a Playwright JSON report with `n` specs that all fail with the SAME error, plus optional extras.
+	function pwReport(specs) {
+		return { suites: [{ title: 'auth', specs }] };
+	}
+	function failSpec(title, message) {
+		return { title, ok: false, tests: [{ results: [{ status: 'unexpected', error: { message } }] }] };
+	}
+	function passSpec(title) {
+		return { title, ok: true, tests: [{ results: [{ status: 'passed' }] }] };
+	}
+
+	it('dedupes N identical errors into ONE group with the right count', () => {
+		const specs = [];
+		for (let i = 0; i < 11; i++) specs.push(failSpec(`shows username ${i}`, "getByTestId('auth-username') not visible"));
+		const out = extractFailingTests(pwReport(specs));
+		assert.equal(out.totalFailing, 11);
+		assert.equal(out.groups.length, 1);
+		assert.equal(out.groups[0].count, 11);
+		assert.match(out.groups[0].error, /auth-username/);
+		// only a bounded number of example titles are retained
+		assert.ok(out.groups[0].titles.length <= MAX_FAILURE_TITLES);
+	});
+
+	it('separates distinct errors and caps distinct groups', () => {
+		const specs = [];
+		for (let i = 0; i < MAX_FAILING_TESTS + 5; i++) specs.push(failSpec(`spec ${i}`, `distinct error number ${i}`));
+		const out = extractFailingTests(pwReport(specs));
+		assert.equal(out.totalFailing, MAX_FAILING_TESTS + 5);
+		assert.equal(out.groups.length, MAX_FAILING_TESTS); // capped
+	});
+
+	it('ignores passed and skipped specs', () => {
+		const specs = [passSpec('ok one'), failSpec('bad one', 'boom'), { title: 'skipped one', ok: true, tests: [{ results: [{ status: 'skipped' }] }] }];
+		const out = extractFailingTests(pwReport(specs));
+		assert.equal(out.totalFailing, 1);
+		assert.equal(out.groups[0].titles[0], 'bad one');
+	});
+
+	it('caps each error line length', () => {
+		const long = 'x'.repeat(MAX_FAILURE_ERR_LEN + 200);
+		const out = extractFailingTests(pwReport([failSpec('long err', long)]));
+		assert.ok(out.groups[0].error.length <= MAX_FAILURE_ERR_LEN);
+	});
+
+	it('walks nested suites', () => {
+		const nested = { suites: [{ title: 'outer', suites: [{ title: 'inner', specs: [failSpec('deep fail', 'nested boom')] }] }] };
+		const out = extractFailingTests(nested);
+		assert.equal(out.totalFailing, 1);
+		assert.match(out.groups[0].error, /nested boom/);
+	});
+
+	it('is null/shape-safe', () => {
+		assert.deepEqual(extractFailingTests(null), { totalFailing: 0, groups: [] });
+		assert.deepEqual(extractFailingTests(undefined), { totalFailing: 0, groups: [] });
+		assert.deepEqual(extractFailingTests('nope'), { totalFailing: 0, groups: [] });
+		assert.deepEqual(extractFailingTests({}), { totalFailing: 0, groups: [] });
+		assert.deepEqual(extractFailingTests({ suites: 'bad' }), { totalFailing: 0, groups: [] });
+	});
+});
+
+describe('buildFailureUserText(input)', () => {
+	it('includes signals, deduped failing tests, and log tails', () => {
+		const text = buildFailureUserText({
+			task: 'auth-notes',
+			template: 'demo',
+			verdict: 'fail',
+			klass: null,
+			testsFailed: 11,
+			testsTotal: 11,
+			buildSucceeded: true,
+			devServerStarted: true,
+			judgeExplanation: 'App built but never rendered the sign-in form.',
+			failingTests: { totalFailing: 11, groups: [{ error: "getByTestId('auth-username') not visible", count: 11, titles: ['a', 'b'] }] },
+			devLogTail: 'listening on 3000\nhydrating…',
+			buildLogTail: '',
+			traceTail: '{"tool":"str_replace"}',
+		});
+		assert.match(text, /Cell: auth-notes\/demo/);
+		assert.match(text, /verdict fail/);
+		assert.match(text, /tests_failed 11\/11/);
+		assert.match(text, /\[11× \]/);
+		assert.match(text, /auth-username/);
+		assert.match(text, /Dev-server log tail:/);
+		assert.match(text, /Judge notes \(what was built\): App built/);
+	});
+
+	it('includes the build log tail ONLY when the build failed', () => {
+		const withBuild = buildFailureUserText({ task: 't', template: 'x', buildSucceeded: false, buildLogTail: 'tsc error TS2304', failingTests: { totalFailing: 0, groups: [] } });
+		assert.match(withBuild, /Build log tail:/);
+		assert.match(withBuild, /tsc error TS2304/);
+		const noBuild = buildFailureUserText({ task: 't', template: 'x', buildSucceeded: true, buildLogTail: 'should not appear', failingTests: { totalFailing: 0, groups: [] } });
+		assert.doesNotMatch(noBuild, /Build log tail:/);
+		assert.doesNotMatch(noBuild, /should not appear/);
+	});
+
+	it('caps the log tails and judge explanation', () => {
+		const big = 'y'.repeat(5000);
+		const text = buildFailureUserText({ task: 't', template: 'x', buildSucceeded: false, judgeExplanation: big, devLogTail: big, buildLogTail: big, failingTests: { totalFailing: 0, groups: [] } });
+		// Prompt must stay bounded — nowhere near the 5000-char raw inputs ×3.
+		assert.ok(text.length < 6000, `expected bounded prompt, got ${text.length}`);
+	});
+
+	it('degrades gracefully with no failing-test detail', () => {
+		const text = buildFailureUserText({ task: 't', template: 'x' });
+		assert.match(text, /\(no failing-test detail captured\)/);
+		assert.match(text, /Signals: \(none\)/);
+	});
+});
+
+describe('parseFailureAnalysis(text)', () => {
+	const valid = JSON.stringify({
+		category: 'agent-logic',
+		single_root_cause: true,
+		root_cause: 'No initial render; UI only paints on onAuthChange which never fires synchronously.',
+		evidence: "getByTestId('auth-username') not visible (×11)",
+		likely_fix: 'Call renderSignedOut() at module scope on load.',
+		owner: 'agent',
+	});
+
+	it('parses a bare JSON object', () => {
+		const out = parseFailureAnalysis(valid);
+		assert.equal(out.category, 'agent-logic');
+		assert.equal(out.owner, 'agent');
+		assert.equal(out.single_root_cause, true);
+		assert.match(out.root_cause, /No initial render/);
+		assert.match(out.evidence, /auth-username/);
+		assert.match(out.likely_fix, /renderSignedOut/);
+	});
+
+	it('parses JSON wrapped in prose', () => {
+		const out = parseFailureAnalysis(`Here is my diagnosis:\n${valid}\nHope that helps.`);
+		assert.equal(out.category, 'agent-logic');
+		assert.equal(out.owner, 'agent');
+	});
+
+	it('parses a ```json fenced block', () => {
+		const out = parseFailureAnalysis('```json\n' + valid + '\n```');
+		assert.equal(out.category, 'agent-logic');
+	});
+
+	it('coerces unknown category/owner to null', () => {
+		const out = parseFailureAnalysis(JSON.stringify({ category: 'quantum', owner: 'aliens', root_cause: 'x' }));
+		assert.equal(out.category, null);
+		assert.equal(out.owner, null);
+		assert.equal(out.root_cause, 'x');
+	});
+
+	it('returns null on malformed JSON', () => {
+		assert.equal(parseFailureAnalysis('{not valid json at all'), null);
+		assert.equal(parseFailureAnalysis('just some prose, no braces'), null);
+	});
+
+	it('returns null when the object carries nothing usable', () => {
+		assert.equal(parseFailureAnalysis(JSON.stringify({ single_root_cause: true })), null);
+		assert.equal(parseFailureAnalysis(JSON.stringify({ category: 'nonsense' })), null);
+	});
+
+	it('is null-safe and never throws on junk input', () => {
+		assert.equal(parseFailureAnalysis(null), null);
+		assert.equal(parseFailureAnalysis(undefined), null);
+		assert.equal(parseFailureAnalysis(''), null);
+		assert.equal(parseFailureAnalysis('   '), null);
+		assert.equal(parseFailureAnalysis(42), null);
+		assert.equal(parseFailureAnalysis(JSON.stringify(['array', 'not', 'object'])), null);
 	});
 });


### PR DESCRIPTION
## What

Adds a **deep root-cause analysis pass that fires only on failing bench cells**. Passing / clean-partial cells stay on the existing cheap per-cell analysis path (no extra model call).

Motivated by the `auth-notes/demo` run (0/11 tests) that the existing per-cell analysis misdiagnosed as a "scoring/harness mismatch" — because it never saw the failing test output. The real cause was a broken initial-render bootstrap in the agent's app. This change feeds the actual failing-test evidence + log tails to the judge model so it can name the true root cause.

## How

- **`steps/lib/analysis.mjs`** (pure, unit-tested):
  - `isFailureCell(result)` — trigger predicate (`verdict==='fail'` OR `klass==='agent_fail'` OR `tests_failed>0` OR `dev_server_started===false` OR `build_succeeded===false`).
  - `extractFailingTests(pwResults)` — walks the (nested) Playwright JSON report, lifts each failing spec's first error, **dedupes identical errors** (so 11 identical `getByTestId('auth-username')` failures collapse to one group with `count: 11`), caps distinct groups (8) and error length (300 chars). Never throws.
  - `FAILURE_SYSTEM` — prompt: diagnose the single most likely root cause from quoted evidence, output strict JSON.
  - `buildFailureUserText()` — assembles failing tests + dev.log tail (≤1500) + build.log tail (≤1500, only when the build failed) + judge explanation (≤1500) + trace tail.
  - `parseFailureAnalysis()` — tolerant parser (bare JSON / ```json fence / JSON embedded in prose → object; malformed → `null`; **never throws**). Coerces `category`/`owner` to closed vocabularies.
  - `FAILURE_MAX_TOKENS = 600`.
- **`steps/analyze-cell.mjs`** — after the existing cheap analysis, `if (isFailureCell(result))` reads the staged evidence, calls the same Bedrock `converse` path (reuses `BENCH_JUDGE_MODEL`, Opus 4.8), and writes `result.failure_analysis`. Fully inside the existing never-throw / always-exit-0 isolation.
- **`steps/3-build-and-test.sh`** — copies `pw-results.json` / `dev.log` / `build.log` to **stable** `/tmp` paths (the per-step `CELL_TMP` uses `$$` and is gone by the analyze step — mirrors how `/tmp/trace.json` is already staged). Best-effort (`|| true`), never fails the build step.
- **`.github/workflows/agent-bench.yml`** — passes `PW_RESULTS` / `DEV_LOG` / `BUILD_LOG` env into the "4b. Analyze cell" step.
- **`steps/analyze.mjs`** — renders a `## 🔴 Failure root-cause` section (per failed cell: category badge, owner, root cause, quoted evidence blockquote, likely fix) and folds category/owner counts into the exec summary (e.g. "1 failing cell(s) diagnosed: 1 agent-logic · owners: 1 agent").
- **`steps/lib/analysis.test.mjs`** — unit tests for `isFailureCell` (each trigger + null-safety), `extractFailingTests` (dedup + cap + nested suites + shape-safety), `buildFailureUserText` (bounding, build-log gating), `parseFailureAnalysis` (valid / prose-wrapped / fenced / malformed / null-safe). No live Bedrock.

## Token bounding

The deep pass fires only on the ≈0–3 failing cells per run; input is capped (≤8 test groups × 300 + 2 × 1500 log tails + 1500 judge + trace tail) and output is ≤600 tokens. Passing/partial-clean cells are untouched (same cheap 420-token path).

## Validation

- `tsc --noEmit` clean.
- `node --test` green — 199 tests, 195 pass, 0 fail, 4 skipped (pre-existing).
- `bash -n 3-build-and-test.sh` OK; `agent-bench.yml` YAML parses.
- End-to-end smoke (real Bedrock, synthetic failing cell): `analyze-cell.mjs` correctly deduped 11→1, quoted the failing test as evidence, diagnosed `agent-logic` / owner `agent`, exit 0. `analyze.mjs` rendered the new section and fold-in line, excluded the passing cell, exit 0.
- Confirmed: the deep pass can **never** fail a cell (guarded, always exit 0) and passing cells are unaffected.
