### PR TITLE
fix(ci): require the umbrella changeset entry when a re-exported sibling ships

### DIFF
--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -32,3 +32,10 @@ jobs:
           PR_TITLE: ${{ github.event.pull_request.title }}
       - name: Block major version bumps (pre-release)
         run: node --experimental-strip-types scripts/changeset-guard.ts block-major
+      # The umbrella re-exports its siblings and ships docs/ assembled from their
+      # READMEs, but caret ranges keep a sibling's new version in range, so
+      # `changeset version` never bumps the umbrella on its own. Its packed
+      # content still moves and publish then aborts the whole release run
+      # (#273, previously #212), so require the umbrella entry up front.
+      - name: Verify the umbrella is bumped with its siblings
+        run: node --experimental-strip-types scripts/changeset-guard.ts verify-umbrella

--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -20,6 +20,11 @@ jobs:
 
       # Guards import only Node built-ins, so Node type-strips and runs the TS
       # directly.
+      # The guards decide whether a release can go out, so they are unit-tested
+      # first, against throwaway git repos in a temp dir. A regression shows up
+      # here instead of as a wrong verdict in the steps below.
+      - name: Test the changeset guards
+        run: node --test scripts/changeset-guard.test.mjs
       # Catches malformed changesets (broken frontmatter, unknown package,
       # invalid bump type) that the regex parser silently ignores and would
       # otherwise fail post-merge at `changeset version`. Validates only the
@@ -36,6 +41,7 @@ jobs:
       # READMEs, but caret ranges keep a sibling's new version in range, so
       # `changeset version` never bumps the umbrella on its own. Its packed
       # content still moves and publish then aborts the whole release run
-      # (#273, previously #212), so require the umbrella entry up front.
+      # (#273, previously #212), so require the umbrella entry up front, and
+      # treat removing an existing one as the same failure.
       - name: Verify the umbrella is bumped with its siblings
         run: node --experimental-strip-types scripts/changeset-guard.ts verify-umbrella

