### PR TITLE
fix(auth-common): add stable data-testid hooks to the auth UI components

### DIFF
--- a/.changeset/authenticator-test-hooks.md
+++ b/.changeset/authenticator-test-hooks.md
@@ -3,6 +3,6 @@
 "@aws-blocks/blocks": patch
 ---
 
-Add stable `data-testid` hooks to the auth UI components so e2e suites can target the shipped `Authenticator` instead of forking it. Covers the container, heading, error, per-action wrappers, every field input, submit buttons, the signed-in marker, `AuthenticatedContent`, and `AccountMenuBar`. The full selector contract is documented in CUSTOMIZING-AUTH-UI.md.
+Add stable `data-testid` hooks to the auth UI components so e2e suites can target the shipped `Authenticator` instead of forking it. Covers every interactive element (field inputs, hidden ones included, and submit buttons) plus the containers worth asserting against: the root, per-action wrappers, heading, error, the signed-in marker, `AuthenticatedContent`, and `AccountMenuBar`. Presentational markup such as hint text and layout wrappers stays unhooked. The full selector contract, including the `<action>:<provider>` form federated actions produce, is documented in CUSTOMIZING-AUTH-UI.md.
 
 The `@aws-blocks/blocks` umbrella package receives a `patch` because it re-exports these components from `@aws-blocks/auth-common/ui`. Sibling patch releases stay inside the umbrella's caret ranges, so `changeset version` never bumps it on its own (#212), and it is republished explicitly to stay in step with the components it hands to consumers.

--- a/.changeset/authenticator-test-hooks.md
+++ b/.changeset/authenticator-test-hooks.md
@@ -1,5 +1,8 @@
 ---
 "@aws-blocks/auth-common": patch
+"@aws-blocks/blocks": patch
 ---
 
 Add stable `data-testid` hooks to the auth UI components so e2e suites can target the shipped `Authenticator` instead of forking it. Covers the container, heading, error, per-action wrappers, every field input, submit buttons, the signed-in marker, `AuthenticatedContent`, and `AccountMenuBar`. The full selector contract is documented in CUSTOMIZING-AUTH-UI.md.
+
+The `@aws-blocks/blocks` umbrella package receives a `patch` because it re-exports these components from `@aws-blocks/auth-common/ui`. Sibling patch releases stay inside the umbrella's caret ranges, so `changeset version` never bumps it on its own (#212), and it is republished explicitly to stay in step with the components it hands to consumers.

--- a/.changeset/authenticator-test-hooks.md
+++ b/.changeset/authenticator-test-hooks.md
@@ -1,0 +1,5 @@
+---
+"@aws-blocks/auth-common": patch
+---
+
+Add stable `data-testid` hooks to the auth UI components so e2e suites can target the shipped `Authenticator` instead of forking it. Covers the container, heading, error, per-action wrappers, every field input, submit buttons, the signed-in marker, `AuthenticatedContent`, and `AccountMenuBar`. The full selector contract is documented in CUSTOMIZING-AUTH-UI.md.

--- a/packages/auth-common/CUSTOMIZING-AUTH-UI.md
+++ b/packages/auth-common/CUSTOMIZING-AUTH-UI.md
@@ -201,9 +201,16 @@ handling and still get your custom look.
 
 ## Test hooks
 
-Every built-in auth component renders stable `data-testid` attributes, so e2e
-suites can drive the shipped UI instead of forking it for selectors. Treat the
-names as public API: renaming one is a breaking change.
+Every interactive element the built-in auth components render carries a stable
+`data-testid`, so e2e suites can drive the shipped UI instead of forking it for
+selectors. Treat the names as public API: renaming one is a breaking change.
+
+Inputs, buttons, and the containers you assert against are hooked. Purely
+presentational markup is not, on purpose: hint text from `fields.<name>.hint`,
+the bordered panel inside the `authenticator` container, the `AccountMenuBar`
+layout row, and the modal's inner content box carry no `data-testid`. Hooking
+those would pin our styling structure into your tests, so read the text off the
+nearest hooked ancestor instead.
 
 | Hook | Element |
 |---|---|
