### PR TITLE
fix(agent): AgentCore runtime role inherits the handler's BB grants (5/5)

### DIFF
--- a/packages/bb-agent/src/index.cdk.test.ts
+++ b/packages/bb-agent/src/index.cdk.test.ts
@@ -19,9 +19,9 @@ import assert from 'node:assert';
 import { dirname } from 'node:path';
 import { test } from 'node:test';
 import { fileURLToPath } from 'node:url';
-import { DEFAULT_NODE_RUNTIME, Scope } from '@aws-blocks/core/cdk';
+import { DEFAULT_NODE_RUNTIME, finalizeAgentRuntimeRoles, Scope } from '@aws-blocks/core/cdk';
 import * as cdk from 'aws-cdk-lib';
-import { Template } from 'aws-cdk-lib/assertions';
+import { Match, Template } from 'aws-cdk-lib/assertions';
 import type { Construct } from 'constructs';
 import { Agent } from './index.cdk.js';
 
@@ -122,5 +122,37 @@ test('CDK: BB_AGENT_REQUIRE_VERIFIED_IDENTITY tracks the authorizer (fail-closed
 	});
 	Template.fromStack(jwt.stack).hasResourceProperties('AWS::BedrockAgentCore::Runtime', {
 		EnvironmentVariables: { BB_AGENT_REQUIRE_VERIFIED_IDENTITY: 'true' },
+	});
+});
+
+test('CDK: the AgentCore runtime role inherits the handler role\'s BB grants', () => {
+	// The agent loop runs in the container, so its tool handlers call other BBs from the
+	// runtime role. BBs grant the shared Lambda handler role; the stack finalizer copies
+	// those grants onto every registered runtime role. Simulate a BB grant on the handler,
+	// run the finalizer (BlocksStack.create does this in a real app), and assert it lands.
+	const { stack, parent } = setup();
+	// A BB would do e.g. table.grantReadWriteData(this.handler); emulate with a distinctive action.
+	stack.handler.addToRolePolicy(
+		new cdk.aws_iam.PolicyStatement({
+			actions: ['dynamodb:GetItem'],
+			resources: ['arn:aws:dynamodb:us-east-1:123456789012:table/SomeOtherBBTable'],
+		}),
+	);
+	new Agent(parent, 'chat', { systemPrompt: 'test', agentcoreAssetPath: ASSET_DIR });
+	// The registry finalizer runs after all BBs construct; call it directly (the stub isn't a
+	// real BlocksStack.create, which would call it at index.ts:82).
+	finalizeAgentRuntimeRoles(stack, stack.handler);
+	const template = Template.fromStack(stack);
+	// The copied statement should appear on an IAM policy scoped to the other BB's table —
+	// i.e. the runtime role now has access it wouldn't get from the Agent's own grants.
+	template.hasResourceProperties('AWS::IAM::Policy', {
+		PolicyDocument: {
+			Statement: Match.arrayWith([
+				Match.objectLike({
+					Action: 'dynamodb:GetItem',
+					Resource: 'arn:aws:dynamodb:us-east-1:123456789012:table/SomeOtherBBTable',
+				}),
+			]),
+		},
 	});
 });

--- a/packages/bb-agent/src/index.cdk.ts
+++ b/packages/bb-agent/src/index.cdk.ts
@@ -6,7 +6,7 @@ import { join } from 'node:path';
 import { DistributedTable } from '@aws-blocks/bb-distributed-table';
 import { FileBucket } from '@aws-blocks/bb-file-bucket';
 import type { ScopeParent } from '@aws-blocks/core';
