### PR TITLE
fix(create-blocks-app): register Amplify auth config

### DIFF
--- a/.changeset/few-lizards-shake.md
+++ b/.changeset/few-lizards-shake.md
@@ -1,0 +1,5 @@
+---
+'@aws-blocks/create-blocks-app': patch
+---
+
+Store Amplify Cognito runtime configuration in the shared config registry.

--- a/packages/create-blocks-app/src/cli.test.ts
+++ b/packages/create-blocks-app/src/cli.test.ts
@@ -181,6 +181,12 @@ describe('create-blocks-app auto-detection', () => {
       assert.match(readFileSync(cognitoVerifierPath, 'utf-8'), /from '@aws-blocks\/blocks'/);
       assert.doesNotMatch(readFileSync(generateClientPath, 'utf-8'), /@aws-blocks\/core/);
       assert.doesNotMatch(readFileSync(cognitoVerifierPath, 'utf-8'), /@aws-blocks\/core/);
+
+      const blocksIntegration = readFileSync(join(tmpDir, 'amplify', 'blocks.ts'), 'utf-8');
+      assert.match(blocksIntegration, /import \{ registerConfig \} from '@aws-blocks\/blocks\/cdk';/);
+      assert.match(blocksIntegration, /registerConfig\(blocks, 'COGNITO_USER_POOL_ID', cfnUserPool\.ref\);/);
+      assert.match(blocksIntegration, /registerConfig\(blocks, 'COGNITO_CLIENT_ID', cfnUserPoolClient\.ref\);/);
+      assert.doesNotMatch(blocksIntegration, /blocks\.handler\.addEnvironment\('COGNITO_/);
     } finally {
       rmSync(tmpDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
     }

--- a/packages/create-blocks-app/templates/amplify/amplify-blocks.ts
+++ b/packages/create-blocks-app/templates/amplify/amplify-blocks.ts
@@ -5,6 +5,7 @@
  * Passes Cognito config so Blocks can verify bearer tokens.
  */
 import { createBlocksBackend } from '../aws-blocks/index.cdk.js';
+import { registerConfig } from '@aws-blocks/blocks/cdk';
 
 export async function initBlocks(backend: any) {
   const blocksStack = backend.createStack('blocks');
@@ -14,9 +15,8 @@ export async function initBlocks(backend: any) {
   // Pass Amplify's Cognito config to the Blocks Lambda (if auth is configured)
   if (backend.auth?.resources?.cfnResources) {
     const { cfnUserPool, cfnUserPoolClient } = backend.auth.resources.cfnResources;
-    blocks.handler.addEnvironment('COGNITO_USER_POOL_ID', cfnUserPool.ref);
-    blocks.handler.addEnvironment('COGNITO_CLIENT_ID', cfnUserPoolClient.ref);
-    blocks.handler.addEnvironment('COGNITO_REGION', blocksStack.region);
+    registerConfig(blocks, 'COGNITO_USER_POOL_ID', cfnUserPool.ref);
+    registerConfig(blocks, 'COGNITO_CLIENT_ID', cfnUserPoolClient.ref);
   }
 
   // Surface Blocks API URL in amplify_outputs.json

--- a/test-apps/amplify-gen2/amplify/blocks.ts
+++ b/test-apps/amplify-gen2/amplify/blocks.ts
@@ -5,6 +5,7 @@
  * Passes Cognito config so Blocks can verify bearer tokens.
  */
 import { createBlocksBackend } from '../aws-blocks/index.cdk.js';
+import { registerConfig } from '@aws-blocks/blocks/cdk';
 
 export async function initBlocks(backend: any) {
   const blocksStack = backend.createStack('blocks');
@@ -14,9 +15,8 @@ export async function initBlocks(backend: any) {
   // Pass Amplify's Cognito config to the Blocks Lambda (if auth is configured)
   if (backend.auth?.resources?.cfnResources) {
     const { cfnUserPool, cfnUserPoolClient } = backend.auth.resources.cfnResources;
-    blocks.handler.addEnvironment('COGNITO_USER_POOL_ID', cfnUserPool.ref);
-    blocks.handler.addEnvironment('COGNITO_CLIENT_ID', cfnUserPoolClient.ref);
-    blocks.handler.addEnvironment('COGNITO_REGION', blocksStack.region);
+    registerConfig(blocks, 'COGNITO_USER_POOL_ID', cfnUserPool.ref);
+    registerConfig(blocks, 'COGNITO_CLIENT_ID', cfnUserPoolClient.ref);
   }
 
   // Surface Blocks API URL in amplify_outputs.json


### PR DESCRIPTION
## Problem

The Amplify Gen 2 overlay adds Cognito values directly to the shared Blocks Lambda environment. This bypasses the shared config registry and consumes the Lambda environment-variable budget. It also injects `COGNITO_REGION`, which the generated Cognito verifier does not read.

**Issue #, if available:** N/A

## Changes

- Register the generated Cognito verifier's User Pool ID and Client ID through `registerConfig()` from `@aws-blocks/blocks/cdk`.
- Remove the unused `COGNITO_REGION` injection.
- Keep the Amplify Gen 2 integration fixture aligned with the generated overlay.
- Add a scaffold test that verifies the copied overlay uses the config registry and does not directly inject Cognito environment variables.
- Add a patch changeset for `@aws-blocks/create-blocks-app`.

## Validation

- `npm run build --workspace @aws-blocks/create-blocks-app`
- `npm test --workspace @aws-blocks/create-blocks-app` (50 passing tests)
- `npx tsc --noEmit --target ES2022 --module NodeNext --moduleResolution NodeNext --skipLibCheck test-apps/amplify-gen2/amplify/blocks.ts`
- `npm run lint:deps`
- `changeset status --since=origin/main`

## Checklist

- [x] PR description included
- [x] Tests are changed or added
- [ ] Relevant documentation is changed or added (not applicable: the generated auth API and workflow are unchanged)

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._