### PR TITLE
fix(ci): dedupe constructs/aws-cdk-lib in amplify-interop test to stop dual-install TS2345

### DIFF
--- a/.github/workflows/e2e-amplify-interop.yml
+++ b/.github/workflows/e2e-amplify-interop.yml
@@ -77,6 +77,44 @@ jobs:
           npm create amplify@latest -- --yes
           node $GITHUB_WORKSPACE/packages/create-blocks-app/dist/index.js --yes .
 
+      # De-skew the sandbox typecheck against the drifting Amplify scaffold.
+      #
+      # `npm create amplify@latest` installs its OWN aws-cdk-lib/constructs at
+      # whatever versions it currently ships, which drift from the versions this
+      # repo builds against. The generated aws-blocks/index.cdk.ts resolves
+      # aws-cdk-lib (Stack/Mixins) from THIS scaffold's tree, while the Blocks
+      # packages — linked in as `file:` deps (symlinks) — resolve their own
+      # constructs/aws-cdk-lib from the REPO's tree via the symlink realpath.
+      # tsc dedups modules by package id (name@version), so when the two trees
+      # are DIFFERENT versions it treats them as distinct declarations and the
+      # nominally-private Construct#host member no longer matches — failing with
+      # TS2345 "separate declarations of a private property 'host'".
+      #
+      # Fix: pin the scaffold's constructs/aws-cdk-lib to the repo's EXACT
+      # installed versions (read from node_modules, not the package.json semver
+      # range, so the ids match precisely — a range could resolve to a newer
+      # patch and re-drift), then reinstall so the overrides apply. Matching
+      # versions => matching package ids => tsc dedups to one declaration.
+      - name: Pin constructs/aws-cdk-lib to the repo's versions
+        run: |
+          cd /tmp/amplify-interop-test
+          node -e '
+            const fs = require("fs");
+            const ws = process.env.GITHUB_WORKSPACE;
+            const ver = (n) => {
+              try { return require(ws + "/node_modules/" + n + "/package.json").version; }
+              catch { const p = require(ws + "/package.json"); return (p.devDependencies || {})[n] || (p.dependencies || {})[n]; }
+            };
+            const constructsV = ver("constructs"), cdkV = ver("aws-cdk-lib");
+            if (!constructsV || !cdkV) throw new Error("could not determine constructs/aws-cdk-lib version from repo");
+            const pkg = JSON.parse(fs.readFileSync("package.json", "utf8"));
+            pkg.overrides = { ...pkg.overrides, constructs: constructsV, "aws-cdk-lib": cdkV };
+            fs.writeFileSync("package.json", JSON.stringify(pkg, null, 2) + "\n");
+            console.log("pinned overrides: constructs=" + constructsV + " aws-cdk-lib=" + cdkV);
+          '
+          rm -rf node_modules package-lock.json
+          npm install
+
       - name: Deploy sandbox
         run: |
           cd /tmp/amplify-interop-test

--- a/.github/workflows/e2e-amplify-interop.yml
+++ b/.github/workflows/e2e-amplify-interop.yml
@@ -93,7 +93,11 @@ jobs:
       # Fix: pin the scaffold's constructs/aws-cdk-lib to the repo's EXACT
       # installed versions (read from node_modules, not the package.json semver
       # range, so the ids match precisely — a range could resolve to a newer
-      # patch and re-drift), then reinstall so the overrides apply. Matching
+      # patch and re-drift). The scaffold lists both as DIRECT devDependencies,
+      # and npm refuses an `overrides` entry for a directly-depended package
+      # unless the direct spec matches the override exactly (EOVERRIDE) — so pin
+      # the direct dep specs to those same exact versions AND set the overrides
+      # (the latter also dedupes any transitive copies), then reinstall. Matching
       # versions => matching package ids => tsc dedups to one declaration.
       - name: Pin constructs/aws-cdk-lib to the repo's versions
         run: |
@@ -108,9 +112,15 @@ jobs:
             const constructsV = ver("constructs"), cdkV = ver("aws-cdk-lib");
             if (!constructsV || !cdkV) throw new Error("could not determine constructs/aws-cdk-lib version from repo");
             const pkg = JSON.parse(fs.readFileSync("package.json", "utf8"));
-            pkg.overrides = { ...pkg.overrides, constructs: constructsV, "aws-cdk-lib": cdkV };
+            const pins = { constructs: constructsV, "aws-cdk-lib": cdkV };
+            for (const [name, v] of Object.entries(pins)) {
+              for (const bucket of ["dependencies", "devDependencies"]) {
+                if (pkg[bucket] && pkg[bucket][name]) pkg[bucket][name] = v;
+              }
+            }
+            pkg.overrides = { ...pkg.overrides, ...pins };
             fs.writeFileSync("package.json", JSON.stringify(pkg, null, 2) + "\n");
-            console.log("pinned overrides: constructs=" + constructsV + " aws-cdk-lib=" + cdkV);
+            console.log("pinned constructs=" + constructsV + " aws-cdk-lib=" + cdkV + " (direct deps + overrides)");
           '
           rm -rf node_modules package-lock.json
           npm install


### PR DESCRIPTION
## Root cause

The `E2E Amplify Interop` harness scaffolds a throwaway app with **unpinned** `npm create amplify@latest` into `/tmp`, which installs its OWN `constructs` (`^10.0.0`) and `aws-cdk-lib` (`2.244.0`). It then typechecks the generated `aws-blocks/index.cdk.ts` against the **repo's** `constructs` (`^10.6.0`) / `aws-cdk-lib` (`2.257.0`), which the Blocks packages resolve through their `file:` symlinks back into the repo tree.

`tsc` deduplicates modules by **package id** (`name@version`), not by file path. When the two physical `constructs` trees are *different* versions they get distinct package ids, so the nominally-private `Construct#host` member no longer matches across them and the typecheck fails:

```
TS2345: ... Types have separate declarations of a private property 'host'.
```

This currently fails on **all PRs**.

## Fix

Add a step to the smoke job (between "Scaffold Amplify + Blocks app" and "Deploy sandbox") that pins the scaffolded app's `constructs` and `aws-cdk-lib` to the repo's **exact installed** versions — read from `$GITHUB_WORKSPACE/node_modules` (falling back to the repo `package.json` range) — via npm `overrides`, then `rm -rf node_modules package-lock.json && npm install` so a single copy of each resolves.

Matching versions => matching package ids => `tsc` dedups the two physical `constructs` trees to one declaration => the `host` skew (and TS2345) disappears. Reading the *resolved installed* version rather than the semver range keeps the ids exactly aligned, so a newer patch can't silently re-introduce the drift.

## Notes

- CI harness / test-infrastructure fix — **owned by the harness maintainers**.
- Only `.github/workflows/e2e-amplify-interop.yml` changes: one added step, no deletions.
- Authoritative validation is this PR's own `e2e-amplify-interop` check (the full `npm create amplify` scaffold needs AWS/network and isn't runnable locally). The dedupe mechanism was verified locally against the repo's real `node_modules` (`pinned overrides: constructs=10.6.0 aws-cdk-lib=2.257.0`).
