### PR TITLE
docs: add AGENTS.md, CLAUDE.md, and API Design Guidelines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,7 +45,6 @@ docs/tech-design-output
 .bb-data-*/
 
 # Local dev artifacts
-CLAUDE.md
 conversation.md
 **/error_e2e_*.txt
 **/error_hosting.txt

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,18 +16,18 @@ You're an engineer working **on AWS Blocks itself** — the framework and its Bu
 ## 🚦 Core rules (these gate a PR)
 
 1. CDK synth must run with **`--conditions=cdk`**. Without it, BBs load their mocks and synth produces no infrastructure.
-2. Persist application state **only through Building Blocks** — no local files, in-memory arrays, or ad-hoc databases.
+2. Persist application state **only through Building Blocks** — no local files, in-memory arrays, or ad-hoc databases. Without this → state vanishes on deploy (Lambda is stateless) or diverges between local dev and AWS.
 3. Inject BB config with **`registerConfig()`**, never `handler.addEnvironment()` (Lambda env has a ~4 KB cap).
 4. Call BB data methods **only inside request/job handlers** — never at module top level or during synth (the CDK class stubs them with `synthGuard` to throw).
 5. **Never attach `Error.cause` enumerably** — it leaks SDK metadata (`$metadata`, ARNs) when an error is serialized to the client.
 6. Errors cross the wire by **`name`, not `code`** — match with `isBlocksError(e, SomeErrors.Foo)` (works the same server- and client-side).
-7. **`get()`-style reads return `null`** for not-found — throw only for violated preconditions (e.g. a failed conditional write).
+7. **`get()`-style reads return `null`** for not-found — throw only for violated preconditions (e.g. a failed conditional write). Without this → callers need try/catch for normal control flow, and missing-item checks become invisible.
 8. Keep customer-facing code cast-free: **no `as any` / `: any` / `@ts-ignore`** (a cast usually means a public type is wrong — fix the type).
 9. Every API method is a public, internet-reachable RPC endpoint with no auth by default — **gate inside each method** with `await auth.requireAuth(context)`.
 10. Every change to a published package **ships a changeset** covering all changed packages (its text becomes the public changelog).
-11. Keep docs **runnable** — every README/JSDoc snippet, command, package name, and relative link is correct at HEAD; a dead link in a published `packages/*/README.md` is a defect.
-12. **No root `/` route**, and a route wildcard must be the last path segment.
-13. Refer to the project as **"AWS Blocks"** (no article — "built with AWS Blocks").
+11. Keep docs **runnable** — every README/JSDoc snippet, command, package name, and relative link is correct at HEAD; a dead link in a published `packages/*/README.md` is a defect. Without this → users copy-paste broken code and lose trust in the framework.
+12. **No root `/` route**, and a route wildcard must be the last path segment. Violating this → API Gateway rejects the route or swallows all traffic into one handler.
+13. Refer to the project as **"AWS Blocks"** (no article — "built with AWS Blocks"). Inconsistent naming → confuses search, docs, and brand recognition.
 
 ---
 
@@ -268,7 +268,7 @@ tmux kill-session -t dev
 
 Sandbox deploys take 2–3 minutes (CDK CloudFormation). Use the same tmux + polling pattern.
 
