### PR TITLE
fix(bb-distributed-data): register DSQL runtime config

### DIFF
--- a/.changeset/quiet-donkeys-remember.md
+++ b/.changeset/quiet-donkeys-remember.md
@@ -1,0 +1,5 @@
+---
+'@aws-blocks/bb-distributed-data': patch
+---
+
+Move DSQL runtime configuration to the shared config registry.

--- a/packages/bb-distributed-data/src/index.cdk.test.ts
+++ b/packages/bb-distributed-data/src/index.cdk.test.ts
@@ -14,7 +14,7 @@ import { Template, Match } from 'aws-cdk-lib/assertions';
 import { mkdirSync, writeFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import type { ScopeParent } from '@aws-blocks/core';
-import { DEFAULT_NODE_RUNTIME } from '@aws-blocks/core/cdk';
+import { DEFAULT_NODE_RUNTIME, finalizeConfigRegistry } from '@aws-blocks/core/cdk';
 import { DistributedDatabase } from './index.cdk.js';
 
 const MIGRATIONS_DIR = '.bb-data/__test_cdk_migrations__';
@@ -31,6 +31,7 @@ function synth(build: (stack: cdk.Stack) => void): Template {
   (globalThis as any).CURRENT_BLOCKS_STACK = stack;
   try {
     build(stack);
+    finalizeConfigRegistry(stack, handler);
     return Template.fromStack(stack);
   } finally {
     delete (globalThis as any).CURRENT_BLOCKS_STACK;
@@ -110,19 +111,27 @@ test('CDK: handler gets dsql:DbConnect policy (least privilege)', () => {
   });
 });
 
-// --- Environment variables ---
+// --- Runtime configuration ---
 
-test('CDK: handler gets ENDPOINT and REGION env vars', () => {
+test('CDK: runtime endpoint and region use the config registry', () => {
   const template = synth((stack) => {
     new DistributedDatabase(scope(stack), 'mydsql');
   });
   const fns = template.findResources('AWS::Lambda::Function');
   const handlerFn = Object.entries(fns).find(([id]) => id.startsWith('Handler'));
   assert.ok(handlerFn, 'Handler Lambda should exist');
-  const env = (handlerFn![1] as any).Properties?.Environment?.Variables ?? {};
+  const env = (handlerFn?.[1] as any).Properties?.Environment?.Variables ?? {};
   const envKeys = Object.keys(env);
-  assert.ok(envKeys.some(k => k.includes('ENDPOINT')), `Expected ENDPOINT env var, got: ${envKeys}`);
-  assert.ok(envKeys.some(k => k.includes('REGION')), `Expected REGION env var, got: ${envKeys}`);
+  assert.ok(!envKeys.some(k => k.endsWith('_ENDPOINT')), `Unexpected direct ENDPOINT env var: ${envKeys}`);
+  assert.ok(!envKeys.some(k => k.endsWith('_REGION')), `Unexpected direct REGION env var: ${envKeys}`);
+  assert.ok(env.BLOCKS_CONFIG_BUCKET, 'Handler Lambda should receive the config bucket');
+  assert.strictEqual(env.BLOCKS_CONFIG_KEY, 'blocks-config.json');
+
+  const configBlob = JSON.stringify(
+    Object.values(template.findResources('Custom::CDKBucketDeployment')),
+  );
+  assert.match(configBlob, /BLOCKS_[A-Za-z0-9_]+_ENDPOINT/);
+  assert.match(configBlob, /BLOCKS_[A-Za-z0-9_]+_REGION/);
 });
 
 // --- CfnOutput ---

--- a/packages/bb-distributed-data/src/index.cdk.ts
+++ b/packages/bb-distributed-data/src/index.cdk.ts
@@ -7,7 +7,7 @@
  * Optionally runs migrations via a CustomResource Lambda.
  */
 
-import { Scope, DEFAULT_NODE_RUNTIME, synthGuard } from '@aws-blocks/core/cdk';
+import { Scope, DEFAULT_NODE_RUNTIME, registerConfig, synthGuard } from '@aws-blocks/core/cdk';
 import type { ScopeParent } from '@aws-blocks/core';
 import * as cdk from 'aws-cdk-lib';
 import * as iam from 'aws-cdk-lib/aws-iam';
@@ -44,9 +44,9 @@ export class DistributedDatabase extends Scope {
 
     const endpoint = cluster.getAtt('Endpoint').toString();
 
-    // Env vars for runtime
-    this.handler.addEnvironment(`BLOCKS_${envName}_ENDPOINT`, endpoint);
-    this.handler.addEnvironment(`BLOCKS_${envName}_REGION`, region);
+    // Runtime configuration
+    registerConfig(this, `BLOCKS_${envName}_ENDPOINT`, endpoint);
+    registerConfig(this, `BLOCKS_${envName}_REGION`, region);
 
     // IAM grant — app Lambda gets DML-only access via custom DB role (least privilege)
     this.handler.addToRolePolicy(new iam.PolicyStatement({


### PR DESCRIPTION
## Problem

`DistributedDatabase` registers its DSQL endpoint and region directly on the shared Blocks Lambda. Resource mappings should use the shared config registry so they do not consume the Lambda environment-variable budget.

**Issue #, if available:** N/A

## Changes

- Register the DSQL endpoint and region through `registerConfig()`.
- Keep the migration custom-resource Lambda environment unchanged; it is separate from the customer-facing Blocks Lambda.
- Update CDK synthesis coverage to verify the application handler receives config-registry wiring, has no direct endpoint or region variables, and the deployed config includes both values.
- Add a patch changeset for `@aws-blocks/bb-distributed-data`.

## Validation

- `npm run build --workspace @aws-blocks/bb-distributed-data`
- `npm test --workspace @aws-blocks/bb-distributed-data` (146 passing tests)
- `npm run lint:deps`
- `changeset status --since=origin/main`

## Checklist

- [x] PR description included
- [x] Tests are changed or added
- [ ] Relevant documentation is changed or added (not applicable: no user-facing API or workflow change)

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._