### PR TITLE
fix(ci): lint should not fail when a PR touches no packages/ files

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "test:e2e:hosting-ssr-astro": "cd test-apps/hosting-ssr-astro && npm run test:e2e:sandbox",
     "test:e2e:hosting-ssr-astro-default404": "cd test-apps/hosting-ssr-astro-default404 && npm run test:e2e:sandbox",
     "check:exports-consistency": "npx tsx scripts/check-aws-blocks-exports-consistency.ts",
-    "lint": "biome lint --skip=correctness/noUndeclaredDependencies --reporter=github --changed --since=origin/main packages/",
+    "lint": "biome lint --skip=correctness/noUndeclaredDependencies --reporter=github --changed --since=origin/main --no-errors-on-unmatched packages/",
     "lint:deps": "npx tsx scripts/lint-deps.ts",
     "update:api": "bash scripts/update-api-reports.sh",
     "check:api": "bash scripts/update-api-reports.sh && npx tsx scripts/check-api-reports.ts"


### PR DESCRIPTION
## Problem

`npm run lint` runs `biome lint --changed --since=origin/main packages/`. When a PR changes no files under `packages/` (e.g. CI, scripts, or changeset-only PRs), Biome's changed-file set is empty and it exits 1 with "No files were processed in the specified paths." The lint step in `pr-checks.yml` is `continue-on-error`, so this doesn't block merge — but it shows a misleading red "lint failed" annotation, and `npm run lint` fails the same way locally on those branches.

## Change

Add `--no-errors-on-unmatched` to the `lint` script. Biome then treats "no matching files" as success (exit 0). Real lint violations still fail — the flag only affects the empty-match case.

## Validation

This PR changes only `package.json` (no `packages/` files) — the exact case that used to fail. `npm run lint` now exits 0.