-**If you deployed a sandbox and are done with it, always run `npm run sandbox:destroy` before finishing.**
+**If you deployed a sandbox and are done with it, always run `npm run destroy` (from the test app directory) before finishing.**
 Leaving sandboxes running wastes AWS resources.
 
 ---

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,332 @@
+# AGENTS.md — AWS Blocks (contributor guide)
+
+> **AWS Blocks** is an Infrastructure-from-Code TypeScript monorepo. One `aws-blocks/` directory defines an entire backend; each **Building Block (BB)** bundles a CDK construct + an AWS-runtime SDK client + a local mock behind one strongly-typed API. Frontends import the backend's types directly — no client generation step. Everything runs locally with no AWS account; deploy with `cdk deploy`.
+
+## How to work here
+You're an engineer working **on AWS Blocks itself** — the framework and its Building Blocks. (If the task is building an app *with* AWS Blocks, this is the wrong doc → run `npm create @aws-blocks/blocks-app@latest my-app`.) You serve the project, its users, and its maintainers — not only the request in front of you.
+
+- **Default to making the change** — implement it, don't just describe it.
+- **Definition of done = the "Before you open a PR" checklist passes** (build, lint, tests, changeset, docs).
+- **Stay inside Building Blocks** for anything they cover; reach for the escape hatch (raw CDK construct / AWS SDK / `RawRoute`) only when no BB fits.
+- **Stop and ask** before any breaking change — changed return types, narrowed unions, removed exports, a changed export map, or a changed on-disk format — and surface it for maintainer review.
+- If a task isn't covered here, **say so** rather than guessing — your operator may have pointed you at the wrong tool.
+
+---
+
+## 🚦 Core rules (these gate a PR)
+
+1. CDK synth must run with **`--conditions=cdk`**. Without it, BBs load their mocks and synth produces no infrastructure.
+2. Persist application state **only through Building Blocks** — no local files, in-memory arrays, or ad-hoc databases.
+3. Inject BB config with **`registerConfig()`**, never `handler.addEnvironment()` (Lambda env has a ~4 KB cap).
+4. Call BB data methods **only inside request/job handlers** — never at module top level or during synth (the CDK class stubs them with `synthGuard` to throw).
+5. **Never attach `Error.cause` enumerably** — it leaks SDK metadata (`$metadata`, ARNs) when an error is serialized to the client.
+6. Errors cross the wire by **`name`, not `code`** — match with `isBlocksError(e, SomeErrors.Foo)` (works the same server- and client-side).
+7. **`get()`-style reads return `null`** for not-found — throw only for violated preconditions (e.g. a failed conditional write).
+8. Keep customer-facing code cast-free: **no `as any` / `: any` / `@ts-ignore`** (a cast usually means a public type is wrong — fix the type).
+9. Every API method is a public, internet-reachable RPC endpoint with no auth by default — **gate inside each method** with `await auth.requireAuth(context)`.
+10. Every change to a published package **ships a changeset** covering all changed packages (its text becomes the public changelog).
+11. Keep docs **runnable** — every README/JSDoc snippet, command, package name, and relative link is correct at HEAD; a dead link in a published `packages/*/README.md` is a defect.
+12. **No root `/` route**, and a route wildcard must be the last path segment.
+13. Refer to the project as **"AWS Blocks"** (no article — "built with AWS Blocks").
+
+---
+
+## Architecture in 60 seconds
+
+**Conditional exports** swap the implementation per environment. Every BB `package.json`:
+```jsonc
+"type": "module",
+"exports": { ".": {
+  "browser":     "./dist/index.browser.js",   // browser stub
+  "cdk":         { "types": "./dist/index.cdk.d.ts", "default": "./dist/index.cdk.js" },
+  "aws-runtime": "./dist/index.aws.js",        // Lambda runtime (--conditions=aws-runtime)
+  "types":       "./dist/index.mock.d.ts",     // ← types resolve to the MOCK
+  "default":     "./dist/index.mock.js"        // ← local dev + tests
+}}
+```
+- `Scope` is the namespace + registration bus; BBs **extend** it (never wrap it) — that's how infra discovery, IAM propagation, and `fullId` computation work.
+- `BlocksStack` / `BlocksBackend` anchor the infra; `ApiNamespace` turns an app's module of methods into a JSON-RPC endpoint at `POST /aws-blocks/api`. A BB doesn't auto-expose RPC — the app wraps the methods it wants to call.
+- **Resource names are derived, not handed off.** Each layer computes the same deterministic name from `fullId` independently: the CDK layer provisions a resource named `fullId.substring(0,255)`; the runtime and mock layers call `registerSdkIdentifiers(this.fullId, {...})` in their constructor and resolve it with `getSdkIdentifiers(this)` **at call time** (a same-process registry, so co-located BBs can find each other). The mock uses a `mock-`-prefixed name and persists to disk. Extra (non-name) config is the only thing the CDK layer pushes to the runtime, via `registerConfig()`.
+- Some BBs return **live client objects, not data** (e.g. a realtime channel). They use the **Transferable** pattern: the server value serializes (`toJSON()` → `{__blocks: …}`) and re-hydrates into a live client object via client middleware. `bb-realtime` is the canonical end-to-end example.
+
+### Core API & glossary
+| Symbol | From | What it is |
+|---|---|---|
+| `Scope` | `@aws-blocks/core` (runtime/mock) **or** `@aws-blocks/core/cdk` (CDK) | base class every BB extends |
+| `ScopeParent` | `@aws-blocks/core` (always) | the parent argument type |
+| `ApiNamespace`, `ApiError`, `isBlocksError` | `@aws-blocks/core` | RPC wrapper · HTTP-mapped error · typed-error guard |
+| `registerSdkIdentifiers`, `getSdkIdentifiers` | `@aws-blocks/core` | register (in mock/runtime ctor) / resolve (at call time) a BB's resource names |
+| `registerConfig`, `synthGuard` | `@aws-blocks/core/cdk` | inject Lambda config at synth · `(): never` stub for runtime-only methods |
+| `scope.registerClientMiddleware(pkg)` | `Scope` method (codegen) | registers the client-plugin **package specifier** that hydrates a Transferable into a live client object — the plugin does the hydration, this just registers it |
+| `getMockDataDir` | `@aws-blocks/core/bb-utils` | mock persistence dir → `.bb-data/{fullId}/` |
+| `auth.requireAuth(context)` | an auth BB | gate a method; returns the user or throws 401 |
+| `RawRoute` | `@aws-blocks/core` | escape hatch for a raw HTTP route when JSON-RPC isn't enough |
+| `fullId` | — | a BB instance's unique scoped id (drives resource + mock-data naming) |
+| reference object | — | the lightweight handle `fromExisting()` returns (e.g. `{ tableName }`), passed into a constructor — not a constructed BB |
+| Transferable | — | a server value that serializes (`toJSON()` → `{__blocks: …}`) and re-hydrates into a live client object via client middleware. Canonical example: `bb-realtime` |
+
+---
+
+## How an app consumes a BB (the mental model authoring serves)
+```ts
+// aws-blocks/index.ts — define backend + the API surface
+const scope = new Scope('app');
+const notes = new KVStore(scope, 'notes');
+const auth  = new AuthBasic(scope, 'auth');
+export const authApi = auth.createApi();                 // BB-authored state machine
+export const api = new ApiNamespace(scope, 'api', (context) => ({
+  async addNote(text: string) {
+    const user = await auth.requireAuth(context);        // gate: methods are public by default
+    await notes.put(`${user.userId}:${crypto.randomUUID()}`, text);
+  },
+}));
+
+// aws-blocks/index.handler.ts — Lambda entry (lazy import so config loads first)
+export const handler = createLambdaHandler(() => import('./index.js'));
+
+// frontend — typed import of the backend, no codegen
+import { api } from 'aws-blocks';
+await api.addNote('hello');
+```
+> A method that returns a live client object (rather than plain data) returns a Transferable — see `bb-realtime`, where `getChannel()` hands the client a channel it `subscribe()`s to (server-side `publish`/`subscribe`; client-side hydration via the registered client middleware).
+
+---
+
+## 🧱 Authoring a NEW Building Block
+
+**Reference, don't clone.** `packages/bb-kv-store/` is the canonical reference for the file structure and the conditional-export layering (`index.mock/aws/cdk/browser.ts` + `types.ts`/`errors.ts`/`version.ts`, the `Scope` subclass, `synthGuard` stubs) — read it to learn the *shape*, not to copy wholesale. Its data model is a DynamoDB key/value table; **that does not generalize.** Pick the closest-shaped BB and understand every line you carry over:
+
+| Your BB is… | Reference | Note |
+|---|---|---|
+| key/value or single-table | `bb-kv-store` / `bb-distributed-table` | the typical file skeleton below |
+| relational / SQL | `bb-data` (`Database`) / `bb-distributed-data` (`DistributedDatabase`) | `migrationsPath` + ordered `.sql` |
+| auth / composed from other BBs (no own infra) | `bb-auth-basic` | uses `index.ts` only; exposes `createApi()` |
+| background work (SQS + event source) | `bb-async-job` | `submit()` + a job handler |
+| WebSocket / returns a live client object | `bb-realtime` | client hydration (Transferable) + server APIs; `index.ts`/middleware; `Symbol.for` shared per-stack infra |
+| object storage | `bb-file-bucket` | `scan({prefix})` is valid here (S3 scopes natively) |
+
+> **Two references, two purposes.** Use `bb-kv-store` to learn the **typical file layout & layering**. Use `bb-realtime` to learn the **full client↔server surface** — it's the one BB that demonstrates client-side hydration end-to-end: a server method returns a Transferable (a channel handle) that serializes via `toJSON()` and re-hydrates into a live client object through a registered client middleware, alongside server-side `publish`/`subscribe`. The data BBs only exercise the server/data side. **Don't copy `bb-realtime`'s layout** for a simple BB — it's atypical (single `index.ts`, no mock/aws/cdk split, middleware files, shared per-stack infra).
+>
+> Some BBs use a single `index.ts` (no `index.mock/aws/cdk.ts`) and own no CDK/AWS layer (`bb-auth-basic`, `bb-realtime`) — don't force the skeleton onto them. And **never copy a reference's package.json verbatim** — regenerate `files[]` and the `test` glob from your actual `src/` (reference scripts can be stale — e.g. one currently names a non-existent test file and omits a real one).
+
+**Standard file shape** (`bb-kv-store`):
+```
+packages/bb-{name}/
+  README.md            # authoritative user doc (runnable snippets, "When to use / When not")
+  DESIGN.md            # internals + mock↔AWS differences (shipped per-BB convention)
+  API.md               # GENERATED by api-extractor — never hand-edit
+  package.json  tsconfig.json  api-extractor.json
+  src/
+    version.ts         # GENERATED (prebuild) — BB_NAME, BB_VERSION
+    types.ts           # TYPES ONLY — `import type` only; no const/function/class
+    errors.ts          # XxxErrors as-const + blocksError()
+    index.mock.ts      # default + types entry
+    index.aws.ts       # aws-runtime entry
+    index.cdk.ts       # cdk entry
+    index.browser.ts   # browser stub: re-exports types + error constants; methods are server-side (throw)
+    index.test.ts  parity.test.ts  index.cdk.test.ts
+```
+
+**The non-obvious bits of the three layers:**
+```ts
+// index.mock.ts — local dev + tests; persists to disk; self-registers a mock name
+super(id, { parent: scope, bbName: BB_NAME, bbVersion: BB_VERSION });
+registerSdkIdentifiers(this.fullId, { tableName: `mock-${this.fullId}` });
+this.file = join(getMockDataDir(this), 'store.json');                    // .bb-data/{fullId}/
+
+// index.aws.ts — real SDK client; registers in ctor, resolves at call time
+readonly bbName = BB_NAME;
+constructor(...) { super(...); registerSdkIdentifiers(this.fullId, { tableName: /* derived */ });
+                   this.client = new DynamoDBClient({ customUserAgent: this.buildUserAgentChain() }); }
+async get(key: string): Promise<T | null> {
+  const { tableName } = getSdkIdentifiers(this);                         // ← call time, never the ctor
+  /* GetItem; return null when absent */
+}
+
+// index.cdk.ts — provisions infra; does NOT register identifiers (it derives the same name)
+import { Scope, registerConfig, synthGuard } from '@aws-blocks/core/cdk';
+static fromExisting(tableName: string): ExternalTableRef { return { __brand: 'ExternalTableRef', tableName }; }
+constructor(...) {
+  super(id, { parent: scope });                                          // no bbName/bbVersion here
+  this.table = new Table(this, 'table', { tableName: this.fullId.substring(0, 255) /* … */ });
+  this.table.grantReadWriteData(this.handler);                           // grant on the SHARED handler
+  registerConfig(this, 'BLOCKS_THING_FLAG', '…');                        // extra config only (not addEnvironment)
+}
+get(..._a: unknown[]): never { return synthGuard('Thing', 'get'); }      // stub EVERY runtime method
+```
+> Returning a live client object? Make it a Transferable (`toJSON()` → `{__blocks: 'ns/type', …}`) and register a client plugin with `scope.registerClientMiddleware`; the mock must return a functional Transferable too. `bb-realtime` is the reference.
+
+**Checklist for a new BB:**
+- conditional exports across all entry points + `prebuild` version script
+- `types.ts` types-only
+- every named export in `index.mock.ts` exists in cdk/aws/browser (enforced by `conditional-exports.test.ts` in `packages/blocks`)
+- ship `README.md` + `DESIGN.md` via `package.json` `"files"`
+- register in the umbrella `packages/blocks` exactly like an existing BB (add dependency + a catalog/README row + re-export from its `index.ts` **and** `index.cdk.ts`)
+- add to the root `workspaces`
+- add an instance + test to `test-apps/comprehensive` (zero casts)
+- `npx changeset add`.
+
+---
+
+## Quick Start by Task
+
+### Implementing a New Building Block
+**→ Start here:** Read `CONTRIBUTING.md` for the full checklist, then:
+1. Read `docs/design/API-DESIGN.md` for API guidelines (G1–G18)
+2. Study an existing BB (e.g., `packages/bb-kv-store/`) for the file pattern
+3. Read `docs/reference/building-block-structure.md` for conventions
+4. Follow the **"Authoring a NEW Building Block"** section above
+
+### Fixing a Bug
+**Always repro before you fix.** Write a failing test that demonstrates the bug — this is your red. Then make it green. Never fix a bug without a test that would have caught it.
+
+**Prefer e2e over unit for repros.** An e2e test in `test-apps/comprehensive/test/` exercises the same path a customer would hit. Use unit tests only for purely internal logic.
+
+1. `npm install` at root
+2. `npm run build`
+3. **Write a failing test first** — reproduce the bug in `test-apps/comprehensive/test/` (preferred) or `packages/<affected>/src/*.test.ts` (if purely internal). Confirm it fails.
+4. Fix the code in `packages/bb-*/`
+5. Confirm your test now passes: `npm run test:e2e:local` (e2e) or `cd packages/<affected> && npm test` (unit)
+6. Run full integration tests: `npm run test:e2e:local` from root
+7. Verify no regressions in related packages
+
+### Understanding Architecture
+1. `docs/reference/ARCHITECTURE-LAYERS.md` — the four-export layer model
+2. `docs/reference/building-block-structure.md` — file conventions
+3. Root `README.md` — how conditional exports work
+
+### Discovering Building Block Documentation
+When working in an AWS Blocks application (not this monorepo), Building Block documentation lives in `node_modules`. Start from `node_modules/@aws-blocks/blocks/README.md` — it lists all Building Blocks with their package names and has instructions for locating each package's full README.
+
+---
+
+## Conventions
+
+| Area | Rule |
+|---|---|
+| Linter/formatter | **Biome** (not ESLint/Prettier): tabs (width 4), 120 cols, single quotes, trailing commas everywhere, semicolons always. `biome check` = lint + format + import-sort. |
+| Modules | **ESM everywhere**; relative imports carry the `.js` extension. `strict: true`, ES2022, `moduleResolution: bundler`. |
+| Naming | BB class `PascalCase`, no "BB" prefix (`KVStore`). pkg `@aws-blocks/bb-{kebab}`. errors `{Class}Errors`. The **`BLOCKS_` env prefix is framework-reserved** — not for example app code. Auth BBs lead with `Auth` (`AuthBasic`, `AuthOIDC`, `AuthCognito`). |
+| Schema validation | When a BB accepts a user-provided validation schema, type it as **`StandardSchemaV1`** (Zod/Valibot/ArkType) — don't pull a schema lib into the BB's runtime deps (it's the consumer's choice); if your own tests use `zod`, keep it a `devDependency`. (A BB may take a schema lib as a real `dependency` only for its *own* internal needs, e.g. `bb-agent`.) Validate via `schema['~standard'].validate(value)`, before conditional checks. |
+| Tests | **`node:test` + `node:assert`** (not Jest/Vitest), run on compiled `dist/`. Reset `.bb-data` between tests. Mock tests can't catch AWS-path serialization bugs — serialization/behavior changes also need a sandbox e2e. |
+| Async | `async/await` only; prefer **`Array.fromAsync()`** over `for await` push-loops. |
+
+---
+
+## ⚠️ E2E Tests Are Customer DX — No Type Casts
+
+The e2e tests in `test-apps/comprehensive/` represent exactly what a customer would write. They exist to validate the end-to-end type-safe DX, so **never use `as any`, `: any`, or other type casts** in test code that represents customer usage.
+
+**What represents customer code:** API calls, their return values, callback parameters, and any chaining or destructuring of results. If a customer would write it, the test should compile without casts.
+
+**What doesn't:** Test infrastructure like fetch spies, cookie jars, server lifecycle, and deploy scripts. Casts in plumbing code are fine.
+
+If a test won't compile without a cast, the Building Block's public types are wrong — fix the types at the source, not in the test.
+
+---
+
+## ⚠️ Docstrings Are Sacred
+
+**Never remove, truncate, or rewrite existing JSDoc/docstrings** on exported functions, types, classes, or interfaces. These are the primary documentation surface for customers and agents working in IDEs — they show on hover and in autocomplete.
+
+When modifying a function:
+- **Preserve** all existing docstring content (usage examples, parameter descriptions, best practices, scaling notes)
+- **Add** to docstrings if the behavior changes
+- **Update** references if names change
+- **Never** strip a docstring down to a one-liner summary
+
+If you must rewrite a file from scratch, diff the docstrings against the previous version before committing.
+
+---
+
+## ⚠️ Running Long-Lived Processes (dev server, sandbox)
+
+**Never run `npm run dev`, `npm run sandbox`, or any blocking server directly in a shell command.**
+These processes don't exit — they will hang the agent indefinitely.
+
+### Required pattern: tmux + polling
+
+```bash
+# 1. Start in a background tmux session
+tmux new-session -d -s dev 'cd test-apps/comprehensive && npm run dev'
+
+# 2. Poll every few seconds until ready
+for i in $(seq 1 30); do
+  sleep 3
+  OUTPUT=$(tmux capture-pane -t dev -p)
+  echo "$OUTPUT" | grep -q "local server running" && echo "READY" && break
+  echo "... waiting ($i)"
+done
+
+# 3. Do your work (run tests, curl endpoints, etc.)
+
+# 4. Kill the session when done
+tmux kill-session -t dev
+```
+
+### Sandbox lifecycle
+
+Sandbox deploys take 2–3 minutes (CDK CloudFormation). Use the same tmux + polling pattern.
+
+**If you deployed a sandbox and are done with it, always run `npm run sandbox:destroy` before finishing.**
+Leaving sandboxes running wastes AWS resources.
+
+---
+
+## Local dev, deploy & stages
+
+| Command | Purpose |
+|---|---|
+| `npm run build` · `npm test` (`test:unit`) | TS project-reference build · unit tests on `dist/` |
+| `npm run build:force` | Clean + rebuild (use after refactors) |
+| `npm run test:e2e:local` / `test:e2e:sandbox` | e2e against the dev server / a real AWS sandbox |
+| `npm run lint` / `lint:deps` | Biome / undeclared-dependency check (blocking) |
+| `npm run check:api` | API Extractor reports |
+| `npm run update:api` | Regenerate API reports (after intentional API changes) |
+| `npx changeset add` | required for any published-package change |
+
+- Node **22** (`.nvmrc`). Mock data → `.bb-data/{fullId}/`.
+- Stages: a transient **sandbox** vs **production**. Spin a sandbox via the scripts in `@aws-blocks/blocks/scripts` (`startSandbox`/`startDevServer`); run `test:e2e:sandbox` to validate the real AWS path; tear it down (`npm run destroy`) when done.
+
+---
+
+## ✅ Before you open a PR
+
+- [ ] `npm run build && npm run lint:deps && npm test && npm run test:e2e:local` pass locally
+- [ ] Changeset added (covers every changed published package), changelog-appropriate wording
+- [ ] README / DESIGN / JSDoc updated **in this PR**; snippets, commands, links verified at HEAD
+- [ ] Conditional-export parity holds; new runtime methods have `synthGuard` stubs
+- [ ] New behavior or security change ships a test (sandbox e2e if serialization changed)
+- [ ] Breaking change? → flag for maintainer review (see "How to work here"); prefer a backward-compatible fallback
+
+CI runs build, lint, the undeclared-dependency check, unit + e2e tests, and a changeset check.
+
+---
+
+## API design principles (beyond the Core rules)
+
+- **Options objects, not positional params** — adding an options field is non-breaking; a positional argument is not. Avoid overloads (vary behavior with options).
+- **Method names signal cost** — `get`/`put`/`delete`; expose `*Batch` only when the service has a native batch API; `query` is indexed, `scan` is full-table.
+- Use `AsyncIterable` for **unbounded result sets**; be **async by default** for anything touching storage/network.
+- **Return client-safe values** — plain JSON-serializable data, or a Transferable for live client objects (`bb-realtime`); never return a `Scope` subclass from an `ApiNamespace` method.
+- **Don't leak AWS primitives** (ARNs, SDK types, service IDs) in public signatures — the CDK entry may use CDK types.
+- `fromExisting()` returns a **reference object** (a constructor input), not a constructed BB.
+- **The constructor is the only side effect** — register/provision there; methods are pure runtime ops.
+- **Document every public method** (one-liner, params, returns, throwable errors, an example); keep README and JSDoc in sync.
+
+For the full set of guidelines (G1–G18) with rationale, examples, and the BB design document template, see [`docs/design/API-DESIGN.md`](docs/design/API-DESIGN.md).
+
+---
+
+## Reviewing a PR
+Check correctness/security, mock↔aws↔cdk↔browser consistency + conditional-export parity, doc accuracy (verify snippets/links at HEAD), and test coverage. Label **Blocking** / **Suggestion** / **Nit**, cite a location with a concrete fix, and reserve change-requests for substance (correctness, security, broken backward-compat, behavior change without a test) — not style.
+
+## Where to look
+- `packages/bb-kv-store/` — reference for the typical file layout & layering (its *data model* is KV-specific).
+- `packages/bb-realtime/` — reference for the full client↔server surface + the Transferable client-hydration pattern.
+- Each BB's `README.md` — the authoritative API doc for that block.
+- `docs/` — architecture and design background
+- `packages/hosting/README.md` — SPA/SSR frontend hosting
+- `bb-data` / `bb-distributed-data` READMEs — DB migrations
+- `native/*` — Kotlin/Swift/Dart client codegen
+- per-template `AGENTS.md` (via `npm create @aws-blocks/blocks-app@latest my-app`) — building an app *with* AWS Blocks.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,10 @@
 
 - **[guides/extending-with-existing-aws-resources.md](./guides/extending-with-existing-aws-resources.md)** — Brownfield interop: `BlocksStack`, `BlocksBackend`, `fromExisting`, custom BBs, vendorize
 