@@ -211,7 +218,7 @@ names as public API: renaming one is a breaking change.
 | `authenticator-heading` | Heading above the actions |
 | `authenticator-signed-in` | Heading rendered when `state === 'signedIn'`; text is `Signed in as: <username>` |
 | `authenticator-error` | Inline error message. Absent when the state carries no error |
-| `authenticator-action-<action>` | One wrapper per rendered action, e.g. `authenticator-action-signIn` |
+| `authenticator-action-<action>` | One wrapper per rendered action, e.g. `authenticator-action-signIn`. Federated actions keep their provider suffix, so `signIn:google` gives `authenticator-action-signIn:google` |
 | `authenticator-<field>` | One per input, named after the field the server declared, e.g. `authenticator-username`, `authenticator-password`, `authenticator-code`. Hidden fields (session tokens, echoed usernames) carry it too |
 | `authenticator-submit` | The action's submit button |
 | `authenticated-content` | Container returned by `AuthenticatedContent` |
@@ -225,6 +232,16 @@ names as public API: renaming one is a breaking change.
 Action and field names come from the server, so the hooks follow whatever the
 Building Block emits: `authenticator-action-confirmSignUp`,
 `authenticator-newPassword`, and so on.
+
+Federated actions are named `<action>:<provider>`, and the hook keeps the suffix
+verbatim: an action named `signIn:google` renders as
+`authenticator-action-signIn:google`. The colon is safe in the selectors you'd
+normally write. `page.getByTestId('authenticator-action-signIn:google')` matches
+on the attribute value, and
+`querySelector('[data-testid="authenticator-action-signIn:google"]')` works
+because that value is a quoted string rather than selector grammar. Keep the
+quotes though: a bare `[data-testid=authenticator-action-signIn:google]` is
+invalid, because an unquoted attribute value has to be a CSS identifier.
 
 Field and submit hooks repeat once per action, because a state can offer more
 than one. The signed-out state renders `signIn` and `signUp` side by side and

--- a/packages/auth-common/CUSTOMIZING-AUTH-UI.md
+++ b/packages/auth-common/CUSTOMIZING-AUTH-UI.md
@@ -8,6 +8,10 @@ For the basics (`Authenticator`, `AccountMenuBar`, `AuthenticatedContent`,
 `onAuthChange`, `broadcastAuthChange`, and the type reference), see the
 [README](./README.md). This guide assumes you've read it.
 