-import { registerConfig, Scope } from '@aws-blocks/core/cdk';
+import { registerAgentRuntimeRole, registerConfig, Scope } from '@aws-blocks/core/cdk';
 import * as cdk from 'aws-cdk-lib';
 import {
 	AgentCoreRuntime,
@@ -166,6 +166,13 @@ export class Agent extends Scope {
 			// Expose the runtime ARN so the Lambda runtime path can return it from stream()
 			// and the client can open the SSE connection directly.
 			registerConfig(this, `BB_AGENT_${this.fullId}_RUNTIME_ARN`, runtime.agentRuntimeArn);
+
+			// The agent loop runs in the container, so its tool handlers call other BBs
+			// (KVStore, DistributedTable, …) from `runtime.role` — a different principal than
+			// the Lambda `handler` that every BB grants. Register the role so the stack
+			// finalizer copies the handler's accumulated BB permissions onto it (after all BBs
+			// have granted the handler); otherwise cross-BB tool calls hit AccessDenied on AWS.
+			registerAgentRuntimeRole(this, runtime.role);
 		}
 	}
 

--- a/packages/core/src/cdk/blocks-backend.ts
+++ b/packages/core/src/cdk/blocks-backend.ts
@@ -10,6 +10,7 @@ import { pathToFileURL } from 'node:url';
 import { DEFAULT_NODE_RUNTIME } from './node-version.js';
 import { addBlocksStackMetadata } from './stack-metadata.js';
 import { finalizeConfigRegistry, registerConfig } from './config-registry.js';
+import { finalizeAgentRuntimeRoles } from './runtime-role-registry.js';
 import { BLOCKS_NAMESPACE, BLOCKS_RPC_PREFIX } from '../constants.js';
 import { registerBuiltinRoutes } from '../builtin-routes.js';
 
@@ -247,6 +248,9 @@ export class BlocksBackend extends Construct {
 
     // Finalize BB config → S3 (after all BBs have registered their config)
     finalizeConfigRegistry(backend, backend.handler);
+    // Give each AgentCore Runtime role the handler's accumulated BB grants (after all BBs
+    // have granted the handler) so agent tools can reach other BBs from the container.
+    finalizeAgentRuntimeRoles(backend, backend.handler);
 
     return backend;
   }

--- a/packages/core/src/cdk/index.ts
+++ b/packages/core/src/cdk/index.ts
@@ -14,12 +14,14 @@ import {
 } from '../common/index.js';
 import { assertCdkConditionActive, BlocksBackend, setupBlocksInfra } from './blocks-backend.js';
 import { finalizeConfigRegistry } from './config-registry.js';
+import { finalizeAgentRuntimeRoles } from './runtime-role-registry.js';
 import { addBlocksStackMetadata } from './stack-metadata.js';
 
 export { ApiError, DEFAULT_API_ERROR_NAME, hasAuthError, isBlocksError } from '../errors.js';
 export type { ScopeOptions } from '../index.js';
 export { BlocksBackend, type BlocksBackendProps } from './blocks-backend.js';
 export { finalizeConfigRegistry, registerConfig } from './config-registry.js';
+export { finalizeAgentRuntimeRoles, registerAgentRuntimeRole } from './runtime-role-registry.js';
 export { SandboxDisableDeletionProtection } from './mixins.js';
 export { DEFAULT_NODE_RUNTIME } from './node-version.js';
 export { synthGuard } from './synth-guard.js';
@@ -75,6 +77,9 @@ export class BlocksStack extends cdk.Stack implements BaseBlocksStack {
 		}
 		// Finalize BB config → S3 (after all BBs have registered their config)
 		finalizeConfigRegistry(stack, stack.handler);
+		// Give each AgentCore Runtime role the handler's accumulated BB grants (after all BBs
+		// have granted the handler) so agent tools can reach other BBs from the container.
+		finalizeAgentRuntimeRoles(stack, stack.handler);
 
 		new cdk.CfnOutput(stack, 'ApiUrl', { value: stack.apiUrl });
 

