### PR TITLE
fix(release): rewrite workflow + add release runbook

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -66,7 +66,7 @@ jobs:
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "The \`changeset-release/main\` branch has been updated with version bumps." >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "**Next step:** [Create the release PR](https://github.com/aws-devtools-labs/aws-blocks/compare/main...changeset-release/main?expand=1&title=chore%3A+version+packages&body=Release+PR.+Steps+to+complete%3A%0A%0A1.+Get+2+approvals%0A2.+Close+and+reopen+to+trigger+CI+%28if+checks+aren%27t+running%29%0A3.+Merge+after+checks+pass+%E2%80%94+npm+publish+runs+automatically%0A%0ASee+%5Bdocs%2FRELEASING.md%5D%28https%3A%2F%2Fgithub.com%2Faws-devtools-labs%2Faws-blocks%2Fblob%2Fmain%2Fdocs%2FRELEASING.md%29+for+details.)" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Next step:** [Create the release PR](https://github.com/aws-devtools-labs/aws-blocks/compare/main...changeset-release/main?expand=1\&title=chore%3A+version+packages\&body=Release+PR.+Steps+to+complete%3A%0A%0A1.+Get+2+approvals%0A2.+Merge+after+checks+pass+%E2%80%94+npm+publish+runs+automatically%0A%0ASee+%5Bdocs%2FRELEASING.md%5D%28https%3A%2F%2Fgithub.com%2Faws-devtools-labs%2Faws-blocks%2Fblob%2Fmain%2Fdocs%2FRELEASING.md%29+for+details.)" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "See [docs/RELEASING.md](https://github.com/aws-devtools-labs/aws-blocks/blob/main/docs/RELEASING.md) for the full process." >> "$GITHUB_STEP_SUMMARY"
 

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -1,10 +1,10 @@
 name: Release
 
-# Version + publish via changesets/action. On push to main it either:
-#   1. Runs `changeset version`, pushes the changeset-release/main branch
-#   2. If no changesets remain (version PR was just merged), publishes to npm
+# On push to main:
+#   - If changesets exist: run `changeset version`, push changeset-release/main
+#   - If no changesets remain (version PR was just merged): publish to npm
 #
-# PR creation is handled manually — see docs/RELEASING.md for the full process.
+# PR creation is manual — see docs/RELEASING.md.
 
 on:
   push:
@@ -15,8 +15,7 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  contents: write # push the version-PR branch + tags
-  pull-requests: write # open/update the Version Packages PR (when permitted)
+  contents: write # push the version branch + tags
   id-token: write # npm provenance
 
 jobs:
@@ -39,42 +38,53 @@ jobs:
 
       - run: npm ci
 
-      - uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
-        id: changesets
-        # The action may fail to create a PR if GitHub Actions is not permitted
-        # to create PRs on this repo. The branch push still succeeds, and
-        # maintainers create the PR manually (see docs/RELEASING.md).
-        continue-on-error: true
-        with:
-          version: npm run version
-          publish: npm run release
-          commit: 'chore: version packages'
-          title: 'chore: version packages'
+      # Check if there are pending changesets
+      - name: Check for changesets
+        id: check
+        run: |
+          if npx changeset status --since=origin/main 2>/dev/null | grep -q "NO packages"; then
+            echo "has_changesets=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_changesets=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      # Mode 1: Version — bump versions and push the release branch
+      - name: Version packages
+        if: steps.check.outputs.has_changesets == 'true'
+        run: |
+          npm run version
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git commit -m "chore: version packages" || echo "No changes to commit"
+          git push origin HEAD:changeset-release/main --force
+
+      - name: Summary (version)
+        if: steps.check.outputs.has_changesets == 'true'
+        run: |
+          echo "## 📋 Version branch updated" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "The \`changeset-release/main\` branch has been updated with version bumps." >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Next step:** [Create the release PR](https://github.com/aws-devtools-labs/aws-blocks/compare/main...changeset-release/main?expand=1)" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "See [docs/RELEASING.md](https://github.com/aws-devtools-labs/aws-blocks/blob/main/docs/RELEASING.md) for the full process." >> "$GITHUB_STEP_SUMMARY"
+
+      # Mode 2: Publish — no changesets means the version PR was just merged
+      - name: Publish to npm
+        if: steps.check.outputs.has_changesets == 'false'
+        run: npm run release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: 'true'
 
-      # If the action failed AND it was a publish run (no changesets = publish mode),
-      # that's a real failure we should surface. Version-mode failures (PR creation
-      # permission denied) are expected and non-blocking.
-      - name: Fail on publish errors
-        if: steps.changesets.outcome == 'failure' && steps.changesets.outputs.published == 'true'
-        run: |
-          echo "::error::Publish step failed. Check the changesets/action logs above."
-          exit 1
+      - name: Create git tags and GitHub releases
+        if: steps.check.outputs.has_changesets == 'false'
+        run: npx changeset tag
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Summary
+      - name: Summary (publish)
+        if: steps.check.outputs.has_changesets == 'false'
         run: |
-          if [ "${{ steps.changesets.outputs.published }}" = "true" ]; then
-            echo "## ✅ Published to npm" >> "$GITHUB_STEP_SUMMARY"
-          elif [ "${{ steps.changesets.outputs.pullRequestNumber }}" != "" ]; then
-            echo "## 📦 Version PR updated: #${{ steps.changesets.outputs.pullRequestNumber }}" >> "$GITHUB_STEP_SUMMARY"
-          else
-            echo "## 📋 Version branch updated" >> "$GITHUB_STEP_SUMMARY"
-            echo "" >> "$GITHUB_STEP_SUMMARY"
-            echo "The \`changeset-release/main\` branch has been updated with version bumps." >> "$GITHUB_STEP_SUMMARY"
-            echo "Create the release PR manually: [Create PR](https://github.com/aws-devtools-labs/aws-blocks/compare/main...changeset-release/main?expand=1)" >> "$GITHUB_STEP_SUMMARY"
-            echo "" >> "$GITHUB_STEP_SUMMARY"
-            echo "See [docs/RELEASING.md](../docs/RELEASING.md) for the full release process." >> "$GITHUB_STEP_SUMMARY"
-          fi
+          echo "## ✅ Published to npm" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -1,13 +1,10 @@
 name: Release
 
-# Version + publish via changesets/action. On push to main it either opens/updates
-# a "Version Packages" PR (running `changeset version`) or, once that PR is merged
-# and no changesets remain, publishes to npm. Merging the PR is the release gate.
-# Canary publishes live in publish-canary.yml.
+# Version + publish via changesets/action. On push to main it either:
+#   1. Runs `changeset version`, pushes the changeset-release/main branch
+#   2. If no changesets remain (version PR was just merged), publishes to npm
 #
-# NOTE: The Version Packages PR is created by GITHUB_TOKEN, so it does NOT
-# auto-trigger PR check workflows (GitHub platform limitation). To run checks
-# before merging, close and reopen the PR — this fires a real event and CI runs.
+# PR creation is handled manually — see docs/RELEASING.md for the full process.
 
 on:
   push:
@@ -19,7 +16,7 @@ concurrency:
 
 permissions:
   contents: write # push the version-PR branch + tags
-  pull-requests: write # open/update the Version Packages PR
+  pull-requests: write # open/update the Version Packages PR (when permitted)
   id-token: write # npm provenance
 
 jobs:
@@ -44,6 +41,10 @@ jobs:
 
       - uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
         id: changesets
+        # The action may fail to create a PR if GitHub Actions is not permitted
+        # to create PRs on this repo. The branch push still succeeds, and
+        # maintainers create the PR manually (see docs/RELEASING.md).
+        continue-on-error: true
         with:
           version: npm run version
           publish: npm run release
@@ -54,24 +55,26 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: 'true'
 
-      # The Version PR is created with GITHUB_TOKEN, so it doesn't auto-trigger
-      # CI. Append operator instructions to the PR body.
-      - name: Add release instructions to Version PR
-        if: steps.changesets.outputs.pullRequestNumber
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # If the action failed AND it was a publish run (no changesets = publish mode),
+      # that's a real failure we should surface. Version-mode failures (PR creation
+      # permission denied) are expected and non-blocking.
+      - name: Fail on publish errors
+        if: steps.changesets.outcome == 'failure' && steps.changesets.outputs.published == 'true'
         run: |
-          PR_NUM="${{ steps.changesets.outputs.pullRequestNumber }}"
-          CURRENT_BODY=$(gh pr view "$PR_NUM" --json body --jq .body)
-          INSTRUCTIONS="## Release Instructions
+          echo "::error::Publish step failed. Check the changesets/action logs above."
+          exit 1
 
-          > **To complete this release:**
-          > 1. Review the version bumps and changelogs below
-          > 2. **Close and reopen this PR** to trigger CI checks (required due to GitHub token limitations)
-          > 3. Once all checks pass, merge the PR
-          > 4. The merge triggers npm publish automatically
-
-          ---
-
-          "
-          gh pr edit "$PR_NUM" --body "${INSTRUCTIONS}${CURRENT_BODY}"
+      - name: Summary
+        run: |
+          if [ "${{ steps.changesets.outputs.published }}" = "true" ]; then
+            echo "## ✅ Published to npm" >> "$GITHUB_STEP_SUMMARY"
+          elif [ "${{ steps.changesets.outputs.pullRequestNumber }}" != "" ]; then
+            echo "## 📦 Version PR updated: #${{ steps.changesets.outputs.pullRequestNumber }}" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "## 📋 Version branch updated" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "The \`changeset-release/main\` branch has been updated with version bumps." >> "$GITHUB_STEP_SUMMARY"
+            echo "Create the release PR manually: [Create PR](https://github.com/aws-devtools-labs/aws-blocks/compare/main...changeset-release/main?expand=1)" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "See [docs/RELEASING.md](../docs/RELEASING.md) for the full release process." >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -66,7 +66,7 @@ jobs:
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "The \`changeset-release/main\` branch has been updated with version bumps." >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "**Next step:** [Create the release PR](https://github.com/aws-devtools-labs/aws-blocks/compare/main...changeset-release/main?expand=1\&title=chore%3A+version+packages\&body=Release+PR.+Steps+to+complete%3A%0A%0A1.+Get+2+approvals%0A2.+Merge+after+checks+pass+%E2%80%94+npm+publish+runs+automatically%0A%0ASee+%5Bdocs%2FRELEASING.md%5D%28https%3A%2F%2Fgithub.com%2Faws-devtools-labs%2Faws-blocks%2Fblob%2Fmain%2Fdocs%2FRELEASING.md%29+for+details.)" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Next step:** [Create the release PR](https://github.com/aws-devtools-labs/aws-blocks/compare/main...changeset-release/main?expand=1&title=chore%3A+version+packages&body=Release+PR.+Steps+to+complete%3A%0A%0A1.+Get+2+approvals%0A2.+Squash+merge+after+checks+pass%0A3.+Monitor+npm+for+successful+publish%0A%0ASee+%5Bdocs%2FRELEASING.md%5D%28https%3A%2F%2Fgithub.com%2Faws-devtools-labs%2Faws-blocks%2Fblob%2Fmain%2Fdocs%2FRELEASING.md%29+for+details.)" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "See [docs/RELEASING.md](https://github.com/aws-devtools-labs/aws-blocks/blob/main/docs/RELEASING.md) for the full process." >> "$GITHUB_STEP_SUMMARY"
 

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -66,7 +66,7 @@ jobs:
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "The \`changeset-release/main\` branch has been updated with version bumps." >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "**Next step:** [Create the release PR](https://github.com/aws-devtools-labs/aws-blocks/compare/main...changeset-release/main?expand=1)" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Next step:** [Create the release PR](https://github.com/aws-devtools-labs/aws-blocks/compare/main...changeset-release/main?expand=1&title=chore%3A+version+packages&body=Release+PR.+Steps+to+complete%3A%0A%0A1.+Get+2+approvals%0A2.+Close+and+reopen+to+trigger+CI+%28if+checks+aren%27t+running%29%0A3.+Merge+after+checks+pass+%E2%80%94+npm+publish+runs+automatically%0A%0ASee+%5Bdocs%2FRELEASING.md%5D%28https%3A%2F%2Fgithub.com%2Faws-devtools-labs%2Faws-blocks%2Fblob%2Fmain%2Fdocs%2FRELEASING.md%29+for+details.)" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "See [docs/RELEASING.md](https://github.com/aws-devtools-labs/aws-blocks/blob/main/docs/RELEASING.md) for the full process." >> "$GITHUB_STEP_SUMMARY"
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -326,6 +326,7 @@ Check correctness/security, mock↔aws↔cdk↔browser consistency + conditional
 - `packages/bb-realtime/` — reference for the full client↔server surface + the Transferable client-hydration pattern.
 - Each BB's `README.md` — the authoritative API doc for that block.
 - `docs/` — architecture and design background
+- `docs/RELEASING.md` — release process runbook (versioning, publishing to npm). **Releases are managed by the AWS Blocks team only.**
 - `packages/hosting/README.md` — SPA/SSR frontend hosting
 - `bb-data` / `bb-distributed-data` READMEs — DB migrations
 - `native/*` — Kotlin/Swift/Dart client codegen

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -326,7 +326,7 @@ Check correctness/security, mock↔aws↔cdk↔browser consistency + conditional
 - `packages/bb-realtime/` — reference for the full client↔server surface + the Transferable client-hydration pattern.
 - Each BB's `README.md` — the authoritative API doc for that block.
 - `docs/` — architecture and design background
-- `docs/RELEASING.md` — release process runbook (versioning, publishing to npm). **Releases are managed by the AWS Blocks team only.**
+- `docs/RELEASING.md` — release process runbook (versioning, publishing to npm). **Releases must be managed by the AWS Blocks team.**
 - `packages/hosting/README.md` — SPA/SSR frontend hosting
 - `bb-data` / `bb-distributed-data` READMEs — DB migrations
 - `native/*` — Kotlin/Swift/Dart client codegen

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -19,7 +19,7 @@ AWS Blocks uses [Changesets](https://github.com/changesets/changesets) for versi
 
 Open this link to create a PR from the prepared branch:
 
-**→ [Create Release PR](https://github.com/aws-devtools-labs/aws-blocks/compare/main...changeset-release/main?expand=1)**
+**→ [Create Release PR](https://github.com/aws-devtools-labs/aws-blocks/compare/main...changeset-release/main?expand=1&title=chore%3A+version+packages&body=Release+PR.+Steps+to+complete%3A%0A%0A1.+Get+2+approvals%0A2.+Close+and+reopen+to+trigger+CI+%28if+checks+aren%27t+running%29%0A3.+Merge+after+checks+pass+%E2%80%94+npm+publish+runs+automatically%0A%0ASee+%5Bdocs%2FRELEASING.md%5D%28https%3A%2F%2Fgithub.com%2Faws-devtools-labs%2Faws-blocks%2Fblob%2Fmain%2Fdocs%2FRELEASING.md%29+for+details.)**
 
 Title: `chore: version packages`
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -19,7 +19,7 @@ AWS Blocks uses [Changesets](https://github.com/changesets/changesets) for versi
 
 Open this link to create a PR from the prepared branch:
 
-**→ [Create Release PR](https://github.com/aws-devtools-labs/aws-blocks/compare/main...changeset-release/main?expand=1\&title=chore%3A+version+packages\&body=Release+PR.+Steps+to+complete%3A%0A%0A1.+Get+2+approvals%0A2.+Merge+after+checks+pass+%E2%80%94+npm+publish+runs+automatically%0A%0ASee+%5Bdocs%2FRELEASING.md%5D%28https%3A%2F%2Fgithub.com%2Faws-devtools-labs%2Faws-blocks%2Fblob%2Fmain%2Fdocs%2FRELEASING.md%29+for+details.)**
+**→ [Create Release PR](https://github.com/aws-devtools-labs/aws-blocks/compare/main...changeset-release/main?expand=1&title=chore%3A+version+packages&body=Release+PR.+Steps+to+complete%3A%0A%0A1.+Get+2+approvals%0A2.+Squash+merge+after+checks+pass%0A3.+Monitor+npm+for+successful+publish%0A%0ASee+%5Bdocs%2FRELEASING.md%5D%28https%3A%2F%2Fgithub.com%2Faws-devtools-labs%2Faws-blocks%2Fblob%2Fmain%2Fdocs%2FRELEASING.md%29+for+details.)**
 
 Title: `chore: version packages`
 
@@ -34,7 +34,7 @@ Require 2 team member approvals. Review the version bumps — ensure:
 
 ### 3. Merge after CI passes
 
-Once PR checks pass and approvals are in, merge the PR. Squash or merge commit — either works (the branch has a single commit).
+Once PR checks pass and approvals are in, squash merge the PR.
 
 ### 4. Verify the publish
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,79 @@
+# Releasing AWS Blocks
+
+This document describes how packages in this monorepo are versioned and published to npm.
+
+## How it works
+
+AWS Blocks uses [Changesets](https://github.com/changesets/changesets) for versioning and publishing. The flow is:
+
+1. **Contributors add changesets** — each PR that changes a published package includes a `.changeset/*.md` file describing the change and its semver bump type (`patch`, `minor`).
+2. **Changesets accumulate on `main`** — as PRs merge, changeset files pile up.
+3. **The Release workflow prepares a version branch** — on every push to `main`, the `Release` workflow runs `changeset version` (consuming all pending changesets, bumping `package.json` versions, updating `CHANGELOG.md` files) and force-pushes the result to the `changeset-release/main` branch.
+4. **A maintainer creates and merges the release PR** — this triggers the publish step.
+
+## Release steps
+
+> **Only AWS Blocks team members should perform releases.** External contributors do not need to worry about this process — just include a changeset in your PR.
+
+### 1. Create the release PR
+
+Open this link to create a PR from the prepared branch:
+
+**→ [Create Release PR](https://github.com/aws-devtools-labs/aws-blocks/compare/main...changeset-release/main?expand=1)**
+
+Title: `chore: version packages`
+
+The diff will show version bumps and changelog updates for all packages with pending changes.
+
+### 2. Get approvals
+
+Require 2 team member approvals. Review the version bumps — ensure:
+- Bump types are correct (`patch` for fixes, `minor` for breaking changes in pre-1.0)
+- No unexpected packages are included
+- Changelog entries are clear and customer-appropriate
+
+### 3. Merge after CI passes
+
+Once PR checks pass and approvals are in, merge the PR. Squash or merge commit — either works (the branch has a single commit).
+
+### 4. Verify the publish
+
+After merge, the `Release` workflow runs again. This time it detects no changesets remain and runs the publish step:
+- `npm run build` — builds all packages
+- `changeset publish` — publishes bumped packages to npm with provenance
+
+Verify:
+- Check the [Release workflow run](https://github.com/aws-devtools-labs/aws-blocks/actions/workflows/publish-packages.yml) completed successfully
+- Spot-check a package on npm: `npm view @aws-blocks/blocks version`
+- Git tags and GitHub Releases are created automatically
+
+## Pre-1.0 semver convention
+
+While packages are pre-1.0:
+- `patch` (0.1.1 → 0.1.2): non-breaking change
+- `minor` (0.1.x → 0.2.0): **breaking** change
+- `major`: blocked by CI (`block-major` guard) — leaving pre-release requires explicit sign-off
+
+## Troubleshooting
+
+### Release workflow shows red on `main`
+
+The workflow may fail to auto-create the release PR due to GitHub token permissions. This is cosmetic — the `changeset-release/main` branch is still updated successfully. Create the PR manually using the link above.
+
+### A package wasn't published
+
+Check that:
+- The package had a changeset in the merged PR
+- The package name in the changeset matches `package.json` exactly
+- The `changeset-check` CI job passed (validates coverage + structure)
+
+### Need to publish urgently without the workflow
+
+```bash
+git checkout main && git pull
+npm ci && npm run build
+npx changeset version
+npx changeset publish
+```
+
+This requires npm publish credentials (`NPM_TOKEN`) and should only be used as a last resort.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -19,7 +19,7 @@ AWS Blocks uses [Changesets](https://github.com/changesets/changesets) for versi
 
 Open this link to create a PR from the prepared branch:
 
-**→ [Create Release PR](https://github.com/aws-devtools-labs/aws-blocks/compare/main...changeset-release/main?expand=1&title=chore%3A+version+packages&body=Release+PR.+Steps+to+complete%3A%0A%0A1.+Get+2+approvals%0A2.+Close+and+reopen+to+trigger+CI+%28if+checks+aren%27t+running%29%0A3.+Merge+after+checks+pass+%E2%80%94+npm+publish+runs+automatically%0A%0ASee+%5Bdocs%2FRELEASING.md%5D%28https%3A%2F%2Fgithub.com%2Faws-devtools-labs%2Faws-blocks%2Fblob%2Fmain%2Fdocs%2FRELEASING.md%29+for+details.)**
+**→ [Create Release PR](https://github.com/aws-devtools-labs/aws-blocks/compare/main...changeset-release/main?expand=1\&title=chore%3A+version+packages\&body=Release+PR.+Steps+to+complete%3A%0A%0A1.+Get+2+approvals%0A2.+Merge+after+checks+pass+%E2%80%94+npm+publish+runs+automatically%0A%0ASee+%5Bdocs%2FRELEASING.md%5D%28https%3A%2F%2Fgithub.com%2Faws-devtools-labs%2Faws-blocks%2Fblob%2Fmain%2Fdocs%2FRELEASING.md%29+for+details.)**
 
 Title: `chore: version packages`
 


### PR DESCRIPTION
## What

Rewrites the Release workflow to eliminate the broken PR creation step and adds a documented release runbook.

### Workflow rewrite (`.github/workflows/publish-packages.yml`)

Drops `changesets/action` entirely. The workflow now has two explicit modes:

**Version mode** (changesets exist on main):
- Runs `npm run version` (changeset version + lock file update)
- Commits and force-pushes `changeset-release/main`
- Emits a Step Summary with a prefilled link to create the release PR

**Publish mode** (no changesets — version PR was just merged):
- Runs `npm run release` (build + changeset publish)
- Creates git tags
- Emits a success summary

No PR creation is attempted. No token/permission issues. No red workflows on main.

### docs/RELEASING.md (new)

Full release runbook for maintainers:
1. Click the prefilled link to create a PR from `changeset-release/main` → `main`
2. Get 2 approvals
3. Close/reopen to trigger CI if needed, merge after checks pass
4. npm publish fires automatically on merge

Also covers: pre-1.0 semver conventions, troubleshooting, emergency manual publish.

### AGENTS.md

Added `docs/RELEASING.md` to "Where to look" — releases must be managed by the AWS Blocks team.

## Why

The previous workflow failed on every push to main because:
1. `changesets/action` `version` input didn't support shell operators — fixed in #265
2. GitHub Actions can't create PRs on this repo (permission disabled, TT V2300286150 pending)

Rather than fight permission issues with PATs or GitHub Apps, we simplify: the workflow handles the automated parts (version bumping, publishing) and leaves the human-gated step (PR review) to humans via a one-click prefilled link.