+## Design
+
+- **[design/API-DESIGN.md](./design/API-DESIGN.md)** — Building Block API design guidelines (G1–G18) and preliminary design document template
+
 ## Decisions
 
 - **[DECISIONS.md](./DECISIONS.md)** — Architectural decisions and rationale

--- a/docs/design/API-DESIGN.md
+++ b/docs/design/API-DESIGN.md
@@ -67,6 +67,8 @@ async getStore() {
 }
 ```
 
+> **Note:** `ClientSafe` and `BlocksTransferable` are conceptual types shown here for illustration. The actual enforcement is structural — `ApiNamespace` constrains return types at the type level, and the `__blocks` serialization protocol is convention-based rather than interface-enforced.
+
 The error is immediate, in the editor, before any code runs. Customers don't need to memorize which types are returnable &mdash; the compiler tells them.
 
 **Building Block authors:**
@@ -590,13 +592,13 @@ async function validateOrThrow<T>(schema: StandardSchemaV1<T>, value: unknown): 
 Some Building Blocks produce a pre-wired `ApiNamespace` that the customer exports for client consumption. For example, auth BBs expose a state machine (sign-in, sign-up, sign-out) as an `ApiNamespace` so the frontend Authenticator component can interact with it. The convention for this pattern:
 
 1. **Method name:** `createApi()` &mdash; short, clear, and the return type (`ApiNamespace`) already communicates what it is.
-2. **Parameters:** `(scope: ScopeParent, id: string)` &mdash; the customer controls where the namespace lives in the scope tree and what it's called.
+2. **Parameters:** None &mdash; the BB internally scopes the namespace (using `this` as the parent and a fixed id), so the customer doesn't need to supply scope or id.
 3. **Customer usage:** The customer exports the result so the frontend can import it.
 
 ```typescript
 // Backend — customer exports the BB-produced namespace
 const auth = new AuthBasic(scope, 'auth');
