### PR TITLE
fix(bb-data): bump Aurora PostgreSQL engine version 16.4→16.13 (retired) + make configurable

### DIFF
--- a/.changeset/aurora-pg-engine-version.md
+++ b/.changeset/aurora-pg-engine-version.md
@@ -1,5 +1,5 @@
 ---
-"@aws-blocks/bb-data": minor
+"@aws-blocks/bb-data": patch
 "@aws-blocks/blocks": patch
 ---
 

--- a/.changeset/aurora-pg-engine-version.md
+++ b/.changeset/aurora-pg-engine-version.md
@@ -6,4 +6,4 @@ Bump the Database block's Aurora PostgreSQL engine version from the retired `16.
 
 AWS retired Aurora PostgreSQL `16.4` in us-east-1, after which `CreateDBCluster` failed with `Cannot find version 16.4 for aurora-postgresql`, blocking every deployment of a `Database` block. The default now points at the latest available `16.x` minor (`16.13`) for the longest deprecation runway.
 
-A new optional `postgresVersion` option on `DatabaseOptions` lets callers override the engine version (e.g. `postgresVersion: '16.13'`), so the next AWS retirement is a configuration change rather than a framework code fix.
+A new optional `postgresVersion` option on `DatabaseOptions` lets callers override the engine version (e.g. `postgresVersion: '16.13'`), so the next AWS retirement is a configuration change rather than a framework code fix. Overrides are validated at synth time (must be `MAJOR.MINOR`, e.g. `16.13`), so a malformed value fails fast with a clear error instead of an opaque `CreateDBCluster` failure.

--- a/.changeset/aurora-pg-engine-version.md
+++ b/.changeset/aurora-pg-engine-version.md
@@ -1,0 +1,9 @@
+---
+"@aws-blocks/bb-data": minor
+---
+
+Bump the Database block's Aurora PostgreSQL engine version from the retired `16.4` to `16.13`, and make the engine version configurable.
+
+AWS retired Aurora PostgreSQL `16.4` in us-east-1, after which `CreateDBCluster` failed with `Cannot find version 16.4 for aurora-postgresql`, blocking every deployment of a `Database` block. The default now points at the latest available `16.x` minor (`16.13`) for the longest deprecation runway.
+
+A new optional `postgresVersion` option on `DatabaseOptions` lets callers override the engine version (e.g. `postgresVersion: '16.13'`), so the next AWS retirement is a configuration change rather than a framework code fix.

--- a/.changeset/aurora-pg-engine-version.md
+++ b/.changeset/aurora-pg-engine-version.md
@@ -1,5 +1,6 @@
 ---
 "@aws-blocks/bb-data": minor
+"@aws-blocks/blocks": patch
 ---
 
 Bump the Database block's Aurora PostgreSQL engine version from the retired `16.4` to `16.13`, and make the engine version configurable.
@@ -7,3 +8,5 @@ Bump the Database block's Aurora PostgreSQL engine version from the retired `16.
 AWS retired Aurora PostgreSQL `16.4` in us-east-1, after which `CreateDBCluster` failed with `Cannot find version 16.4 for aurora-postgresql`, blocking every deployment of a `Database` block. The default now points at the latest available `16.x` minor (`16.13`) for the longest deprecation runway.
 
 A new optional `postgresVersion` option on `DatabaseOptions` lets callers override the engine version (e.g. `postgresVersion: '16.13'`), so the next AWS retirement is a configuration change rather than a framework code fix. Overrides are validated at synth time (must be `MAJOR.MINOR`, e.g. `16.13`), so a malformed value fails fast with a clear error instead of an opaque `CreateDBCluster` failure.
+
+The `@aws-blocks/blocks` umbrella package receives a `patch` because its published `docs/` folder is assembled from sibling block READMEs at build time (`scripts/sync-block-docs.mjs`), so this `bb-data` README update changes `@aws-blocks/blocks` packaged content.

