### PR TITLE
fix(release): anchor rsync package manifest excludes to repo root

### DIFF
--- a/.github/workflows/publish-swift.yml
+++ b/.github/workflows/publish-swift.yml
@@ -136,12 +136,17 @@ jobs:
             -not -name '..' \
             -exec rm -rf {} +
 
-          # Copy native/swift contents to target repo root
+          # Copy native/swift contents to target repo root.
+          # Anchor the root package.json/package-lock.json excludes with a
+          # leading '/' so they only skip native/swift's changeset-tooling
+          # manifests. Unanchored patterns match at every depth and would also
+          # drop Demo/typescript-demo/package.json + package-lock.json, which
+          # the demo needs (and which carry the dependency/security fixes).
           rsync -a --exclude='.changeset' \
                    --exclude='node_modules' \
                    --exclude='.build' \
-                   --exclude='package.json' \
-                   --exclude='package-lock.json' \
+                   --exclude='/package.json' \
+                   --exclude='/package-lock.json' \
                    --exclude='Demo/typescript-demo/node_modules' \
                    ./ ../../target-repo/
 


### PR DESCRIPTION
## Summary

The Swift SDK release process (`publish-swift.yml`) syncs `native/swift/` into the public `aws-blocks-swift` repo via `rm -rf` + `rsync`. The rsync step excludes `package.json` / `package-lock.json` to skip `native/swift`'s changeset-tooling manifests — but the patterns are **unanchored**, so rsync matches them at *every* depth and also drops:

- `Demo/typescript-demo/package.json`
- `Demo/typescript-demo/package-lock.json`

Because the target repo's synced content is `rm -rf`'d first, a release would **delete** the demo's manifest + lockfile from `aws-blocks-swift` rather than update them. That breaks `npm install` for the demo and silently drops the files carrying its dependency/security fixes (the exact fixes that clear the open Dependabot alerts).

## Fix

Anchor both excludes with a leading `/`, scoping them to the rsync source root (`native/swift/`):

```diff
-                   --exclude='package.json' \
-                   --exclude='package-lock.json' \
+                   --exclude='/package.json' \
+                   --exclude='/package-lock.json' \
```

Root manifests are still skipped; the demo's manifest and lockfile now sync through as intended.

## Verification

Local sync simulation replicating the workflow's `find … -rm -rf` + `rsync`:

| Check | Result |
|---|---|
| root `package.json` / `package-lock.json` skipped | ✅ |
| `Demo/typescript-demo/package.json` synced | ✅ |
| `Demo/typescript-demo/package-lock.json` synced | ✅ |
| `Demo/typescript-demo/node_modules` still excluded | ✅ |
| stale target-repo file replaced | ✅ |

## Why now

This unblocks the pending 0.1.1 release: the demo dependency fix is already staged in the monorepo (changeset `little-lamps-camp.md` + patched lockfile), but without this change the release would drop the lockfile on sync instead of propagating it.

Workflow-only change (no `native/swift/` SDK source touched), so no changeset is included.