--- a/scripts/changeset-guard.test.mjs
+++ b/scripts/changeset-guard.test.mjs
@@ -1,0 +1,517 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Unit tests for scripts/changeset-guard.ts. Every case builds a throwaway git
+// repo in a temp dir, copies the real guard into its scripts/ (the guard roots
+// itself at `import.meta.dirname/..`, so the copy sees the fixture as the repo),
+// commits a base, points refs/remotes/origin/main at it, then commits the "PR"
+// changes on top and runs the guard for real: real git, real fs, no stubs.
+//
+// Run: node --test scripts/changeset-guard.test.mjs
+
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import {
+	copyFileSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { describe, it } from "node:test";
+
+const SCRIPTS_DIR = import.meta.dirname;
+const GUARD_SRC = join(SCRIPTS_DIR, "changeset-guard.ts");
+const REPO_ROOT = join(SCRIPTS_DIR, "..");
+
+const UMBRELLA = "@aws-blocks/blocks";
+const SIBLING = "@aws-blocks/core";
+const OTHER_SIBLING = "@aws-blocks/bb-kv-store";
+// In the workspace but not re-exported by the umbrella, so releasing it alone
+// must never trigger the umbrella requirement.
+const NON_SIBLING = "@aws-blocks/create-blocks-app";
+
+// Keeps the fixture repo free of the host's git config (signing hooks, aliases,
+// templates) so the tests behave the same on a laptop and on a runner.
+const GIT_ENV = {
+	...process.env,
+	GIT_CONFIG_GLOBAL: "/dev/null",
+	GIT_CONFIG_SYSTEM: "/dev/null",
+	GIT_AUTHOR_NAME: "Guard Test",
+	GIT_AUTHOR_EMAIL: "guard@test.invalid",
+	GIT_COMMITTER_NAME: "Guard Test",
+	GIT_COMMITTER_EMAIL: "guard@test.invalid",
+};
+
+function git(cwd, ...args) {
+	return execFileSync("git", args, { cwd, env: GIT_ENV, encoding: "utf-8" });
+}
+
+function write(dir, relPath, contents) {
+	const full = join(dir, relPath);
+	mkdirSync(dirname(full), { recursive: true });
+	writeFileSync(full, contents);
+}
+
+function pkgJson(name, extra = {}) {
+	return `${JSON.stringify({ name, version: "0.1.0", ...extra }, null, 2)}\n`;
+}
+
+/** `---\n<entries>\n---\n\n<body>` frontmatter, the shape `npx changeset` writes. */
+function changeset(entries, body = "A change.") {
+	const lines = Object.entries(entries).map(([pkg, bump]) => `"${pkg}": ${bump}`);
+	return `---\n${lines.join("\n")}\n---\n\n${body}\n`;
+}
+
+/**
+ * A fixture repo whose base commit is what origin/main points at. `files` is
+ * merged over the default workspace layout before that base commit is made.
+ */
+function baseRepo(t, files = {}) {
+	const dir = mkdtempSync(join(tmpdir(), "changeset-guard-"));
+	t.after(() => rmSync(dir, { recursive: true, force: true }));
+
+	mkdirSync(join(dir, "scripts"), { recursive: true });
+	copyFileSync(GUARD_SRC, join(dir, "scripts", "changeset-guard.ts"));
+
+	const workspaces = [
+		"packages/blocks",
+		"packages/core",
+		"packages/bb-kv-store",
+		"packages/create-blocks-app",
+	];
+	const layout = {
+		"package.json": `${JSON.stringify({ name: "fixture-root", private: true, workspaces }, null, 2)}\n`,
+		"packages/blocks/package.json": pkgJson(UMBRELLA, {
+			dependencies: {
+				[SIBLING]: "^0.1.0",
+				[OTHER_SIBLING]: "^0.1.0",
+				"aws-cdk-lib": "^2.0.0",
+			},
+		}),
+		"packages/core/package.json": pkgJson(SIBLING),
+		"packages/bb-kv-store/package.json": pkgJson(OTHER_SIBLING),
+		"packages/create-blocks-app/package.json": pkgJson(NON_SIBLING),
+		".changeset/config.json": `${JSON.stringify({ changelog: "@changesets/cli/changelog" }, null, 2)}\n`,
+		".changeset/README.md": "# Changesets\n",
+		...files,
+	};
+
+	for (const [relPath, contents] of Object.entries(layout)) {
+		if (contents === null) continue;
+		write(dir, relPath, contents);
+	}
+
+	git(dir, "init", "-q", "-b", "main");
+	git(dir, "add", "-A");
+	git(dir, "commit", "-q", "-m", "base");
+	git(dir, "update-ref", "refs/remotes/origin/main", "HEAD");
+	return dir;
+}
+
+/** Applies the PR's changes on top of the base and commits them. `null` deletes. */
+function commitPr(dir, files) {
+	for (const [relPath, contents] of Object.entries(files)) {
+		if (contents === null) {
+			rmSync(join(dir, relPath), { force: true });
+			continue;
+		}
+		write(dir, relPath, contents);
+	}
+	git(dir, "add", "-A");
+	git(dir, "commit", "-q", "-m", "pr");
+}
+
+/**
+ * Runs the guard in the fixture and returns its exit code plus combined
+ * stdout+stderr. A non-zero exit is the behaviour under test, so the throw
+ * execFileSync raises for it is unwrapped rather than propagated.
+ */
+function guard(dir, command, env = {}) {
+	try {
+		const stdout = execFileSync(
+			process.execPath,
+			["--experimental-strip-types", join(dir, "scripts", "changeset-guard.ts"), command],
+			{
+				cwd: dir,
+				env: { ...GIT_ENV, ...env },
+				encoding: "utf-8",
+				stdio: ["ignore", "pipe", "pipe"],
+			},
+		);
+		return { status: 0, output: stdout };
+	} catch (err) {
+		return { status: err.status ?? 1, output: `${err.stdout ?? ""}${err.stderr ?? ""}` };
+	}
+}
+
+describe("verify-umbrella: a sibling release needs the umbrella entry", () => {
+	it("fails when this PR releases a re-exported sibling and nothing bumps the umbrella", (t) => {
+		const dir = baseRepo(t);
+		commitPr(dir, { ".changeset/ship-core.md": changeset({ [SIBLING]: "patch" }) });
+
+		const { status, output } = guard(dir, "verify-umbrella");
+		assert.equal(status, 1, output);
+		assert.match(output, /releases package\(s\) that @aws-blocks\/blocks re-exports/);
+		assert.match(output, /@aws-blocks\/core/);
+	});
+
+	it("passes when the same changeset bumps the umbrella too", (t) => {
+		const dir = baseRepo(t);
+		commitPr(dir, {
+			".changeset/ship-core.md": changeset({ [SIBLING]: "patch", [UMBRELLA]: "patch" }),
+		});
+
+		const { status, output } = guard(dir, "verify-umbrella");
+		assert.equal(status, 0, output);
+		assert.match(output, /is bumped alongside them/);
+	});
+
+	it("passes when a changeset already pending on main bumps the umbrella", (t) => {
+		const dir = baseRepo(t, {
+			".changeset/pending-umbrella.md": changeset({ [UMBRELLA]: "patch" }),
+		});
+		commitPr(dir, { ".changeset/ship-core.md": changeset({ [SIBLING]: "patch" }) });
+
+		const { status, output } = guard(dir, "verify-umbrella");
+		assert.equal(status, 0, output);
+	});
+
+	it("passes when the PR releases only a package the umbrella does not re-export", (t) => {
+		const dir = baseRepo(t);
+		commitPr(dir, { ".changeset/cli.md": changeset({ [NON_SIBLING]: "patch" }) });
+
+		const { status, output } = guard(dir, "verify-umbrella");
+		assert.equal(status, 0, output);
+		assert.match(output, /No changeset here releases/);
+	});
+
+	it("does not fail an unrelated PR for a sibling release someone else left pending", (t) => {
+		const dir = baseRepo(t, {
+			".changeset/someone-elses-core.md": changeset({ [SIBLING]: "patch" }),
+		});
+		commitPr(dir, { "README.md": "# fixture\n" });
+
+		const { status, output } = guard(dir, "verify-umbrella");
+		assert.equal(status, 0, output);
+	});
+});
+
+describe("verify-umbrella: withdrawing the umbrella entry", () => {
+	it("fails when the PR deletes the only changeset that bumped the umbrella", (t) => {
+		const dir = baseRepo(t, {
+			".changeset/pending-core.md": changeset({ [SIBLING]: "patch" }),
+			".changeset/pending-umbrella.md": changeset({ [UMBRELLA]: "patch" }),
+		});
+		commitPr(dir, { ".changeset/pending-umbrella.md": null });
+
+		const { status, output } = guard(dir, "verify-umbrella");
+		assert.equal(status, 1, output);
+		assert.match(output, /removes the @aws-blocks\/blocks entry from/);
+		assert.match(output, /\.changeset\/pending-umbrella\.md/);
+		assert.match(output, /@aws-blocks\/core/);
+	});
+
+	it("fails when the PR strips the umbrella line out of an existing changeset", (t) => {
+		const dir = baseRepo(t, {
+			".changeset/pending-core.md": changeset({ [SIBLING]: "patch" }),
+			".changeset/pending-cli.md": changeset({ [NON_SIBLING]: "patch", [UMBRELLA]: "patch" }),
+		});
+		commitPr(dir, {
+			".changeset/pending-cli.md": changeset({ [NON_SIBLING]: "patch" }),
+		});
+
+		const { status, output } = guard(dir, "verify-umbrella");
+		assert.equal(status, 1, output);
+		assert.match(output, /removes the @aws-blocks\/blocks entry from/);
+		assert.match(output, /\.changeset\/pending-cli\.md/);
+	});
+
+	it("fails when the withdrawn changeset also released a sibling of its own", (t) => {
+		const dir = baseRepo(t, {
+			".changeset/core-and-umbrella.md": changeset({
+				[SIBLING]: "patch",
+				[UMBRELLA]: "patch",
+			}),
+		});
+		commitPr(dir, {
+			".changeset/core-and-umbrella.md": changeset({ [SIBLING]: "patch" }),
+		});
+
+		const { status, output } = guard(dir, "verify-umbrella");
+		assert.equal(status, 1, output);
+	});
+
+	it("passes when the withdrawal leaves no sibling release pending (a revert)", (t) => {
+		const dir = baseRepo(t, {
+			".changeset/core-and-umbrella.md": changeset({
+				[SIBLING]: "patch",
+				[UMBRELLA]: "patch",
+			}),
+		});
+		commitPr(dir, { ".changeset/core-and-umbrella.md": null });
+
+		const { status, output } = guard(dir, "verify-umbrella");
+		assert.equal(status, 0, output);
+		assert.match(output, /No changeset here releases/);
+	});
+
+	it("passes when the umbrella entry moves to another changeset", (t) => {
+		const dir = baseRepo(t, {
+			".changeset/pending-core.md": changeset({ [SIBLING]: "patch" }),
+			".changeset/pending-umbrella.md": changeset({ [UMBRELLA]: "patch" }),
+		});
+		commitPr(dir, {
+			".changeset/pending-umbrella.md": null,
+			".changeset/consolidated.md": changeset({ [SIBLING]: "patch", [UMBRELLA]: "patch" }),
+		});
+
+		const { status, output } = guard(dir, "verify-umbrella");
+		assert.equal(status, 0, output);
+	});
+
+	it("passes for the release PR, which consumes every changeset at once", (t) => {
+		const dir = baseRepo(t, {
+			".changeset/pending-core.md": changeset({ [SIBLING]: "patch" }),
+			".changeset/pending-umbrella.md": changeset({ [UMBRELLA]: "patch" }),
+		});
+		commitPr(dir, {
+			".changeset/pending-core.md": null,
+			".changeset/pending-umbrella.md": null,
+			"packages/core/package.json": pkgJson(SIBLING, { version: "0.1.1" }),
+		});
+
+		const { status, output } = guard(dir, "verify-umbrella", {
+			PR_TITLE: "chore: version packages",
+		});
+		assert.equal(status, 0, output);
+	});
+
+	it("ignores nested .changeset subdirectories, which changesets never reads", (t) => {
+		const dir = baseRepo(t, {
+			".changeset/pending-core.md": changeset({ [SIBLING]: "patch" }),
+			".changeset/archive/old.md": changeset({ [UMBRELLA]: "patch" }),
+			".changeset/pending-umbrella.md": changeset({ [UMBRELLA]: "patch" }),
+		});
+		commitPr(dir, { ".changeset/archive/old.md": null });
+
+		const { status, output } = guard(dir, "verify-umbrella");
+		assert.equal(status, 0, output);
+		assert.doesNotMatch(output, /archive/);
+	});
+});
+
+describe("verify-umbrella: fails loudly instead of asserting nothing", () => {
+	it("fails when the umbrella package.json cannot be parsed", (t) => {
+		const dir = baseRepo(t);
+		commitPr(dir, {
+			".changeset/ship-core.md": changeset({ [SIBLING]: "patch" }),
+			"packages/blocks/package.json": '{ "name": "@aws-blocks/blocks", oops\n',
+		});
+
+		const { status, output } = guard(dir, "verify-umbrella");
+		assert.equal(status, 1, output);
+		assert.match(output, /Cannot parse @aws-blocks\/blocks's package\.json/);
+		assert.doesNotMatch(output, /No changeset here releases/);
+	});
+
+	it("fails when the umbrella package.json is missing", (t) => {
+		const dir = baseRepo(t);
+		commitPr(dir, {
+			".changeset/ship-core.md": changeset({ [SIBLING]: "patch" }),
+			"packages/blocks/package.json": null,
+		});
+
+		const { status, output } = guard(dir, "verify-umbrella");
+		assert.equal(status, 1, output);
+		assert.match(output, /Cannot read @aws-blocks\/blocks's package\.json/);
+	});
+
+	it("fails when the umbrella declares no @aws-blocks/* dependencies", (t) => {
+		const dir = baseRepo(t);
+		commitPr(dir, {
+			".changeset/ship-core.md": changeset({ [SIBLING]: "patch" }),
+			"packages/blocks/package.json": pkgJson(UMBRELLA, {
+				dependencies: { "aws-cdk-lib": "^2.0.0" },
+			}),
+		});
+
+		const { status, output } = guard(dir, "verify-umbrella");
+		assert.equal(status, 1, output);
+		assert.match(output, /declares no @aws-blocks\/\* dependencies/);
+	});
+
+	it("fails when the umbrella has no dependencies block at all", (t) => {
+		const dir = baseRepo(t);
+		commitPr(dir, {
+			".changeset/ship-core.md": changeset({ [SIBLING]: "patch" }),
+			"packages/blocks/package.json": pkgJson(UMBRELLA),
+		});
+
+		const { status, output } = guard(dir, "verify-umbrella");
+		assert.equal(status, 1, output);
+		assert.match(output, /has no "dependencies" object/);
+	});
+});
+
+describe("verify-coverage", () => {
+	it("fails when a changed package has no changeset entry", (t) => {
+		const dir = baseRepo(t);
+		commitPr(dir, { "packages/core/src/index.ts": "export const a = 1;\n" });
+
+		const { status, output } = guard(dir, "verify-coverage");
+		assert.equal(status, 1, output);
+		assert.match(output, /@aws-blocks\/core/);
+	});
+
+	it("passes when every changed package is covered", (t) => {
+		const dir = baseRepo(t);
+		commitPr(dir, {
+			"packages/core/src/index.ts": "export const a = 1;\n",
+			".changeset/ship-core.md": changeset({ [SIBLING]: "patch", [UMBRELLA]: "patch" }),
+		});
+
+		const { status, output } = guard(dir, "verify-coverage");
+		assert.equal(status, 0, output);
+		assert.match(output, /are covered by changesets/);
+	});
+
+	it("skips the release PR, which has consumed its changesets already", (t) => {
+		const dir = baseRepo(t);
+		commitPr(dir, { "packages/core/package.json": pkgJson(SIBLING, { version: "0.1.1" }) });
+
+		const { status, output } = guard(dir, "verify-coverage", {
+			PR_TITLE: "chore: version packages",
+		});
+		assert.equal(status, 0, output);
+		assert.match(output, /Skipping coverage check for the release PR/);
+	});
+
+	it("fails loudly when a changed package's package.json cannot be parsed", (t) => {
+		const dir = baseRepo(t);
+		commitPr(dir, { "packages/core/package.json": "{ not json\n" });
+
+		const { status, output } = guard(dir, "verify-coverage");
+		assert.equal(status, 1, output);
+		assert.match(output, /Cannot parse packages\/core\/package\.json/);
+		assert.doesNotMatch(output, /No publishable packages were changed/);
+	});
+});
+
+describe("block-major", () => {
+	it("fails on a major bump", (t) => {
+		const dir = baseRepo(t);
+		commitPr(dir, { ".changeset/big.md": changeset({ [SIBLING]: "major" }) });
+
+		const { status, output } = guard(dir, "block-major");
+		assert.equal(status, 1, output);
+		assert.match(output, /Major version bumps are not allowed/);
+	});
+
+	it("passes on minor and patch bumps", (t) => {
+		const dir = baseRepo(t);
+		commitPr(dir, {
+			".changeset/breaking.md": changeset({ [SIBLING]: "minor", [UMBRELLA]: "patch" }),
+		});
+
+		const { status, output } = guard(dir, "block-major");
+		assert.equal(status, 0, output);
+	});
+});
+
+describe("validate-structure", () => {
+	it("passes on well-formed changesets, including an empty one", (t) => {
+		const dir = baseRepo(t);
+		commitPr(dir, {
+			".changeset/ok.md": changeset({ [SIBLING]: "patch", [UMBRELLA]: "patch" }),
+			// What `changeset --empty` writes: no entries, so the frontmatter body is
+			// a single blank line.
+			".changeset/empty.md": changeset({}, "Empty changeset."),
+		});
+
+		const { status, output } = guard(dir, "validate-structure");
+		assert.equal(status, 0, output);
+	});
+
+	it("fails on a package name that is not in the workspace", (t) => {
+		const dir = baseRepo(t);
+		commitPr(dir, { ".changeset/typo.md": changeset({ "@aws-blocks/kv-store": "patch" }) });
+
+		const { status, output } = guard(dir, "validate-structure");
+		assert.equal(status, 1, output);
+		assert.match(output, /unknown package "@aws-blocks\/kv-store"/);
+	});
+
+	it("fails on an invalid bump type", (t) => {
+		const dir = baseRepo(t);
+		commitPr(dir, { ".changeset/bad-bump.md": changeset({ [SIBLING]: "pathc" }) });
+
+		const { status, output } = guard(dir, "validate-structure");
+		assert.equal(status, 1, output);
+		assert.match(output, /invalid bump "pathc"/);
+	});
+
+	it("fails on broken frontmatter", (t) => {
+		const dir = baseRepo(t);
+		commitPr(dir, { ".changeset/no-frontmatter.md": `"${SIBLING}": patch\n` });
+
+		const { status, output } = guard(dir, "validate-structure");
+		assert.equal(status, 1, output);
+		assert.match(output, /missing or malformed frontmatter/);
+	});
+
+	it("fails loudly when a workspace member's package.json cannot be parsed", (t) => {
+		// Silently skipping it shrinks the set of legitimate package names, which
+		// used to surface as a bogus "unknown package" error for every entry.
+		const dir = baseRepo(t);
+		commitPr(dir, {
+			".changeset/ok.md": changeset({ [SIBLING]: "patch", [UMBRELLA]: "patch" }),
+			"packages/core/package.json": "{ not json\n",
+		});
+
+		const { status, output } = guard(dir, "validate-structure");
+		assert.equal(status, 1, output);
+		assert.match(output, /Cannot parse packages\/core\/package\.json/);
+		assert.doesNotMatch(output, /unknown package/);
+	});
+
+	it("fails loudly when the root package.json declares no workspaces", (t) => {
+		const dir = baseRepo(t);
+		commitPr(dir, {
+			".changeset/ok.md": changeset({ [SIBLING]: "patch", [UMBRELLA]: "patch" }),
+			"package.json": `${JSON.stringify({ name: "fixture-root", private: true }, null, 2)}\n`,
+		});
+
+		const { status, output } = guard(dir, "validate-structure");
+		assert.equal(status, 1, output);
+		assert.match(output, /no "workspaces" array/);
+		assert.doesNotMatch(output, /unknown package/);
+	});
+});
+
+describe("cli", () => {
+	it("exits 2 on an unknown command", (t) => {
+		const dir = baseRepo(t);
+		const { status, output } = guard(dir, "verify-everything");
+		assert.equal(status, 2, output);
+		assert.match(output, /Unknown command: verify-everything/);
+	});
+});
+
+describe("the real umbrella package.json", () => {
+	// The fail-loud paths above are only safe to ship if the real repo satisfies
+	// them, so assert the invariant they depend on against the real file.
+	it("parses and declares the siblings the guard asserts against", () => {
+		const raw = readFileSync(join(REPO_ROOT, "packages", "blocks", "package.json"), "utf-8");
+		const deps = JSON.parse(raw).dependencies;
+		assert.equal(typeof deps, "object");
+		const siblings = Object.keys(deps).filter(
+			(name) => name.startsWith("@aws-blocks/") && name !== UMBRELLA,
+		);
+		assert.ok(siblings.length > 0, "the umbrella must re-export at least one sibling");
+		assert.ok(siblings.includes(SIBLING), `expected ${SIBLING} among ${siblings.join(", ")}`);
+	});
+});

--- a/scripts/changeset-guard.test.mjs
+++ b/scripts/changeset-guard.test.mjs
@@ -302,6 +302,21 @@ describe("verify-umbrella: withdrawing the umbrella entry", () => {
 		assert.equal(status, 0, output);
 		assert.doesNotMatch(output, /archive/);
 	});
+
+	it("copes with a merge base that has no .changeset directory at all", (t) => {
+		// Nothing can have been withdrawn from a directory that did not exist, so
+		// the missing base listing must not read as a git failure.
+		const dir = baseRepo(t, {
+			".changeset/config.json": null,
+			".changeset/README.md": null,
+		});
+		commitPr(dir, { ".changeset/ship-core.md": changeset({ [SIBLING]: "patch" }) });
+
+		const { status, output } = guard(dir, "verify-umbrella");
+		assert.equal(status, 1, output);
+		assert.match(output, /releases package\(s\) that @aws-blocks\/blocks re-exports/);
+		assert.doesNotMatch(output, /fatal|ENOENT/);
+	});
 });
 
 describe("verify-umbrella: fails loudly instead of asserting nothing", () => {

--- a/scripts/changeset-guard.ts
+++ b/scripts/changeset-guard.ts
@@ -27,6 +27,20 @@
  *                   sibling's new version in range, so `changeset version`
  *                   leaves the umbrella alone while its packed content still
  *                   moves, and publish then fails the whole release run.
+ *                   Withdrawal counts as the same failure: removing an umbrella
+ *                   entry an existing changeset already declared re-opens the
+ *                   hole, so that case is checked against every pending sibling
+ *                   release rather than only this PR's.
+ *                   Only the entry's presence is checked, never its bump level.
+ *                   A `patch` on the umbrella satisfies the guard even when a
+ *                   sibling ships `minor` (a pre-1.0 break), because deciding
+ *                   how breakage should propagate through re-exports is a
+ *                   versioning-policy question, separate from the publish
+ *                   failure this guard exists to prevent.
+ *
+ * Guards fail loudly. When one cannot read what it asserts against (a missing
+ * or malformed package.json, say) it exits non-zero with the reason instead of
+ * printing a green line it did not earn.
  *
  * Pre-1.0 semver convention:
  *   - `patch` (0.1.1 → 0.1.2): non-breaking change
@@ -40,7 +54,7 @@
  *   node --experimental-strip-types scripts/changeset-guard.ts verify-umbrella
  */
 
-import { execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import { readFileSync, readdirSync, existsSync } from "node:fs";
 import { join, resolve } from "node:path";
 
@@ -63,29 +77,54 @@ interface Entry {
 	type: BumpType;
 }
 
-function parseChangesets(): Entry[] {
+/**
+ * A guard could not evaluate what it was asked to assert. Reported as a normal
+ * failure (exit 1) with the reason, never swallowed.
+ */
+class GuardError extends Error {}
+
+/** Parse a JSON file, failing the guard loudly if it is unreadable or invalid. */
+function readJson(path: string, label: string): Record<string, unknown> {
+	let raw: string;
+	try {
+		raw = readFileSync(path, "utf-8");
+	} catch (err) {
+		throw new GuardError(`Cannot read ${label} (${path}): ${(err as Error).message}`);
+	}
+	try {
+		return JSON.parse(raw);
+	} catch (err) {
+		throw new GuardError(`Cannot parse ${label} (${path}) as JSON: ${(err as Error).message}`);
+	}
+}
+
+/** The `@aws-blocks/*` bumps declared in one changeset's frontmatter. */
+function parseEntries(file: string, content: string): Entry[] {
 	const entries: Entry[] = [];
-	if (!existsSync(CHANGESET_DIR)) return entries;
+	const frontmatterMatch = content.match(/^---\n([\s\S]*?)\n---/);
+	if (!frontmatterMatch) return entries;
+
+	for (const line of frontmatterMatch[1].split("\n")) {
+		const entryMatch = line.match(
+			/['"]?(@aws-blocks\/[^'":\s]+)['"]?\s*:\s*['"]?(major|minor|patch)['"]?/,
+		);
+		if (entryMatch) {
+			entries.push({ file, pkg: entryMatch[1], type: entryMatch[2] as BumpType });
+		}
+	}
+	return entries;
+}
+
+function parseChangesets(): Entry[] {
+	if (!existsSync(CHANGESET_DIR)) return [];
 
 	const files = readdirSync(CHANGESET_DIR).filter(
 		(f) => f.endsWith(".md") && f !== "README.md",
 	);
 
-	for (const file of files) {
-		const content = readFileSync(join(CHANGESET_DIR, file), "utf-8");
-		const frontmatterMatch = content.match(/^---\n([\s\S]*?)\n---/);
-		if (!frontmatterMatch) continue;
-
-		for (const line of frontmatterMatch[1].split("\n")) {
-			const entryMatch = line.match(
-				/['"]?(@aws-blocks\/[^'":\s]+)['"]?\s*:\s*['"]?(major|minor|patch)['"]?/,
-			);
-			if (entryMatch) {
-				entries.push({ file, pkg: entryMatch[1], type: entryMatch[2] as BumpType });
-			}
-		}
-	}
-	return entries;
+	return files.flatMap((file) =>
+		parseEntries(file, readFileSync(join(CHANGESET_DIR, file), "utf-8")),
+	);
 }
 
 /** Package names (@aws-blocks/*) covered by any changeset entry. */
@@ -93,19 +132,31 @@ function getCoveredPackages(): Set<string> {
 	return new Set(parseChangesets().map((e) => e.pkg));
 }
 
-/** Files changed vs origin/main, as repo-relative paths. */
+/** Where this branch left origin/main. Memoised: several guards ask for it. */
+let mergeBaseCache: string | undefined;
+function getMergeBase(): string {
+	if (mergeBaseCache === undefined) {
+		mergeBaseCache = execFileSync("git", ["merge-base", "origin/main", "HEAD"], {
+			cwd: ROOT,
+			encoding: "utf-8",
+		}).trim();
+	}
+	return mergeBaseCache;
+}
+
+/** Files changed vs origin/main, as repo-relative paths. Includes deletions. */
+let changedFilesCache: string[] | undefined;
 function getChangedFiles(): string[] {
-	const mergeBase = execSync("git merge-base origin/main HEAD", {
-		cwd: ROOT,
-		encoding: "utf-8",
-	}).trim();
-	return execSync(`git diff --name-only ${mergeBase}`, {
-		cwd: ROOT,
-		encoding: "utf-8",
-	})
-		.trim()
-		.split("\n")
-		.filter(Boolean);
+	if (changedFilesCache === undefined) {
+		changedFilesCache = execFileSync("git", ["diff", "--name-only", getMergeBase()], {
+			cwd: ROOT,
+			encoding: "utf-8",
+		})
+			.trim()
+			.split("\n")
+			.filter(Boolean);
+	}
+	return changedFilesCache;
 }
 
 /** Publishable @aws-blocks/* packages with file changes vs origin/main. */
@@ -118,13 +169,9 @@ function getChangedPackages(): Set<string> {
 		const pkgJsonPath = join(PACKAGES_DIR, match[1], "package.json");
 		if (!existsSync(pkgJsonPath)) continue;
 
-		try {
-			const pkgJson = JSON.parse(readFileSync(pkgJsonPath, "utf-8"));
-			if (typeof pkgJson.name === "string" && pkgJson.name.startsWith(SCOPE)) {
-				packages.add(pkgJson.name);
-			}
-		} catch {
-			// skip unreadable package.json
+		const pkgJson = readJson(pkgJsonPath, `packages/${match[1]}/package.json`);
+		if (typeof pkgJson.name === "string" && pkgJson.name.startsWith(SCOPE)) {
+			packages.add(pkgJson.name);
 		}
 	}
 	return packages;
@@ -170,47 +217,110 @@ function verifyCoverage(): number {
  * dependencies. Releasing any of them can change what the umbrella's tarball
  * ships without touching a single file the umbrella owns, which is why a file
  * diff can't be the signal here.
+ *
+ * An unreadable, malformed or sibling-less package.json fails the guard. With an
+ * empty sibling set every PR would sail through the check while printing the
+ * green line, so the one thing this must not do is carry on quietly.
  */
 function getUmbrellaSiblings(): Set<string> {
-	const siblings = new Set<string>();
 	const pkgJsonPath = join(PACKAGES_DIR, "blocks", "package.json");
-	if (!existsSync(pkgJsonPath)) return siblings;
+	const deps = readJson(pkgJsonPath, `${UMBRELLA_PKG}'s package.json`).dependencies;
 
-	try {
-		const deps = JSON.parse(readFileSync(pkgJsonPath, "utf-8")).dependencies;
-		if (deps && typeof deps === "object") {
-			for (const name of Object.keys(deps)) {
-				if (name.startsWith(SCOPE) && name !== UMBRELLA_PKG) siblings.add(name);
-			}
-		}
-	} catch {
-		// unreadable package.json: nothing to assert against
+	if (deps === null || typeof deps !== "object") {
+		throw new GuardError(
+			`${UMBRELLA_PKG}'s package.json (${pkgJsonPath}) has no "dependencies" object, so\n` +
+			`the set of re-exported siblings cannot be determined.`,
+		);
+	}
+
+	const siblings = new Set(
+		Object.keys(deps as Record<string, unknown>).filter(
+			(name) => name.startsWith(SCOPE) && name !== UMBRELLA_PKG,
+		),
+	);
+
+	if (siblings.size === 0) {
+		throw new GuardError(
+			`${UMBRELLA_PKG}'s package.json (${pkgJsonPath}) declares no ${SCOPE}* dependencies.\n` +
+			`The umbrella exists to re-export its siblings, so either that file was edited by\n` +
+			`mistake or the umbrella has moved and this guard needs updating. Passing every PR\n` +
+			`on an empty sibling set would be worse than failing here.`,
+		);
 	}
 	return siblings;
 }
 
-/** Changeset filenames added or modified by this PR (vs origin/main). */
+/** Changeset filenames added, modified or deleted by this PR (vs origin/main). */
 function getChangedChangesetFiles(): Set<string> {
 	const names = new Set<string>();
 	for (const file of getChangedFiles()) {
-		const match = file.match(/^\.changeset\/(.+\.md)$/);
+		const match = file.match(/^\.changeset\/([^/]+\.md)$/);
 		if (match && match[1] !== "README.md") names.add(match[1]);
 	}
 	return names;
 }
 
+/** A changeset's entries as of the merge base; empty if this PR added the file. */
+function parseChangesetAtMergeBase(file: string): Entry[] {
+	let content: string;
+	try {
+		content = execFileSync("git", ["show", `${getMergeBase()}:.changeset/${file}`], {
+			cwd: ROOT,
+			encoding: "utf-8",
+			stdio: ["ignore", "pipe", "ignore"],
+		});
+	} catch {
+		return []; // absent at the merge base
+	}
+	return parseEntries(file, content);
+}
+
+/**
+ * Changesets this PR takes the umbrella entry away from: they declared
+ * `@aws-blocks/blocks` at the merge base and no longer do, whether the line was
+ * deleted or the whole file was. Coverage can be withdrawn as easily as it can
+ * be forgotten, and the release aborts either way.
+ */
+function getWithdrawnUmbrellaFiles(pending: Entry[]): string[] {
+	const stillDeclaring = new Set(
+		pending.filter((e) => e.pkg === UMBRELLA_PKG).map((e) => e.file),
+	);
+	return [...getChangedChangesetFiles()]
+		.filter(
+			(file) =>
+				!stillDeclaring.has(file) &&
+				parseChangesetAtMergeBase(file).some((e) => e.pkg === UMBRELLA_PKG),
+		)
+		.sort();
+}
+
+/** Why an unbumped umbrella takes the whole release run down with it. */
+const UMBRELLA_PUBLISH_FAILURE =
+	`${UMBRELLA_PKG} pins its siblings with caret ranges, so their new versions stay in\n` +
+	`range and \`changeset version\` leaves the umbrella at its current version. Its packed\n` +
+	`content still moves (the re-exported APIs, plus docs/ assembled from sibling READMEs at\n` +
+	`pack time), and publish then aborts the whole release run with "${UMBRELLA_PKG}@<version>\n` +
+	`already exists with different content" (issue #273, previously #212).\n\n`;
+
 function verifyUmbrella(): number {
 	const siblings = getUmbrellaSiblings();
+	const pending = parseChangesets();
 	const touched = getChangedChangesetFiles();
-	// Only this PR's own changesets trigger the check. Reading every pending
-	// changeset would fail unrelated PRs for an omission someone else merged.
-	const released = [
-		...new Set(
-			parseChangesets()
-				.filter((e) => touched.has(e.file) && siblings.has(e.pkg))
-				.map((e) => e.pkg),
-		),
-	].sort();
+	const withdrawnFrom = getWithdrawnUmbrellaFiles(pending);
+
+	const siblingReleases = (entries: Entry[]) =>
+		[...new Set(entries.filter((e) => siblings.has(e.pkg)).map((e) => e.pkg))].sort();
+
+	// Normally only this PR's own changesets trigger the check: reading every
+	// pending changeset would fail unrelated PRs for an omission someone else
+	// merged. Withdrawal is the exception. This PR is what removed the coverage,
+	// so every pending sibling release becomes its problem, including ones it
+	// never touched. A revert that drops the sibling entries along with the
+	// umbrella one leaves nothing pending and still passes.
+	const released =
+		withdrawnFrom.length > 0
+			? siblingReleases(pending)
+			: siblingReleases(pending.filter((e) => touched.has(e.file)));
 
 	if (released.length === 0) {
 		console.log(`✓ No changeset here releases a package ${UMBRELLA_PKG} re-exports.`);
@@ -219,11 +329,28 @@ function verifyUmbrella(): number {
 
 	// Coverage from any pending changeset counts: what matters is whether the
 	// next release republishes the umbrella, not which PR asked for it.
-	if (getCoveredPackages().has(UMBRELLA_PKG)) {
+	if (pending.some((e) => e.pkg === UMBRELLA_PKG)) {
 		console.log(
 			`✓ ${released.length} re-exported package(s) released, and ${UMBRELLA_PKG} is bumped alongside them.`,
 		);
 		return 0;
+	}
+
+	if (withdrawnFrom.length > 0) {
+		console.error(`\n❌ This PR removes the ${UMBRELLA_PKG} entry from:\n`);
+		for (const file of withdrawnFrom) {
+			console.error(`   • .changeset/${file}`);
+		}
+		console.error("\nwhile these re-exported package(s) are still pending release:\n");
+		for (const pkg of released) {
+			console.error(`   • ${pkg}`);
+		}
+		console.error(
+			`\nNothing bumps ${UMBRELLA_PKG} any more. ${UMBRELLA_PUBLISH_FAILURE}` +
+			`Keep the entry, or move it to another pending changeset:\n\n` +
+			`   "${UMBRELLA_PKG}": patch\n`,
+		);
+		return 1;
 	}
 
 	console.error(`\n❌ This PR releases package(s) that ${UMBRELLA_PKG} re-exports:\n`);
@@ -231,12 +358,7 @@ function verifyUmbrella(): number {
 		console.error(`   • ${pkg}`);
 	}
 	console.error(
-		`\nNothing bumps ${UMBRELLA_PKG}. It pins its siblings with caret ranges, so their\n` +
-		`new versions stay in range and \`changeset version\` leaves the umbrella at its\n` +
-		`current version. Its packed content still moves (the re-exported APIs, plus\n` +
-		`docs/ assembled from sibling READMEs at pack time), and publish then aborts the\n` +
-		`whole release run with "${UMBRELLA_PKG}@<version> already exists with different\n` +
-		`content" (issue #273, previously #212).\n\n` +
+		`\nNothing bumps ${UMBRELLA_PKG}. ${UMBRELLA_PUBLISH_FAILURE}` +
 		`Add this line to your changeset:\n\n` +
 		`   "${UMBRELLA_PKG}": patch\n`,
 	);
@@ -269,24 +391,20 @@ function blockMajor(): number {
  *  may legitimately reference). Workspace entries here are explicit paths. */
 function getWorkspacePackageNames(): Set<string> {
 	const names = new Set<string>();
-	let workspaces: unknown;
-	try {
-		workspaces = JSON.parse(readFileSync(join(ROOT, "package.json"), "utf-8")).workspaces;
-	} catch {
-		return names;
+	const workspaces = readJson(join(ROOT, "package.json"), "the root package.json").workspaces;
+	if (!Array.isArray(workspaces)) {
+		throw new GuardError(
+			'The root package.json has no "workspaces" array, so changeset package names cannot\n' +
+			"be validated against the workspace.",
+		);
 	}
-	if (!Array.isArray(workspaces)) return names;
 
 	for (const ws of workspaces) {
 		if (typeof ws !== "string" || ws.includes("*")) continue;
 		const pkgJsonPath = join(ROOT, ws, "package.json");
 		if (!existsSync(pkgJsonPath)) continue;
-		try {
-			const pkg = JSON.parse(readFileSync(pkgJsonPath, "utf-8"));
-			if (typeof pkg.name === "string") names.add(pkg.name);
-		} catch {
-			// skip unreadable package.json
-		}
+		const pkg = readJson(pkgJsonPath, `${ws}/package.json`);
+		if (typeof pkg.name === "string") names.add(pkg.name);
 	}
 	return names;
 }
@@ -354,26 +472,32 @@ function validateStructure(): number {
 	return 0;
 }
 
-const command = process.argv[2];
+function main(): number {
+	const command = process.argv[2];
 
-switch (command) {
-	case "verify-coverage":
-		process.exit(verifyCoverage());
-		break;
-	case "block-major":
-		process.exit(blockMajor());
-		break;
-	case "validate-structure":
-		process.exit(validateStructure());
-		break;
-	case "verify-umbrella":
-		process.exit(verifyUmbrella());
-		break;
-	default:
-		console.error(
-			`Unknown command: ${command ?? "(none)"}\n` +
-			"Usage: node --experimental-strip-types scripts/changeset-guard.ts " +
-			"<verify-coverage|block-major|validate-structure|verify-umbrella>",
-		);
-		process.exit(2);
+	switch (command) {
+		case "verify-coverage":
+			return verifyCoverage();
+		case "block-major":
+			return blockMajor();
+		case "validate-structure":
+			return validateStructure();
+		case "verify-umbrella":
+			return verifyUmbrella();
+		default:
+			console.error(
+				`Unknown command: ${command ?? "(none)"}\n` +
+				"Usage: node --experimental-strip-types scripts/changeset-guard.ts " +
+				"<verify-coverage|block-major|validate-structure|verify-umbrella>",
+			);
+			return 2;
+	}
+}
+
+try {
+	process.exit(main());
+} catch (err) {
+	if (!(err instanceof GuardError)) throw err;
+	console.error(`\n❌ ${err.message}\n`);
+	process.exit(1);
 }

--- a/scripts/changeset-guard.ts
+++ b/scripts/changeset-guard.ts
@@ -260,18 +260,34 @@ function getChangedChangesetFiles(): Set<string> {
 	return names;
 }
 
-/** A changeset's entries as of the merge base; empty if this PR added the file. */
-function parseChangesetAtMergeBase(file: string): Entry[] {
-	let content: string;
-	try {
-		content = execFileSync("git", ["show", `${getMergeBase()}:.changeset/${file}`], {
-			cwd: ROOT,
-			encoding: "utf-8",
-			stdio: ["ignore", "pipe", "ignore"],
-		});
-	} catch {
-		return []; // absent at the merge base
+/** Changeset filenames that existed in .changeset/ at the merge base. */
+let baseChangesetsCache: Set<string> | undefined;
+function getChangesetsAtMergeBase(): Set<string> {
+	if (baseChangesetsCache === undefined) {
+		let listing: string;
+		try {
+			listing = execFileSync("git", ["ls-tree", "--name-only", `${getMergeBase()}:.changeset`], {
+				cwd: ROOT,
+				encoding: "utf-8",
+				stdio: ["ignore", "pipe", "ignore"],
+			});
+		} catch {
+			// No .changeset directory at the merge base, so nothing can have been
+			// withdrawn. This is the only reason the listing can legitimately fail,
+			// which is why it is asked for once here rather than per file below.
+			listing = "";
+		}
+		baseChangesetsCache = new Set(listing.split("\n").filter(Boolean));
 	}
+	return baseChangesetsCache;
+}
+
+/** A changeset's entries as of the merge base. Only call it for files that existed there. */
+function parseChangesetAtMergeBase(file: string): Entry[] {
+	const content = execFileSync("git", ["show", `${getMergeBase()}:.changeset/${file}`], {
+		cwd: ROOT,
+		encoding: "utf-8",
+	});
 	return parseEntries(file, content);
 }
 
@@ -285,10 +301,12 @@ function getWithdrawnUmbrellaFiles(pending: Entry[]): string[] {
 	const stillDeclaring = new Set(
 		pending.filter((e) => e.pkg === UMBRELLA_PKG).map((e) => e.file),
 	);
+	const atMergeBase = getChangesetsAtMergeBase();
 	return [...getChangedChangesetFiles()]
 		.filter(
 			(file) =>
 				!stillDeclaring.has(file) &&
+				atMergeBase.has(file) &&
 				parseChangesetAtMergeBase(file).some((e) => e.pkg === UMBRELLA_PKG),
 		)
 		.sort();

--- a/scripts/changeset-guard.ts
+++ b/scripts/changeset-guard.ts
@@ -21,6 +21,13 @@
  *                   it can't parse, so a typo'd package or bad bump would slip
  *                   through and only fail post-merge at `changeset version`.
  *
+ *   verify-umbrella Exit non-zero if this PR releases a package the umbrella
+ *                   `@aws-blocks/blocks` re-exports without any pending
+ *                   changeset bumping the umbrella too. Caret ranges keep the
+ *                   sibling's new version in range, so `changeset version`
+ *                   leaves the umbrella alone while its packed content still
+ *                   moves, and publish then fails the whole release run.
+ *
  * Pre-1.0 semver convention:
  *   - `patch` (0.1.1 → 0.1.2): non-breaking change
  *   - `minor` (0.1.x → 0.2.0): BREAKING change (the pre-release breaking channel)
@@ -30,6 +37,7 @@
  *   node --experimental-strip-types scripts/changeset-guard.ts verify-coverage
  *   node --experimental-strip-types scripts/changeset-guard.ts block-major
  *   node --experimental-strip-types scripts/changeset-guard.ts validate-structure
+ *   node --experimental-strip-types scripts/changeset-guard.ts verify-umbrella
  */
 
 import { execSync } from "node:child_process";
@@ -40,6 +48,7 @@ const ROOT = resolve(import.meta.dirname, "..");
 const PACKAGES_DIR = join(ROOT, "packages");
 const CHANGESET_DIR = join(ROOT, ".changeset");
 const SCOPE = "@aws-blocks/";
+const UMBRELLA_PKG = "@aws-blocks/blocks";
 
 // changesets/action opens its "Version Packages" PR with this title.
 const RELEASE_PR_TITLE_PREFIX = "chore: version packages";
@@ -84,22 +93,25 @@ function getCoveredPackages(): Set<string> {
 	return new Set(parseChangesets().map((e) => e.pkg));
 }
 
-/** Publishable @aws-blocks/* packages with file changes vs origin/main. */
-function getChangedPackages(): Set<string> {
+/** Files changed vs origin/main, as repo-relative paths. */
+function getChangedFiles(): string[] {
 	const mergeBase = execSync("git merge-base origin/main HEAD", {
 		cwd: ROOT,
 		encoding: "utf-8",
 	}).trim();
-	const changedFiles = execSync(`git diff --name-only ${mergeBase}`, {
+	return execSync(`git diff --name-only ${mergeBase}`, {
 		cwd: ROOT,
 		encoding: "utf-8",
 	})
 		.trim()
 		.split("\n")
 		.filter(Boolean);
+}
 
+/** Publishable @aws-blocks/* packages with file changes vs origin/main. */
+function getChangedPackages(): Set<string> {
 	const packages = new Set<string>();
-	for (const file of changedFiles) {
+	for (const file of getChangedFiles()) {
 		const match = file.match(/^packages\/([^/]+)\//);
 		if (!match) continue;
 
@@ -151,6 +163,84 @@ function verifyCoverage(): number {
 		console.log("✓ No publishable packages were changed.");
 	}
 	return 0;
+}
+
+/**
+ * The `@aws-blocks/*` packages the umbrella re-exports, read from its own
+ * dependencies. Releasing any of them can change what the umbrella's tarball
+ * ships without touching a single file the umbrella owns, which is why a file
+ * diff can't be the signal here.
+ */
+function getUmbrellaSiblings(): Set<string> {
+	const siblings = new Set<string>();
+	const pkgJsonPath = join(PACKAGES_DIR, "blocks", "package.json");
+	if (!existsSync(pkgJsonPath)) return siblings;
+
+	try {
+		const deps = JSON.parse(readFileSync(pkgJsonPath, "utf-8")).dependencies;
+		if (deps && typeof deps === "object") {
+			for (const name of Object.keys(deps)) {
+				if (name.startsWith(SCOPE) && name !== UMBRELLA_PKG) siblings.add(name);
+			}
+		}
+	} catch {
+		// unreadable package.json: nothing to assert against
+	}
+	return siblings;
+}
+
+/** Changeset filenames added or modified by this PR (vs origin/main). */
+function getChangedChangesetFiles(): Set<string> {
+	const names = new Set<string>();
+	for (const file of getChangedFiles()) {
+		const match = file.match(/^\.changeset\/(.+\.md)$/);
+		if (match && match[1] !== "README.md") names.add(match[1]);
+	}
+	return names;
+}
+
+function verifyUmbrella(): number {
+	const siblings = getUmbrellaSiblings();
+	const touched = getChangedChangesetFiles();
+	// Only this PR's own changesets trigger the check. Reading every pending
+	// changeset would fail unrelated PRs for an omission someone else merged.
+	const released = [
+		...new Set(
+			parseChangesets()
+				.filter((e) => touched.has(e.file) && siblings.has(e.pkg))
+				.map((e) => e.pkg),
+		),
+	].sort();
+
+	if (released.length === 0) {
+		console.log(`✓ No changeset here releases a package ${UMBRELLA_PKG} re-exports.`);
+		return 0;
+	}
+
+	// Coverage from any pending changeset counts: what matters is whether the
+	// next release republishes the umbrella, not which PR asked for it.
+	if (getCoveredPackages().has(UMBRELLA_PKG)) {
+		console.log(
+			`✓ ${released.length} re-exported package(s) released, and ${UMBRELLA_PKG} is bumped alongside them.`,
+		);
+		return 0;
+	}
+
+	console.error(`\n❌ This PR releases package(s) that ${UMBRELLA_PKG} re-exports:\n`);
+	for (const pkg of released) {
+		console.error(`   • ${pkg}`);
+	}
+	console.error(
+		`\nNothing bumps ${UMBRELLA_PKG}. It pins its siblings with caret ranges, so their\n` +
+		`new versions stay in range and \`changeset version\` leaves the umbrella at its\n` +
+		`current version. Its packed content still moves (the re-exported APIs, plus\n` +
+		`docs/ assembled from sibling READMEs at pack time), and publish then aborts the\n` +
+		`whole release run with "${UMBRELLA_PKG}@<version> already exists with different\n` +
+		`content" (issue #273, previously #212).\n\n` +
+		`Add this line to your changeset:\n\n` +
+		`   "${UMBRELLA_PKG}": patch\n`,
+	);
+	return 1;
 }
 
 function blockMajor(): number {
@@ -276,11 +366,14 @@ switch (command) {
 	case "validate-structure":
 		process.exit(validateStructure());
 		break;
+	case "verify-umbrella":
+		process.exit(verifyUmbrella());
+		break;
 	default:
 		console.error(
 			`Unknown command: ${command ?? "(none)"}\n` +
 			"Usage: node --experimental-strip-types scripts/changeset-guard.ts " +
-			"<verify-coverage|block-major|validate-structure>",
+			"<verify-coverage|block-major|validate-structure|verify-umbrella>",
 		);
 		process.exit(2);
 }


### PR DESCRIPTION
Fixes #273

`@aws-blocks/blocks` re-exports core, every `bb-*` block and `auth-common/ui`, and ships a `docs/` folder assembled from sibling READMEs at pack time. It pins those siblings with caret ranges, so when a sibling gets a patch release the new version stays in range and `changeset version` leaves the umbrella alone. Its packed content still moves, and `scripts/publish/publish.ts` then aborts the entire release run with "already exists with different content". That is what happened in #212 (`fc8cfad`), and `b920f9e` was the same omission caught one commit earlier. #212 asked for recurrence prevention and it was never added.

### Why not `linked` or `fixed`

I ran `changeset version` in a scratch worktree of main with a single sibling-only changeset (`"@aws-blocks/auth-common": patch`) against all three configs:

| config | auth-common | blocks | core | bb-kv-store |
|---|---|---|---|---|
| today (`fixed: []`, `linked: []`) | 0.1.4 | 0.2.5 (not bumped) | 0.1.16 | 0.1.4 |
| `linked: [[blocks, ...deps]]` | **0.3.3** | 0.3.3 | 0.1.16 | 0.1.4 |
| `fixed: [[blocks, ...deps]]` | **0.3.3** | 0.3.3 | **0.3.3** | **0.3.3** |

`linked` does pull the umbrella in, but it drags auth-common from 0.1.3 to 0.3.3 because the group is forced onto one shared version, and `fixed` does that to all 21 members on every release. Both rewrite sibling version numbers and blow past the pre-1.0 convention documented at the top of `changeset-guard.ts`, so neither is usable. Versioning stays as it is and the requirement becomes explicit in CI instead.

### What this adds

`changeset-guard.ts verify-umbrella`, wired into `changeset-check.yml`. If a changeset **touched by this PR** bumps a package listed in `packages/blocks/package.json` dependencies, some pending changeset has to bump `@aws-blocks/blocks`, otherwise the check fails and prints the line to add.

Two deliberate scoping choices:

- The trigger only looks at the PR's own changesets. Reading every pending changeset would fail unrelated PRs for an omission somebody else merged, which is the trap #189 had to undo for the integrity gate.
- Coverage is accepted from any pending changeset, because what matters is whether the next release republishes the umbrella, not which PR asked for it.

The sibling list is derived from the umbrella's own dependencies rather than hardcoded, so it tracks new blocks automatically. Packages outside that list (`hosting`, `pipeline`, `create-blocks-app`) do not trigger it; their README edits still ship into `docs/`, and that dimension is already covered by the `Blocks Package Integrity` gate.

### Verification

Five scenarios, run locally against the real repo state:

| scenario | expected | result |
|---|---|---|
| PR touches no changeset | pass | `✓ No changeset here releases a package @aws-blocks/blocks re-exports.` exit 0 |
| PR bumps `auth-common`, another pending changeset covers blocks | pass | `✓ 1 re-exported package(s) released, and @aws-blocks/blocks is bumped alongside them.` exit 0 |
| PR bumps `auth-common`, nothing covers blocks | fail | exit 1 with the message below |
| PR bumps `hosting` only (not an umbrella dep) | pass | exit 0 |
| release PR shape, every changeset deleted | pass | exit 0 |

Failure output:

```
❌ This PR releases package(s) that @aws-blocks/blocks re-exports:

   • @aws-blocks/auth-common

Nothing bumps @aws-blocks/blocks. It pins its siblings with caret ranges, so their
new versions stay in range and `changeset version` leaves the umbrella at its
current version. Its packed content still moves (the re-exported APIs, plus
docs/ assembled from sibling READMEs at pack time), and publish then aborts the
whole release run with "@aws-blocks/blocks@<version> already exists with different
content" (issue #273, previously #212).

Add this line to your changeset:

   "@aws-blocks/blocks": patch
```

Also confirmed: `npx tsc -p scripts/tsconfig.json --noEmit` clean, and `validate-structure`, `verify-coverage` and `block-major` still pass after the small `getChangedFiles()` extraction they now share.

No changeset here. Nothing under `packages/` changes, so `verify-coverage` does not ask for one, matching #189 which was also CI only.
