### PR TITLE
fix(test-apps): resolve comprehensive E2E against workspace source (#257)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -56937,15 +56937,28 @@
         "aws-blocks"
       ],
       "dependencies": {
+        "@aws-blocks/auth-common": "*",
         "@aws-blocks/bb-agent": "*",
         "@aws-blocks/bb-app-setting": "*",
         "@aws-blocks/bb-async-job": "*",
+        "@aws-blocks/bb-auth-basic": "*",
+        "@aws-blocks/bb-auth-cognito": "*",
+        "@aws-blocks/bb-auth-oidc": "*",
+        "@aws-blocks/bb-cron-job": "*",
+        "@aws-blocks/bb-dashboard": "*",
+        "@aws-blocks/bb-data": "*",
         "@aws-blocks/bb-distributed-data": "*",
+        "@aws-blocks/bb-distributed-table": "*",
+        "@aws-blocks/bb-email-client": "*",
+        "@aws-blocks/bb-file-bucket": "*",
         "@aws-blocks/bb-knowledge-base": "*",
+        "@aws-blocks/bb-kv-store": "*",
         "@aws-blocks/bb-logger": "*",
         "@aws-blocks/bb-metrics": "*",
+        "@aws-blocks/bb-realtime": "*",
         "@aws-blocks/bb-tracer": "*",
         "@aws-blocks/blocks": "*",
+        "@aws-blocks/core": "*",
         "zod": "^4.3.0"
       },
       "devDependencies": {

--- a/test-apps/comprehensive/package.json
+++ b/test-apps/comprehensive/package.json
@@ -23,15 +23,28 @@
     "vendorize": "node ../../packages/blocks/dist/vendorize.js"
   },
   "dependencies": {
+    "@aws-blocks/auth-common": "*",
     "@aws-blocks/bb-agent": "*",
     "@aws-blocks/bb-app-setting": "*",
     "@aws-blocks/bb-async-job": "*",
+    "@aws-blocks/bb-auth-basic": "*",
+    "@aws-blocks/bb-auth-cognito": "*",
+    "@aws-blocks/bb-auth-oidc": "*",
+    "@aws-blocks/bb-cron-job": "*",
+    "@aws-blocks/bb-dashboard": "*",
+    "@aws-blocks/bb-data": "*",
     "@aws-blocks/bb-distributed-data": "*",
+    "@aws-blocks/bb-distributed-table": "*",
+    "@aws-blocks/bb-email-client": "*",
+    "@aws-blocks/bb-file-bucket": "*",
     "@aws-blocks/bb-knowledge-base": "*",
+    "@aws-blocks/bb-kv-store": "*",
     "@aws-blocks/bb-logger": "*",
     "@aws-blocks/bb-metrics": "*",
+    "@aws-blocks/bb-realtime": "*",
     "@aws-blocks/bb-tracer": "*",
     "@aws-blocks/blocks": "*",
+    "@aws-blocks/core": "*",
     "zod": "^4.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Closes #257

## Problem

On `main`, the comprehensive local E2E suite (`test-apps/comprehensive`) could type-check its backend against **nested published** `@aws-blocks/*` packages under `test-apps/comprehensive/node_modules/@aws-blocks/*` instead of the workspace source under `packages/*`. This makes the suite unable to validate unreleased API changes.

Symptom: after #38 added `AuthCognito.admin` to source (and the comprehensive backend started calling `authC.admin.*`), `npm run test:e2e:local` fails the backend type check with:

```
Property 'admin' does not exist on type 'AuthCognito<...>'.
```

because the nested published `@aws-blocks/bb-auth-cognito@0.1.5` predates the `admin` getter.

## Root cause

- The comprehensive app declared only a **subset** of `@aws-blocks/*` as direct deps via `"*"`. Critically, `@aws-blocks/bb-auth-cognito` was **not** a direct dependency — it was pulled in transitively through `@aws-blocks/blocks`.
- `@aws-blocks/blocks` declares its building-block deps with **published semver ranges** (e.g. `"@aws-blocks/bb-auth-cognito": "^0.1.5"`).
- The local `packages/bb-auth-cognito` version (`0.1.5`) **equals** the published version, so npm treats the registry tarball as an equally-valid satisfier of `^0.1.5` and — depending on tree state — can nest the published copy under the test app.
- #38 changed the **source** (`admin` getter) without a version bump, so source drifted ahead of the published `0.1.5`. When resolution lands on the nested published copy, the `admin` getter is missing → type error.

## Fix

Declare **all** `@aws-blocks/*` packages that `@aws-blocks/blocks` re-exports as **direct `"*"` dependencies** of `test-apps/comprehensive` (matching the repo's existing npm-workspaces convention; npm 10 here does not support the `workspace:` protocol). This pins the entire re-exported surface — including `bb-auth-cognito` — to workspace links, so npm can never nest a published copy. Only the test app's `package.json` and the regenerated `package-lock.json` change; no source under `packages/*` and no version bumps.

## Verification

- **traceResolution** now resolves to workspace source:
  `@aws-blocks/bb-auth-cognito` → `packages/bb-auth-cognito/dist/index.d.ts` (was the nested published copy).
- **Symlink:** `node_modules/@aws-blocks/bb-auth-cognito -> ../../packages/bb-auth-cognito`; no nested published copy exists anywhere under `test-apps/comprehensive/node_modules`.
- `npm run build:packages` → exit 0. Backend `tsc --noEmit` → exit 0; the `admin` error is gone.
- **Node 20.20.1:** full `npm run test:e2e:local` runs to completion — 373 tests, 351 pass, 1 skipped. The only failures (`Realtime`, `Agent BB`) are environmental: Node 20 lacks a global `WebSocket`, and the agent streams over that same realtime transport.
- **Node 22.22.1:** full `npm run test:e2e:local` is **fully green** — **373 tests, 372 pass, 0 fail, 0 cancelled, 1 skipped** (+ the vendorize step: 8/8 pass). `Realtime`, `AuthCognito`, and `Agent BB` all pass once Node provides a global `WebSocket`. The remaining skip is a sandbox-only test requiring a deployed AWS environment.

> Note: the comprehensive Realtime suite requires a global `WebSocket`, which is only available by default on **Node ≥ 22**. Under Node 20 the Realtime/Agent suites fail purely for that environmental reason; the #257 fix itself (workspace type resolution) is verified green on both Node 20 and Node 22.

## Changeset

Not needed — `bb-test-comprehensive` is in the `.changeset/config.json` `ignore` list, and this is a test-infra-only change (no publishable package modified).
