### PR TITLE
fix(release): republish @aws-blocks/blocks umbrella (missing changeset)

### DIFF
--- a/.changeset/blocks-umbrella-republish.md
+++ b/.changeset/blocks-umbrella-republish.md
@@ -1,0 +1,5 @@
+---
+"@aws-blocks/blocks": patch
+---
+
+Republish the umbrella `@aws-blocks/blocks` package so its tarball matches the updated re-exported APIs (`@aws-blocks/core`, `@aws-blocks/bb-agent`) and synced block docs. The sibling patch releases stayed within `blocks`' caret dependency ranges, so `changeset version` did not auto-bump the umbrella package, and the publish integrity guard requires a version bump when packed content changes.


### PR DESCRIPTION
## Summary
Publish is failing with:

```
Error: @aws-blocks/blocks@0.2.2 already exists with different content. Did you forget to include it in your changeset?
    at publish (scripts/publish/publish.ts:313:12)
```

## Root cause
`@aws-blocks/blocks` is the umbrella package: it `export *`s `@aws-blocks/core` and re-exports every `bb-*` block in `src/index.ts`, and assembles `packages/blocks/docs/` from each block's README at pack time (`scripts/sync-block-docs.mjs`). It ships `dist`, `docs`, and `src`.

Recently merged PRs bumped packages it re-exports:
- #177 → `@aws-blocks/core` 0.1.13
- #161 + #162 → `@aws-blocks/bb-agent` 0.3.1

`blocks` pins those with caret ranges (`^0.1.10`, `^0.3.0`), and the new versions stay in range — so `changeset version` does **not** bump `blocks` (verified locally: core/bb-agent/data-common/hosting all bump, `blocks` is left untouched). But its packed `dist`/`docs` still change, so re-publishing `0.2.2` trips the integrity guard.

## Fix
Add an explicit changeset bumping `@aws-blocks/blocks` (patch) → next Version Packages run produces `0.2.3` and publish uploads cleanly. This matches existing precedent (the current `0.2.2` entry in blocks' CHANGELOG was itself an explicit docs-sync changeset).

## Follow-up (not in this PR)
Prevent recurrence by making the umbrella auto-bump on any sibling release — e.g. a `fixed` group in `.changeset/config.json`, or a pack-time assertion that the umbrella was bumped when a re-exported dep changes.

## Test plan
- [x] `changeset version` locally: with only the pending changesets, `blocks` stays 0.2.2 (repro); adding this changeset bumps it to 0.2.3
- [ ] CI publish succeeds after merge + Version Packages