--- a/packages/core/src/cdk/runtime-role-registry.ts
+++ b/packages/core/src/cdk/runtime-role-registry.ts
@@ -1,0 +1,94 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import * as cdk from 'aws-cdk-lib';
+import * as iam from 'aws-cdk-lib/aws-iam';
+import type { Construct } from 'constructs';
+
+const REGISTRY_KEY = Symbol.for('BLOCKS_AGENT_RUNTIME_ROLES');
+
+interface RuntimeRoleRegistryState {
+	roles: iam.IRole[];
+	finalized: boolean;
+}
+
+/**
+ * Get or create the AgentCore-runtime-role registry for a given stack.
+ * Collects the execution roles of every Agent BB's AgentCore Runtime so their
+ * IAM can be reconciled with the shared Lambda handler role at synth time.
+ */
+function getRegistry(stack: cdk.Stack): RuntimeRoleRegistryState {
+	let state = (stack as any)[REGISTRY_KEY] as RuntimeRoleRegistryState | undefined;
+	if (!state) {
+		state = { roles: [], finalized: false };
+		(stack as any)[REGISTRY_KEY] = state;
+	}
+	return state;
+}
+
+/**
+ * Register an AgentCore Runtime execution role so it inherits the shared Lambda
+ * handler role's permissions at synth finalize time (see `finalizeAgentRuntimeRoles`).
+ *
+ * Why: the agent loop runs inside the AgentCore container, so its tool handlers call
+ * other Building Blocks (KVStore, DistributedTable, FileBucket, …) from THIS role — a
+ * different principal than the Lambda `handler` that every BB grants via
+ * `grant*Data(this.handler)`. Without reconciliation the container gets AccessDenied on
+ * any BB beyond the Agent's own resources.
+ *
+ * @param scope - The CDK construct (used to find the parent stack)
+ * @param role - The AgentCore Runtime execution role to augment
+ */
+export function registerAgentRuntimeRole(scope: Construct, role: iam.IRole): void {
+	const stack = cdk.Stack.of(scope);
+	getRegistry(stack).roles.push(role);
+}
+
+/**
+ * Finalize AgentCore runtime roles: copy the shared Lambda handler role's accumulated
+ * permissions onto every registered runtime role, so a tool handler running in the
+ * container has the same Building Block access it would have in the Lambda.
+ *
+ * Must be called AFTER all BBs are constructed (i.e., after the backendCDKPath import
+ * completes in BlocksStack.create() / BlocksBackend.create()) — that's when the handler
+ * role's default policy has accumulated every BB's grant. Construction order of
+ * `new Agent()` vs `new KVStore()` is arbitrary, so this can't happen in the Agent
+ * constructor.
+ *
+ * Copies the handler's default-policy statements. This mirrors "the runtime has the same
+ * capability as the handler"; it is intentionally broad. Scoping the copy to only the BBs
+ * a given agent's tools touch is future work (needs per-agent grant declaration).
+ *
+ * @param scope - The CDK construct to resolve the stack from
+ * @param handler - The shared Lambda function whose role's grants converge all BB permissions
+ */
+export function finalizeAgentRuntimeRoles(
+	scope: Construct,
+	handler: cdk.aws_lambda.IFunction,
+): void {
+	const stack = cdk.Stack.of(scope);
+	const registry = getRegistry(stack);
+
+	if (registry.finalized) return;
+	registry.finalized = true;
+
+	if (registry.roles.length === 0) return;
+
+	const handlerRole = handler.role;
+	if (!handlerRole) return;
+
+	// All BB grants (grant*Data / addToRolePolicy) land on the handler role's
+	// auto-created DefaultPolicy. `PolicyDocument.statements` is private, so read the
+	// public JSON shape (`.Statement`) and clone each statement onto the runtime roles.
+	const defaultPolicy = handlerRole.node.tryFindChild('DefaultPolicy') as iam.Policy | undefined;
+	if (!defaultPolicy) return;
+	const doc = defaultPolicy.document.toJSON() as { Statement?: Array<Record<string, unknown>> } | undefined;
+	const statements = doc?.Statement ?? [];
+	if (statements.length === 0) return;
+
+	for (const role of registry.roles) {
+		for (const statement of statements) {
+			role.addToPrincipalPolicy(iam.PolicyStatement.fromJson(statement));
+		}
+	}
+}

--- a/packages/core/src/index.cdk.ts
+++ b/packages/core/src/index.cdk.ts
@@ -8,7 +8,7 @@ export { EventSourceMapping } from './lambda-handler.js';
 export { BlocksStackProps } from './common/index.js';
 export { registerSdkIdentifiers, getSdkIdentifiers, getAllSdkIdentifiers, _resetSdkRegistry } from './common/sdk-registry.js';
 export { getConfig, getConfigSync, preloadConfig, loadConfigToProcessEnv, _resetConfigCache } from './common/config.js';
