### PR TITLE
fix(release): fix version command syntax + switch to GITHUB_TOKEN

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -68,7 +68,7 @@ jobs:
           > **To complete this release:**
           > 1. Review the version bumps and changelogs below
           > 2. **Close and reopen this PR** to trigger CI checks (required due to GitHub token limitations)
-          > 3. Once all checks pass, merge with **Create a merge commit**
+          > 3. Once all checks pass, merge the PR
           > 4. The merge triggers npm publish automatically
 
           ---

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -43,7 +43,7 @@ jobs:
 
       - uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
         with:
-          version: npx changeset version && npm install --package-lock-only
+          version: npm run version
           publish: npm run release
           commit: 'chore: version packages'
           title: 'chore: version packages'

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -4,6 +4,10 @@ name: Release
 # a "Version Packages" PR (running `changeset version`) or, once that PR is merged
 # and no changesets remain, publishes to npm. Merging the PR is the release gate.
 # Canary publishes live in publish-canary.yml.
+#
+# NOTE: The Version Packages PR is created by GITHUB_TOKEN, so it does NOT
+# auto-trigger PR check workflows (GitHub platform limitation). To run checks
+# before merging, close and reopen the PR — this fires a real event and CI runs.
 
 on:
   push:
@@ -29,9 +33,6 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
-          # Use the ops token so the Version Packages PR triggers CI (a PR opened
-          # with the default GITHUB_TOKEN does not fire other workflows).
-          token: ${{ secrets.OPS_GITHUB_TOKEN }}
 
       - uses: actions/setup-node@v5
         with:
@@ -48,6 +49,6 @@ jobs:
           commit: 'chore: version packages'
           title: 'chore: version packages'
         env:
-          GITHUB_TOKEN: ${{ secrets.OPS_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: 'true'

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -43,6 +43,7 @@ jobs:
       - run: npm ci
 
       - uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
+        id: changesets
         with:
           version: npm run version
           publish: npm run release
@@ -52,3 +53,25 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: 'true'
+
+      # The Version PR is created with GITHUB_TOKEN, so it doesn't auto-trigger
+      # CI. Append operator instructions to the PR body.
+      - name: Add release instructions to Version PR
+        if: steps.changesets.outputs.pullRequestNumber
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUM="${{ steps.changesets.outputs.pullRequestNumber }}"
+          CURRENT_BODY=$(gh pr view "$PR_NUM" --json body --jq .body)
+          INSTRUCTIONS="## Release Instructions
+
+          > **To complete this release:**
+          > 1. Review the version bumps and changelogs below
+          > 2. **Close and reopen this PR** to trigger CI checks (required due to GitHub token limitations)
+          > 3. Once all checks pass, merge with **Create a merge commit**
+          > 4. The merge triggers npm publish automatically
+
+          ---
+
+          "
+          gh pr edit "$PR_NUM" --body "${INSTRUCTIONS}${CURRENT_BODY}"

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "build:tech-design-pdf": "node scripts/build-tech-design-pdf.mjs",
     "review-pr": "bash scripts/review-pr.sh",
     "publish:local": "tsx scripts/publish/publish.ts",
+    "version": "changeset version && npm install --package-lock-only",
     "release": "npm run build && changeset publish",
     "monte-carlo": "tsx scripts/monte-carlo.ts",
     "monte-carlo:cached": "tsx scripts/monte-carlo.ts --cached",


### PR DESCRIPTION
## What

Fixes two issues in the Release workflow introduced by #214:

1. **`Too many arguments passed to changesets`** — the `version` input doesn't support shell operators (`&&`). Moved the compound command into an npm script (`npm run version`).

2. **`Resource not accessible by personal access token`** — the `OPS_GITHUB_TOKEN` PAT lacked `pull-requests:write` scope on this repo. Switched to the built-in `GITHUB_TOKEN` which gets `pull-requests: write` from the workflow's permissions block.

## Release process after this fix

When changesets accumulate on main, the Release workflow creates/updates a **"chore: version packages"** PR automatically. The PR body will include operator instructions.

**To complete a release:**
1. Review the Version Packages PR (bumped versions + changelogs)
2. **Close and reopen the PR** — this triggers CI checks (the built-in GITHUB_TOKEN doesn't auto-trigger other workflows; a close/reopen fires a real event)
3. Once checks pass, merge the PR
4. The merge triggers the Release workflow again → `changeset publish` → packages appear on npm

## Tradeoff

Using `GITHUB_TOKEN` means the Version PR doesn't auto-trigger CI on creation. The close/reopen step is a one-click workaround. The alternative (a PAT or GitHub App token) introduces secret management overhead. We can revisit if the friction is too high.

## Changes

- `.github/workflows/publish-packages.yml` — use `GITHUB_TOKEN`, remove `OPS_GITHUB_TOKEN` references, add step to prepend release instructions to the Version PR body
- `package.json` — add `version` script: `changeset version && npm install --package-lock-only`