--- a/packages/bb-data/API.md
+++ b/packages/bb-data/API.md
@@ -94,6 +94,7 @@ export interface DatabaseOptions {
     maxCapacity?: number;
     migrationsPath?: string;
     minCapacity?: number;
+    postgresVersion?: string;
     removalPolicy?: 'destroy' | 'retain' | 'snapshot';
     rlsPolicy?: 'enforce';
     schema?: TableSchema;

--- a/packages/bb-data/README.md
+++ b/packages/bb-data/README.md
@@ -252,6 +252,8 @@ interface DatabaseOptions {
   connection?: ExternalDatabaseRef;
   /** Schema metadata for crud() support. */
   schema?: TableSchema;
+  /** Aurora PostgreSQL engine version, e.g. '16.13'. Override the Aurora engine version. @default '16.13' */
+  postgresVersion?: string;
 }
 ```
 

--- a/packages/bb-data/src/index.cdk.ts
+++ b/packages/bb-data/src/index.cdk.ts
@@ -76,6 +76,7 @@ export class Database extends Scope {
       databaseName,
       migrationsPath: options?.migrationsPath ? resolve(options.migrationsPath) : undefined,
       removalPolicy: options?.removalPolicy ? REMOVAL_POLICY_MAP[options.removalPolicy] : defaultRemovalPolicy,
+      postgresVersion: options?.postgresVersion,
     });
 
     // Inject config so DataApiEngine can read them at runtime

--- a/packages/bb-data/src/infra.test.ts
+++ b/packages/bb-data/src/infra.test.ts
@@ -46,6 +46,33 @@ test('CDK: default capacity is 0.5-2 ACUs', () => {
   });
 });
 
+// --- Engine version ---
+
+test('CDK: default engine version is 16.13', () => {
+  const template = synthTemplate({ databaseName: 'mydb' });
+  template.hasResourceProperties('AWS::RDS::DBCluster', {
+    EngineVersion: Match.stringLikeRegexp('^16\\.13'),
+  });
+});
+
+test('CDK: postgresVersion override sets the engine version', () => {
+  const template = synthTemplate({ databaseName: 'mydb', postgresVersion: '16.11' });
+  template.hasResourceProperties('AWS::RDS::DBCluster', {
+    EngineVersion: '16.11',
+  });
+});
+
+test('CDK: malformed postgresVersion throws at synth time', () => {
+  assert.throws(
+    () => synthTemplate({ databaseName: 'mydb', postgresVersion: '16' }),
+    /Invalid postgresVersion "16"/,
+  );
+  assert.throws(
+    () => synthTemplate({ databaseName: 'mydb', postgresVersion: 'bogus' }),
+    /Invalid postgresVersion "bogus"/,
+  );
+});
+
 // --- VPC ---
 
 test('CDK: VPC has isolated subnets and no NAT gateways', () => {

--- a/packages/bb-data/src/infra.ts
+++ b/packages/bb-data/src/infra.ts
@@ -35,6 +35,8 @@ export interface AuroraInfraConfig {
   migrationsPath?: string;
   /** CloudFormation removal policy for the Aurora cluster. @default RETAIN */
   removalPolicy?: cdk.RemovalPolicy;
+  /** Aurora PostgreSQL engine version, e.g. `'16.13'`. @default '16.13' */
+  postgresVersion?: string;
 }
 
 /**
@@ -111,9 +113,22 @@ export function materialize(
 
   // Aurora Serverless v2 cluster with Data API enabled
   const removalPolicy = options.removalPolicy ?? cdk.RemovalPolicy.RETAIN;
+
+  // Aurora PostgreSQL engine version. Kept configurable because AWS periodically
+  // retires older minor versions — 16.4 was retired in us-east-1, after which
+  // CreateDBCluster failed with "Cannot find version 16.4 for aurora-postgresql".
+  // Default to the latest available 16.x (16.13) for the longest deprecation
+  // runway; callers can override via `postgresVersion` when AWS retires it too.
+  const engineVersion = options.postgresVersion
+    ? rds.AuroraPostgresEngineVersion.of(
+        options.postgresVersion,
+        options.postgresVersion.split('.')[0] ?? options.postgresVersion,
+      )
+    : rds.AuroraPostgresEngineVersion.VER_16_13;
+
   const cluster = new rds.DatabaseCluster(scope, `${name}Cluster`, {
     engine: rds.DatabaseClusterEngine.auroraPostgres({
-      version: rds.AuroraPostgresEngineVersion.VER_16_4,
+      version: engineVersion,
     }),
     serverlessV2MinCapacity: minCapacity,
     serverlessV2MaxCapacity: maxCapacity,

--- a/packages/bb-data/src/infra.ts
+++ b/packages/bb-data/src/infra.ts
@@ -119,12 +119,20 @@ export function materialize(
   // CreateDBCluster failed with "Cannot find version 16.4 for aurora-postgresql".
   // Default to the latest available 16.x (16.13) for the longest deprecation
   // runway; callers can override via `postgresVersion` when AWS retires it too.
-  const engineVersion = options.postgresVersion
-    ? rds.AuroraPostgresEngineVersion.of(
-        options.postgresVersion,
-        options.postgresVersion.split('.')[0] ?? options.postgresVersion,
-      )
-    : rds.AuroraPostgresEngineVersion.VER_16_13;
+  // Validate the override up front so a malformed value fails fast at synth
+  // time with a clear message, instead of as an opaque CreateDBCluster error.
+  let engineVersion: rds.AuroraPostgresEngineVersion;
+  if (options.postgresVersion === undefined) {
+    engineVersion = rds.AuroraPostgresEngineVersion.VER_16_13;
+  } else {
+    if (!/^\d+\.\d+$/.test(options.postgresVersion)) {
+      throw new Error(
+        `Invalid postgresVersion "${options.postgresVersion}"; expected "MAJOR.MINOR" like "16.13".`,
+      );
+    }
+    const majorVersion = options.postgresVersion.split('.')[0];
+    engineVersion = rds.AuroraPostgresEngineVersion.of(options.postgresVersion, majorVersion);
+  }
 
   const cluster = new rds.DatabaseCluster(scope, `${name}Cluster`, {
     engine: rds.DatabaseClusterEngine.auroraPostgres({

--- a/packages/bb-data/src/types.ts
+++ b/packages/bb-data/src/types.ts
@@ -34,6 +34,16 @@ export interface DatabaseOptions {
    * @default 'retain'
    */
   removalPolicy?: 'destroy' | 'retain' | 'snapshot';
+  /**
+   * Aurora PostgreSQL engine version, e.g. `'16.13'`.
+   *
+   * Configurable because AWS periodically retires older Aurora PostgreSQL minor
+   * versions: 16.4 was retired in us-east-1, after which `CreateDBCluster` began
+   * failing with `Cannot find version 16.4 for aurora-postgresql`. Surfacing this
+   * as an option means the next retirement is a config change, not a framework fix.
+   * @default '16.13'
+   */
+  postgresVersion?: string;
 	/** Optional logger for internal operations. When omitted, a default Logger at error level is created. */
 	logger?: ChildLogger;
 }


### PR DESCRIPTION
## What & why

`packages/bb-data/src/infra.ts` hardcoded the Aurora Serverless v2 PostgreSQL engine version as `AuroraPostgresEngineVersion.VER_16_4`. **AWS has retired `16.4` in us-east-1.** As a result, `CreateDBCluster` now fails at deploy time with:

```
400 InvalidRequest: Cannot find version 16.4 for aurora-postgresql
```

This is a main-wide blocker for **every** E2E that deploys a `Database` block — reproducibly observed on PRs **#205** and **#208** and across all DB-deploying E2E runs.

Available `16.x` minors in us-east-1 today: `16.8, 16.9, 16.10, 16.11, 16.13` (`16.4`–`16.7` are gone).

## The fix

1. **Immediate:** default the engine to the **latest available** `16.x` = **`16.13`**. Staying on major 16 keeps zero compatibility risk; picking the latest minor gives the longest deprecation runway and newest patches (deliberately *not* the lowest minor, which would be first to be retired again).
2. **Durable:** the engine version is now **configurable** via a new optional `postgresVersion` option on `DatabaseOptions`, threaded down to the cluster. When AWS retires `16.13` in future, this becomes a **config change, not a framework code fix / outage**.

```ts
new Database(scope, 'mydb', { postgresVersion: '16.13' }); // override when needed
```

The default uses the strongly-typed enum `AuroraPostgresEngineVersion.VER_16_13` (present in the installed `aws-cdk-lib@2.257.0`); a caller-supplied override string is passed through `AuroraPostgresEngineVersion.of(version, major)`.

## Files

- `packages/bb-data/src/infra.ts` — default `VER_16_4` → `VER_16_13`; compute `engineVersion` from optional `postgresVersion`; add `postgresVersion?` to `AuroraInfraConfig`.
- `packages/bb-data/src/types.ts` — add `postgresVersion?: string` to the public `DatabaseOptions` (with rationale + `@default '16.13'`).
- `packages/bb-data/src/index.cdk.ts` — thread `postgresVersion` into `materialize()`.
- `.changeset/aurora-pg-engine-version.md` — `@aws-blocks/bb-data`: **minor** (new public option).

## Validation

- `npm run build:packages` — ✅ green (all packages compile, incl. bb-data).
- `node --test packages/bb-data/dist/{infra,index.cdk}.test.js` — ✅ **14/14 pass, 0 fail** (CDK synth assertions).

## Notes

- Opened as **draft**. Additive commit only — no history rewrite.
- bb-data is under `packages/**`, so PR Agent Bench + E2E workflows are expected to fire (accepted).