-export const authApi = auth.createApi(scope, 'auth-api');
+export const authApi = auth.createApi();
 
 // Frontend — imports and uses it like any other ApiNamespace
 import { authApi } from 'aws-blocks';

--- a/docs/design/API-DESIGN.md
+++ b/docs/design/API-DESIGN.md
@@ -1,0 +1,712 @@
+# Building Block API Design Guidelines
+
+This document provides API design guidance for AWS Blocks Building Blocks and defines the template used for preliminary BB design documents (`BB-*.md`).
+
+## Part 1: API Design Guidance
+
+These guidelines apply to all Building Blocks &mdash; first-party and customer-authored. They exist to create consistency across the ecosystem, prevent one-way doors, and keep APIs extensible without breaking changes.
+
+### Living Document
+
+This document is the authoritative reference for BB API conventions. When implementation work surfaces an ambiguity, edge case, or decision that reveals a general principle, that principle must be **backported here** as a new guideline or clarification to an existing one. The goal is to keep this document complete enough that future BB authors (human or AI) can design conformant APIs without re-discovering the same decisions. Append new guidelines at the end of Part 1 using the next available `G` number. Update existing guidelines in-place when a clarification refines (but does not contradict) the original intent.
+
+### G1: Options Objects Over Positional Parameters
+
+After the required `scope` and `id` constructor arguments, all further configuration goes in a single options object. Methods follow the same rule: required arguments first, then an optional options object last.
+
+```typescript
+// ✅ Good — extensible without breaking changes
+constructor(scope: ScopeParent, id: string, options?: KVStoreOptions);
+async set(key: string, value: T, options?: SetOptions): Promise<void>;
+
+// ❌ Bad — adding a parameter later is a breaking change
+constructor(scope: ScopeParent, id: string, ttl?: number);
+async set(key: string, value: T, ifNotExists?: boolean): Promise<void>;
+```
+
+**Why:** Adding a new field to an options object is non-breaking. Adding a new positional parameter (even optional) changes the function signature and can break existing callers in subtle ways (e.g., `undefined` passed explicitly).
+
+### G2: Favor Client-Safe Return Types
+
+Building Block methods should favor returning client-safe values &mdash; values that can be returned from `ApiNamespace` methods to the frontend without transformation. This keeps the API layer thin and avoids forcing customers to manually convert BB results into wire-friendly shapes.
+
+There are three categories of return values. The first two are **client-safe**. The third is **server-only** and should be the exception, not the norm.
+
+| Category | What It Is | Serialization | Example |
+|----------|-----------|---------------|---------|
+| **Plain data** | Objects, arrays, primitives, `null` | `JSON.stringify()` natively | `{ id: string; name: string }` |
+| **Transferable** | Functional object with `toJSON()` | `toJSON()` produces a `__blocks` descriptor; client plugin hydrates | `RealtimeChannel` (see G15) |
+| **Server-only** | Building Block instances (extend `Scope`) | Not serializable &mdash; cannot cross the wire | `KVStore`, `AuthCognito` |
+
+**How customers tell at a glance:**
+
+`ApiNamespace` constrains return types to `ClientSafe` &mdash; a type that accepts plain data and Transferables but rejects `Scope` subclasses. If a customer tries to return a server-only object from an API method, TypeScript errors immediately:
+
+```typescript
+// The constraint (inside core)
+type ClientSafe = JsonSerializable | BlocksTransferable;
+
+interface BlocksTransferable {
+	toJSON(): { __blocks: string; [key: string]: JsonSerializable };
+}
+
+// ✅ Good — plain data
+async getUser(id: string) {
+	const user = await store.get(id);
+	return user;  // { id: string; name: string } — plain object, client-safe
+}
+
+// ✅ Good — Transferable
+async getChannel(name: string) {
+	return rt.getChannel(name);  // RealtimeChannel — has toJSON(), client-safe
+}
+
+// ❌ TypeScript error — Scope subclass is not ClientSafe
+async getStore() {
+	return store;  // KVStore extends Scope — not assignable to ClientSafe
+}
+```
+
+The error is immediate, in the editor, before any code runs. Customers don't need to memorize which types are returnable &mdash; the compiler tells them.
+
+**Building Block authors:**
+
+When designing a BB method's return type, choose based on what the caller needs:
+
+- Returning **data** the caller will read → plain object (G3 applies: `null` for absence, throw for failure)
+- Returning a **capability** the caller will interact with on the client → Transferable (G15 applies: `toJSON()` + client plugin)
+- Returning something the caller will use **only on the server** → no constraint, but document it clearly and do not expose it from `ApiNamespace` methods
+
+**Why not class instances for data?**
+
+Class instances that don't implement `BlocksTransferable` are rejected by the `ClientSafe` constraint. This is intentional. Classes lose their prototypes during JSON serialization, methods disappear, and `instanceof` checks fail on the other side. Plain objects avoid all of these problems. If a BB method returns data, it must be a plain object. If it returns a capability, it must be a Transferable.
+
+### G3: Null for Absence, Throw for Failure
+
+When a requested item doesn't exist, return `null`. When an operation fails due to a violated precondition, throw.
+
+```typescript
+// ✅ Good
+async get(key: string): Promise<T | null>;  // null = not found
+async set(key: string, value: T, options?: { ifNotExists?: boolean }): Promise<void>;
+// throws ConditionalCheckFailedException if ifNotExists and key exists
+
+// ❌ Bad — throwing for "not found" forces try/catch on every read
+async get(key: string): Promise<T>;  // throws if not found
+```
+
+**Why:** "Not found" is a normal control flow outcome, not an error. Throwing for it forces callers into try/catch for routine lookups. Precondition violations (conditional writes, auth failures) are genuine errors that should throw.
+
+### G4: Async by Default
+
+All methods that touch storage, network, or state must return `Promise`. Even if the mock implementation is synchronous, the method signature must be async.
+
+```typescript
+// ✅ Good — works for both mock (sync internally) and AWS (async network call)
+async get(key: string): Promise<T | null>;
+
+// ❌ Bad — locks you into synchronous implementation forever
+get(key: string): T | null;
+```
+
+**Why:** The mock may be in-memory today but on-disk tomorrow. The AWS runtime is always async. A sync signature is a one-way door that cannot be changed to async without breaking callers.
+
+### G5: Use AsyncIterable for Unbounded Result Sets
+
+When a method can return an unbounded number of results, return `AsyncIterable` instead of an array. This lets the implementation paginate internally without exposing pagination mechanics to the caller.
+
+```typescript
+// ✅ Good — caller uses for-await, pagination is internal
+query(options: QueryOptions): AsyncIterable<Item>;
+
+// ❌ Bad — forces caller to manage pagination tokens
+query(options: QueryOptions): Promise<{ items: Item[]; nextToken?: string }>;
+```
+
+**Why:** Pagination tokens are an implementation detail of the underlying service. Exposing them leaks the abstraction and creates a different API shape per service. `AsyncIterable` is a standard language primitive that works with `for await`, spread into arrays, and composes with utility libraries.
+
+**Server-only vs client-facing:** `AsyncIterable` is appropriate for server-side BB methods that are consumed within the IFC layer (e.g., `table.query()` inside an API method that collects results and returns plain data). An `AsyncIterable` cannot be returned directly from an `ApiNamespace` method to the client &mdash; it is not `ClientSafe` (see G2). For client-facing streaming (e.g., Realtime subscriptions, LLM streaming), use a Transferable (see G15) that the client plugin hydrates into a client-side `AsyncIterable`.
+
+**Exception:** If the caller genuinely needs page-level control (e.g., displaying page numbers in a UI), a separate paginated method can be offered alongside the `AsyncIterable` version.
+
+### G6: Typed Error Constants
+
+Every Building Block that throws catchable errors must export a `{BlockName}Errors` constant object.
+
+Prefer matching the AWS SDK error name when the error describes a customer-initiated condition (e.g., a conditional write that failed), the name is self-explanatory without knowing the underlying service, and it has community recognition (Googling it yields useful results). `ConditionalCheckFailedException` is a good example — the customer asked for a condition, it failed, and the name says so.
+
+Create a Blocks-specific error name when the AWS error is a generic bucket (e.g., `ValidationException` used for dozens of unrelated conditions), describes an infrastructure detail the BB abstracts away (e.g., `ProvisionedThroughputExceededException` on a PAY_PER_REQUEST table), or would confuse customers who don't know the underlying service.
+
+```typescript
+export const KVStoreErrors = {
+	ConditionalCheckFailed: 'ConditionalCheckFailedException',
+} as const;
+```
+
+Constant keys drop the `Exception` suffix for brevity (e.g., `ConditionalCheckFailed`); the values retain the full string (e.g., `'ConditionalCheckFailedException'`) which is what `error.name` is matched against at runtime.
+
+**Why:** Typed constants prevent typos in catch blocks and enable autocomplete. Matching AWS error names means customers who already know DynamoDB (or read AWS docs) encounter familiar names. 
+
+### G7: Constructor is the Only Side Effect
+
+Building Block constructors register infrastructure and configure scope. No other method should have infrastructure side effects. Methods are purely runtime operations.
+
+```typescript
+const store = new KVStore(scope, 'data');       // ✅ constructor: registers DynamoDB table
+
+export const api = new ApiNamespace(scope, 'api', (context) => ({
+	async setValue(key: string, value: string) {
+		await store.put(key, value);              // ✅ runtime: called inside an API method
+	}
+}));
+
+// ❌ Bad — method creates infrastructure
+await store.addIndex('byEmail', { ... });        // creates GSI at runtime??
+```
+
+**Why:** Infrastructure is derived at synth time from constructor calls. If methods also create infrastructure, the synth phase would need to execute arbitrary runtime code to discover all resources. This breaks the clean separation between "what exists" (constructor) and "what happens" (methods).
+
+### G7a: Runtime Methods Must Not Execute at Construction Time
+
+The IFC layer file is imported during CDK synth to discover infrastructure. Any code at the top level of this file executes during synth &mdash; not at runtime. Runtime methods (anything that reads/writes data, sends messages, etc.) must only be called inside API handlers, job handlers, or other runtime callbacks &mdash; never at the top level.
+
+```typescript
+const store = new KVStore(scope, 'data');
+const secrets = new AppSecrets(scope, 'secrets');
+
+// ❌ WRONG — executes during CDK synth, not at runtime
+await secrets.put('api-key', 'sk_live_...');
+await store.put('default', 'value');
+
+// ✅ CORRECT — executes at runtime inside an API handler
+export const api = new ApiNamespace(scope, 'api', (context) => ({
+	async setup() {
+		await secrets.put('api-key', 'sk_live_...');
+	}
+}));
+```
+
+**Enforcement:** Runtime methods should detect when they are called outside a runtime execution context (i.e., during CDK synth or IFC import) and throw a descriptive error:
+
+```
+Error: AppSecrets.put() cannot be called during construction.
+Runtime methods must be called inside an API handler, job handler,
+or other runtime callback. This code is executing during CDK synth,
+not at request time.
+```
+
+The detection mechanism is TBD &mdash; possible approaches include checking for a runtime context flag set by the request dispatcher, or detecting the absence of a Lambda/local-server execution environment. The goal is to fail fast with a clear message rather than silently executing during synth (which would fail anyway due to missing infrastructure).
+
+### G8: Prefer Narrow Types Over Broad Ones
+
+Use the most specific type that doesn't paint you into a corner. Prefer string literal unions over `string` when the set of values is known and stable. Prefer `number` over `string` for numeric values. But don't over-constrain &mdash; if the set of values is likely to grow, use `string` with documented conventions.
+
+```typescript
+// ✅ Good — known, stable set
+billingMode: 'PAY_PER_REQUEST' | 'PROVISIONED';
+
+// ✅ Good — open-ended, will grow
+eventType: string;  // documented: 'user.created', 'user.deleted', etc.
+
+// ❌ Bad — stringly typed when a union would work
+billingMode: string;
+```
+
+**Why:** Narrow types catch mistakes at compile time. But a union that grows with every release forces consumers to handle new variants in exhaustive switches &mdash; which is a breaking change. Use unions for stable, closed sets; use `string` (with docs) for open, evolving sets.
+
+### G9: fromExisting() for External Resources
+
+Building Blocks that provision infrastructure should support wrapping pre-existing resources via a static `fromExisting()` factory. This returns a reference object passed to the constructor's options, not a fully constructed Building Block.
+
+```typescript
+// ✅ Good — explicit opt-in, constructor still controls lifecycle
+const store = new KVStore(scope, 'legacy', {
+	table: KVStore.fromExisting('my-existing-table')
+});
+
+// ❌ Bad — static factory returns a full instance, bypassing scope registration
+const store = KVStore.fromExisting(scope, 'legacy', 'my-existing-table');
+```
+
+**Why:** The constructor is where scope registration, permission grants, and infrastructure decisions happen. `fromExisting()` is a data factory that produces a reference &mdash; the constructor decides what to do with it. This keeps the constructor as the single entry point for all Building Block lifecycle concerns.
+
+### G10: No Leaking AWS Primitives
+
+Public method signatures must not expose AWS SDK types, ARNs, or service-specific identifiers. These are implementation details that change between mock and AWS runtime.
+
+```typescript
+// ✅ Good — abstract
+async get(key: string): Promise<T | null>;
+
+// ❌ Bad — leaks DynamoDB types
+async get(key: string): Promise<GetCommandOutput>;
+```
+
+**Why:** Customers should not need to import `@aws-sdk/*` to use a Building Block. Leaking SDK types also couples the public API to a specific AWS SDK version, making upgrades a breaking change.
+
+**Exception:** The CDK implementation (`index.cdk.ts`) necessarily uses CDK types. This is expected &mdash; the CDK export is consumed by the build system, not by customer runtime code.
+
+### G11: Document Everything Agents Need
+
+Every public method must include JSDoc with:
+
+- One-line description
+- `@param` for each parameter
+- `@returns` description
+- `@throws` for each catchable error (with the typed constant name)
+- At least one inline usage example
+
+Beyond method-level JSDoc, the class-level JSDoc on the Building Block itself must include:
+
+- **When to use** &mdash; what problem this BB solves and when to reach for it
+- **When NOT to use** &mdash; what alternative BB or approach is better for adjacent use cases
+- **Best practices** &mdash; key patterns for using the BB correctly (e.g., key design for KVStore, index design for DistributedTable)
+- **Scaling characteristics** &mdash; what happens as usage grows (throughput limits, cost model, latency profile)
+
+```typescript
+/**
+ * Simple key-value storage backed by DynamoDB.
+ *
+ * **When to use:** You need fast, single-key lookups with simple get/set/delete
+ * semantics. Good for caches, session stores, feature flags, and config values.
+ *
+ * **When NOT to use:** If you need to query by multiple fields, use
+ * `DistributedTable`. If you need full SQL, use `Database`.
+ *
+ * **Best practices:**
+ * - Keep keys short and descriptive (e.g., `user:{id}`, `session:{token}`)
+ * - Store one logical entity per KVStore instance
+ * - Use `{ ifNotExists: true }` for idempotent creates
+ *
+ * **Scaling:** PAY_PER_REQUEST billing. Single-digit ms reads/writes.
+ * Throughput scales automatically. Items limited to 400 KB.
+ */
+export class KVStore<T = string> extends Scope { ... }
+```
+
+This same information must be mirrored in the Building Block's `README.md` at the package root. The JSDoc is the quick reference; the README provides depth, examples, and migration guidance. Both must stay in sync — the README is the source of truth, and the JSDoc should be a condensed version of it.
+
+**Why:** AI coding agents read JSDoc to decide how to use a method and class-level docs to decide *which* BB to use. Missing or vague docs lead to incorrect BB selection and code generation. The README serves agents that discover documentation from `node_modules` . 
+
+### G12: Avoid Overloads
+
+Use options objects to vary behavior instead of method overloads. If two operations are semantically different, give them different method names.
+
+```typescript
+// ✅ Good — one method, options control behavior
+async set(key: string, value: T, options?: { ifNotExists?: boolean }): Promise<void>;
+
+// ❌ Bad — overloads create ambiguity for agents and humans
+async set(key: string, value: T): Promise<void>;
+async set(key: string, value: T, ifNotExists: boolean): Promise<void>;
+```
+
+**Why:** TypeScript overloads produce confusing IntelliSense, make JSDoc harder to write, and are a common source of agent errors. A single signature with an options object is unambiguous.
+
+### G13: Scope Extends, Not Wraps
+
+Building Blocks extend `Scope` (or a `Scope` subclass). They do not wrap or contain a scope.
+
+```typescript
+// ✅ Good
+class KVStore extends Scope { ... }
+
+// ❌ Bad
+class KVStore {
+	private scope: Scope;
+	...
+}
+```
+
+**Why:** Extending `Scope` integrates the Building Block into the scope hierarchy automatically. This is how the build system discovers infrastructure, how permissions propagate, and how `fullId` is computed. Wrapping breaks all of these.
+
+### G14: Method Naming Conventions
+
+Method names should signal what the operation does, what it returns, and roughly how it scales. Consistent verb choices across Building Blocks let developers (and agents) predict behavior without reading docs.
+
+**Single-item operations** &mdash; O(1), return a single value or `null`:
+
+| Verb | Meaning | Returns | Examples |
+|------|---------|---------|----------|
+| `get` | Retrieve one item by key/ID | `Promise<T \| null>` | `store.get(key)`, `settings.get(name)`, `cache.get(key)` |
+| `put` | Write one item (upsert, full replace) | `Promise<void>` | `store.put(key, value)`, `table.put(item)`, `cache.put(key, value)` |
+| `delete` | Remove one item by key/ID | `Promise<void>` | `store.delete(key)`, `bucket.delete(path)` |
+
+`put` follows the AWS convention (`PutItem`, `PutObject`, `PutParameter`). It always means upsert with full replace. Do not use `create` for idempotent writes &mdash; use `put` with `{ ifNotExists: true }`.
+
+**Batch operations** &mdash; operate on multiple items in one call:
+
+| Verb | Meaning | Returns | Examples |
+|------|---------|---------|----------|
+| `getBatch` | Retrieve multiple items by key | `Promise<Map<string, T \| null>>` | `store.getBatch(keys)` |
+| `putBatch` | Write multiple items | `Promise<void>` | `store.putBatch(entries)`, `table.putBatch(items)` |
+| `deleteBatch` | Remove multiple items by key | `Promise<void>` | `store.deleteBatch(keys)` |
+
+Batch methods mirror their single-item counterparts with a `Batch` suffix. They should accept arrays (or iterables) and handle chunking internally (e.g., DynamoDB's 25-item `BatchWriteItem` limit). Partial failures should throw with enough detail to identify which items failed.
+
+**Only expose batch methods when the underlying AWS service provides a native batch API** that offers a clear performance or scaling advantage over sequential single-item calls (e.g., DynamoDB `BatchGetItem`/`BatchWriteItem`, S3 `DeleteObjects`, SQS `SendMessageBatch`). A Building Block must not offer batch methods that merely loop over single-item operations internally &mdash; this misleads callers about performance characteristics and hides the true cost model. If no native batch API exists, let callers compose single-item calls with `Promise.all()` or similar patterns explicitly.
+
+**Unbounded retrieval** &mdash; returns multiple items, potentially paginated:
+
+| Verb | Meaning | Returns | Cost Signal | Examples |
+|------|---------|---------|-------------|----------|
+| `query` | Retrieve items matching an indexed condition | `AsyncIterable<T>` | Efficient &mdash; reads only matching items from an index | `table.query({ index: 'byEmail', ... })` |
+| `scan` | Enumerate all items, optionally filtered | `AsyncIterable<T>` | Expensive &mdash; reads every item in the collection | `table.scan()`, `bucket.scan({ prefix: 'uploads/' })` |
+
+`query` signals that the operation uses an index and scales with the result set size, not the total data size. `scan` signals that the operation touches every item and scales with total data size &mdash; it is intentionally named to communicate cost. Both must return `AsyncIterable` per G5.
+
+Use `query` when the caller provides indexed key conditions. Use `scan` when the operation must enumerate all items (with optional client-side filtering). The name `scan` is borrowed directly from DynamoDB to reinforce the cost implication.
+
+**Fire-and-forget** &mdash; dispatch work, don't wait for a result:
+
+| Verb | Meaning | Returns | Examples |
+|------|---------|---------|----------|
+| `send` | Dispatch a message or email | `Promise<void>` | `email.send(to, subject, body)`, `queue.send(message)` |
+| `emit` | Record a metric or event | `Promise<void>` | `metrics.emit(name, value)`, `analytics.emit(event)` |
+| `publish` | Broadcast to subscribers | `Promise<void>` | `realtime.publish(channel, data)` |
+| `submit` | Enqueue a job for async processing | `Promise<{ jobId: string }>` | `asyncJob.submit(payload)` |
+
+`send` is for point-to-point delivery. `publish` is for fan-out. `emit` is for telemetry/observability. `submit` returns a handle for tracking.
+
+**Streaming / subscription** &mdash; long-lived, push-based:
+
+| Verb | Meaning | Server Returns | Client Receives | Examples |
+|------|---------|---------------|-----------------|----------|
+| `subscribe` | Listen for incoming messages | Transferable | `AsyncIterable<T>` or event-based object | `realtime.subscribe(channel)` |
+| `stream` | Receive incremental output | Transferable | `AsyncIterable<T>` | `llm.stream(prompt)` |
+
+Streaming methods return **Transferables** (see G15). On the server, the returned object is fully functional (e.g., a real WebSocket subscription or SSE stream). It serializes via `toJSON()` into a `__blocks` descriptor. The client plugin hydrates it into a client-side object with the same interface. The customer sees the same `.subscribe()` / `for await` API on both sides.
+
+```typescript
+// Backend — returns a Transferable
+async getChannel(name: string) {
+	return rt.subscribe(name);  // functional on server, has toJSON()
+}
+
+// Client — plugin hydrates into a live client-side subscription
+const channel = await api.getChannel('chat');
+for await (const msg of channel) { /* ... */ }
+```
+
+**Gated access** &mdash; enforce a precondition, throw if unmet:
+
+| Verb | Meaning | Returns | Examples |
+|------|---------|---------|----------|
+| `require*` | Assert a condition; throw if not met | `Promise<T>` (never null) | `auth.requireAuth(context)`, `auth.requireRole(context, 'admin')` |
+| `check*` | Test a condition; return boolean | `Promise<boolean>` | `auth.checkAuth(context)` |
+| `getCurrent*` | Retrieve the current contextual value | `Promise<T \| null>` | `auth.getCurrentUser(context)` |
+
+`require*` throws (e.g., 401) &mdash; use when the caller cannot proceed without the value. `getCurrent*` returns null &mdash; use when the caller can handle absence. `check*` returns a boolean &mdash; use for branching without retrieving the full object.
+
+**Resource URL generation:**
+
+| Verb | Meaning | Returns | Examples |
+|------|---------|---------|----------|
+| `getUrl` | Generate a URL (e.g., presigned) | `Promise<string>` | `bucket.getUrl(path, { expiresIn: 3600 })` |
+
+**Verbs to avoid:**
+
+| Avoid | Use Instead | Reason |
+|-------|-------------|--------|
+| `create` | `put` with `{ ifNotExists: true }` | `create` implies non-idempotency; conditional options are more explicit |
+| `set` | `put` | `put` is the AWS standard (`PutItem`, `PutObject`, `PutParameter`); `set` is a JavaScript `Map` idiom that doesn't map to AWS |
+| `update` | `put` | `update` implies partial patch semantics; if you need partial updates, name the method `patch` |
+| `fetch` | `get` | `fetch` is ambiguous with the Fetch API |
+| `remove` | `delete` | Consistency; `delete` is the standard across AWS SDKs |
+| `find` | `query` / `scan` | `find` is ambiguous about whether it returns one or many |
+| `list` | `scan` | `list` understates the cost of a full enumeration; `scan` communicates that every item is read |
+| `invoke` | Prefer domain-specific verbs | `invoke` is too generic; use `generate`, `submit`, `send`, etc. Exception: `Agent.invoke()` is acceptable when the operation is genuinely "invoke an agent" |
+
+### G15: Transferables for Client-Side Live Objects
+
+Some Building Blocks need to return objects that have client-side behavior &mdash; a Realtime channel you can `.subscribe()` to, a file upload handle you can `.pause()` and `.resume()`, etc. These cannot be serialized as plain JSON. AWS Blocks solves this with **Transferables**: fully functional server-side objects that serialize themselves into descriptors via `toJSON()`, which client plugins then hydrate back into live client-side objects.
+
+**The problem:**
+
+```typescript
+// Backend — returns a live server-side object
+getChannel(name: string) {
+	return rt.getChannel(name);  // RealtimeChannel instance with .subscribe()
+}
+
+// Client — what arrives after JSON serialization?
+const channel = await api.getChannel('chat');
+channel.subscribe();  // 💥 subscribe is not a function — it was stripped during serialization
+```
+
+**The solution: Transferables with `toJSON()`**
+
+A Transferable is a class that is fully functional on the server *and* knows how to serialize itself into a descriptor for the wire. It uses JavaScript's built-in `toJSON()` protocol &mdash; `JSON.stringify()` automatically calls `toJSON()` on any object that defines it. The API handler needs no special logic.
+
+```typescript
+// 1. The BB defines the Transferable class (server-side, fully functional)
+class RealtimeChannel {
+	readonly channel: string;
+
+	constructor(channel: string) {
+		this.channel = channel;
+	}
+
+	// Real server-side methods (work in Lambda, SSR, backend-to-backend)
+	subscribe(callback: (msg: Message) => void): void { /* ... */ }
+	publish(msg: Message, options?: PublishOptions): Promise<void> { /* ... */ }
+	close(): void { /* ... */ }
+
+	// Serialization — called automatically by JSON.stringify()
+	toJSON(): { __blocks: 'realtime/channel'; channel: string } {
+		return { __blocks: 'realtime/channel', channel: this.channel };
+	}
+}
+
+// 2. The BB's API method returns the real object
+getChannel(name: string): RealtimeChannel {
+	return new RealtimeChannel(name);  // fully functional on the server
+}
+
+// 3. The API handler does nothing special — JSON.stringify() calls toJSON()
+JSON.stringify(result);  // → '{"__blocks":"realtime/channel","channel":"chat"}'
+
+// 4. The BB's client plugin hydrates the descriptor back into a client-side object
+// (registered via scope.registerClientMiddleware)
+function hydrateResponse(data: unknown): unknown {
+	if (isTransferable(data, 'realtime/channel')) {
+		return new RealtimeChannelClient(data.channel);  // client-side impl
+	}
+	return data;
+}
+
+// 5. The customer's experience is seamless
+const channel = await api.getChannel('chat');  // RealtimeChannelClient (hydrated)
+channel.subscribe((msg) => console.log(msg));  // ✅ works
+```
+
+**How it flows:**
+
+```
+Backend method → returns RealtimeChannel (real object, functional on server)
+    ↓
+API handler → JSON.stringify() calls .toJSON() automatically
+    ↓
+Wire → { "__blocks": "realtime/channel", "channel": "chat" }
+    ↓
+Client proxy → JSON.parse
+    ↓
+Client plugin middleware → sees __blocks tag, calls hydrateResponse()
+    ↓
+Customer code → receives RealtimeChannelClient with live client methods
+```
+
+**Why `toJSON()` and not a custom serialization hook:**
+
+- `toJSON()` is a built-in JavaScript protocol. `JSON.stringify()` already calls it. The API handler needs zero awareness of Transferables.
+- Nested Transferables work automatically. If a return value contains a Transferable inside a plain object, `JSON.stringify()` walks the tree and calls `toJSON()` at each level.
+- Every developer and AI agent already knows how `toJSON()` works. No Blocks-specific serialization API to learn.
+
+**Server-side vs client-side implementations:**
+
+The Transferable class is functional on both sides, but the implementations differ:
+
+| Side | Class | Methods | Source |
+|------|-------|---------|--------|
+| Server (Lambda) | `RealtimeChannel` | Real AWS SDK calls (AppSync, IoT, etc.) | `aws-runtime` export |
+| Server (Mock) | `RealtimeChannel` | In-process event emitter | `default` export |
+| Client (Browser) | `RealtimeChannelClient` | WebSocket connection | Client plugin |
+
+The server-side class has `toJSON()`. The client-side class does not (it never needs to serialize back). Both expose the same method signatures to the customer.
+
+**Rules for Transferables:**
+
+1. The `__blocks` field is reserved. Customer data must never use it. The client proxy should warn on `__blocks` fields in non-plugin responses.
+2. The `toJSON()` return value must be plain JSON-serializable. No functions, no circular references.
+3. The BB's `types` export declares the hydrated client type, not the descriptor. The customer's IDE shows `RealtimeChannel` with full method autocomplete, never the raw `{ __blocks: ... }` shape.
+4. Transferables can be nested inside plain return values (e.g., `{ channel: RealtimeChannel, metadata: {...} }`). `JSON.stringify()` handles this automatically via `toJSON()`.
+5. Every BB that defines a Transferable must register a client plugin via `scope.registerClientMiddleware()`. Without the plugin, the raw descriptor leaks to the customer.
+6. The mock implementation should also return a functional Transferable with `toJSON()`, so that local development exercises the same serialization path.
+
+**Relationship to G2 (Return Plain Objects):**
+
+G2 still applies to the vast majority of BB methods. Transferables are the explicit exception for methods that return *capabilities* (live connections, streams, upload handles) rather than *data*. If a method returns data, it must return a plain object. If it returns a capability, it must use the Transferable pattern.
+
+### G16: Accept Standard Schema for Runtime Validation
+
+When a BB accepts a schema for runtime validation (e.g., validating items on write, messages on publish, payloads on send), it must accept any schema that implements the [Standard Schema](https://standardschema.dev/) `StandardSchemaV1` interface &mdash; not a specific library like Zod.
+
+Standard Schema is a common interface implemented by Zod (3.24+), Valibot (1.0+), ArkType (2.0+), and many others. By accepting `StandardSchemaV1`, AWS Blocks gets:
+
+- **No vendor lock-in** &mdash; customers use whichever schema library they prefer
+- **No Blocks dependency on Zod** &mdash; `@standard-schema/spec` is types-only (zero runtime)
+- **End-to-end type safety** &mdash; `StandardSchemaV1<Input, Output>` carries inferred types that BBs can extract via `StandardSchemaV1.InferOutput<S>`
+- **Runtime validation** &mdash; BBs call `schema['~standard'].validate(value)` at runtime
+
+**Usage in BB options:**
+
+```typescript
+import type { StandardSchemaV1 } from '@standard-schema/spec';
+
+interface DistributedTableOptions<T> {
+	schema?: StandardSchemaV1<T>;
+	// ...
+}
+```
+
+**Customer experience (no wrapper needed):**
+
+```typescript
+import { z } from 'zod';
+import * as v from 'valibot';
+
+// Zod — works directly
+new DistributedTable(scope, 'users', {
+	schema: z.object({ id: z.string(), name: z.string() }),
+});
+
+// Valibot — works directly
+new DistributedTable(scope, 'users', {
+	schema: v.object({ id: v.string(), name: v.string() }),
+});
+```
+
+**Validation at runtime (inside BB implementation):**
+
+```typescript
+async function validateOrThrow<T>(schema: StandardSchemaV1<T>, value: unknown): Promise<T> {
+	const result = schema['~standard'].validate(value);
+	const resolved = result instanceof Promise ? await result : result;
+	if (resolved.issues) {
+		throw new Error(`ValidationFailed: ${resolved.issues[0].message}`);
+	}
+	return resolved.value;
+}
+```
+
+**When to require a schema vs. make it optional:**
+
+- **Optional** &mdash; data storage BBs (DistributedTable, KVStore) where the customer may not want validation overhead
+- **Optional** &mdash; messaging BBs (Queue, AsyncJob, Realtime) where the customer may trust the producer
+- **Never required** &mdash; schemas are always opt-in. Compile-time type parameters (`<T>`) provide safety without runtime cost when that's sufficient
+
+### G17: BB-Produced ApiNamespaces Use `createApi()`
+
+Some Building Blocks produce a pre-wired `ApiNamespace` that the customer exports for client consumption. For example, auth BBs expose a state machine (sign-in, sign-up, sign-out) as an `ApiNamespace` so the frontend Authenticator component can interact with it. The convention for this pattern:
+
+1. **Method name:** `createApi()` &mdash; short, clear, and the return type (`ApiNamespace`) already communicates what it is.
+2. **Parameters:** `(scope: ScopeParent, id: string)` &mdash; the customer controls where the namespace lives in the scope tree and what it's called.
+3. **Customer usage:** The customer exports the result so the frontend can import it.
+
+```typescript
+// Backend — customer exports the BB-produced namespace
+const auth = new AuthBasic(scope, 'auth');
+export const authApi = auth.createApi(scope, 'auth-api');
+
+// Frontend — imports and uses it like any other ApiNamespace
+import { authApi } from 'aws-blocks';
+const state = await authApi.getAuthState();
+```
+
+**When to use this pattern:** A BB needs to expose a set of client-callable methods that are intrinsic to the BB's functionality (not custom business logic). The BB owns the method implementations; the customer just decides where to mount them and what to name the export. Examples: auth BBs expose a sign-in/sign-up state machine; `DistributedTable` exposes a CRUD API with authorization hooks.
+
+**When NOT to use:** If the customer is writing the method bodies themselves, they should use `ApiNamespace` directly. `createApi()` is for BB-authored method sets.
+
+### G18: Don't Expose Options That Misrepresent Cost
+
+Method parameters and options must not imply a performance optimization that the underlying service does not actually provide. If an option makes the API *look* cheaper or more targeted but the implementation still performs the expensive operation, the option is misleading and must not be offered.
+
+```typescript
+// ❌ Bad — implies prefix filtering is efficient, but DynamoDB Scan reads every item
+// regardless of FilterExpression. The filter only reduces network transfer, not read cost.
+scan(options?: { prefix?: string }): AsyncIterable<Item>;
+
+// ✅ Good — scan() communicates full-table cost. Customers filter in their loop
+// or switch to DistributedTable with a sort key for efficient prefix queries.
+scan(): AsyncIterable<Item>;
+
+// ✅ Also good — FileBucket.scan({ prefix }) IS efficient because S3 ListObjectsV2
+// natively supports prefix-scoped listing without reading non-matching objects.
+scan(options?: { prefix?: string }): AsyncIterable<FileInfo>;
+```
+
+**Why:** Customers (and agents) use parameter availability as a signal for how to use the API. A `prefix` option on a method backed by a full table scan teaches customers to rely on a pattern that will not scale. When the efficient alternative exists (e.g., `DistributedTable.query()` with a sort key), the absence of the option on the simpler BB nudges customers toward the right tool.
+
+**The test:** Before adding a filtering or scoping option, ask: "Does the underlying service use this parameter to *reduce the work performed*, or only to *filter the results after the work is done*?" If the latter, omit the option and document why.
+
+---
+
+## Part 2: Preliminary Design Document Template
+
+Each Building Block gets a preliminary design document at `docs/design/BB-{name}.md` during the design phase. These documents are intentionally rough &mdash; they capture intent and API shape, not final implementation. Once a Building Block is implemented, the documentation migrates to the package:
+
+- **`packages/bb-{name}/README.md`** &mdash; Usage documentation (when to use, API, examples, best practices, scaling/cost). Self-contained for agents and humans.
+- **`packages/bb-{name}/DESIGN.md`** &mdash; Design documentation (infrastructure details, mock parity gaps, serialization, interface decisions). For extenders and advanced customers.
+
+Both files ship with the npm package. The preliminary doc in `docs/design/BB-{name}.md` is replaced with a redirect pointing to the package's README and DESIGN files.
+
+### Required Sections
+
+Every `BB-*.md` must include these sections in this order:
+
+**1. Title and Disclaimer**
+
+```markdown
+# BB: {Name} (Preliminary)
+
+> **⚠️ PRELIMINARY DESIGN** — This document is a rough starting point, not a
+> finalized specification. The API surface, mock behavior, and infrastructure
+> details must be validated against the [AWS Blocks API Design Guidelines](./API-DESIGN.md)
+> and built in accordance with the the Building Block architecture (see `docs/reference/`).
+> Expect breaking changes. Do not build against this document without confirming
+> the current state of the implementation.
+```
+
+**2. Metadata**
+
+- **Package:** NPM package name
+- **Type:** Primitive, Composite, or Client-facing 
+- **AWS Service:** Underlying service(s), or "None" for composites
+
+**3. Purpose**
+
+One to three sentences. What problem does this BB solve? When should a customer reach for it vs an alternative?
+
+**4. API Surface**
+
+Full TypeScript signatures for the class, its methods, and all supporting interfaces. Include JSDoc with `@throws` tags. This is the reviewable contract.
+
+**5. Error Constants**
+
+The exported `{Name}Errors` object with all typed error names.
+
+**6. Infrastructure (CDK)**
+
+What AWS resources are created, with what configuration. Include partition keys, billing modes, permissions, naming conventions, and removal policies. For composites, state that infrastructure is inherited.
+
+**Important:** Use `registerConfig(scope, key, value)` from `@aws-blocks/core/cdk` to pass resource identifiers (ARNs, URLs, paths) to the Lambda runtime. Do **not** use `handler.addEnvironment()` — Lambda env vars have a 4KB combined limit. See `packages/core/src/cdk/config-registry.ts`.
+
+**7. Mock Implementation**
+
+How the mock works (storage mechanism, behavioral notes). Must call out where mock behavior intentionally matches AWS and where it diverges.
+
+**8. Mock vs AWS Parity Gap Mitigations**
+
+Table with columns: Parity Gap, Impact, Mitigation. Every known divergence must be listed with either an active mitigation or an explicit "no mitigation" with rationale.
+
+**9. Serialization** (if applicable)
+
+How data is serialized/deserialized. What formats are supported. Whether runtime validation occurs.
+
+**10. Usage Examples**
+
+At minimum: basic usage, one non-trivial pattern (e.g., conditional write, error handling), and `fromExisting()` if supported.
+
+**11. Open Questions**
+
+Unresolved design questions. These should be answered before the BB exits preliminary status.
+
+### Optional Sections
+
+- **Client Plugin** &mdash; for client-facing BBs that register browser middleware
+- **Dev Server Plugin** &mdash; for BBs that attach to the local dev server (e.g., WebSocket)
+- **Migration** &mdash; for BBs that replace or wrap existing Amplify/CDK patterns
+
+### Example
+
+See `packages/bb-kv-store/DESIGN.md` for an example of a fully implemented Block.


### PR DESCRIPTION
## Summary

Adds contributor and AI-agent orientation guides to the repo root:

- **AGENTS.md** — Comprehensive codebase orientation for humans and AI agents working ON AWS Blocks itself: architecture overview, core rules (1–13), BB authoring guide, conventions, dev commands, and a pre-PR checklist.
- **CLAUDE.md** — One-line pointer (`@AGENTS.md`) so Claude-based tooling reads the guide automatically.
- **docs/design/API-DESIGN.md** — Full Building Block API design guidelines (G1–G18) covering options objects, return types, error constants, method naming conventions, Transferables, StandardSchema, and the preliminary design document template.

Also updates `docs/README.md` to link to the new design doc, and removes `CLAUDE.md` from `.gitignore`.

## Relationship to PR #86

PR #86 (by @hfurkanbozkurt, now closed) introduced a draft AGENTS.md. This PR **supersedes** it — the AGENTS.md here uses #86's comprehensive structure as its base (architecture, core rules, authoring guide, conventions) and incorporates additional agent-ergonomic content (tmux patterns for long-lived processes, docstrings-are-sacred warning, no-casts-in-e2e rule, quick-start-by-task section, discovering-BB-docs tip). The API-DESIGN.md is net-new.

## Verification

All file paths, directory references, package names, dev commands, and conditional export structures referenced in both documents have been verified against the actual repo at HEAD. No internal/private references are present.