### PR TITLE
chore(dart): Change readme license to Apache-2.0

### DIFF
--- a/native/dart/README.md
+++ b/native/dart/README.md
@@ -128,4 +128,4 @@ The output is a single self-contained `.blocks.dart` file. For backends with rea
 
 ## License
 
-MIT
+Apache-2.0


### PR DESCRIPTION
Our project has Apache-2.0 license, this readme indicated MIT license.