### PR TITLE
fix(create-blocks-app): fix Amplify integration scripts

### DIFF
--- a/.changeset/clear-amplify-dev-server.md
+++ b/.changeset/clear-amplify-dev-server.md
@@ -1,0 +1,5 @@
+---
+'@aws-blocks/create-blocks-app': patch
+---
+
+Include the local dev-server script and use public AWS Blocks imports when adding AWS Blocks to an Amplify Gen 2 project.

--- a/packages/create-blocks-app/src/cli.test.ts
+++ b/packages/create-blocks-app/src/cli.test.ts
@@ -170,6 +170,17 @@ describe('create-blocks-app auto-detection', () => {
       const result = run(['-y', '--skip-install'], tmpDir);
       assert.strictEqual(result.exitCode, 0);
       assert.match(result.stdout, /Detected Amplify Gen 2 project/);
+      const packageJson = JSON.parse(readFileSync(join(tmpDir, 'package.json'), 'utf-8'));
+      const serverPath = join(tmpDir, 'aws-blocks', 'scripts', 'server.ts');
+      const generateClientPath = join(tmpDir, 'aws-blocks', 'scripts', 'generate-client.ts');
+      const cognitoVerifierPath = join(tmpDir, 'aws-blocks', 'cognito-verifier.ts');
+      assert.strictEqual(packageJson.scripts['blocks:dev'], 'tsx watch aws-blocks/scripts/server.ts');
+      assert.ok(existsSync(serverPath));
+      assert.match(readFileSync(serverPath, 'utf-8'), /startDevServer/);
+      assert.match(readFileSync(generateClientPath, 'utf-8'), /from '@aws-blocks\/blocks\/scripts'/);
+      assert.match(readFileSync(cognitoVerifierPath, 'utf-8'), /from '@aws-blocks\/blocks'/);
+      assert.doesNotMatch(readFileSync(generateClientPath, 'utf-8'), /@aws-blocks\/core/);
+      assert.doesNotMatch(readFileSync(cognitoVerifierPath, 'utf-8'), /@aws-blocks\/core/);
     } finally {
       rmSync(tmpDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
     }

--- a/packages/create-blocks-app/templates/amplify/aws-blocks/cognito-verifier.ts
+++ b/packages/create-blocks-app/templates/amplify/aws-blocks/cognito-verifier.ts
@@ -8,8 +8,7 @@
  * No session store, no sign-in flow, no cookies — pure stateless verification.
  */
 
-import { ApiError } from '@aws-blocks/core';
-import type { BlocksContext } from '@aws-blocks/core';
+import { ApiError, type BlocksContext } from '@aws-blocks/blocks';
 import { CognitoJwtVerifier } from 'aws-jwt-verify';
 
 type CognitoVerifierInstance = ReturnType<typeof CognitoJwtVerifier.create>;

--- a/packages/create-blocks-app/templates/amplify/aws-blocks/scripts/generate-client.ts
+++ b/packages/create-blocks-app/templates/amplify/aws-blocks/scripts/generate-client.ts
@@ -3,12 +3,12 @@
  *
  * Run: npm run blocks:generate-client
  *
- * Uses the core generateClientCode() to discover ApiNamespace exports,
+ * Uses generateClientCode() to discover ApiNamespace exports,
  * then injects the Amplify auth middleware and URL configuration.
  */
-import { resolve, dirname, join } from 'node:path';
-import { writeFileSync, mkdirSync } from 'node:fs';
-import { generateClientCode } from '@aws-blocks/core/scripts';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { generateClientCode } from '@aws-blocks/blocks/scripts';
 
 const awsBlocksDir = resolve(dirname(new URL(import.meta.url).pathname), '..');
 const foundationPath = join(awsBlocksDir, 'index.ts');
@@ -21,8 +21,8 @@ let code = await generateClientCode(foundationPath);
 // Standard: __BLOCKS_ApiNamespaceClient__('name')
 // Amplify:  __BLOCKS_ApiNamespaceClient__('name', { url: BLOCKS_API_URL })
 code = code.replace(
-  /__BLOCKS_ApiNamespaceClient__\('([^']+)'\)/g,
-  "__BLOCKS_ApiNamespaceClient__('$1', { url: BLOCKS_API_URL })"
+	/__BLOCKS_ApiNamespaceClient__\('([^']+)'\)/g,
+	"__BLOCKS_ApiNamespaceClient__('$1', { url: BLOCKS_API_URL })",
 );
 
 // Replace the auto-generated header and imports with Amplify-specific preamble

--- a/packages/create-blocks-app/templates/amplify/aws-blocks/scripts/server.ts
+++ b/packages/create-blocks-app/templates/amplify/aws-blocks/scripts/server.ts
@@ -1,0 +1,10 @@
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { startDevServer } from '@aws-blocks/blocks/scripts';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+startDevServer({
+	backendPath: join(__dirname, '..', 'index.ts'),
+	port: 3001,
+});


### PR DESCRIPTION
## Problem

**Issue #, if available:** Fixes #241

The Amplify Gen 2 integration had two missing-module failures:

- `blocks:dev` referenced `aws-blocks/scripts/server.ts`, but the Amplify overlay did not include that file.
- `blocks:generate-client` and the generated Cognito verifier imported the internal `@aws-blocks/core` package directly even though the template declares the public `@aws-blocks/blocks` package.

## Changes

- Add the missing Amplify `aws-blocks/scripts/server.ts` template, using the existing backend-template local server pattern on port 3001.
- Replace the two direct internal-package imports with the corresponding public `@aws-blocks/blocks` and `@aws-blocks/blocks/scripts` exports.
- Extend the Amplify auto-detection regression test to verify that generated scripts have their required files and use no direct `@aws-blocks/core` imports.
- Add a patch changeset for `@aws-blocks/create-blocks-app`.

## Validation

- Added regression assertions that fail before the template and import fixes.
- `npm run build`
- `npm run lint:deps`
- `npm test`
- `npm run test:e2e:local` (comprehensive: 372 passed, 0 failed, 1 skipped; vendorize: 8 passed, 0 failed)
- `npm pack --dry-run --workspace @aws-blocks/create-blocks-app` confirms the new template is included.
- `npx changeset status`

## Checklist

- [x] PR description included
- [x] Tests are changed or added
- [ ] Relevant documentation is changed or added (not applicable: this fixes existing generated commands and dependency boundaries; it adds no new user-facing workflow or API documentation.)

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._