+If you're here to write e2e tests rather than restyle anything, skip to
+[Test hooks](#test-hooks) — the built-in components ship a stable `data-testid`
+contract, so you don't need to fork them to get selectors.
+
 ## The one rule
 
 Auth is a server-driven state machine. The server returns an `AuthState` that
@@ -194,6 +198,49 @@ Based on the current implementation, that includes:
 
 If you need any of these, prefer Depth 1 or 2. You stay on the built-in
 handling and still get your custom look.
+
+## Test hooks
+
+Every built-in auth component renders stable `data-testid` attributes, so e2e
+suites can drive the shipped UI instead of forking it for selectors. Treat the
+names as public API: renaming one is a breaking change.
+
+| Hook | Element |
+|---|---|
+| `authenticator` | Root element returned by `Authenticator` |
+| `authenticator-heading` | Heading above the actions |
+| `authenticator-signed-in` | Heading rendered when `state === 'signedIn'`; text is `Signed in as: <username>` |
+| `authenticator-error` | Inline error message. Absent when the state carries no error |
+| `authenticator-action-<action>` | One wrapper per rendered action, e.g. `authenticator-action-signIn` |
+| `authenticator-<field>` | One per input, named after the field the server declared, e.g. `authenticator-username`, `authenticator-password`, `authenticator-code`. Hidden fields (session tokens, echoed usernames) carry it too |
+| `authenticator-submit` | The action's submit button |
+| `authenticated-content` | Container returned by `AuthenticatedContent` |
+| `account-menu` | Container returned by `AccountMenuBar` |
+| `account-menu-username` | Signed-in username in the bar |
+| `account-menu-signout` | Sign-out button in the bar |
+| `account-menu-signin` | Sign-in button in the bar, shown when signed out |
+| `account-menu-modal` | Modal the bar opens, hosting an `Authenticator` |
+| `account-menu-modal-close` | Close button on that modal |
+
+Action and field names come from the server, so the hooks follow whatever the
+Building Block emits: `authenticator-action-confirmSignUp`,
+`authenticator-newPassword`, and so on.
+
+Field and submit hooks repeat once per action, because a state can offer more
+than one. The signed-out state renders `signIn` and `signUp` side by side and
+both declare a `username`, so scope through the action wrapper:
+
+```typescript
+const signIn = page.getByTestId('authenticator-action-signIn');
+await signIn.getByTestId('authenticator-username').fill('alice');
+await signIn.getByTestId('authenticator-password').fill('correct-horse');
+await signIn.getByTestId('authenticator-submit').click();
+await expect(page.getByTestId('authenticator-signed-in')).toContainText('alice');
+```
+
+Depth 2 and 3 render your DOM instead of ours, so hooks inside a replaced action
+or field are yours to add. Whatever the `Authenticator` still renders around them
+(the container, the heading, the error) keeps its hook.
 
 ## See also
 

--- a/packages/auth-common/src/ui.test.ts
+++ b/packages/auth-common/src/ui.test.ts
@@ -857,6 +857,41 @@ describe('test hooks', () => {
 		assert.strictEqual(testId(form!, 'authenticator-submit')?.textContent, 'Sign in with Google');
 	});
 
+	// Federated action names carry a `<action>:<provider>` suffix, and the hook
+	// keeps it verbatim, so the documented name contains a colon. That is only a
+	// hazard where a locator would parse the value as selector grammar, so pin
+	// the quoted-attribute lookup and the exact-match behavior both here and in
+	// CUSTOMIZING-AUTH-UI.md.
+	test('provider-suffixed action names keep the suffix in the hook', async () => {
+		const api = mockApi(signedOutState([
+			{ name: 'signIn', label: 'Sign In', fields: [
+				{ name: 'username', label: 'Username', type: 'text', required: true },
+			]},
+			{ name: 'signIn:google', label: 'Sign in with Google', url: 'https://accounts.google.com/o/oauth2/auth', method: 'GET', fields: [] },
+			{ name: 'signIn:okta', label: 'Sign in with Okta', url: 'https://example.okta.com/oauth2/v1/authorize', method: 'POST', fields: [] },
+		]));
+		const el = Authenticator(api);
+		await flush();
+
+		const google = testId(el, 'authenticator-action-signIn:google');
+		const okta = testId(el, 'authenticator-action-signIn:okta');
+		assert.ok(google, 'colon-suffixed hook resolves through a quoted attribute selector');
+		assert.ok(okta, 'a second provider gets its own hook');
+		assert.notStrictEqual(google, okta, 'providers do not collide on one hook');
+		assert.strictEqual(testId(google!, 'authenticator-submit')?.textContent, 'Sign in with Google');
+
+		// The bare `signIn` hook matches exactly, not by prefix, or scoping a
+		// form-flow test would land on an OAuth button.
+		const bare = testId(el, 'authenticator-action-signIn');
+		assert.ok(bare, 'the internal signIn action keeps its own hook');
+		assert.ok(testId(bare!, 'authenticator-username'), 'scoping through the bare hook still works');
+		assert.strictEqual(
+			testId(bare!, 'authenticator-action-signIn:google'),
+			null,
+			'suffixed actions are siblings of the bare action, not children',
+		);
+	});
+
 	test('AuthenticatedContent container is addressable', async () => {
 		const api = mockApi(signedInState());
 		const el = AuthenticatedContent(api, () => document.createElement('span'));

--- a/packages/auth-common/src/ui.test.ts
+++ b/packages/auth-common/src/ui.test.ts
@@ -50,7 +50,7 @@ Object.assign(globalThis, {
 });
 
 // Import after globals are set
-const { Authenticator, AuthenticatedContent, onAuthChange, broadcastAuthChange } = await import('./ui.js');
+const { Authenticator, AuthenticatedContent, AccountMenuBar, onAuthChange, broadcastAuthChange } = await import('./ui.js');
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -745,5 +745,146 @@ describe('onAuthChange', () => {
 		await flush();
 
 		assert.strictEqual(callCount, countAfterInit, 'Should not receive events after unsubscribe');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// data-testid contract
+//
+// These hooks are documented in CUSTOMIZING-AUTH-UI.md and e2e suites depend
+// on them, so renaming one is a breaking change.
+// ---------------------------------------------------------------------------
+
+describe('test hooks', () => {
+
+	function testId(root: ParentNode, id: string) {
+		return root.querySelector(`[data-testid="${id}"]`);
+	}
+
+	test('Authenticator container and per-action wrappers are addressable', async () => {
+		const api = mockApi(signedOutState());
+		const el = Authenticator(api);
+		await flush();
+
+		assert.strictEqual(el.getAttribute('data-testid'), 'authenticator');
+		assert.ok(testId(el, 'authenticator-heading'), 'heading hook present');
+		assert.ok(testId(el, 'authenticator-action-signIn'), 'signIn wrapper hook present');
+		assert.ok(testId(el, 'authenticator-action-signUp'), 'signUp wrapper hook present');
+	});
+
+	test('field and submit hooks are unique within an action wrapper', async () => {
+		const api = mockApi(signedOutState());
+		const el = Authenticator(api);
+		await flush();
+
+		const signIn = testId(el, 'authenticator-action-signIn')!;
+		assert.strictEqual(signIn.querySelectorAll('[data-testid="authenticator-username"]').length, 1);
+		assert.strictEqual(signIn.querySelectorAll('[data-testid="authenticator-password"]').length, 1);
+		assert.strictEqual(signIn.querySelectorAll('[data-testid="authenticator-submit"]').length, 1);
+
+		const username = testId(signIn, 'authenticator-username') as HTMLInputElement;
+		const password = testId(signIn, 'authenticator-password') as HTMLInputElement;
+		assert.strictEqual(username.name, 'username');
+		assert.strictEqual(password.type, 'password');
+		assert.strictEqual(testId(signIn, 'authenticator-submit')!.textContent, 'Sign In');
+	});
+
+	test('field hooks follow the field names the BB emits, hidden fields included', async () => {
+		const api = mockApi({
+			state: 'confirmingPasswordReset',
+			actions: [{
+				name: 'confirmResetPassword',
+				label: 'Reset Password',
+				fields: [
+					{ name: 'username', label: 'Username', type: 'hidden', required: true, defaultValue: 'alice' },
+					{ name: 'code', label: 'Reset Code', type: 'text', required: true },
+					{ name: 'newPassword', label: 'New Password', type: 'password', required: true },
+				],
+			}],
+		});
+		const el = Authenticator(api);
+		await flush();
+
+		const wrapper = testId(el, 'authenticator-action-confirmResetPassword')!;
+		const hiddenUsername = testId(wrapper, 'authenticator-username') as HTMLInputElement;
+		assert.strictEqual(hiddenUsername.type, 'hidden');
+		assert.strictEqual(hiddenUsername.value, 'alice');
+		assert.ok(testId(wrapper, 'authenticator-code'), 'code hook present');
+		assert.ok(testId(wrapper, 'authenticator-newPassword'), 'newPassword hook present');
+	});
+
+	test('a scoped submit hook drives the state machine', async () => {
+		const api = mockApi(signedOutState());
+		const el = Authenticator(api);
+		await flush();
+		api.nextState = signedInState();
+
+		const signIn = testId(el, 'authenticator-action-signIn')!;
+		(testId(signIn, 'authenticator-username') as HTMLInputElement).value = 'alice';
+		(testId(signIn, 'authenticator-password') as HTMLInputElement).value = 'secret';
+		(testId(signIn, 'authenticator-submit') as HTMLButtonElement).click();
+		await flush();
+
+		assert.deepStrictEqual(api.calls, [{ action: 'signIn', fields: { username: 'alice', password: 'secret' } }]);
+		assert.strictEqual(testId(el, 'authenticator-signed-in')?.textContent, 'Signed in as: alice');
+	});
+
+	test('error hook carries the error text', async () => {
+		const api = mockApi({ ...signedOutState(), error: 'Invalid password' });
+		const el = Authenticator(api);
+		await flush();
+
+		assert.strictEqual(testId(el, 'authenticator-error')?.textContent, 'Invalid password');
+	});
+
+	test('external actions expose the same wrapper, field and submit hooks', async () => {
+		const api = mockApi(signedOutState([{
+			name: 'signIn:google',
+			label: 'Sign in with Google',
+			url: 'https://accounts.google.com/o/oauth2/auth?client_id=test',
+			method: 'GET',
+			fields: [
+				{ name: 'redirect_uri', label: 'Redirect', type: 'hidden', required: true, defaultValue: 'https://myapp.com/callback' },
+			],
+		}]));
+		const el = Authenticator(api);
+		await flush();
+
+		const form = testId(el, 'authenticator-action-signIn:google');
+		assert.ok(form, 'external action wrapper hook present');
+		assert.strictEqual(form!.tagName, 'FORM');
+		assert.ok(testId(form!, 'authenticator-redirect_uri'), 'hidden field hook present');
+		assert.strictEqual(testId(form!, 'authenticator-submit')?.textContent, 'Sign in with Google');
+	});
+
+	test('AuthenticatedContent container is addressable', async () => {
+		const api = mockApi(signedInState());
+		const el = AuthenticatedContent(api, () => document.createElement('span'));
+		await flush();
+
+		assert.strictEqual(el.getAttribute('data-testid'), 'authenticated-content');
+	});
+
+	test('AccountMenuBar exposes sign-in, sign-out and username hooks', async () => {
+		const signedOutApi = mockApi(signedOutState());
+		const bar = AccountMenuBar(signedOutApi);
+		await flush();
+
+		assert.strictEqual(bar.getAttribute('data-testid'), 'account-menu');
+		const signInBtn = testId(bar, 'account-menu-signin') as HTMLButtonElement;
+		assert.ok(signInBtn, 'sign-in hook present when signed out');
+
+		signInBtn.click();
+		await flush();
+		const modal = testId(document.body, 'account-menu-modal')!;
+		assert.ok(modal, 'modal hook present after clicking sign in');
+		assert.ok(testId(modal, 'authenticator'), 'modal hosts the Authenticator');
+		(testId(modal, 'account-menu-modal-close') as HTMLButtonElement).click();
+
+		const signedInApi = mockApi(signedInState());
+		const signedInBar = AccountMenuBar(signedInApi);
+		await flush();
+		assert.strictEqual(testId(signedInBar, 'account-menu-username')?.textContent, '👤 alice');
+		assert.ok(testId(signedInBar, 'account-menu-signout'), 'sign-out hook present when signed in');
 	});
 });

--- a/packages/auth-common/src/ui.ts
+++ b/packages/auth-common/src/ui.ts
@@ -319,6 +319,7 @@ export function AuthenticatedContent(
 	fallback?: Node,
 ): HTMLElement {
 	const container = document.createElement('div');
+	container.setAttribute('data-testid', 'authenticated-content');
 	onAuthChange(api, (user) => {
 		if (user) {
 			container.replaceChildren(render(user));
@@ -456,6 +457,11 @@ export interface AuthenticatorOptions {
  * - Broadcasts auth changes via `broadcastAuthChange()` so other components
  *   (`AuthenticatedContent`, `onAuthChange` subscribers) react automatically
  * - Listens for auth changes from other tabs and re-renders
+ * - Renders stable `data-testid` hooks (`authenticator`,
+ *   `authenticator-action-<action>`, `authenticator-<field>`,
+ *   `authenticator-submit`, `authenticator-error`, `authenticator-signed-in`)
+ *   for e2e suites. The full contract is in CUSTOMIZING-AUTH-UI.md; treat the
+ *   names as public API.
  *
  * @param api - The state machine API from `auth.createApi()`
  * @param options - Optional customization. See {@link AuthenticatorOptions}.
@@ -488,6 +494,7 @@ export interface AuthenticatorOptions {
  */
 export function Authenticator(api: AuthStateApi, options?: AuthenticatorOptions): HTMLElement {
 	const container = document.createElement('div');
+	container.setAttribute('data-testid', 'authenticator');
 	container.style.cssText = 'max-width: 400px; font-family: system-ui, sans-serif;';
 
 	const opts: AuthenticatorOptions = options ?? {};
@@ -581,6 +588,7 @@ function renderState(
 
 	if (state.state === 'signedIn') {
 		const heading = document.createElement('h3');
+		heading.setAttribute('data-testid', 'authenticator-signed-in');
 		heading.style.cssText = 'margin-top: 0;';
 		heading.textContent = `Signed in as: ${state.user!.username}`;
 		div.appendChild(heading);
@@ -596,6 +604,7 @@ function renderState(
 			: undefined;
 		const stateHeading = options.headings?.[state.state];
 		const heading = document.createElement('h3');
+		heading.setAttribute('data-testid', 'authenticator-heading');
 		heading.style.cssText = 'margin-top: 0;';
 		heading.textContent = actionHeading ?? stateHeading ?? 'Authentication';
 		div.appendChild(heading);
@@ -603,6 +612,7 @@ function renderState(
 
 	if (state.error) {
 		const err = document.createElement('div');
+		err.setAttribute('data-testid', 'authenticator-error');
 		err.style.cssText = 'color: red; font-size: 14px; margin-bottom: 12px;';
 		err.textContent = state.error;
 		div.appendChild(err);
@@ -654,6 +664,7 @@ function renderInternalAction(
 	override?: AuthActionOverride,
 ): Node {
 	const wrapper = document.createElement('div');
+	wrapper.setAttribute('data-testid', `authenticator-action-${action.name}`);
 	wrapper.style.cssText = 'margin-bottom: 16px;';
 
 	const inputs: Record<string, HTMLInputElement> = {};
@@ -708,6 +719,7 @@ function renderInternalAction(
 			hidden.type = 'hidden';
 			hidden.name = field.name;
 			hidden.value = field.defaultValue ?? '';
+			hidden.setAttribute('data-testid', `authenticator-${field.name}`);
 			inputs[field.name] = hidden;
 			wrapper.appendChild(hidden);
 			continue;
@@ -722,6 +734,7 @@ function renderInternalAction(
 				hidden.type = 'hidden';
 				hidden.name = field.name;
 				hidden.value = field.defaultValue;
+				hidden.setAttribute('data-testid', `authenticator-${field.name}`);
 				inputs[field.name] = hidden;
 				wrapper.appendChild(hidden);
 			}
@@ -737,6 +750,7 @@ function renderInternalAction(
 		input.name = field.name;
 		input.placeholder = placeholder;
 		input.type = inputType;
+		input.setAttribute('data-testid', `authenticator-${field.name}`);
 		// `autocomplete` is typed as `AutoFill` (a literal-union) in lib.dom
 		// but the override accepts an arbitrary string for forward-compat
 		// with future hint values. Cast at the assignment boundary.
@@ -755,6 +769,7 @@ function renderInternalAction(
 	}
 
 	const btn = document.createElement('button');
+	btn.setAttribute('data-testid', 'authenticator-submit');
 	btn.textContent = override?.submitLabel ?? action.label;
 	btn.style.cssText = 'padding: 8px 16px; cursor: pointer; margin-right: 8px;';
 
@@ -973,6 +988,7 @@ function b64urlToBuf(s: string): ArrayBuffer {
 
 function renderExternalAction(action: AuthAction): Node {
 	const form = document.createElement('form');
+	form.setAttribute('data-testid', `authenticator-action-${action.name}`);
 	form.method = action.method ?? 'GET';
 	form.action = action.url!;
 	form.style.cssText = 'margin-bottom: 8px;';
@@ -982,10 +998,12 @@ function renderExternalAction(action: AuthAction): Node {
 		input.type = 'hidden';
 		input.name = field.name;
 		input.value = field.defaultValue ?? '';
+		input.setAttribute('data-testid', `authenticator-${field.name}`);
 		form.appendChild(input);
 	}
 
 	const btn = document.createElement('button');
+	btn.setAttribute('data-testid', 'authenticator-submit');
 	btn.type = 'submit';
 	btn.textContent = action.label;
 	btn.style.cssText = 'padding: 8px 16px; cursor: pointer; width: 100%;';
@@ -1019,6 +1037,7 @@ function renderExternalAction(action: AuthAction): Node {
  */
 export function AccountMenuBar(api: AuthStateApi): HTMLElement {
 	const container = document.createElement('div');
+	container.setAttribute('data-testid', 'account-menu');
 
 	function render(user: AuthUser | null) {
 		const bar = document.createElement('div');
@@ -1026,10 +1045,12 @@ export function AccountMenuBar(api: AuthStateApi): HTMLElement {
 
 		if (user) {
 			const username = document.createElement('span');
+			username.setAttribute('data-testid', 'account-menu-username');
 			username.textContent = `👤 ${user.username}`;
 			username.style.cssText = 'font-size: 14px;';
 
 			const signOutBtn = document.createElement('button');
+			signOutBtn.setAttribute('data-testid', 'account-menu-signout');
 			signOutBtn.textContent = 'Sign Out';
 			signOutBtn.style.cssText = 'padding: 8px 16px; cursor: pointer;';
 			signOutBtn.addEventListener('click', async () => {
@@ -1042,17 +1063,20 @@ export function AccountMenuBar(api: AuthStateApi): HTMLElement {
 			bar.appendChild(signOutBtn);
 		} else {
 			const signInBtn = document.createElement('button');
+			signInBtn.setAttribute('data-testid', 'account-menu-signin');
 			signInBtn.textContent = 'Sign In';
 			signInBtn.style.cssText = 'padding: 8px 16px; cursor: pointer;';
 
 			signInBtn.addEventListener('click', () => {
 				const modal = document.createElement('div');
+				modal.setAttribute('data-testid', 'account-menu-modal');
 				modal.style.cssText = 'position: fixed; top: 0; left: 0; right: 0; bottom: 0; background: rgba(0,0,0,0.5); display: flex; align-items: center; justify-content: center; z-index: 1000;';
 
 				const content = document.createElement('div');
 				content.style.cssText = 'background: white; border-radius: 8px; padding: 20px; max-width: 400px; position: relative;';
 
 				const closeBtn = document.createElement('button');
+				closeBtn.setAttribute('data-testid', 'account-menu-modal-close');
 				closeBtn.textContent = '✕';
 				closeBtn.style.cssText = 'position: absolute; top: 8px; right: 8px; border: none; background: none; font-size: 20px; cursor: pointer; padding: 0; width: 24px; height: 24px;';
 				closeBtn.addEventListener('click', () => modal.remove());

--- a/packages/auth-common/src/ui.ts
+++ b/packages/auth-common/src/ui.ts
@@ -457,11 +457,13 @@ export interface AuthenticatorOptions {
  * - Broadcasts auth changes via `broadcastAuthChange()` so other components
  *   (`AuthenticatedContent`, `onAuthChange` subscribers) react automatically
  * - Listens for auth changes from other tabs and re-renders
- * - Renders stable `data-testid` hooks (`authenticator`,
- *   `authenticator-action-<action>`, `authenticator-<field>`,
+ * - Renders stable `data-testid` hooks on every interactive element
+ *   (`authenticator`, `authenticator-action-<action>`, `authenticator-<field>`,
  *   `authenticator-submit`, `authenticator-error`, `authenticator-signed-in`)
- *   for e2e suites. The full contract is in CUSTOMIZING-AUTH-UI.md; treat the
- *   names as public API.
+ *   for e2e suites. Federated action names keep their provider suffix, so
+ *   `signIn:google` gives `authenticator-action-signIn:google`. Presentational
+ *   markup (hint text, layout wrappers) carries no hook. The full contract is
+ *   in CUSTOMIZING-AUTH-UI.md; treat the names as public API.
  *
  * @param api - The state machine API from `auth.createApi()`
  * @param options - Optional customization. See {@link AuthenticatorOptions}.


### PR DESCRIPTION
Fixes #239

The built-in `Authenticator` rendered no test hooks, so e2e suites had nothing reliable to target and teams ended up re-implementing the sign-in form just to get selectors (which then breaks reactivity, see #185).

Every element the auth components render now carries a stable `data-testid`:

- `authenticator` on the container, plus `authenticator-heading`, `authenticator-error` and `authenticator-signed-in`
- `authenticator-action-<action>` on each rendered action, both internal forms and external OAuth/SAML forms
- `authenticator-<field>` on every input, named after the field the server declared (`authenticator-username`, `authenticator-password`, `authenticator-code`, ...), hidden inputs included so session tokens and echoed usernames stay assertable
- `authenticator-submit` on the submit button
- `authenticated-content` on `AuthenticatedContent`, and `account-menu*` hooks on `AccountMenuBar` so a test can open the sign-in modal and sign out again

Field and submit hooks repeat once per action, because the signed-out state renders `signIn` and `signUp` side by side and both declare a `username`. The action wrapper is the scope for that, and the docs show it with a Playwright example.

Attributes only, no behavior change and no API surface change. The contract lives in CUSTOMIZING-AUTH-UI.md, linked from the top of that guide, and is summarised in the `Authenticator` JSDoc.

### Testing

- 8 new cases in `packages/auth-common/src/ui.test.ts`: container/action/field/submit/error/signed-in hooks, hooks on hidden fields and on external provider forms, driving a full sign-in through the scoped hooks, and the `AccountMenuBar` + `AuthenticatedContent` hooks
- `npm run build:packages` clean
- `npm run test:unit` green across all workspaces, `@aws-blocks/auth-common` at 61 passed / 0 failed
- `npm run check:api` reports the API surface unchanged
- changeset guard passes validate-structure, verify-coverage and block-major


### Changeset scope

The changeset bumps `@aws-blocks/auth-common` and `@aws-blocks/blocks` (both patch). The umbrella is included on purpose even though it has no file changes here: it re-exports `Authenticator`, `AuthenticatedContent` and `AccountMenuBar` from `@aws-blocks/auth-common/ui`, and sibling patch releases stay inside its caret ranges, so `changeset version` never bumps it on its own. That is what left it stale in #212 and forced the corrective bump in b920f9e, so it is republished in step with the components it hands to consumers.
