### PR TITLE
feat(bb-distributed-data): atomic Counter primitive for DSQL

### DIFF
--- a/.changeset/atomic-counter-primitive.md
+++ b/.changeset/atomic-counter-primitive.md
@@ -1,0 +1,5 @@
+---
+"@aws-blocks/bb-distributed-data": minor
+---
+
+Add an atomic `Counter` primitive to `DistributedDatabase`. `db.counter(name).next()` returns a race-free monotonic sequence value (with `.current()` and `.reset()`), backed by a single `INSERT ... ON CONFLICT DO UPDATE ... RETURNING` upsert against a framework-managed `_blocks_counters` table (created automatically on deploy). This replaces the racy `SELECT MAX(seq) + 1` read-modify-write pattern that DSQL otherwise forces, since it has no sequences (`SERIAL` / `BIGSERIAL`).

--- a/packages/bb-distributed-data/API.md
+++ b/packages/bb-distributed-data/API.md
@@ -6,6 +6,7 @@
 
 import type { ChildLogger } from '@aws-blocks/bb-logger';
 import { createKyselyAdapter } from '@aws-blocks/data-common';
+import type { DatabaseBase } from '@aws-blocks/data-common';
 import { DatabaseEngine } from '@aws-blocks/data-common';
 import { Scope } from '@aws-blocks/core';
 import type { ScopeParent } from '@aws-blocks/core';
@@ -13,11 +14,21 @@ import { sql } from '@aws-blocks/data-common';
 import { SqlQuery } from '@aws-blocks/data-common';
 import { Transaction } from '@aws-blocks/data-common';
 