-export { BlocksStack, Scope, SandboxDisableDeletionProtection, BlocksBackend, registerConfig, finalizeConfigRegistry, synthGuard, DEFAULT_NODE_RUNTIME, type BlocksBackendProps } from './cdk/index.js';
+export { BlocksStack, Scope, SandboxDisableDeletionProtection, BlocksBackend, registerConfig, finalizeConfigRegistry, registerAgentRuntimeRole, finalizeAgentRuntimeRoles, synthGuard, DEFAULT_NODE_RUNTIME, type BlocksBackendProps } from './cdk/index.js';
 export {
   Hosting,
   type HostingProps,


### PR DESCRIPTION
## Problem

The agent loop runs inside the **AgentCore container**, so a tool handler that calls another Building Block — `KVStore`, `DistributedTable`, `FileBucket`, `Database`, … — does so from the **Runtime execution role**. But every BB grants the **shared Lambda handler role** (`grant*Data(this.handler)` / `handler.addToRolePolicy(...)`). The runtime is a separate IAM principal nothing else grants to, so it only had the Agent's own Bedrock/S3/convos+messages access.

**Result:** any tool that touches another BB fails on AWS with e.g. `dynamodb:GetItem` AccessDenied. On Lambda this worked because the handler role accumulates every BB's grant; moving the loop into the container broke that. Found via a **live standalone e2e deploy** (`saveNote`/`listNotes` over a KVStore failed with AccessDenied).

## Fix

A **runtime-role registry** in core, mirroring the existing `config-registry` pattern:

- `registerAgentRuntimeRole(scope, role)` — Agents register their `runtime.role`.
- `finalizeAgentRuntimeRoles(stack, handler)` — called at the existing "after all BBs" seam in `BlocksStack.create` / `BlocksBackend.create` (right after `finalizeConfigRegistry`). It reads the handler role's accumulated **DefaultPolicy** statements and copies them onto every registered runtime role.

Timing matters: `new Agent()` and `new KVStore()` construct in arbitrary order, so the handler's grants aren't complete when the Agent constructor runs — the copy must happen at the finalizer (after the backend module import), not in the constructor. No `IAspect` (none exists in the repo); this uses the proven finalizer seam.

### Changes
- **core:** new `cdk/runtime-role-registry.ts` (`registerAgentRuntimeRole` / `finalizeAgentRuntimeRoles`), wired at both finalizer call sites (`cdk/index.ts`, `cdk/blocks-backend.ts`) and re-exported from `@aws-blocks/core/cdk`.
- **bb-agent:** `registerAgentRuntimeRole(this, runtime.role)` after the Runtime is created. The hand-written Bedrock/S3/own-tables grants stay (they're correct + independent of app BBs).
- **test:** grant the stub handler a foreign-table `dynamodb:GetItem`, run the finalizer, assert it appears on the runtime role's policy.

## Scope note (intentional)

This copies **all** the handler's permissions onto the runtime role — "the runtime has the same capability as the handler." It's intentionally broad; on a large app CDK may spill the runtime's inline policy into a managed policy (observed live — harmless). **Scoping** the copy to only the BBs a given agent's tools actually use is future work (needs per-agent grant declaration, e.g. `new Agent({ grants: [...] })`).

## Verification

- `packages/bb-agent` 107 tests pass (incl. the new runtime-role-inheritance synth test); `packages/core` 584 pass.
- **Proven end-to-end on a live AWS sandbox:** with this fix deployed, `saveNote hello` → saved and `listNotes` → returned the note, with **zero AccessDenied** — the exact repro that failed before. HITL, browser-direct WebSocket streaming, and `resolveToolContext` (from #261) all still work.

Stacked on #252 → #261. Capstone of the AgentCore migration — the migration isn't functionally complete for real agents (which use BBs in tools) without it.