+// @public
+export class Counter {
+    // @internal
+    constructor(resolveBase: () => Promise<DatabaseBase>, name: string);
+    current(): Promise<number>;
+    next(delta?: number): Promise<number>;
+    reset(value?: number): Promise<void>;
+}
+
 export { createKyselyAdapter }
 
 // @public (undocumented)
 export class DistributedDatabase extends Scope {
     constructor(scope: ScopeParent, id: string, _options?: DistributedDatabaseOptions);
+    counter(name: string): Counter;
     // (undocumented)
     execute(query: SqlQuery): Promise<{
         rowCount: number;

--- a/packages/bb-distributed-data/DESIGN.md
+++ b/packages/bb-distributed-data/DESIGN.md
@@ -120,6 +120,28 @@ async transaction<T>(fn, options?) {
 
 Default: no retry (honest, predictable). `retryOnConflict: true` is explicit opt-in with JSDoc warning about side effects.
 
+## Atomic Counters
+
+DSQL has no sequences (`SERIAL` / `BIGSERIAL` are rejected by the validator), so code that needs a monotonic sequence number is otherwise pushed into a racy `SELECT MAX(seq) + 1` read-modify-write: two concurrent callers read the same maximum and both write the same next value, producing duplicate or skipped numbers.
+
+`db.counter(name)` replaces that pattern with a single atomic upsert against a framework-managed table:
+
+```sql
+CREATE TABLE IF NOT EXISTS _blocks_counters (name TEXT PRIMARY KEY, value BIGINT NOT NULL DEFAULT 0);
+
+-- Counter.next(delta) — atomic read-and-increment in one statement:
+INSERT INTO _blocks_counters (name, value) VALUES ($name, $delta)
+  ON CONFLICT (name) DO UPDATE SET value = _blocks_counters.value + $delta
+  RETURNING value;
+```
+
+- **Atomicity** — the increment is one `INSERT ... ON CONFLICT DO UPDATE ... RETURNING` statement, so there is no read-then-write window for a competing writer. It runs inside `transaction({ retryOnConflict: true })` so a DSQL OCC conflict on the row retries transparently.
+- **Managed table** — `_blocks_counters` is created by the migration Lambda (admin) on every deploy, like `_migrations`. The app runtime is DML-only and never issues the DDL. Because the table is admin-owned and not named `_migrations`, `provisionAppRole` automatically grants the app role `SELECT/INSERT/UPDATE/DELETE` on it.
+- **Mock parity** — `DsqlMockEngine` creates the same table inside its `withDdl` init window, so `db.counter()` behaves identically against PGlite locally.
+- **Range** — values are stored as `BIGINT` and returned as `number` (exact up to 2^53 − 1).
+
+API: `Counter.next(delta = 1)`, `Counter.current()`, `Counter.reset(value = 0)`.
+
 ## Error Translation
 
 Happens in the engine layer (same pattern as bb-data engines):
@@ -155,6 +177,7 @@ The `DistributedDatabase` class does not wrap errors — engines handle translat
 - Retries with exponential backoff on transient connection errors (cluster may take a moment after creation)
 - `.sql` files bundled into the Lambda package via CDK `commandHooks`
 - `migrationsHash` property triggers re-invocation when files change
+- **Ensures the `_blocks_counters` table** exists (see [Atomic Counters](#atomic-counters)) — created here as admin so the DML grants below cover it
 - **Provisions custom DB role** on every deploy (idempotent):
   1. `CREATE ROLE "app_role" WITH LOGIN` (if not exists)
   2. `AWS IAM GRANT "app_role" TO 'arn:aws:iam::...:role/...'` (maps IAM to DB role)

--- a/packages/bb-distributed-data/README.md
+++ b/packages/bb-distributed-data/README.md
@@ -61,6 +61,25 @@ interface TransactionOptions {
 }
 ```
 
+## Atomic Counters
+
+DSQL has no sequences (`SERIAL` / `BIGSERIAL`), so a monotonic sequence number would otherwise force a racy `SELECT MAX(seq) + 1` read-modify-write — two concurrent callers read the same maximum and both write the same next value, producing duplicate or skipped numbers. `db.counter(name)` gives you a race-free named counter instead: each operation is a single atomic upsert wrapped in OCC retry.
+
+```typescript
+// Per-user monotonic sequence, safe under concurrency:
+const seq = await db.counter(`notes:${userId}`).next();
+await db.execute(
+  sql`INSERT INTO notes (id, user_id, seq, body) VALUES (${id}, ${userId}, ${seq}, ${body})`
+);
+
+await db.counter('signups').next();      // increment by 1, returns the new value
+await db.counter('score').next(10);      // increment by a custom (integer) delta
+await db.counter('signups').current();   // read without incrementing (0 if never seen)
+await db.counter('signups').reset();     // set back to 0
+```
+
+Counters are stored in a framework-managed `_blocks_counters` table that is created automatically on deploy — no migration required. Values are stored as `BIGINT` and returned as `number` (exact up to `Number.MAX_SAFE_INTEGER`).
+
 ## Migrations
 
 One DDL statement per file. DML in separate files. This matches DSQL's transaction constraints.
@@ -102,7 +121,7 @@ DSQL is a subset of PostgreSQL. The local mock enforces these restrictions so co
 | Triggers | Event-driven logic (EventBridge, Lambda) |
 | Views | CTEs or application-layer query composition |
 | PL/pgSQL functions | `LANGUAGE SQL` functions or app logic |
-| SERIAL / BIGSERIAL | UUIDs (`gen_random_uuid()`) |
+| SERIAL / BIGSERIAL | UUIDs (`gen_random_uuid()`) for IDs; `db.counter()` for monotonic sequences |
 | TRUNCATE | `DELETE FROM` |
 | Temporary tables | CTEs or subqueries |
 | LISTEN / NOTIFY | AppSync Events, EventBridge, or polling |

--- a/packages/bb-distributed-data/src/counter.test.ts
+++ b/packages/bb-distributed-data/src/counter.test.ts
@@ -1,0 +1,158 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Tests for the atomic Counter primitive (DSQL upsert semantics).
+ *
+ * Runs against the mock engine (PGlite). The atomic upsert replaces the racy
+ * `SELECT MAX(seq) + 1` read-modify-write that DSQL otherwise forces (no
+ * sequences), so the headline test asserts no duplicate values under
+ * concurrent increments.
+ */
+
+import { describe, it, before, after, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { rmSync } from 'node:fs';
+import { DatabaseBase, sql } from '@aws-blocks/data-common';
+import { DsqlMockEngine } from './engines/dsql-mock-engine.js';
+import { Counter, ensureCounterTable, COUNTER_TABLE } from './counter.js';
+import { DistributedDatabase } from './index.mock.js';
+
+const DIR = '.bb-data/__test_counter__';
+
+describe('Counter (mock)', () => {
+  let engine: DsqlMockEngine;
+  let base: DatabaseBase;
+  const counter = (name: string) => new Counter(async () => base, name);
+
+  before(async () => {
+    rmSync(DIR, { recursive: true, force: true });
+    engine = new DsqlMockEngine(DIR);
+    base = new DatabaseBase(engine);
+    // The counter table is DDL — created by admin/migrations in prod. Locally
+    // it goes through the same withDdl escape hatch the migration runner uses.
+    await engine.withDdl(() => ensureCounterTable(engine));
+  });
+
+  after(async () => {
+    await engine.destroy();
+    rmSync(DIR, { recursive: true, force: true });
+  });
+
+  beforeEach(async () => {
+    await base.execute(sql`DELETE FROM _blocks_counters`);
+  });
+
+  it('next() returns a monotonic sequence starting at 1', async () => {
+    const c = counter('seq');
+    assert.equal(await c.next(), 1);
+    assert.equal(await c.next(), 2);
+    assert.equal(await c.next(), 3);
+  });
+
+  it('next(delta) adds an arbitrary integer, including negatives', async () => {
+    const c = counter('by-tens');
+    assert.equal(await c.next(10), 10);
+    assert.equal(await c.next(5), 15);
+    assert.equal(await c.next(-3), 12);
+  });
+
+  it('current() reads without incrementing; unknown counter is 0', async () => {
+    const c = counter('reads');
+    assert.equal(await c.current(), 0);
+    await c.next();
+    await c.next();
+    assert.equal(await c.current(), 2);
+    assert.equal(await c.current(), 2);
+  });
+
+  it('reset() sets an explicit value', async () => {
+    const c = counter('resettable');
+    await c.next();
+    await c.next();
+    await c.reset(100);
+    assert.equal(await c.current(), 100);
+    assert.equal(await c.next(), 101);
+    await c.reset();
+    assert.equal(await c.current(), 0);
+  });
+
+  it('named counters are independent', async () => {
+    const a = counter('a');
+    const b = counter('b');
+    await a.next();
+    await a.next();
+    await a.next();
+    await b.next();
+    assert.equal(await a.current(), 3);
+    assert.equal(await b.current(), 1);
+  });
+
+  it('recovers from an OCC conflict via retry without double counting', async () => {
+    const c = counter('occ');
+    assert.equal(await c.next(), 1);
+    engine.simulateConflict();
+    // First commit throws 40001 and rolls back; retry succeeds. The rolled-back
+    // attempt must NOT leak its increment.
+    assert.equal(await c.next(), 2);
+    assert.equal(await c.current(), 2);
+  });
+
+  it('concurrent next() calls never produce a duplicate value', async () => {
+    const c = counter('race');
+    const N = 25;
+    const results = await Promise.all(Array.from({ length: N }, () => c.next()));
+    const unique = new Set(results);
+    assert.equal(
+      unique.size,
+      N,
+      `expected ${N} unique values, got ${unique.size}: ${[...results].sort((x, y) => x - y).join(',')}`,
+    );
+    assert.equal(Math.max(...results), N);
+    assert.equal(Math.min(...results), 1);
+    assert.equal(await c.current(), N);
+  });
+
+  it('rejects an empty counter name', () => {
+    assert.throws(() => counter(''), /non-empty string/);
+  });
+
+  it('rejects a non-integer delta or reset value', async () => {
+    const c = counter('validate');
+    await assert.rejects(() => c.next(1.5), /must be an integer/);
+    await assert.rejects(() => c.reset(0.5), /must be an integer/);
+  });
+});
+
+describe('DistributedDatabase.counter (mock integration)', () => {
+  const scope = { id: 'test' };
+  let db: InstanceType<typeof DistributedDatabase>;
+
+  before(async () => {
+    db = new DistributedDatabase(scope as any, 'counterint');
+    // Clear any state persisted from a previous run of this data dir.
+    await db.execute(sql`DELETE FROM _blocks_counters`);
+  });
+
+  after(async () => {
+    await (db as any).mockEngine.destroy();
+  });
+
+  it('auto-creates the counter table with no migrations configured', async () => {
+    // No migrationsPath was provided, yet counter() works — proving the table
+    // is created during init (mirrors the migration Lambda creating it in prod).
+    const seq = db.counter('notes:user-1');
+    assert.equal(await seq.next(), 1);
+    assert.equal(await seq.next(), 2);
+    assert.equal(await db.counter('notes:user-2').next(), 1);
+  });
+
+  it('persists to the framework-managed _blocks_counters table', async () => {
+    assert.equal(COUNTER_TABLE, '_blocks_counters');
+    await db.counter('direct-check').next(7);
+    const row = await db.queryOne<{ value: string | number }>(
+      sql`SELECT value FROM _blocks_counters WHERE name = ${'direct-check'}`,
+    );
+    assert.equal(Number(row?.value), 7);
+  });
+});

--- a/packages/bb-distributed-data/src/counter.ts
+++ b/packages/bb-distributed-data/src/counter.ts
@@ -1,0 +1,141 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Atomic named counters for {@link DistributedDatabase} (Aurora DSQL).
+ *
+ * Aurora DSQL does not support sequences (`SERIAL`, `BIGSERIAL`, `CREATE SEQUENCE`),
+ * so code that needs a monotonic sequence number is otherwise forced into a racy
+ * `SELECT MAX(seq) + 1` read-modify-write: two concurrent callers read the same
+ * max and both write the same next value, producing duplicate or skipped numbers.
+ *
+ * This primitive replaces that pattern with a single atomic upsert against a
+ * framework-managed `_blocks_counters` table, wrapped in an OCC-retrying
+ * transaction so concurrent callers never observe a duplicate value.
+ */
+
+import type { DatabaseBase, DatabaseEngine } from '@aws-blocks/data-common';
+import { sql } from '@aws-blocks/data-common';
+import { transactionWithRetry } from './transaction.js';
+
+/** Name of the framework-managed table backing all atomic counters. */
+export const COUNTER_TABLE = '_blocks_counters';
+
+/**
+ * Idempotent DDL for the framework-managed counter table.
+ *
+ * Created by the migration Lambda (as admin) in production and by the mock
+ * engine during local init — never by the app runtime, which is DML-only.
+ */
+export const COUNTER_TABLE_DDL =
+  `CREATE TABLE IF NOT EXISTS ${COUNTER_TABLE} (name TEXT PRIMARY KEY, value BIGINT NOT NULL DEFAULT 0)`;
+
+/**
+ * Create the framework-managed counter table if it does not already exist.
+ *
+ * Must run with DDL privileges — the admin role via the migration Lambda in
+ * production, or inside `DsqlMockEngine.withDdl(...)` locally. The app runtime
+ * only has DML access and must not call this.
+ */
+export async function ensureCounterTable(engine: DatabaseEngine): Promise<void> {
+  await engine.execute(COUNTER_TABLE_DDL);
+}
+
+function assertValidName(name: string): void {
+  if (typeof name !== 'string' || name.length === 0) {
+    throw new Error('Counter name must be a non-empty string');
+  }
+}
+
+function assertInteger(label: string, n: number): void {
+  if (!Number.isInteger(n)) {
+    throw new Error(`Counter ${label} must be an integer, received: ${n}`);
+  }
+}
+
+/**
+ * A named, atomic counter backed by {@link DistributedDatabase} (Aurora DSQL).
+ *
+ * Obtain one via {@link DistributedDatabase.counter}. Every mutation is a single
+ * atomic upsert wrapped in an OCC-retrying transaction, so concurrent callers
+ * never observe a duplicate or skipped value — the correct replacement for a
+ * racy `SELECT MAX(seq) + 1` read-modify-write.
+ *
+ * Values are stored as `BIGINT` and returned as `number`; they are exact up to
+ * `Number.MAX_SAFE_INTEGER` (2^53 − 1).
+ *
+ * @example
+ * ```ts
+ * // Per-user monotonic sequence, race-free under concurrency:
+ * const seq = await db.counter(`notes:${userId}`).next();
+ * await db.execute(sql`
+ *   INSERT INTO notes (id, user_id, seq, body) VALUES (${id}, ${userId}, ${seq}, ${body})
+ * `);
+ * ```
+ */
+export class Counter {
+  /** @internal Use {@link DistributedDatabase.counter} to construct. */
+  constructor(
+    private readonly resolveBase: () => Promise<DatabaseBase>,
+    private readonly name: string,
+  ) {
+    assertValidName(name);
+  }
+
+  /**
+   * Atomically add `delta` to the counter and return its new value.
+   * The first call on a never-seen counter returns `delta` (default 1).
+   *
+   * @param delta - Integer amount to add. Defaults to 1. May be negative.
+   * @returns The counter value after applying `delta`.
+   */
+  async next(delta = 1): Promise<number> {
+    assertInteger('delta', delta);
+    const base = await this.resolveBase();
+    return transactionWithRetry(
+      base,
+      async (tx) => {
+        const rows = await tx.query<{ value: string | number | bigint }>(sql`
+          INSERT INTO _blocks_counters (name, value) VALUES (${this.name}, ${delta})
+          ON CONFLICT (name) DO UPDATE SET value = _blocks_counters.value + ${delta}
+          RETURNING value
+        `);
+        return Number(rows[0]!.value);
+      },
+      { retryOnConflict: true },
+    );
+  }
+
+  /**
+   * Read the current counter value without modifying it.
+   * Returns 0 if the counter has never been incremented.
+   */
+  async current(): Promise<number> {
+    const base = await this.resolveBase();
+    const row = await base.queryOne<{ value: string | number | bigint }>(
+      sql`SELECT value FROM _blocks_counters WHERE name = ${this.name}`,
+    );
+    return row ? Number(row.value) : 0;
+  }
+
+  /**
+   * Atomically set the counter to an explicit value (default 0).
+   * The next {@link Counter.next} call returns `value + delta`.
+   *
+   * @param value - Integer value to store. Defaults to 0.
+   */
+  async reset(value = 0): Promise<void> {
+    assertInteger('value', value);
+    const base = await this.resolveBase();
+    await transactionWithRetry(
+      base,
+      async (tx) => {
+        await tx.execute(sql`
+          INSERT INTO _blocks_counters (name, value) VALUES (${this.name}, ${value})
+          ON CONFLICT (name) DO UPDATE SET value = ${value}
+        `);
+      },
+      { retryOnConflict: true },
+    );
+  }
+}

--- a/packages/bb-distributed-data/src/index.aws.ts
+++ b/packages/bb-distributed-data/src/index.aws.ts
@@ -12,6 +12,7 @@ import { DatabaseBase, type SqlQuery, type Transaction } from '@aws-blocks/data-
 import { DsqlSigner } from '@aws-sdk/dsql-signer';
 import { DsqlEngine } from './engines/dsql-engine.js';
 import { transactionWithRetry } from './transaction.js';
+import { Counter } from './counter.js';
 import type { DistributedDatabaseOptions, TransactionOptions } from './types.js';
 import { ENV_SANITIZE, sanitizeDbRoleName } from './constants.js';
 import { Logger } from '@aws-blocks/bb-logger';
@@ -64,6 +65,18 @@ export class DistributedDatabase extends Scope {
     return transactionWithRetry(this.base, fn, options);
   }
 
+  /**
+   * Get a named atomic counter backed by this database.
+   *
+   * Use this instead of a racy `SELECT MAX(seq) + 1` read-modify-write when you
+   * need a monotonic sequence number — DSQL has no sequences (SERIAL / BIGSERIAL).
+   *
+   * @param name - Stable identifier for the counter (e.g. `notes:${userId}`).
+   */
+  counter(name: string): Counter {
+    return new Counter(async () => this.base, name);
+  }
+
   /** @internal */
   getEngine() { return this.base.getEngine(); }
 }
@@ -71,4 +84,5 @@ export class DistributedDatabase extends Scope {
 export { sql, createKyselyAdapter } from '@aws-blocks/data-common';
 export type { SqlQuery, Transaction } from '@aws-blocks/data-common';
 export { DistributedDatabaseErrors } from './errors.js';
+export { Counter } from './counter.js';
 export type { DistributedDatabaseOptions, TransactionOptions } from './types.js';

--- a/packages/bb-distributed-data/src/index.mock.ts
+++ b/packages/bb-distributed-data/src/index.mock.ts
@@ -12,6 +12,7 @@ import { DatabaseBase, type SqlQuery, type Transaction } from '@aws-blocks/data-
 import { DsqlMockEngine } from './engines/dsql-mock-engine.js';
 import { runMigrations, loadMigrationsFromDir } from './migrations.js';
 import { transactionWithRetry } from './transaction.js';
+import { Counter, ensureCounterTable } from './counter.js';
 import type { DistributedDatabaseOptions, TransactionOptions } from './types.js';
 import { Logger } from '@aws-blocks/bb-logger';
 import type { ChildLogger } from '@aws-blocks/bb-logger';
@@ -19,7 +20,7 @@ import type { ChildLogger } from '@aws-blocks/bb-logger';
 export class DistributedDatabase extends Scope {
   private base: DatabaseBase;
   private mockEngine: DsqlMockEngine;
-  private migrationsRun: Promise<void> | null = null;
+  private initPromise: Promise<void>;
 
   /** @internal Logger for internal operations. Defaults to error-level when not provided. */
   protected log: ChildLogger;
@@ -31,15 +32,19 @@ export class DistributedDatabase extends Scope {
     this.base = new DatabaseBase(this.mockEngine);
     registerSdkIdentifiers(this.fullId, { clusterEndpoint: `mock-endpoint-${this.fullId}` });
 
-    if (options?.migrationsPath) {
-      const path = options.migrationsPath;
-      this.migrationsRun = loadMigrationsFromDir(path)
-        .then(m => this.mockEngine.withDdl(() => runMigrations(this.mockEngine, m)))
-        .then(() => {});
-    }
+    // Create the framework-managed counter table (and run migrations, if any)
+    // in a single DDL window — the mock engine rejects DDL outside withDdl,
+    // mirroring the app runtime's DML-only access.
+    const migrationsPath = options?.migrationsPath;
+    this.initPromise = this.mockEngine.withDdl(async () => {
+      await ensureCounterTable(this.mockEngine);
+      if (migrationsPath) {
+        await runMigrations(this.mockEngine, await loadMigrationsFromDir(migrationsPath));
+      }
+    });
   }
 
-  private async ready(): Promise<void> { if (this.migrationsRun) await this.migrationsRun; }
+  private async ready(): Promise<void> { await this.initPromise; }
 
   query<T>(query: SqlQuery): Promise<T[]> { return this.ready().then(() => this.base.query<T>(query)); }
   queryOne<T>(query: SqlQuery): Promise<T | null> { return this.ready().then(() => this.base.queryOne<T>(query)); }
@@ -56,6 +61,18 @@ export class DistributedDatabase extends Scope {
     return transactionWithRetry(this.base, fn, options);
   }
 
+  /**
+   * Get a named atomic counter backed by this database.
+   *
+   * Use this instead of a racy `SELECT MAX(seq) + 1` read-modify-write when you
+   * need a monotonic sequence number — DSQL has no sequences (SERIAL / BIGSERIAL).
+   *
+   * @param name - Stable identifier for the counter (e.g. `notes:${userId}`).
+   */
+  counter(name: string): Counter {
+    return new Counter(async () => { await this.ready(); return this.base; }, name);
+  }
+
   /** Test helper: simulate OCC conflict on next commit. */
   simulateConflict(): void { this.mockEngine.simulateConflict(); }
 
@@ -66,4 +83,5 @@ export class DistributedDatabase extends Scope {
 export { sql, createKyselyAdapter } from '@aws-blocks/data-common';
 export type { SqlQuery, Transaction } from '@aws-blocks/data-common';
 export { DistributedDatabaseErrors } from './errors.js';
+export { Counter } from './counter.js';
 export type { DistributedDatabaseOptions, TransactionOptions } from './types.js';

--- a/packages/bb-distributed-data/src/migration-lambda.ts
+++ b/packages/bb-distributed-data/src/migration-lambda.ts
@@ -19,6 +19,7 @@ import { existsSync } from 'node:fs';
 import type { CloudFormationCustomResourceEvent } from 'aws-lambda';
 import { DsqlEngine } from './engines/dsql-engine.js';
 import { runMigrations, loadMigrationsFromDir } from './migrations.js';
+import { ensureCounterTable } from './counter.js';
 import { LAMBDA_MIGRATIONS_DIR } from './constants.js';
 
 // Set by the CDK construct's environment config. Default is the Lambda deployment root
@@ -146,6 +147,10 @@ export const handler = async (event: CloudFormationCustomResourceEvent): Promise
     } else {
       console.log('[bb-distributed-data] No migrations directory bundled, skipping migrations');
     }
+
+    // 1.5 Ensure the framework-managed atomic counter table exists (admin-owned).
+    //     provisionAppRole below grants the app role DML on it (it is != _migrations).
+    await withRetry(() => ensureCounterTable(engine));
 
     // 2. Provision the app Lambda's custom DB role (least-privilege DML access)
     await withRetry(() => provisionAppRole(engine, dbRoleName, appRoleArn));


### PR DESCRIPTION
## Summary

Adds an atomic `Counter` primitive to `DistributedDatabase` (Aurora DSQL) so applications can get a **race-free monotonic sequence number** without hand-rolling a `SELECT MAX(seq) + 1` read-modify-write.

## The gap this closes

Aurora DSQL has **no sequences** — the framework's own validation layer rejects `SERIAL` / `BIGSERIAL` / `CREATE SEQUENCE`. So code that needs a per-entity sequence number is pushed into:

```sql
SELECT COALESCE(MAX(seq), 0) + 1 FROM notes WHERE user_id = $1;  -- then a SEPARATE INSERT
```

Two concurrent same-user writes both read `seq = N` and both insert `seq = N+1` → **duplicate sequence numbers** and unstable ordering. This was surfaced as finding **C3-F3** in the PR #194 single-table-bench audit (`oidc-dsql-notes` task), tagged there as *"arguably FRAMEWORK — no atomic sequence/auto-increment helper"* and **not** fixable inside the bench task harness. This PR is that framework fix.

## What's added

`db.counter(name)` returns a `Counter` with:

- `next(delta = 1)` — atomically increment and return the new value
- `current()` — read without incrementing (0 if never seen)
- `reset(value = 0)` — set to an explicit value

Each mutation is a **single atomic upsert** wrapped in OCC retry:

```sql
INSERT INTO _blocks_counters (name, value) VALUES ($name, $delta)
  ON CONFLICT (name) DO UPDATE SET value = _blocks_counters.value + $delta
  RETURNING value;
```

DSQL supports `INSERT ... ON CONFLICT DO UPDATE ... RETURNING`, so there is no read-then-write window for a competing writer. It runs inside `transaction({ retryOnConflict: true })` so a DSQL OCC conflict on the row retries transparently.

The backing store is a framework-managed `_blocks_counters` table:
- Created by the migration Lambda (admin) on **every** deploy, exactly like `_migrations` — no user migration required.
- `provisionAppRole` already grants the app role DML on every admin-owned table `!= _migrations`, so the app runtime automatically gets `SELECT/INSERT/UPDATE/DELETE` on it (the app runtime stays DML-only and never issues DDL).
- The local `DsqlMockEngine` creates the same table inside its `withDdl` init window → identical behavior against PGlite.

## Tests

11 new tests in `counter.test.ts` (real PGlite via `DsqlMockEngine`, no mocks/stubs):
- monotonic `next()` → 1, 2, 3…; custom + negative deltas; `current()` / unseen = 0; `reset()`; two named counters isolated
- **OCC**: `simulateConflict()` then `next()` still returns the correct value and does not double-count (proves the rolled-back attempt is discarded)
- **Concurrency**: `Promise.all` of 25 concurrent `next()` calls → 25 **unique** values, min 1 / max 25 (proves no duplicate sequence — the exact `oidc-dsql-notes` race)
- input validation (empty name, non-integer delta)
- `DistributedDatabase` mock integration: counter table auto-created without `migrationsPath`; value persists in `_blocks_counters`

Full package suite: **157/157 passing**. Build clean (`tsc --build`). API report regenerated via api-extractor.

## Placement rationale (new PR off `main`, not bench PR #194)

This is a **runtime capability gap in deployed Lambda code**. A bench/harness helper runs in the test harness, not the deployed app, so it structurally cannot fix a runtime concurrency bug. The PR #194 audit itself separated this: findings #1–#8 (task-test gaps) belong in the bench PR, while C3-F3 was tagged "arguably FRAMEWORK / not tasks-fixable". The fix archetype — "an atomic `increment()` / conditional-update on the data block, or a Counter block" — is exactly a framework primitive. Hence a new branch off `main`.

Opened as **draft**.

🤖 Generated with Roko AI Agent
