### PR TITLE
fix(core): stream cdk deploy output to stdout and keep a backgrounded deploy alive (#222)

### DIFF
--- a/.changeset/deploy-stream-and-signal-lifecycle.md
+++ b/.changeset/deploy-stream-and-signal-lifecycle.md
@@ -24,7 +24,21 @@ Two causes, both fixed:
   arrives, plus an idle heartbeat while a slow resource is converging. A single
   SIGTERM, or any SIGHUP, no longer abandons a converging deploy: it logs and
   keeps streaming. Ctrl-C, or a second SIGTERM, aborts and reaps the CDK process
-  tree.
+  tree. Repeat deliveries of the same signal inside the coalescing window log one
+  line instead of one per delivery.
 
-The deploy also prints its terminal status on stdout for both success and
-failure, so a caller that only captures stdout can tell the two apart.
+Worth knowing before you upgrade:
+
+- **The signal resilience is POSIX-only.** It needs process groups (`detached` is
+  passed only when `process.platform !== 'win32'`) and real signal delivery, and
+  Windows has neither: nothing outside the process delivers SIGTERM/SIGHUP there,
+  so a kill on the process tree still ends the deploy and the abort path reaps by
+  pid. Streaming, the heartbeat and the `--ci` argv apply on every platform.
+- **The `❌ Deployment failed.` banner moved from stderr to stdout**
+  (`console.error` → `console.log`), so a caller capturing only stdout can tell a
+  failed deploy from a killed process. Anything grepping *stderr* for that exact
+  string will no longer match it. The failure *reason* has not moved: the CDK CLI
+  keeps error-level output on stderr even under `--ci`, and the deploy entrypoint
+  still prints the error itself with `console.error`, so stderr remains the place
+  to grep for why a deploy failed. Both halves of that split are now covered by
+  tests, including one against the real CDK CLI.

--- a/.changeset/deploy-stream-and-signal-lifecycle.md
+++ b/.changeset/deploy-stream-and-signal-lifecycle.md
@@ -1,0 +1,30 @@
+---
+"@aws-blocks/core": patch
+"@aws-blocks/blocks": patch
+---
+
+fix(core): stream CloudFormation progress to stdout and stop a stray SIGTERM from killing an in-flight deploy
+
+`npm run deploy` wrote nothing to stdout for the whole CloudFormation phase, and
+a backgrounded deploy was killed (exit 143) while CloudFormation kept going and
+finished server-side. Callers had no progress signal, could not tell success from
+failure, and re-ran deploys that had actually worked.
+
+Two causes, both fixed:
+
+- The CDK CLI picks its log stream as `isCI ? stdout : stderr`, so every
+  CloudFormation event went to stderr and `npm run deploy > deploy.log` captured
+  zero bytes. The deploy now passes `--ci` (log lines on stdout, errors still on
+  stderr) and `--progress events` (one line per resource transition instead of a
+  progress bar that needs a TTY).
+- The deploy ran `cdk deploy` through a blocking synchronous spawn with the child
+  in this process's group, so signals could not be handled and the default
+  SIGTERM disposition killed the CLI mid-deploy. The CDK CLI is now spawned in
+  its own process group with its output piped and relayed line by line as it
+  arrives, plus an idle heartbeat while a slow resource is converging. A single
+  SIGTERM, or any SIGHUP, no longer abandons a converging deploy: it logs and
+  keeps streaming. Ctrl-C, or a second SIGTERM, aborts and reaps the CDK process
+  tree.
+
+The deploy also prints its terminal status on stdout for both success and
+failure, so a caller that only captures stdout can tell the two apart.

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -172,7 +172,25 @@ jobs:
         run: npm run check:api
 
       - name: Unit Tests
+        env:
+          # The real-CDK stream-routing probe in packages/core guards the issue #222
+          # root cause (`--ci` is what moves CloudFormation progress off stderr).
+          # Require it here so a runner that cannot resolve the CDK CLI fails
+          # instead of skipping, and have it drop a marker file the next step
+          # checks — a probe that stops running must not read as green.
+          BLOCKS_REQUIRE_CDK_PROBE: '1'
+          BLOCKS_CDK_PROBE_MARKER: ${{ runner.temp }}/cdk-routing-probe.marker
         run: npm run test:unit
+
+      - name: Verify the real-CDK stream-routing probe ran
+        run: |
+          set -euo pipefail
+          marker='${{ runner.temp }}/cdk-routing-probe.marker'
+          if [ ! -s "$marker" ]; then
+            echo "::error::the real-CDK --ci stream-routing probe did not run (no marker at $marker). It is the only test that verifies the CDK CLI still routes deploy logs to stdout under --ci and keeps failures on stderr (issue #222); a silent skip is a regression."
+            exit 1
+          fi
+          cat "$marker"
 
       - name: E2E Test Local
         run: npm run test:e2e:local

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -146,6 +146,8 @@ Each block is its own package; full per-block docs ship in this package under **
 
 `npm run deploy` does a full production deploy; `npm run sandbox:destroy` tears the sandbox down. The same backend code runs in all three — blocks switch implementations automatically.
 
+`npm run deploy` streams CloudFormation events to **stdout** as they happen, so `npm run deploy | tee deploy.log` shows live progress instead of going silent for minutes, and a deploy failure keeps its reason on **stderr** (that stays the place to grep for why a deploy failed). On POSIX the deploy also survives a stray reap: a single `SIGTERM`, or any `SIGHUP` — a closed terminal, a backgrounded `npm run deploy &` — logs a line and keeps streaming rather than abandoning a stack update CloudFormation is still applying. Press Ctrl-C, or send `SIGTERM` twice, to stop it. That signal resilience is POSIX-only: Windows has no process groups and no OS-delivered `SIGTERM`/`SIGHUP`, so there a kill on the process tree still ends the deploy.
+
 ## Testing
 
 The fastest loop is calling your API through its typed import in `test/e2e.test.ts` — no browser, no mocking:

--- a/packages/core/src/scripts/deploy-stream.test.ts
+++ b/packages/core/src/scripts/deploy-stream.test.ts
@@ -15,6 +15,7 @@ import {
   formatElapsed,
   runStreaming,
   DeployProcessError,
+  SIGNAL_COALESCE_MS,
   type OutputSink,
   type SignalRegistry,
 } from './deploy-stream.js';
@@ -52,25 +53,40 @@ async function waitFor(predicate: () => boolean | Promise<boolean>, timeoutMs: n
 // only warn.
 describe('decideSignalResponse — a converging deploy is not abandoned by one signal', () => {
   it('defers the first SIGTERM and explains how to force an abort', () => {
-    const { action, message } = decideSignalResponse('SIGTERM', false);
+    const { action, message } = decideSignalResponse('SIGTERM', null);
     assert.strictEqual(action, 'defer');
     assert.match(message, /Ignoring SIGTERM/);
     assert.match(message, /send SIGTERM again to abort/i);
   });
 
-  it('aborts on a second SIGTERM so an operator is never stuck', () => {
-    const { action, message } = decideSignalResponse('SIGTERM', true);
+  // One `kill -TERM -<pgid>` reaches this process twice under `npm run deploy`:
+  // the group delivers it, then tsx relays it to its child ~50ms later (measured
+  // on a real deploy). Reading that second delivery as "the operator insisted"
+  // aborted deploys that nobody asked to stop.
+  it('coalesces a duplicate delivery of the same SIGTERM instead of aborting', () => {
+    const { action, coalesced } = decideSignalResponse('SIGTERM', 50);
+    assert.strictEqual(action, 'defer');
+    assert.strictEqual(coalesced, true);
+  });
+
+  it('still coalesces at the edge of the window and aborts past it', () => {
+    assert.strictEqual(decideSignalResponse('SIGTERM', SIGNAL_COALESCE_MS - 1).action, 'defer');
+    assert.strictEqual(decideSignalResponse('SIGTERM', SIGNAL_COALESCE_MS).action, 'abort');
+  });
+
+  it('aborts on a deliberate second SIGTERM so an operator is never stuck', () => {
+    const { action, message } = decideSignalResponse('SIGTERM', 5_000);
     assert.strictEqual(action, 'abort');
     assert.match(message, /SIGTERM/);
   });
 
   it('always defers SIGHUP — a closed terminal must not kill a backgrounded deploy', () => {
-    assert.strictEqual(decideSignalResponse('SIGHUP', false).action, 'defer');
-    assert.strictEqual(decideSignalResponse('SIGHUP', true).action, 'defer');
+    assert.strictEqual(decideSignalResponse('SIGHUP', null).action, 'defer');
+    assert.strictEqual(decideSignalResponse('SIGHUP', 60_000).action, 'defer');
   });
 
   it('aborts on the first SIGINT — Ctrl-C is unambiguous intent', () => {
-    const { action, message } = decideSignalResponse('SIGINT', false);
+    const { action, message } = decideSignalResponse('SIGINT', null);
     assert.strictEqual(action, 'abort');
     assert.match(message, /Interrupted/);
   });
@@ -279,6 +295,9 @@ describe('runStreaming — relays output while the child is still running', () =
     assert.ok(await waitFor(() => stdout.text().includes('working'), 15_000), 'child should be running');
     signals.emit('SIGTERM');
     assert.ok(await waitFor(() => stdout.text().includes('Ignoring SIGTERM'), 5_000), 'first SIGTERM is deferred');
+    // Past the coalescing window, so this reads as a deliberate second request
+    // rather than a duplicate delivery of the first.
+    await new Promise((r) => setTimeout(r, SIGNAL_COALESCE_MS + 250));
     signals.emit('SIGTERM');
 
     await assert.rejects(
@@ -290,6 +309,48 @@ describe('runStreaming — relays output while the child is still running', () =
       },
     );
     assert.match(stdout.text(), /Received SIGTERM while deploying/);
+  });
+
+  // The shape that broke a real deploy: `npm run deploy` is npm -> sh -> tsx ->
+  // node, so one `kill -TERM -<pgid>` lands on this process twice (group
+  // delivery, then tsx's relay). Both deliveries must count as one request.
+  it('survives a duplicate SIGTERM delivery and logs the deferral once', { timeout: 30_000 }, async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'blocks-stream-'));
+    try {
+      const marker = join(dir, 'child-finished');
+      const script = join(dir, 'dup.mjs');
+      writeFileSync(
+        script,
+        `import { writeFileSync } from 'node:fs';\n` +
+          `console.log('ProbeStack | CREATE_IN_PROGRESS | AWS::S3::Bucket | Assets');\n` +
+          `setTimeout(() => { writeFileSync(${JSON.stringify(marker)}, 'ok'); console.log('ProbeStack | CREATE_COMPLETE'); }, 700);\n`,
+      );
+
+      const stdout = collectingSink();
+      const signals = new EventEmitter();
+      const run = runStreaming(process.execPath, [script], {
+        stdout,
+        stderr: collectingSink(),
+        heartbeatMs: 0,
+        signalTarget: signals as unknown as SignalRegistry,
+      });
+
+      assert.ok(
+        await waitFor(() => stdout.text().includes('CREATE_IN_PROGRESS'), 15_000),
+        'child should be mid-run before the signals',
+      );
+      signals.emit('SIGTERM');
+      await new Promise((r) => setTimeout(r, 50)); // tsx relays about this fast
+      signals.emit('SIGTERM');
+
+      await run; // resolves ⇒ the duplicate delivery did not abandon the deploy
+      const deferrals = stdout.text().split('\n').filter((line) => line.includes('Ignoring SIGTERM'));
+      assert.strictEqual(deferrals.length, 1, `expected one deferral line, got ${deferrals.length}`);
+      assert.doesNotMatch(stdout.text(), /Received SIGTERM while deploying/);
+      assert.ok(existsSync(marker), 'the deploy must have run to completion');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });
 
@@ -490,6 +551,9 @@ describe('a backgrounded deploy survives the group SIGTERM that killed it before
       assert.ok(child.pid, 'wrapper pid');
       process.kill(-child.pid, 'SIGTERM');
       assert.ok(await waitFor(() => out.includes('Ignoring SIGTERM'), 10_000), 'first SIGTERM is deferred');
+      // Wait out the coalescing window so this is read as a deliberate repeat
+      // rather than a duplicate delivery of the first signal.
+      await new Promise((r) => setTimeout(r, SIGNAL_COALESCE_MS + 250));
       process.kill(-child.pid, 'SIGTERM');
 
       assert.ok(
@@ -506,6 +570,41 @@ describe('a backgrounded deploy survives the group SIGTERM that killed it before
         }, 15_000),
         'the abort must reap the cdk child, not orphan it',
       );
+    } finally {
+      if (child.pid) { try { process.kill(-child.pid, 'SIGKILL'); } catch { /* already gone */ } }
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  // The real-world delivery shape, with real OS signals: `npm run deploy` puts
+  // npm, sh and tsx in the group alongside the deploy CLI, and tsx relays the
+  // SIGTERM it receives to its child, so the CLI is signalled twice in quick
+  // succession. Two group SIGTERMs ~50ms apart reproduce that, and the deploy
+  // must still finish (a real deploy against AWS aborted here before the
+  // coalescing window existed).
+  it('finishes the deploy when one reap delivers SIGTERM twice in quick succession', { timeout: 60_000 }, async () => {
+    const { dir, wrapper } = scaffold(14, 80);
+    const child = spawn(process.execPath, [wrapper, dir], { detached: true, stdio: ['ignore', 'pipe', 'pipe'] });
+    let out = '';
+    child.stdout.setEncoding('utf-8');
+    child.stdout.on('data', (chunk: string) => { out += chunk; });
+
+    try {
+      assert.ok(await waitFor(() => out.includes('CREATE_IN_PROGRESS'), 20_000), 'deploy should be streaming');
+      assert.ok(child.pid, 'wrapper pid');
+
+      process.kill(-child.pid, 'SIGTERM');
+      await new Promise((r) => setTimeout(r, 50));
+      process.kill(-child.pid, 'SIGTERM'); // the wrapper relay, not a second request
+
+      assert.ok(
+        await waitFor(() => child.exitCode !== null || child.signalCode !== null, 30_000),
+        'the wrapper should finish on its own',
+      );
+      assert.doesNotMatch(out, /Received SIGTERM while deploying/, 'a duplicate delivery must not abort');
+      assert.ok(existsSync(join(dir, 'cfn-done')), 'the deploy itself must have run to completion');
+      assert.strictEqual(child.exitCode, 0, `wrapper should exit 0; stdout: ${out}`);
+      assert.strictEqual(readFileSync(join(dir, 'wrapper-status'), 'utf-8'), 'complete');
     } finally {
       if (child.pid) { try { process.kill(-child.pid, 'SIGKILL'); } catch { /* already gone */ } }
       rmSync(dir, { recursive: true, force: true });

--- a/packages/core/src/scripts/deploy-stream.test.ts
+++ b/packages/core/src/scripts/deploy-stream.test.ts
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { describe, it } from 'node:test';
+import { describe, it, type TestContext } from 'node:test';
 import assert from 'node:assert';
 import { EventEmitter } from 'node:events';
 import { spawn, spawnSync } from 'node:child_process';
@@ -45,6 +45,16 @@ async function waitFor(predicate: () => boolean | Promise<boolean>, timeoutMs: n
     await new Promise((r) => setTimeout(r, 25));
   }
   return false;
+}
+
+/** How many relayed lines mention `needle` — one signal must log one line. */
+function countLines(text: string, needle: string): number {
+  return text.split('\n').filter((line) => line.includes(needle)).length;
+}
+
+/** Read an env switch without treating `''`, `'0'` or `'false'` as "on". */
+function envFlag(value: string | undefined): boolean {
+  return value !== undefined && value !== '' && value !== '0' && value !== 'false';
 }
 
 // ── signal policy ───────────────────────────────────────────────────────────
@@ -344,25 +354,130 @@ describe('runStreaming — relays output while the child is still running', () =
       signals.emit('SIGTERM');
 
       await run; // resolves ⇒ the duplicate delivery did not abandon the deploy
-      const deferrals = stdout.text().split('\n').filter((line) => line.includes('Ignoring SIGTERM'));
-      assert.strictEqual(deferrals.length, 1, `expected one deferral line, got ${deferrals.length}`);
+      const deferrals = countLines(stdout.text(), 'Ignoring SIGTERM');
+      assert.strictEqual(deferrals, 1, `expected one deferral line, got ${deferrals}`);
       assert.doesNotMatch(stdout.text(), /Received SIGTERM while deploying/);
       assert.ok(existsSync(marker), 'the deploy must have run to completion');
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
   });
+
+  // A hangup is delivered twice for the same reason a SIGTERM is (the group hangs
+  // up, then a wrapper relays it), and it used to print the deferral line once per
+  // delivery. One hangup is one line; a later hangup is a new event and reports
+  // again rather than being muted for the rest of a multi-minute deploy.
+  it('logs one line for a duplicated SIGHUP and reports a later one again', { timeout: 30_000 }, async () => {
+    const stdout = collectingSink();
+    const signals = new EventEmitter();
+    const run = runStreaming(
+      process.execPath,
+      ['-e', `console.log('working'); setTimeout(() => {}, ${SIGNAL_COALESCE_MS * 2 + 2_000});`],
+      { stdout, stderr: collectingSink(), heartbeatMs: 0, signalTarget: signals as unknown as SignalRegistry },
+    );
+
+    assert.ok(await waitFor(() => stdout.text().includes('working'), 15_000), 'child should be running');
+    signals.emit('SIGHUP');
+    await new Promise((r) => setTimeout(r, 50)); // a relay arrives about this fast
+    signals.emit('SIGHUP');
+    assert.ok(await waitFor(() => stdout.text().includes('Ignoring SIGHUP'), 5_000), 'the hangup is deferred');
+    assert.strictEqual(
+      countLines(stdout.text(), 'Ignoring SIGHUP'),
+      1,
+      `one hangup must log one line, got: ${JSON.stringify(stdout.text())}`,
+    );
+
+    await new Promise((r) => setTimeout(r, SIGNAL_COALESCE_MS + 250));
+    signals.emit('SIGHUP'); // outside the window ⇒ a genuinely new hangup
+    assert.ok(
+      await waitFor(() => countLines(stdout.text(), 'Ignoring SIGHUP') === 2, 5_000),
+      `a later hangup must be reported too, got: ${JSON.stringify(stdout.text())}`,
+    );
+
+    await run; // resolves ⇒ no number of hangups abandons the deploy
+  });
+
+  // Each signal gets its own deferral window. A SIGHUP used to share the SIGTERM's
+  // window, so a hangup landing just after a deferred SIGTERM was swallowed with
+  // no line at all — and the operator lost the one hint that it had been ignored.
+  it('reports a SIGHUP that lands right after a deferred SIGTERM, and still defers', { timeout: 30_000 }, async () => {
+    const stdout = collectingSink();
+    const signals = new EventEmitter();
+    const run = runStreaming(process.execPath, ['-e', "console.log('working'); setTimeout(() => {}, 2500);"], {
+      stdout,
+      stderr: collectingSink(),
+      heartbeatMs: 0,
+      signalTarget: signals as unknown as SignalRegistry,
+    });
+
+    assert.ok(await waitFor(() => stdout.text().includes('working'), 15_000), 'child should be running');
+    signals.emit('SIGTERM');
+    assert.ok(await waitFor(() => stdout.text().includes('Ignoring SIGTERM'), 5_000), 'first SIGTERM is deferred');
+    signals.emit('SIGHUP');
+    assert.ok(
+      await waitFor(() => stdout.text().includes('Ignoring SIGHUP'), 5_000),
+      'the SIGHUP must be reported, not swallowed by the SIGTERM window',
+    );
+
+    await run; // resolves ⇒ neither signal abandoned the deploy
+    assert.doesNotMatch(stdout.text(), /Received SIG(TERM|HUP) while deploying/);
+  });
+
+  // The stream contract from the failure side: progress goes to stdout, but the
+  // reason a deploy failed stays on stderr (the CDK CLI keeps error level there
+  // even under `--ci`) and the runner never merges the two.
+  it('keeps a deploy failure reason on stderr while progress stays on stdout', { timeout: 30_000 }, async () => {
+    const reason =
+      'ProbeStack | CREATE_FAILED | AWS::S3::Bucket | Assets Resource handler returned message: "bucket already exists" (HandlerErrorCode: AlreadyExists)';
+    const stdout = collectingSink();
+    const stderr = collectingSink();
+
+    await assert.rejects(
+      () =>
+        runStreaming(
+          process.execPath,
+          [
+            '-e',
+            "console.log('ProbeStack | CREATE_IN_PROGRESS | AWS::S3::Bucket | Assets');" +
+              `console.error(${JSON.stringify(reason)});` +
+              'process.exit(1);',
+          ],
+          { stdout, stderr, heartbeatMs: 0, signalTarget: new EventEmitter() as unknown as SignalRegistry },
+        ),
+      (error: unknown) => {
+        assert.ok(error instanceof DeployProcessError);
+        assert.strictEqual(error.exitCode, 1);
+        assert.strictEqual(error.aborted, false);
+        return true;
+      },
+    );
+
+    assert.match(stderr.text(), /Resource handler returned message/, 'the failure reason belongs on stderr');
+    assert.doesNotMatch(stdout.text(), /Resource handler returned message/, 'and must not be duplicated onto stdout');
+    assert.match(stdout.text(), /CREATE_IN_PROGRESS/, 'progress still streams to stdout');
+  });
 });
 
 // ── the root cause, verified against the real CDK CLI ───────────────────────
-// `buildCdkDeployArgs` passing `--ci` is load-bearing, so it is checked against
-// the actual CLI rather than trusted: a `cdk deploy` that reaches the credential
-// check writes NOTHING to stdout by default (every line goes to stderr) and
-// writes to stdout once CI mode is on. No credentials, no network and no
-// mutation are involved — the probe deploys a pre-synthesized assembly pinned to
-// the all-zeros account, which never resolves, so CDK always stops before any
-// AWS write.
-describe('the real CDK CLI only logs to stdout in CI mode', () => {
+// `buildCdkDeployArgs` passing `--ci` is load-bearing, so the routing is checked
+// against the actual CLI rather than trusted: a `cdk deploy` writes NOTHING to
+// stdout by default (every line goes to stderr) and writes to stdout once CI mode
+// is on, while the reason a deploy failed stays on stderr either way.
+//
+// The probe is hermetic. It deploys a pre-synthesized assembly pinned to the
+// all-zeros account with every CI marker and credential source stripped from the
+// child's environment, so the CLI stops at the same credential check on every
+// machine: no credentials, no network calls, no mutation, the same two streams
+// every run.
+//
+// Being hermetic is what lets it be mandatory, and mandatory is the point: a
+// probe that quietly skips reads as "covered" while asserting nothing. So there
+// is no environmental skip left. It fails when the CDK CLI cannot be resolved
+// while the probe is required, fails (never skips) when the CLI stops anywhere
+// other than the credential check, and prints CDK_ROUTING_PROBE_EXECUTED — which
+// the last test in this block asserts, and which pr-checks.yml re-checks through
+// BLOCKS_CDK_PROBE_MARKER so a probe that stops running fails the build.
+describe('the real CDK CLI: --ci moves logs to stdout and keeps failures on stderr', () => {
   const cdkBin = (() => {
     try {
       return createRequire(import.meta.url).resolve('aws-cdk/bin/cdk');
@@ -370,6 +485,45 @@ describe('the real CDK CLI only logs to stdout in CI mode', () => {
       return undefined;
     }
   })();
+
+  /** Printed on stdout (and written to `BLOCKS_CDK_PROBE_MARKER`) once the probe ran. */
+  const PROBE_MARKER = 'CDK_ROUTING_PROBE_EXECUTED';
+
+  // CI must run this probe, so a CDK CLI it cannot resolve is a failure there,
+  // not a skip. `BLOCKS_SKIP_CDK_PROBE=1` is the one explicit, greppable way to
+  // opt a runner out on purpose.
+  const probeRequired =
+    (envFlag(process.env.CI) || envFlag(process.env.BLOCKS_REQUIRE_CDK_PROBE)) &&
+    !envFlag(process.env.BLOCKS_SKIP_CDK_PROBE);
+
+  // The line the CLI stops on: the hermetic environment has no credentials for
+  // the all-zeros account, so every probe run reaches exactly this.
+  const FAILURE_REASON =
+    /Need to perform AWS calls for account 000000000000, but no credentials have been configured/;
+
+  // CI markers (the CDK CLI derives its CI default from them) plus every
+  // credential source, so neither the flag under test nor the stop point can be
+  // decided by the environment this suite happens to run in.
+  const STRIPPED_ENV = [
+    'CI',
+    'GITHUB_ACTIONS',
+    'CONTINUOUS_INTEGRATION',
+    'BUILD_NUMBER',
+    'AWS_PROFILE',
+    'AWS_ACCESS_KEY_ID',
+    'AWS_SECRET_ACCESS_KEY',
+    'AWS_SESSION_TOKEN',
+    'AWS_ROLE_ARN',
+    'AWS_WEB_IDENTITY_TOKEN_FILE',
+    'AWS_CONTAINER_CREDENTIALS_FULL_URI',
+    'AWS_CONTAINER_CREDENTIALS_RELATIVE_URI',
+  ];
+
+  interface ProbeRun {
+    stdout: string;
+    stderr: string;
+    status: number | null;
+  }
 
   function writeProbeAssembly(): string {
     const dir = mkdtempSync(join(tmpdir(), 'blocks-cdk-probe-'));
@@ -395,49 +549,263 @@ describe('the real CDK CLI only logs to stdout in CI mode', () => {
     return dir;
   }
 
-  function probeDeploy(assembly: string, ciFlag: '--ci' | '--no-ci') {
-    const env: NodeJS.ProcessEnv = { ...process.env, AWS_EC2_METADATA_DISABLED: 'true' };
-    // CDK derives its CI default from the environment; drop those markers so the
-    // explicit flag is the only thing deciding the routing.
-    for (const key of ['CI', 'GITHUB_ACTIONS', 'CONTINUOUS_INTEGRATION', 'BUILD_NUMBER']) delete env[key];
-    return spawnSync(
-      process.execPath,
-      [
-        cdkBin as string,
-        ...buildCdkDeployArgs({ projectRoot: assembly, outputsFile: join(assembly, 'outputs.json') }).slice(1),
-        ciFlag,
-        'ProbeStack',
-        '--app',
-        assembly,
-      ],
-      { encoding: 'utf-8', env, timeout: 120_000 },
-    );
+  /**
+   * argv for one probe deploy. The flag under test *replaces* the `--ci` that
+   * {@link buildCdkDeployArgs} already adds instead of being appended after it,
+   * so a probe never argues with itself over two conflicting CI flags.
+   */
+  function probeArgv(assembly: string, ciFlag: '--ci' | '--no-ci'): string[] {
+    const deployArgs = buildCdkDeployArgs({
+      projectRoot: assembly,
+      outputsFile: join(assembly, 'outputs.json'),
+    })
+      .slice(1) // drop the leading `cdk`: the CLI entry point is invoked directly
+      .filter((arg) => arg !== '--ci');
+    return [...deployArgs, ciFlag, 'ProbeStack', '--app', assembly];
+  }
+
+  function probeDeploy(assembly: string, ciFlag: '--ci' | '--no-ci'): ProbeRun {
+    const env: NodeJS.ProcessEnv = {
+      ...process.env,
+      AWS_EC2_METADATA_DISABLED: 'true',
+      // Point the shared config/credentials files at paths that do not exist so a
+      // developer's ~/.aws profile cannot carry the probe past the credential check.
+      AWS_SHARED_CREDENTIALS_FILE: join(assembly, 'no-credentials'),
+      AWS_CONFIG_FILE: join(assembly, 'no-config'),
+    };
+    for (const key of STRIPPED_ENV) delete env[key];
+    const result = spawnSync(process.execPath, [cdkBin as string, ...probeArgv(assembly, ciFlag)], {
+      encoding: 'utf-8',
+      env,
+      timeout: 120_000,
+    });
+    return { stdout: result.stdout ?? '', stderr: result.stderr ?? '', status: result.status };
+  }
+
+  function cdkVersion(): string {
+    try {
+      const manifest = createRequire(import.meta.url).resolve('aws-cdk/package.json');
+      return JSON.parse(readFileSync(manifest, 'utf-8')).version;
+    } catch {
+      return 'unknown';
+    }
+  }
+
+  let probes: { withCi: ProbeRun; withoutCi: ProbeRun } | undefined;
+  let executionMarker: string | undefined;
+
+  /**
+   * Run both probe deploys once (they only read the CLI's behaviour) and prove
+   * they got where they were meant to. Returns `undefined` only when there is no
+   * CDK CLI to probe *and* the probe is not required — the single skip left.
+   */
+  function probeOnce(t: TestContext): { withCi: ProbeRun; withoutCi: ProbeRun } | undefined {
+    if (!cdkBin) {
+      assert.ok(
+        !probeRequired,
+        'the real-CDK stream-routing probe is required here but aws-cdk could not be resolved — run `npm ci` at the repo root, or set BLOCKS_SKIP_CDK_PROBE=1 to opt this runner out on purpose',
+      );
+      t.skip('aws-cdk CLI is not installed in this workspace');
+      return undefined;
+    }
+    if (!probes) {
+      const assembly = writeProbeAssembly();
+      try {
+        probes = { withCi: probeDeploy(assembly, '--ci'), withoutCi: probeDeploy(assembly, '--no-ci') };
+      } finally {
+        rmSync(assembly, { recursive: true, force: true });
+      }
+    }
+    // Stopping anywhere other than the credential check means the CLI changed or
+    // the environment leaked credentials, and either invalidates the probe. This
+    // used to skip, which is exactly how a probe rots into a no-op.
+    for (const [flag, run] of [
+      ['--ci', probes.withCi],
+      ['--no-ci', probes.withoutCi],
+    ] as const) {
+      assert.match(
+        run.stderr,
+        FAILURE_REASON,
+        `the ${flag} probe never reached the credential check (exit ${run.status}). stdout: ${JSON.stringify(run.stdout.slice(0, 400))} stderr: ${JSON.stringify(run.stderr.slice(0, 400))}`,
+      );
+    }
+    if (!executionMarker) {
+      executionMarker =
+        `${PROBE_MARKER} aws-cdk@${cdkVersion()} ` +
+        `--ci{stdout:${probes.withCi.stdout.length}B,stderr:${probes.withCi.stderr.length}B} ` +
+        `--no-ci{stdout:${probes.withoutCi.stdout.length}B,stderr:${probes.withoutCi.stderr.length}B}`;
+      console.log(executionMarker);
+      const markerFile = process.env.BLOCKS_CDK_PROBE_MARKER;
+      if (markerFile) writeFileSync(markerFile, `${executionMarker}\n`);
+    }
+    return probes;
   }
 
   it('sends every deploy log line to stderr by default, and to stdout with --ci', { timeout: 180_000 }, (t) => {
-    if (!cdkBin) return t.skip('aws-cdk CLI is not installed in this workspace');
-    const assembly = writeProbeAssembly();
-    try {
-      const withCi = probeDeploy(assembly, '--ci');
-      const reachedCredentialCheck = /Need to perform AWS calls|credentials/i.test(withCi.stderr ?? '');
-      if (!reachedCredentialCheck) {
-        return t.skip(`cdk probe never reached the credential check: ${(withCi.stderr ?? '').slice(0, 300)}`);
-      }
+    const probe = probeOnce(t);
+    if (!probe) return;
+    assert.strictEqual(
+      probe.withoutCi.stdout,
+      '',
+      'the CDK default routes every log line to stderr — this is the 0-byte stdout in issue #222',
+    );
+    assert.notStrictEqual(probe.withoutCi.stderr, '', 'the log output still exists, just on the wrong stream');
+    assert.notStrictEqual(
+      probe.withCi.stdout,
+      '',
+      '--ci must move the deploy log (CloudFormation progress included) onto stdout',
+    );
+  });
 
-      const withoutCi = probeDeploy(assembly, '--no-ci');
-      assert.strictEqual(
-        withoutCi.stdout,
-        '',
-        'the CDK default routes every log line to stderr — this is the 0-byte stdout in issue #222',
+  // The other half of the stream contract this fix tightens: moving progress onto
+  // stdout must not drag the failure reason along with it. The CDK io host routes
+  // error level to stderr whatever CI mode says, so a caller grepping stderr for
+  // why a deploy failed still finds it there under `--ci`.
+  it('keeps a genuine deploy failure reason on stderr under --ci', { timeout: 180_000 }, (t) => {
+    const probe = probeOnce(t);
+    if (!probe) return;
+    assert.notStrictEqual(probe.withCi.status, 0, 'the probe deploy must really have failed');
+    assert.match(probe.withCi.stderr, FAILURE_REASON, 'the failure reason must stay on stderr under --ci');
+    assert.doesNotMatch(
+      probe.withCi.stdout,
+      FAILURE_REASON,
+      '--ci must not move the failure reason onto stdout — stderr stays the place to grep for it',
+    );
+    // Same failure under the default routing: stderr carries the reason *and* the
+    // progress that `--ci` lifts onto stdout.
+    assert.match(probe.withoutCi.stderr, FAILURE_REASON);
+  });
+
+  it('probes with exactly one CI flag on the argv', () => {
+    for (const flag of ['--ci', '--no-ci'] as const) {
+      const argv = probeArgv('/probe-assembly', flag);
+      assert.deepStrictEqual(
+        argv.filter((arg) => arg === '--ci' || arg === '--no-ci'),
+        [flag],
+        `the probe argv must carry only the flag under test: ${argv.join(' ')}`,
       );
-      assert.notStrictEqual(withoutCi.stderr, '', 'the log output still exists, just on the wrong stream');
-      assert.notStrictEqual(
-        withCi.stdout,
-        '',
-        '--ci must move the deploy log (CloudFormation progress included) onto stdout',
-      );
+    }
+  });
+
+  // Guards the guard. If the probe ever stops executing — a dropped dependency, a
+  // reordered CI step, an early return sneaking back in — this fails instead of
+  // the suite quietly shrinking to nothing.
+  it('leaves a greppable marker proving the probe executed', (t) => {
+    if (!cdkBin && !probeRequired) return t.skip('aws-cdk CLI is not installed in this workspace');
+    assert.ok(
+      executionMarker?.startsWith(PROBE_MARKER),
+      `the real-CDK stream-routing probe did not run: expected a ${PROBE_MARKER} line on stdout`,
+    );
+  });
+});
+
+interface FakeDeployOptions {
+  /** How many CloudFormation-shaped event lines the fake cdk prints. */
+  ticks: number;
+  /** Gap between those lines, so a test can keep the deploy mid-flight. */
+  tickMs: number;
+  /**
+   * When set, the fake cdk fails after its last tick instead of completing: it
+   * prints this reason on *stderr* — where the real CDK CLI keeps error level,
+   * `--ci` or not — and exits 1.
+   */
+  failWith?: string;
+}
+
+/**
+ * Write a fake CDK CLI plus the deploy wrapper that runs it through
+ * {@link runStreaming}.
+ *
+ * The wrapper mirrors the entrypoint the templates generate
+ * (`deploy(...).catch((error) => { console.error(error); process.exit(1); })`):
+ * the ❌ verdict goes to stdout so a stdout-only capture can tell a failed deploy
+ * from a killed process, and the error itself goes to stderr.
+ */
+function scaffoldFakeDeploy({ ticks, tickMs, failWith }: FakeDeployOptions): { dir: string; wrapper: string } {
+  const dir = mkdtempSync(join(tmpdir(), 'blocks-deploy-'));
+  const moduleUrl = new URL('./deploy-stream.js', import.meta.url).href;
+  const lastTick = failWith
+    ? `    console.error(${JSON.stringify(failWith)});\n` + `    process.exit(1);\n`
+    : `    writeFileSync(dir + '/cfn-done', 'ok');\n` +
+      `    console.log('ProbeStack | CREATE_COMPLETE | AWS::CloudFormation::Stack | ProbeStack');\n` +
+      `    return;\n`;
+  writeFileSync(
+    join(dir, 'fake-cdk.mjs'),
+    `import { writeFileSync } from 'node:fs';\n` +
+      `const dir = process.argv[2];\n` +
+      `writeFileSync(dir + '/cdk.pid', String(process.pid));\n` +
+      `let n = 0;\n` +
+      `const tick = () => {\n` +
+      `  n += 1;\n` +
+      `  console.log('ProbeStack | ' + n + '/${ticks} | CREATE_IN_PROGRESS | AWS::Lambda::Function | Handler' + n);\n` +
+      `  if (n >= ${ticks}) {\n` +
+      lastTick +
+      `  }\n` +
+      `  setTimeout(tick, ${tickMs});\n` +
+      `};\n` +
+      `tick();\n`,
+  );
+  const wrapper = join(dir, 'wrapper.mjs');
+  writeFileSync(
+    wrapper,
+    `import { writeFileSync } from 'node:fs';\n` +
+      `import { runStreaming } from ${JSON.stringify(moduleUrl)};\n` +
+      `const dir = process.argv[2];\n` +
+      `try {\n` +
+      `  await runStreaming(process.execPath, [dir + '/fake-cdk.mjs', dir], { label: 'cdk deploy', heartbeatMs: 0 });\n` +
+      `  console.log('✅ Deployment complete!');\n` +
+      `  writeFileSync(dir + '/wrapper-status', 'complete');\n` +
+      `} catch (error) {\n` +
+      `  console.log('\\n❌ Deployment failed.');\n` +
+      `  console.error(error);\n` +
+      `  writeFileSync(dir + '/wrapper-status', error && error.aborted ? 'aborted' : 'failed');\n` +
+      `  process.exitCode = 1;\n` +
+      `}\n`,
+  );
+  return { dir, wrapper };
+}
+
+// ── a failed deploy keeps its reason on stderr ──────────────────────────────
+// The exact contract this fix tightens, end to end and platform-independent:
+// moving CloudFormation progress onto stdout must not move the *reason* a deploy
+// failed with it. The reason (and the error object) stay on stderr; only the
+// human-facing ❌ verdict is on stdout, which is a deliberate change — grepping
+// stderr for "Deployment failed" no longer finds it, grepping for the reason
+// still does.
+describe('a failed deploy reports its reason on stderr and its verdict on stdout', () => {
+  it('splits the CDK failure reason (stderr) from the ❌ verdict (stdout)', { timeout: 60_000 }, async () => {
+    const { dir, wrapper } = scaffoldFakeDeploy({
+      ticks: 3,
+      tickMs: 40,
+      failWith:
+        'ProbeStack | CREATE_FAILED | AWS::S3::Bucket | Assets Resource handler returned message: "bucket already exists" (HandlerErrorCode: AlreadyExists)',
+    });
+    // No `detached` here: this asserts the stream contract, not signal handling,
+    // so it runs on every platform including Windows.
+    const child = spawn(process.execPath, [wrapper, dir], { stdio: ['ignore', 'pipe', 'pipe'] });
+    let out = '';
+    let err = '';
+    child.stdout.setEncoding('utf-8');
+    child.stderr.setEncoding('utf-8');
+    child.stdout.on('data', (chunk: string) => { out += chunk; });
+    child.stderr.on('data', (chunk: string) => { err += chunk; });
+
+    try {
+      // 'close' (not 'exit') so both pipes are fully drained before asserting.
+      const code = await new Promise<number | null>((resolve) => child.once('close', resolve));
+
+      assert.strictEqual(code, 1, `a failed deploy must exit non-zero; stdout: ${out}\nstderr: ${err}`);
+      assert.match(err, /Resource handler returned message/, 'the failure reason must land on stderr');
+      assert.doesNotMatch(out, /Resource handler returned message/, 'the failure reason must not move to stdout');
+      assert.match(err, /DeployProcessError/, "the entrypoint's console.error(error) puts the error on stderr");
+      assert.match(out, /❌ Deployment failed\./, 'the verdict is on stdout so a stdout-only capture sees it');
+      assert.doesNotMatch(err, /❌ Deployment failed\./, 'the verdict is no longer on stderr (see the changeset)');
+      assert.match(out, /CREATE_IN_PROGRESS/, 'progress still streams to stdout');
+      assert.strictEqual(readFileSync(join(dir, 'wrapper-status'), 'utf-8'), 'failed');
+      assert.ok(!existsSync(join(dir, 'cfn-done')), 'the failing deploy must not report completion');
     } finally {
-      rmSync(assembly, { recursive: true, force: true });
+      if (child.pid) { try { child.kill('SIGKILL'); } catch { /* already gone */ } }
+      rmSync(dir, { recursive: true, force: true });
     }
   });
 });
@@ -451,49 +819,55 @@ describe('the real CDK CLI only logs to stdout in CI mode', () => {
 // exactly what a harness reaping a backgrounded `npm run deploy &` does. The
 // fake cdk stands in for the CDK CLI: it prints CloudFormation-shaped events and
 // installs no signal handler, so it dies if a signal reaches it.
+//
+// Process groups and OS-delivered SIGTERM/SIGHUP are POSIX-only, which is why
+// this whole block is — and why the signal resilience is documented as POSIX-only
+// rather than universal.
 describe('a backgrounded deploy survives the group SIGTERM that killed it before', { skip: posixOnly }, () => {
-  function scaffold(totalTicks: number, tickMs: number): { dir: string; wrapper: string } {
-    const dir = mkdtempSync(join(tmpdir(), 'blocks-deploy-'));
-    const moduleUrl = new URL('./deploy-stream.js', import.meta.url).href;
-    writeFileSync(
-      join(dir, 'fake-cdk.mjs'),
-      `import { writeFileSync } from 'node:fs';\n` +
-        `const dir = process.argv[2];\n` +
-        `writeFileSync(dir + '/cdk.pid', String(process.pid));\n` +
-        `let n = 0;\n` +
-        `const tick = () => {\n` +
-        `  n += 1;\n` +
-        `  console.log('ProbeStack | ' + n + '/${totalTicks} | CREATE_IN_PROGRESS | AWS::Lambda::Function | Handler' + n);\n` +
-        `  if (n >= ${totalTicks}) {\n` +
-        `    writeFileSync(dir + '/cfn-done', 'ok');\n` +
-        `    console.log('ProbeStack | CREATE_COMPLETE | AWS::CloudFormation::Stack | ProbeStack');\n` +
-        `    return;\n` +
-        `  }\n` +
-        `  setTimeout(tick, ${tickMs});\n` +
-        `};\n` +
-        `tick();\n`,
-    );
-    const wrapper = join(dir, 'wrapper.mjs');
-    writeFileSync(
-      wrapper,
-      `import { writeFileSync } from 'node:fs';\n` +
-        `import { runStreaming } from ${JSON.stringify(moduleUrl)};\n` +
-        `const dir = process.argv[2];\n` +
-        `try {\n` +
-        `  await runStreaming(process.execPath, [dir + '/fake-cdk.mjs', dir], { label: 'cdk deploy', heartbeatMs: 0 });\n` +
-        `  console.log('✅ Deployment complete!');\n` +
-        `  writeFileSync(dir + '/wrapper-status', 'complete');\n` +
-        `} catch (error) {\n` +
-        `  console.log('❌ Deployment failed.');\n` +
-        `  writeFileSync(dir + '/wrapper-status', error && error.aborted ? 'aborted' : 'failed');\n` +
-        `  process.exitCode = 1;\n` +
-        `}\n`,
-    );
-    return { dir, wrapper };
-  }
+
+  // The mechanism behind every case below, asserted directly: on POSIX the CDK
+  // CLI is spawned into its own process group, which is what stops a reap aimed
+  // at the parent shell from reaching it. Windows has no equivalent.
+  it('spawns the CDK CLI into its own process group', { timeout: 30_000 }, async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'blocks-pgid-'));
+    try {
+      const pidFile = join(dir, 'child.pid');
+      const gate = join(dir, 'may-exit');
+      const script = join(dir, 'report-pid.mjs');
+      writeFileSync(
+        script,
+        `import { existsSync, writeFileSync } from 'node:fs';\n` +
+          `writeFileSync(${JSON.stringify(pidFile)}, String(process.pid));\n` +
+          `const wait = () => existsSync(${JSON.stringify(gate)}) ? process.exit(0) : setTimeout(wait, 25);\n` +
+          `wait();\n`,
+      );
+
+      const run = runStreaming(process.execPath, [script], {
+        stdout: collectingSink(),
+        stderr: collectingSink(),
+        heartbeatMs: 0,
+        signalTarget: new EventEmitter() as unknown as SignalRegistry,
+      });
+
+      assert.ok(await waitFor(() => existsSync(pidFile), 15_000), 'child should report its pid');
+      const childPid = Number(readFileSync(pidFile, 'utf-8'));
+      // A process group whose id is the child's pid exists only if the child
+      // leads it — i.e. it was spawned detached, not into this process's group,
+      // so a signal sent to our group cannot reach it.
+      assert.doesNotThrow(
+        () => process.kill(-childPid, 0),
+        `the child must lead its own process group (pid ${childPid})`,
+      );
+
+      writeFileSync(gate, 'go');
+      await run;
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
 
   it('keeps streaming and finishes the deploy after one group SIGTERM', { timeout: 60_000 }, async () => {
-    const { dir, wrapper } = scaffold(12, 80);
+    const { dir, wrapper } = scaffoldFakeDeploy({ ticks: 12, tickMs: 80 });
     // `detached` makes the wrapper a process-group leader, so the test can
     // signal the whole group the way a shell/harness reaps a background job.
     const child = spawn(process.execPath, [wrapper, dir], { detached: true, stdio: ['ignore', 'pipe', 'pipe'] });
@@ -537,7 +911,8 @@ describe('a backgrounded deploy survives the group SIGTERM that killed it before
   });
 
   it('stops the deploy when the group SIGTERM is repeated', { timeout: 60_000 }, async () => {
-    const { dir, wrapper } = scaffold(200, 80); // long enough to still be mid-deploy
+    // 200 ticks: long enough that the deploy is still mid-flight when signalled.
+    const { dir, wrapper } = scaffoldFakeDeploy({ ticks: 200, tickMs: 80 });
     const child = spawn(process.execPath, [wrapper, dir], { detached: true, stdio: ['ignore', 'pipe', 'pipe'] });
     let out = '';
     child.stdout.setEncoding('utf-8');
@@ -583,7 +958,7 @@ describe('a backgrounded deploy survives the group SIGTERM that killed it before
   // must still finish (a real deploy against AWS aborted here before the
   // coalescing window existed).
   it('finishes the deploy when one reap delivers SIGTERM twice in quick succession', { timeout: 60_000 }, async () => {
-    const { dir, wrapper } = scaffold(14, 80);
+    const { dir, wrapper } = scaffoldFakeDeploy({ ticks: 14, tickMs: 80 });
     const child = spawn(process.execPath, [wrapper, dir], { detached: true, stdio: ['ignore', 'pipe', 'pipe'] });
     let out = '';
     child.stdout.setEncoding('utf-8');
@@ -617,7 +992,7 @@ describe('a backgrounded deploy survives the group SIGTERM that killed it before
   // tests are not vacuous: here the wrapper dies (exit 143 / SIGTERM) and takes
   // the in-flight deploy down with it, exactly as reported in issue #222.
   it('demonstrates the old behaviour: a blocking spawnSync deploy is killed mid-flight', { timeout: 60_000 }, async () => {
-    const { dir } = scaffold(200, 80);
+    const { dir } = scaffoldFakeDeploy({ ticks: 200, tickMs: 80 });
     const baseline = join(dir, 'baseline.mjs');
     writeFileSync(
       baseline,

--- a/packages/core/src/scripts/deploy-stream.test.ts
+++ b/packages/core/src/scripts/deploy-stream.test.ts
@@ -1,0 +1,561 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { EventEmitter } from 'node:events';
+import { spawn, spawnSync } from 'node:child_process';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  buildCdkDeployArgs,
+  createLineAssembler,
+  decideSignalResponse,
+  formatElapsed,
+  runStreaming,
+  DeployProcessError,
+  type OutputSink,
+  type SignalRegistry,
+} from './deploy-stream.js';
+
+const isWindows = process.platform === 'win32';
+// The end-to-end signal tests below deliver a *process-group* signal
+// (`kill -TERM -pgid`) — the exact shape of the reap that killed a backgrounded
+// deploy in issue #222. Windows has no process groups, so those cases are
+// POSIX-only; everything else runs everywhere.
+const posixOnly = isWindows ? 'POSIX-only (delivers a process-group signal)' : false;
+
+function collectingSink(): OutputSink & { text(): string } {
+  const chunks: string[] = [];
+  return {
+    write(chunk: string) {
+      chunks.push(chunk);
+      return true;
+    },
+    text: () => chunks.join(''),
+  };
+}
+
+async function waitFor(predicate: () => boolean | Promise<boolean>, timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await predicate()) return true;
+    await new Promise((r) => setTimeout(r, 25));
+  }
+  return false;
+}
+
+// ── signal policy ───────────────────────────────────────────────────────────
+// The "decouple the CLI lifecycle from the in-flight deploy" rule, asserted
+// directly: which signals abandon a converging CloudFormation deploy and which
+// only warn.
+describe('decideSignalResponse — a converging deploy is not abandoned by one signal', () => {
+  it('defers the first SIGTERM and explains how to force an abort', () => {
+    const { action, message } = decideSignalResponse('SIGTERM', false);
+    assert.strictEqual(action, 'defer');
+    assert.match(message, /Ignoring SIGTERM/);
+    assert.match(message, /send SIGTERM again to abort/i);
+  });
+
+  it('aborts on a second SIGTERM so an operator is never stuck', () => {
+    const { action, message } = decideSignalResponse('SIGTERM', true);
+    assert.strictEqual(action, 'abort');
+    assert.match(message, /SIGTERM/);
+  });
+
+  it('always defers SIGHUP — a closed terminal must not kill a backgrounded deploy', () => {
+    assert.strictEqual(decideSignalResponse('SIGHUP', false).action, 'defer');
+    assert.strictEqual(decideSignalResponse('SIGHUP', true).action, 'defer');
+  });
+
+  it('aborts on the first SIGINT — Ctrl-C is unambiguous intent', () => {
+    const { action, message } = decideSignalResponse('SIGINT', false);
+    assert.strictEqual(action, 'abort');
+    assert.match(message, /Interrupted/);
+  });
+});
+
+// ── line assembly ───────────────────────────────────────────────────────────
+// Pipe chunks split wherever the kernel felt like it; a naive split emits torn
+// CloudFormation event lines and drops the final one.
+describe('createLineAssembler — whole lines across chunk boundaries', () => {
+  it('holds a partial line until the rest of it arrives', () => {
+    const assembler = createLineAssembler();
+    assert.deepStrictEqual(assembler.push('CREATE_IN_'), []);
+    assert.deepStrictEqual(assembler.push('PROGRESS\n'), ['CREATE_IN_PROGRESS']);
+  });
+
+  it('emits every complete line in one chunk and buffers the tail', () => {
+    const assembler = createLineAssembler();
+    assert.deepStrictEqual(assembler.push('one\ntwo\nthr'), ['one', 'two']);
+    assert.deepStrictEqual(assembler.flush(), ['thr']);
+  });
+
+  it('strips CRLF so Windows CDK output does not carry stray carriage returns', () => {
+    const assembler = createLineAssembler();
+    assert.deepStrictEqual(assembler.push('one\r\ntwo\r\n'), ['one', 'two']);
+  });
+
+  it('flushes an unterminated last line and then nothing', () => {
+    const assembler = createLineAssembler();
+    assembler.push('tail-without-newline');
+    assert.deepStrictEqual(assembler.flush(), ['tail-without-newline']);
+    assert.deepStrictEqual(assembler.flush(), []);
+  });
+});
+
+describe('formatElapsed', () => {
+  it('renders sub-minute and multi-minute durations', () => {
+    assert.strictEqual(formatElapsed(0), '0s');
+    assert.strictEqual(formatElapsed(45_000), '45s');
+    assert.strictEqual(formatElapsed(245_000), '4m 05s');
+  });
+
+  it('never renders a negative duration', () => {
+    assert.strictEqual(formatElapsed(-1_000), '0s');
+  });
+});
+
+// ── cdk argv contract ───────────────────────────────────────────────────────
+// `--ci` is what moves CloudFormation events off stderr and onto stdout (the CDK
+// CLI picks its stream as `isCI ? stdout : stderr`), and `--progress events`
+// keeps them line-oriented when there is no TTY. Dropping either flag restores
+// the 0-byte stdout, so the argv is pinned here.
+describe('buildCdkDeployArgs — flags that make the deploy observable', () => {
+  const args = buildCdkDeployArgs({ projectRoot: '/app', outputsFile: '.blocks-sandbox/outputs.json' });
+
+  it('sends CDK logs to stdout instead of stderr', () => {
+    assert.ok(args.includes('--ci'), `expected --ci in: ${args.join(' ')}`);
+  });
+
+  it('asks for per-event progress rather than the TTY progress bar', () => {
+    assert.strictEqual(args[args.indexOf('--progress') + 1], 'events');
+  });
+
+  it('keeps the existing non-interactive deploy contract', () => {
+    assert.strictEqual(args[0], 'cdk');
+    assert.strictEqual(args[1], 'deploy');
+    assert.strictEqual(args[args.indexOf('--require-approval') + 1], 'never');
+    assert.strictEqual(args[args.indexOf('--outputs-file') + 1], '.blocks-sandbox/outputs.json');
+    assert.strictEqual(args[args.indexOf('--context') + 1], 'projectRoot=/app');
+  });
+});
+
+// ── streaming ───────────────────────────────────────────────────────────────
+// Real child processes throughout: the proof that output is relayed *while the
+// deploy is still running* is causal, not timing-based — the child only exits
+// after the test has already seen its first line.
+describe('runStreaming — relays output while the child is still running', () => {
+  it('surfaces a line before the child exits (the child waits for us to see it)', { timeout: 30_000 }, async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'blocks-stream-'));
+    try {
+      const gate = join(dir, 'seen-by-parent');
+      // The child prints one line, then blocks until the test writes the gate
+      // file — which the test only does after observing that line. If output
+      // were buffered until exit (the old behaviour), this deadlocks and fails.
+      const script = join(dir, 'gated.mjs');
+      writeFileSync(
+        script,
+        `import { existsSync } from 'node:fs';\n` +
+          `console.log('ProbeStack | CREATE_IN_PROGRESS | AWS::Lambda::Function | Handler');\n` +
+          `const wait = () => existsSync(${JSON.stringify(gate)}) ? console.log('done') : setTimeout(wait, 25);\n` +
+          `wait();\n`,
+      );
+
+      const stdout = collectingSink();
+      const stderr = collectingSink();
+      const run = runStreaming(process.execPath, [script], {
+        stdout,
+        stderr,
+        heartbeatMs: 0,
+        signalTarget: new EventEmitter() as unknown as SignalRegistry,
+      });
+
+      assert.ok(
+        await waitFor(() => stdout.text().includes('CREATE_IN_PROGRESS'), 15_000),
+        'the CloudFormation event line must reach stdout while the child is still alive',
+      );
+      writeFileSync(gate, 'go');
+
+      await run;
+      assert.match(stdout.text(), /CREATE_IN_PROGRESS[\s\S]*done/);
+      assert.strictEqual(stderr.text(), '');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps child stderr on stderr so error output is still distinguishable', { timeout: 30_000 }, async () => {
+    const stdout = collectingSink();
+    const stderr = collectingSink();
+    await runStreaming(
+      process.execPath,
+      ['-e', "console.log('out-line'); console.error('err-line');"],
+      { stdout, stderr, heartbeatMs: 0, signalTarget: new EventEmitter() as unknown as SignalRegistry },
+    );
+    assert.strictEqual(stdout.text(), 'out-line\n');
+    assert.strictEqual(stderr.text(), 'err-line\n');
+  });
+
+  it('prints an idle heartbeat so a silent CloudFormation phase still reports progress', { timeout: 30_000 }, async () => {
+    const stdout = collectingSink();
+    await runStreaming(process.execPath, ['-e', 'setTimeout(() => {}, 900);'], {
+      stdout,
+      stderr: collectingSink(),
+      heartbeatMs: 150,
+      label: 'cdk deploy',
+      signalTarget: new EventEmitter() as unknown as SignalRegistry,
+    });
+    const beats = stdout.text().split('\n').filter((line) => line.includes('still running'));
+    assert.ok(beats.length >= 2, `expected repeated heartbeats, got: ${JSON.stringify(stdout.text())}`);
+    assert.match(beats[0], /\[cdk deploy\] still running after \d+s/);
+  });
+
+  it('throws a DeployProcessError carrying the child exit code', { timeout: 30_000 }, async () => {
+    await assert.rejects(
+      () =>
+        runStreaming(process.execPath, ['-e', 'process.exit(7)'], {
+          stdout: collectingSink(),
+          stderr: collectingSink(),
+          heartbeatMs: 0,
+          signalTarget: new EventEmitter() as unknown as SignalRegistry,
+        }),
+      (error: unknown) => {
+        assert.ok(error instanceof DeployProcessError);
+        assert.strictEqual(error.exitCode, 7);
+        assert.strictEqual(error.aborted, false);
+        return true;
+      },
+    );
+  });
+
+  it('defers a SIGTERM and still completes the run it was told to abandon', { timeout: 30_000 }, async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'blocks-stream-'));
+    try {
+      const marker = join(dir, 'child-finished');
+      const script = join(dir, 'slow.mjs');
+      writeFileSync(
+        script,
+        `import { writeFileSync } from 'node:fs';\n` +
+          `console.log('ProbeStack | CREATE_IN_PROGRESS | AWS::S3::Bucket | Assets');\n` +
+          `setTimeout(() => { writeFileSync(${JSON.stringify(marker)}, 'ok'); console.log('ProbeStack | CREATE_COMPLETE'); }, 700);\n`,
+      );
+
+      const stdout = collectingSink();
+      const signals = new EventEmitter();
+      const run = runStreaming(process.execPath, [script], {
+        stdout,
+        stderr: collectingSink(),
+        heartbeatMs: 0,
+        signalTarget: signals as unknown as SignalRegistry,
+      });
+
+      assert.ok(
+        await waitFor(() => stdout.text().includes('CREATE_IN_PROGRESS'), 15_000),
+        'child should be mid-run before the signal',
+      );
+      signals.emit('SIGTERM');
+
+      await run; // resolves ⇒ the run completed successfully despite the SIGTERM
+      assert.match(stdout.text(), /Ignoring SIGTERM/);
+      assert.match(stdout.text(), /CREATE_COMPLETE/);
+      assert.ok(existsSync(marker), 'the deferred SIGTERM must not have cut the child short');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('aborts on the second SIGTERM and reports it as an abort', { timeout: 30_000 }, async () => {
+    const stdout = collectingSink();
+    const signals = new EventEmitter();
+    const run = runStreaming(process.execPath, ['-e', "console.log('working'); setInterval(() => {}, 1000);"], {
+      stdout,
+      stderr: collectingSink(),
+      heartbeatMs: 0,
+      signalTarget: signals as unknown as SignalRegistry,
+    });
+
+    assert.ok(await waitFor(() => stdout.text().includes('working'), 15_000), 'child should be running');
+    signals.emit('SIGTERM');
+    assert.ok(await waitFor(() => stdout.text().includes('Ignoring SIGTERM'), 5_000), 'first SIGTERM is deferred');
+    signals.emit('SIGTERM');
+
+    await assert.rejects(
+      () => run,
+      (error: unknown) => {
+        assert.ok(error instanceof DeployProcessError);
+        assert.strictEqual(error.aborted, true);
+        return true;
+      },
+    );
+    assert.match(stdout.text(), /Received SIGTERM while deploying/);
+  });
+});
+
+// ── the root cause, verified against the real CDK CLI ───────────────────────
+// `buildCdkDeployArgs` passing `--ci` is load-bearing, so it is checked against
+// the actual CLI rather than trusted: a `cdk deploy` that reaches the credential
+// check writes NOTHING to stdout by default (every line goes to stderr) and
+// writes to stdout once CI mode is on. No credentials, no network and no
+// mutation are involved — the probe deploys a pre-synthesized assembly pinned to
+// the all-zeros account, which never resolves, so CDK always stops before any
+// AWS write.
+describe('the real CDK CLI only logs to stdout in CI mode', () => {
+  const cdkBin = (() => {
+    try {
+      return createRequire(import.meta.url).resolve('aws-cdk/bin/cdk');
+    } catch {
+      return undefined;
+    }
+  })();
+
+  function writeProbeAssembly(): string {
+    const dir = mkdtempSync(join(tmpdir(), 'blocks-cdk-probe-'));
+    writeFileSync(
+      join(dir, 'ProbeStack.template.json'),
+      JSON.stringify({ Resources: { Probe: { Type: 'AWS::SNS::Topic' } } }),
+    );
+    writeFileSync(
+      join(dir, 'manifest.json'),
+      JSON.stringify({
+        version: '22.0.0',
+        artifacts: {
+          ProbeStack: {
+            type: 'aws:cloudformation:stack',
+            // The all-zeros account is never issued, so the deploy cannot touch
+            // real infrastructure even if the runner happens to have credentials.
+            environment: 'aws://000000000000/us-east-1',
+            properties: { templateFile: 'ProbeStack.template.json' },
+          },
+        },
+      }),
+    );
+    return dir;
+  }
+
+  function probeDeploy(assembly: string, ciFlag: '--ci' | '--no-ci') {
+    const env: NodeJS.ProcessEnv = { ...process.env, AWS_EC2_METADATA_DISABLED: 'true' };
+    // CDK derives its CI default from the environment; drop those markers so the
+    // explicit flag is the only thing deciding the routing.
+    for (const key of ['CI', 'GITHUB_ACTIONS', 'CONTINUOUS_INTEGRATION', 'BUILD_NUMBER']) delete env[key];
+    return spawnSync(
+      process.execPath,
+      [
+        cdkBin as string,
+        ...buildCdkDeployArgs({ projectRoot: assembly, outputsFile: join(assembly, 'outputs.json') }).slice(1),
+        ciFlag,
+        'ProbeStack',
+        '--app',
+        assembly,
+      ],
+      { encoding: 'utf-8', env, timeout: 120_000 },
+    );
+  }
+
+  it('sends every deploy log line to stderr by default, and to stdout with --ci', { timeout: 180_000 }, (t) => {
+    if (!cdkBin) return t.skip('aws-cdk CLI is not installed in this workspace');
+    const assembly = writeProbeAssembly();
+    try {
+      const withCi = probeDeploy(assembly, '--ci');
+      const reachedCredentialCheck = /Need to perform AWS calls|credentials/i.test(withCi.stderr ?? '');
+      if (!reachedCredentialCheck) {
+        return t.skip(`cdk probe never reached the credential check: ${(withCi.stderr ?? '').slice(0, 300)}`);
+      }
+
+      const withoutCi = probeDeploy(assembly, '--no-ci');
+      assert.strictEqual(
+        withoutCi.stdout,
+        '',
+        'the CDK default routes every log line to stderr — this is the 0-byte stdout in issue #222',
+      );
+      assert.notStrictEqual(withoutCi.stderr, '', 'the log output still exists, just on the wrong stream');
+      assert.notStrictEqual(
+        withCi.stdout,
+        '',
+        '--ci must move the deploy log (CloudFormation progress included) onto stdout',
+      );
+    } finally {
+      rmSync(assembly, { recursive: true, force: true });
+    }
+  });
+});
+
+// ── end-to-end: a backgrounded deploy reaped by its parent shell ────────────
+// The issue #222 repro, with real OS signals and three real processes:
+//
+//   test ──spawn(detached)──▶ deploy wrapper ──runStreaming──▶ fake cdk
+//
+// The wrapper is its own process-group leader, so `kill -TERM -pgid` reproduces
+// exactly what a harness reaping a backgrounded `npm run deploy &` does. The
+// fake cdk stands in for the CDK CLI: it prints CloudFormation-shaped events and
+// installs no signal handler, so it dies if a signal reaches it.
+describe('a backgrounded deploy survives the group SIGTERM that killed it before', { skip: posixOnly }, () => {
+  function scaffold(totalTicks: number, tickMs: number): { dir: string; wrapper: string } {
+    const dir = mkdtempSync(join(tmpdir(), 'blocks-deploy-'));
+    const moduleUrl = new URL('./deploy-stream.js', import.meta.url).href;
+    writeFileSync(
+      join(dir, 'fake-cdk.mjs'),
+      `import { writeFileSync } from 'node:fs';\n` +
+        `const dir = process.argv[2];\n` +
+        `writeFileSync(dir + '/cdk.pid', String(process.pid));\n` +
+        `let n = 0;\n` +
+        `const tick = () => {\n` +
+        `  n += 1;\n` +
+        `  console.log('ProbeStack | ' + n + '/${totalTicks} | CREATE_IN_PROGRESS | AWS::Lambda::Function | Handler' + n);\n` +
+        `  if (n >= ${totalTicks}) {\n` +
+        `    writeFileSync(dir + '/cfn-done', 'ok');\n` +
+        `    console.log('ProbeStack | CREATE_COMPLETE | AWS::CloudFormation::Stack | ProbeStack');\n` +
+        `    return;\n` +
+        `  }\n` +
+        `  setTimeout(tick, ${tickMs});\n` +
+        `};\n` +
+        `tick();\n`,
+    );
+    const wrapper = join(dir, 'wrapper.mjs');
+    writeFileSync(
+      wrapper,
+      `import { writeFileSync } from 'node:fs';\n` +
+        `import { runStreaming } from ${JSON.stringify(moduleUrl)};\n` +
+        `const dir = process.argv[2];\n` +
+        `try {\n` +
+        `  await runStreaming(process.execPath, [dir + '/fake-cdk.mjs', dir], { label: 'cdk deploy', heartbeatMs: 0 });\n` +
+        `  console.log('✅ Deployment complete!');\n` +
+        `  writeFileSync(dir + '/wrapper-status', 'complete');\n` +
+        `} catch (error) {\n` +
+        `  console.log('❌ Deployment failed.');\n` +
+        `  writeFileSync(dir + '/wrapper-status', error && error.aborted ? 'aborted' : 'failed');\n` +
+        `  process.exitCode = 1;\n` +
+        `}\n`,
+    );
+    return { dir, wrapper };
+  }
+
+  it('keeps streaming and finishes the deploy after one group SIGTERM', { timeout: 60_000 }, async () => {
+    const { dir, wrapper } = scaffold(12, 80);
+    // `detached` makes the wrapper a process-group leader, so the test can
+    // signal the whole group the way a shell/harness reaps a background job.
+    const child = spawn(process.execPath, [wrapper, dir], { detached: true, stdio: ['ignore', 'pipe', 'pipe'] });
+    let out = '';
+    let err = '';
+    child.stdout.setEncoding('utf-8');
+    child.stderr.setEncoding('utf-8');
+    child.stdout.on('data', (chunk: string) => { out += chunk; });
+    child.stderr.on('data', (chunk: string) => { err += chunk; });
+
+    try {
+      assert.ok(
+        await waitFor(() => out.includes('CREATE_IN_PROGRESS'), 20_000),
+        `stdout must carry CloudFormation events while deploying, got: ${JSON.stringify(out)}`,
+      );
+
+      assert.ok(child.pid, 'wrapper pid');
+      process.kill(-child.pid, 'SIGTERM');
+
+      assert.ok(
+        await waitFor(() => out.includes('Ignoring SIGTERM'), 10_000),
+        'the wrapper must report that it is ignoring the SIGTERM',
+      );
+      assert.strictEqual(child.exitCode, null, 'the wrapper must still be alive after the SIGTERM');
+      assert.strictEqual(child.signalCode, null, 'the wrapper must not have been killed by the SIGTERM');
+
+      assert.ok(
+        await waitFor(() => child.exitCode !== null || child.signalCode !== null, 30_000),
+        'the wrapper should finish on its own',
+      );
+      assert.ok(existsSync(join(dir, 'cfn-done')), 'the deploy itself must have run to completion');
+      assert.strictEqual(child.signalCode, null, `wrapper was killed by a signal; stderr: ${err}`);
+      assert.strictEqual(child.exitCode, 0, `wrapper should exit 0; stdout: ${out}\nstderr: ${err}`);
+      assert.strictEqual(readFileSync(join(dir, 'wrapper-status'), 'utf-8'), 'complete');
+      assert.match(out, /✅ Deployment complete!/);
+      assert.ok(out.length > 0, 'stdout must not be empty (issue #222: 0-byte stdout)');
+    } finally {
+      if (child.pid) { try { process.kill(-child.pid, 'SIGKILL'); } catch { /* already gone */ } }
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('stops the deploy when the group SIGTERM is repeated', { timeout: 60_000 }, async () => {
+    const { dir, wrapper } = scaffold(200, 80); // long enough to still be mid-deploy
+    const child = spawn(process.execPath, [wrapper, dir], { detached: true, stdio: ['ignore', 'pipe', 'pipe'] });
+    let out = '';
+    child.stdout.setEncoding('utf-8');
+    child.stdout.on('data', (chunk: string) => { out += chunk; });
+
+    try {
+      assert.ok(await waitFor(() => out.includes('CREATE_IN_PROGRESS'), 20_000), 'deploy should be streaming');
+      const cdkPid = Number(readFileSync(join(dir, 'cdk.pid'), 'utf-8'));
+      assert.ok(cdkPid > 1, 'fake cdk pid');
+
+      assert.ok(child.pid, 'wrapper pid');
+      process.kill(-child.pid, 'SIGTERM');
+      assert.ok(await waitFor(() => out.includes('Ignoring SIGTERM'), 10_000), 'first SIGTERM is deferred');
+      process.kill(-child.pid, 'SIGTERM');
+
+      assert.ok(
+        await waitFor(() => child.exitCode !== null || child.signalCode !== null, 30_000),
+        'the wrapper should exit after the second SIGTERM',
+      );
+      assert.match(out, /Received SIGTERM while deploying/);
+      assert.strictEqual(child.exitCode, 1, `expected a failed exit, stdout: ${out}`);
+      assert.strictEqual(readFileSync(join(dir, 'wrapper-status'), 'utf-8'), 'aborted');
+      assert.ok(!existsSync(join(dir, 'cfn-done')), 'the aborted deploy must not have completed');
+      assert.ok(
+        await waitFor(() => {
+          try { process.kill(cdkPid, 0); return false; } catch { return true; }
+        }, 15_000),
+        'the abort must reap the cdk child, not orphan it',
+      );
+    } finally {
+      if (child.pid) { try { process.kill(-child.pid, 'SIGKILL'); } catch { /* already gone */ } }
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  // Control: the shape the deploy CLI used before this fix — a blocking
+  // `spawnSync` with the child in the parent's process group and no signal
+  // handling. It proves the group SIGTERM above really is lethal, so the passing
+  // tests are not vacuous: here the wrapper dies (exit 143 / SIGTERM) and takes
+  // the in-flight deploy down with it, exactly as reported in issue #222.
+  it('demonstrates the old behaviour: a blocking spawnSync deploy is killed mid-flight', { timeout: 60_000 }, async () => {
+    const { dir } = scaffold(200, 80);
+    const baseline = join(dir, 'baseline.mjs');
+    writeFileSync(
+      baseline,
+      `import { spawnSync } from 'node:child_process';\n` +
+        `import { writeFileSync } from 'node:fs';\n` +
+        `const dir = process.argv[2];\n` +
+        `const result = spawnSync(process.execPath, [dir + '/fake-cdk.mjs', dir], { stdio: 'inherit' });\n` +
+        `writeFileSync(dir + '/wrapper-status', 'baseline:' + result.status);\n`,
+    );
+    const child = spawn(process.execPath, [baseline, dir], { detached: true, stdio: ['ignore', 'pipe', 'pipe'] });
+    let out = '';
+    child.stdout.setEncoding('utf-8');
+    child.stdout.on('data', (chunk: string) => { out += chunk; });
+
+    try {
+      assert.ok(await waitFor(() => out.includes('CREATE_IN_PROGRESS'), 20_000), 'baseline deploy should be running');
+      const cdkPid = Number(readFileSync(join(dir, 'cdk.pid'), 'utf-8'));
+
+      assert.ok(child.pid, 'baseline pid');
+      process.kill(-child.pid, 'SIGTERM');
+
+      assert.ok(
+        await waitFor(() => child.exitCode !== null || child.signalCode !== null, 15_000),
+        'the unguarded wrapper dies on the first group SIGTERM',
+      );
+      assert.strictEqual(child.signalCode, 'SIGTERM', 'the old shape is killed by the signal (exit 143)');
+      assert.ok(!existsSync(join(dir, 'wrapper-status')), 'it never reports a terminal status');
+      assert.ok(!existsSync(join(dir, 'cfn-done')), 'the in-flight deploy is cut short');
+      assert.ok(
+        await waitFor(() => {
+          try { process.kill(cdkPid, 0); return false; } catch { return true; }
+        }, 15_000),
+        'the deploy child shares the group, so it dies too',
+      );
+    } finally {
+      if (child.pid) { try { process.kill(-child.pid, 'SIGKILL'); } catch { /* already gone */ } }
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/core/src/scripts/deploy-stream.ts
+++ b/packages/core/src/scripts/deploy-stream.ts
@@ -1,0 +1,406 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { ChildProcess } from 'node:child_process';
+import { spawnCommand } from './run-command.js';
+import { terminateProcessTree } from './process-tree.js';
+
+// Streaming, signal-resilient runner for the long CloudFormation phase of
+// `npm run deploy`.
+//
+// Two failures made a production deploy unobservable and, worse, made a
+// SUCCESSFUL deploy look like a failure (callers re-ran it, paying for the same
+// stack two or three times):
+//
+//  1. ZERO BYTES ON STDOUT. The CDK CLI sends every non-error message —
+//     including all CloudFormation stack activity — to *stderr* unless CI mode
+//     is on: its io host resolves the target stream as
+//     `isCI ? process.stdout : process.stderr`. So `npm run deploy > deploy.log`
+//     captured nothing at all for the entire (multi-minute) CloudFormation
+//     phase, leaving callers to poll `describe-stacks` by hand.
+//  2. A BACKGROUNDED DEPLOY DIED ON SIGTERM. The old code ran `cdk deploy`
+//     through a *synchronous* spawn, so the event loop was blocked for the whole
+//     deploy: signals could not be handled, the default SIGTERM disposition
+//     killed the CLI (exit 143), and CloudFormation — which executes
+//     server-side once the change set is executing — carried on and finished.
+//     The caller saw a dead process with no output and assumed failure.
+//
+// The fix streams the child's output line by line as it arrives (so stdout is
+// never silent), emits an idle heartbeat so a slow resource still produces
+// progress, and puts the deploy's lifecycle under this CLI's control: the child
+// runs in its own process group and a single SIGTERM/SIGHUP no longer abandons
+// an in-flight deploy.
+
+/** What to do with a signal that arrives while a deploy is in flight. */
+export type DeploySignalAction = 'defer' | 'abort';
+
+export interface DeploySignalResponse {
+  action: DeploySignalAction;
+  /** Operator-facing line explaining what happened and how to force an abort. */
+  message: string;
+}
+
+/** Signals whose delivery we take over while a deploy is in flight. */
+export const DEPLOY_SIGNALS: readonly NodeJS.Signals[] = ['SIGTERM', 'SIGINT', 'SIGHUP'];
+
+/** Default gap (ms) of silence after which the runner prints a progress heartbeat. */
+export const DEFAULT_HEARTBEAT_MS = 30_000;
+
+/** Grace (ms) given to the child tree to exit after an operator-requested abort. */
+export const ABORT_GRACE_MS = 10_000;
+
+/**
+ * Grace (ms) we wait after the child exits for its stdout/stderr pipes to end,
+ * so the last CloudFormation lines are relayed before we resolve. Bounded
+ * because a lingering grandchild could hold the pipe open forever; losing a
+ * trailing line is strictly better than hanging a finished deploy.
+ */
+export const STREAM_FLUSH_GRACE_MS = 2_000;
+
+/**
+ * Decide how to answer a signal that arrives while CloudFormation is still
+ * converging. This is the whole "decouple the CLI lifecycle from the in-flight
+ * deploy" policy, kept pure so it can be asserted directly.
+ *
+ * - `SIGHUP` → always `defer`. A hangup means the terminal or parent shell went
+ *   away (a backgrounded `npm run deploy &`, a closed SSH session). The deploy
+ *   is server-side work that is already paid for; killing the CLI here is what
+ *   produced the phantom failures, so we keep streaming instead.
+ * - `SIGTERM` → `defer` the first time, `abort` after that. A lone SIGTERM is
+ *   almost always process-group collateral (a harness reaping the parent shell,
+ *   a supervisor tidying up) rather than a deliberate "stop the deploy", so the
+ *   first one only warns. An operator who really wants to stop sends it again.
+ *   A SIGKILL follow-up (`docker stop`, most CI cancels) is uncatchable and
+ *   still ends the process immediately, so this cannot wedge a shutdown.
+ * - `SIGINT` → always `abort`. Ctrl-C is unambiguous, interactive intent, so it
+ *   stays responsive on the first press.
+ *
+ * @param signal - the signal received.
+ * @param termAlreadyDeferred - whether a SIGTERM has already been deferred.
+ */
+export function decideSignalResponse(
+  signal: NodeJS.Signals,
+  termAlreadyDeferred: boolean,
+): DeploySignalResponse {
+  if (signal === 'SIGINT') {
+    return {
+      action: 'abort',
+      message:
+        '\n🛑 Interrupted. Stopping the CDK CLI — CloudFormation may keep applying the change set server-side.',
+    };
+  }
+  if (signal === 'SIGHUP') {
+    return {
+      action: 'defer',
+      message:
+        '⚠️  Ignoring SIGHUP: the deploy is still running and CloudFormation is still converging. Streaming continues; send SIGTERM twice to abort.',
+    };
+  }
+  if (signal === 'SIGTERM' && !termAlreadyDeferred) {
+    return {
+      action: 'defer',
+      message:
+        '⚠️  Ignoring SIGTERM: the deploy is still running and CloudFormation is still converging. Send SIGTERM again to abort (the stack update continues server-side either way).',
+    };
+  }
+  return {
+    action: 'abort',
+    message: `\n🛑 Received ${signal} while deploying. Stopping the CDK CLI — CloudFormation may keep applying the change set server-side.`,
+  };
+}
+
+/**
+ * Split a byte stream into whole lines across chunk boundaries.
+ *
+ * The child's output arrives in arbitrary chunks, so a naive
+ * `chunk.toString().split('\n')` emits torn lines (and drops the tail). This
+ * keeps the partial trailing line buffered until it completes; {@link flush}
+ * returns whatever is left when the stream ends (CDK's final line has no
+ * trailing newline).
+ */
+export function createLineAssembler(): {
+  push(chunk: string): string[];
+  flush(): string[];
+} {
+  let buffered = '';
+  return {
+    push(chunk: string): string[] {
+      buffered += chunk;
+      const lines = buffered.split('\n');
+      buffered = lines.pop() ?? '';
+      return lines.map((line) => (line.endsWith('\r') ? line.slice(0, -1) : line));
+    },
+    flush(): string[] {
+      if (!buffered) return [];
+      const last = buffered.endsWith('\r') ? buffered.slice(0, -1) : buffered;
+      buffered = '';
+      return last ? [last] : [];
+    },
+  };
+}
+
+/** Human-readable elapsed time (`45s`, `4m 05s`) for progress lines. */
+export function formatElapsed(ms: number): string {
+  const totalSeconds = Math.max(0, Math.floor(ms / 1000));
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return minutes > 0 ? `${minutes}m ${String(seconds).padStart(2, '0')}s` : `${seconds}s`;
+}
+
+export interface CdkDeployArgsOptions {
+  /** Project root passed to synth as `--context projectRoot=…`. */
+  projectRoot: string;
+  /** Path (relative to the project root) CDK writes stack outputs to. */
+  outputsFile: string;
+}
+
+/**
+ * Build the `cdk deploy` argv used by `npm run deploy`.
+ *
+ * Two of these flags exist purely so the deploy is observable — losing either
+ * one brings back the 0-byte stdout:
+ *
+ * - `--ci`: the CDK CLI picks its log stream as `isCI ? stdout : stderr`, so
+ *   without it every CloudFormation event goes to **stderr** and a caller
+ *   capturing stdout (`npm run deploy > deploy.log`) sees nothing for the whole
+ *   multi-minute deploy. With it, progress goes to stdout and only error-level
+ *   messages stay on stderr.
+ * - `--progress events`: print one line per resource transition instead of the
+ *   redrawing progress bar. The bar needs a TTY, which a piped/backgrounded
+ *   deploy does not have, and a half-rendered bar is not a usable progress
+ *   signal in a log file.
+ */
+export function buildCdkDeployArgs({ projectRoot, outputsFile }: CdkDeployArgsOptions): string[] {
+  return [
+    'cdk',
+    'deploy',
+    '--require-approval',
+    'never',
+    '--ci',
+    '--progress',
+    'events',
+    '--outputs-file',
+    outputsFile,
+    '--context',
+    `projectRoot=${projectRoot}`,
+  ];
+}
+
+/** Unref'd sleep: a pending flush grace must never keep the process alive. */
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms).unref?.();
+  });
+}
+
+/** Minimal sink surface so tests can capture the relayed streams. */
+export interface OutputSink {
+  write(chunk: string): unknown;
+}
+
+/** Minimal signal-registration surface ({@link process} satisfies it). */
+export interface SignalRegistry {
+  on(signal: NodeJS.Signals, handler: () => void): unknown;
+  off(signal: NodeJS.Signals, handler: () => void): unknown;
+}
+
+export interface RunStreamingOptions {
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+  /** Prefix used by the runner's own progress/status lines. Defaults to `deploy`. */
+  label?: string;
+  /** Idle gap before a heartbeat line is printed. `0` disables heartbeats. */
+  heartbeatMs?: number;
+  /** Where child stdout and runner progress lines go. Defaults to `process.stdout`. */
+  stdout?: OutputSink;
+  /** Where child stderr goes. Defaults to `process.stderr`. */
+  stderr?: OutputSink;
+  /** Injected for tests. */
+  now?: () => number;
+  /** Injected for tests: signal registration seam. */
+  signalTarget?: SignalRegistry;
+}
+
+/** Raised when the child exits non-zero, is killed, or the operator aborts. */
+export class DeployProcessError extends Error {
+  readonly exitCode: number | null;
+  readonly signal: NodeJS.Signals | null;
+  readonly aborted: boolean;
+
+  constructor(
+    message: string,
+    details: { exitCode?: number | null; signal?: NodeJS.Signals | null; aborted?: boolean } = {},
+  ) {
+    super(message);
+    this.name = 'DeployProcessError';
+    this.exitCode = details.exitCode ?? null;
+    this.signal = details.signal ?? null;
+    this.aborted = details.aborted ?? false;
+  }
+}
+
+/**
+ * Run a long deployment command, relaying its output line by line as it happens
+ * and keeping it alive across a stray SIGTERM/SIGHUP.
+ *
+ * Behaviour that matters to callers:
+ * - **Streamed, non-empty stdout.** Child stdout is relayed to `stdout` the
+ *   moment a line completes (never buffered until exit) and child stderr to
+ *   `stderr`, so `npm run deploy | tee` shows CloudFormation progress live.
+ * - **Idle heartbeat.** While the child is silent for `heartbeatMs`, a
+ *   `still deploying` line with elapsed time is written to `stdout`, so a
+ *   ten-minute RDS resource never looks like a hung process.
+ * - **Own process group.** The child is spawned `detached` on POSIX, so a
+ *   process-group signal aimed at the parent shell (`kill -TERM -pgid`, a
+ *   harness reaping a backgrounded job) cannot kill the CDK CLI behind our
+ *   back; this runner is the only thing that signals it. Windows has no
+ *   process groups, so the tree is reaped by pid via `terminateProcessTree`.
+ * - **No stdin.** The child gets `ignore` for stdin so a backgrounded deploy
+ *   can never be stopped by SIGTTIN trying to read a terminal it no longer
+ *   owns; the caller must keep passing `--require-approval never`.
+ * - **Signal policy.** See {@link decideSignalResponse}: a deferred signal only
+ *   logs (which itself doubles as a progress signal on stdout), while an abort
+ *   reaps the child tree and throws a {@link DeployProcessError} with
+ *   `aborted: true`.
+ *
+ * Resolves when the child exits 0; otherwise throws {@link DeployProcessError}.
+ */
+export async function runStreaming(
+  command: string,
+  args: string[],
+  options: RunStreamingOptions = {},
+): Promise<void> {
+  const {
+    cwd,
+    env,
+    label = 'deploy',
+    heartbeatMs = DEFAULT_HEARTBEAT_MS,
+    stdout = process.stdout,
+    stderr = process.stderr,
+    now = Date.now,
+    signalTarget = process,
+  } = options;
+
+  const startedAt = now();
+  let lastOutputAt = startedAt;
+  let aborting = false;
+  let termDeferred = false;
+  let exitObserved = false;
+
+  const child: ChildProcess = spawnCommand(command, args, {
+    cwd,
+    env,
+    // stdin ignored (see doc comment); stdout/stderr piped so we can relay them
+    // line by line instead of handing the child our fds and going blind.
+    stdio: ['ignore', 'pipe', 'pipe'],
+    detached: process.platform !== 'win32',
+  });
+
+  const relay = (
+    stream: NodeJS.ReadableStream | null | undefined,
+    sink: OutputSink,
+  ): void => {
+    if (!stream) return;
+    const assembler = createLineAssembler();
+    stream.setEncoding('utf-8');
+    stream.on('data', (chunk: string) => {
+      lastOutputAt = now();
+      for (const line of assembler.push(chunk)) sink.write(`${line}\n`);
+    });
+    stream.on('end', () => {
+      for (const line of assembler.flush()) sink.write(`${line}\n`);
+    });
+  };
+  relay(child.stdout, stdout);
+  relay(child.stderr, stderr);
+
+  const heartbeat =
+    heartbeatMs > 0
+      ? setInterval(() => {
+          if (now() - lastOutputAt < heartbeatMs) return;
+          stdout.write(
+            `⏳ [${label}] still running after ${formatElapsed(now() - startedAt)} — CloudFormation is converging (pid ${child.pid ?? '?'})\n`,
+          );
+        }, heartbeatMs)
+      : undefined;
+  // Never let the heartbeat timer be the reason the process stays alive.
+  heartbeat?.unref?.();
+
+  const exited = new Promise<{ code: number | null; signal: NodeJS.Signals | null }>(
+    (resolve, reject) => {
+      child.once('error', reject);
+      child.once('exit', (code, signal) => {
+        exitObserved = true;
+        resolve({ code, signal });
+      });
+    },
+  );
+  const streamsEnded = Promise.all(
+    [child.stdout, child.stderr].map(
+      (stream) =>
+        new Promise<void>((resolve) => {
+          if (!stream) return resolve();
+          stream.once('end', () => resolve());
+          stream.once('close', () => resolve());
+        }),
+    ),
+  );
+
+  const handlers = new Map<NodeJS.Signals, () => void>();
+  const removeHandlers = (): void => {
+    for (const [signal, handler] of handlers) signalTarget.off(signal, handler);
+    handlers.clear();
+  };
+
+  for (const signal of DEPLOY_SIGNALS) {
+    const handler = (): void => {
+      // The deploy already finished (we are just draining pipes / reporting):
+      // there is nothing left to defer or abort, and reporting an abort here
+      // would turn a successful deploy into a failure.
+      if (exitObserved) return;
+      const { action, message } = decideSignalResponse(signal, termDeferred);
+      if (action === 'defer') {
+        if (signal === 'SIGTERM') termDeferred = true;
+        lastOutputAt = now();
+        stdout.write(`${message}\n`);
+        return;
+      }
+      if (aborting) return; // already tearing down; a repeat signal is a no-op
+      aborting = true;
+      stdout.write(`${message}\n`);
+      // Reap the whole tree (npx → cdk → node), not just the npx parent, so an
+      // abort cannot leave an orphaned CDK CLI still driving the stack.
+      void terminateProcessTree(child, ABORT_GRACE_MS);
+    };
+    handlers.set(signal, handler);
+    signalTarget.on(signal, handler);
+  }
+
+  try {
+    const { code, signal } = await exited;
+    // Let the pipes drain so a caller reading our stdout sees the child's final
+    // lines (CDK's summary / failure reason) before the terminal status.
+    await Promise.race([streamsEnded, delay(STREAM_FLUSH_GRACE_MS)]);
+    if (aborting) {
+      throw new DeployProcessError(
+        `${command} was aborted by an operator signal after ${formatElapsed(now() - startedAt)}`,
+        { exitCode: code, signal, aborted: true },
+      );
+    }
+    if (signal) {
+      throw new DeployProcessError(`${command} was terminated by signal ${signal}`, {
+        exitCode: code,
+        signal,
+      });
+    }
+    if (code !== 0) {
+      throw new DeployProcessError(
+        `${command} ${args.join(' ')} exited with code ${code}`,
+        { exitCode: code },
+      );
+    }
+  } finally {
+    if (heartbeat) clearInterval(heartbeat);
+    removeHandlers();
+  }
+}

--- a/packages/core/src/scripts/deploy-stream.ts
+++ b/packages/core/src/scripts/deploy-stream.ts
@@ -30,6 +30,13 @@ import { terminateProcessTree } from './process-tree.js';
 // progress, and puts the deploy's lifecycle under this CLI's control: the child
 // runs in its own process group and a single SIGTERM/SIGHUP no longer abandons
 // an in-flight deploy.
+//
+// The signal half of that is POSIX-only. It relies on process groups (`detached`)
+// and on real SIGTERM/SIGHUP delivery, neither of which Windows has: `detached`
+// is passed only when `process.platform !== 'win32'`, and on Windows nothing
+// outside the process delivers those signals (a `taskkill` on the tree still
+// ends the deploy). Streaming, the heartbeat and the argv contract are
+// cross-platform; only "survives a stray reap" is POSIX.
 
 /** What to do with a signal that arrives while a deploy is in flight. */
 export type DeploySignalAction = 'defer' | 'abort';
@@ -88,7 +95,9 @@ export const SIGNAL_COALESCE_MS = 2_000;
  * - `SIGHUP` → always `defer`. A hangup means the terminal or parent shell went
  *   away (a backgrounded `npm run deploy &`, a closed SSH session). The deploy
  *   is server-side work that is already paid for; killing the CLI here is what
- *   produced the phantom failures, so we keep streaming instead.
+ *   produced the phantom failures, so we keep streaming instead. Duplicate
+ *   deliveries inside {@link SIGNAL_COALESCE_MS} are coalesced so one hangup
+ *   logs one line, not one per delivery.
  * - `SIGTERM` → `defer` the first time. A lone SIGTERM is almost always
  *   process-group collateral (a harness reaping the parent shell, a supervisor
  *   tidying up) rather than a deliberate "stop the deploy", so it only warns.
@@ -101,8 +110,10 @@ export const SIGNAL_COALESCE_MS = 2_000;
  *   stays responsive on the first press.
  *
  * @param signal - the signal received.
- * @param msSinceFirstDeferral - ms since the first SIGTERM was deferred, or
- *   `null` when none has been deferred yet.
+ * @param msSinceFirstDeferral - ms since the first deferral of *this* signal, or
+ *   `null` when this signal has not been deferred yet. Each signal is tracked
+ *   separately, so a deferred SIGHUP never consumes the SIGTERM abort budget
+ *   (and a repeated SIGHUP is deduped the same way a repeated SIGTERM is).
  * @param coalesceWindowMs - see {@link SIGNAL_COALESCE_MS}.
  */
 export function decideSignalResponse(
@@ -288,18 +299,25 @@ export class DeployProcessError extends Error {
  * - **Idle heartbeat.** While the child is silent for `heartbeatMs`, a
  *   `still deploying` line with elapsed time is written to `stdout`, so a
  *   ten-minute RDS resource never looks like a hung process.
- * - **Own process group.** The child is spawned `detached` on POSIX, so a
- *   process-group signal aimed at the parent shell (`kill -TERM -pgid`, a
- *   harness reaping a backgrounded job) cannot kill the CDK CLI behind our
- *   back; this runner is the only thing that signals it. Windows has no
- *   process groups, so the tree is reaped by pid via `terminateProcessTree`.
+ * - **Own process group (POSIX only).** The child is spawned `detached` on
+ *   POSIX, so a process-group signal aimed at the parent shell
+ *   (`kill -TERM -pgid`, a harness reaping a backgrounded job) cannot kill the
+ *   CDK CLI behind our back; this runner is the only thing that signals it.
+ *   Windows has neither process groups nor OS-delivered SIGTERM/SIGHUP, so the
+ *   signal resilience below does not apply there — a `taskkill` on the tree ends
+ *   the deploy, and the abort path reaps by pid via `terminateProcessTree`.
  * - **No stdin.** The child gets `ignore` for stdin so a backgrounded deploy
  *   can never be stopped by SIGTTIN trying to read a terminal it no longer
  *   owns; the caller must keep passing `--require-approval never`.
- * - **Signal policy.** See {@link decideSignalResponse}: a deferred signal only
- *   logs (which itself doubles as a progress signal on stdout), while an abort
- *   reaps the child tree and throws a {@link DeployProcessError} with
- *   `aborted: true`.
+ * - **Signal policy (POSIX).** See {@link decideSignalResponse}: a deferred
+ *   signal only logs (which itself doubles as a progress signal on stdout),
+ *   while an abort reaps the child tree and throws a {@link DeployProcessError}
+ *   with `aborted: true`. Repeat deliveries of the same signal inside
+ *   {@link SIGNAL_COALESCE_MS} log once, not once per delivery.
+ * - **Streams stay separated.** Child stdout and child stderr are relayed to
+ *   their own sinks and never merged, so a deploy failure reason (which the CDK
+ *   CLI keeps on stderr even under `--ci`) stays on stderr while progress is on
+ *   stdout.
  *
  * Resolves when the child exits 0; otherwise throws {@link DeployProcessError}.
  */
@@ -322,8 +340,11 @@ export async function runStreaming(
   const startedAt = now();
   let lastOutputAt = startedAt;
   let aborting = false;
-  let firstDeferralAt: number | null = null;
   let exitObserved = false;
+  // Per signal, when its current deferral window opened. Kept per signal so a
+  // deferred SIGHUP neither consumes the SIGTERM abort budget nor silently
+  // swallows its own log line.
+  const deferredAt = new Map<NodeJS.Signals, number>();
 
   const child: ChildProcess = spawnCommand(command, args, {
     cwd,
@@ -396,15 +417,18 @@ export async function runStreaming(
       // there is nothing left to defer or abort, and reporting an abort here
       // would turn a successful deploy into a failure.
       if (exitObserved) return;
+      const openedAt = deferredAt.get(signal);
       const { action, message, coalesced } = decideSignalResponse(
         signal,
-        firstDeferralAt === null ? null : now() - firstDeferralAt,
+        openedAt === undefined ? null : now() - openedAt,
       );
       if (action === 'defer') {
-        if (signal === 'SIGTERM' && firstDeferralAt === null) firstDeferralAt = now();
         // A coalesced duplicate is the same signal arriving twice (process group
-        // plus a wrapper relay); log it once, not once per delivery.
+        // plus a wrapper relay); log it once, not once per delivery. Anything
+        // outside the window is a fresh request, so it opens a new window and
+        // reports again instead of being muted for the rest of the deploy.
         if (!coalesced) {
+          deferredAt.set(signal, now());
           lastOutputAt = now();
           stdout.write(`${message}\n`);
         }

--- a/packages/core/src/scripts/deploy-stream.ts
+++ b/packages/core/src/scripts/deploy-stream.ts
@@ -38,6 +38,12 @@ export interface DeploySignalResponse {
   action: DeploySignalAction;
   /** Operator-facing line explaining what happened and how to force an abort. */
   message: string;
+  /**
+   * True when this signal is a duplicate delivery of one the operator already
+   * sent (see {@link SIGNAL_COALESCE_MS}), so the caller can skip logging it
+   * twice.
+   */
+  coalesced?: boolean;
 }
 
 /** Signals whose delivery we take over while a deploy is in flight. */
@@ -58,6 +64,23 @@ export const ABORT_GRACE_MS = 10_000;
 export const STREAM_FLUSH_GRACE_MS = 2_000;
 
 /**
+ * Window (ms) in which repeated SIGTERMs count as ONE operator request.
+ *
+ * A single external signal reaches this process more than once. `npm run deploy`
+ * runs `npm -> sh -> tsx -> node`, so a process-group SIGTERM is delivered to
+ * the node process directly AND relayed to it a second time by `tsx`, which
+ * forwards SIGTERM/SIGINT to its child. Measured on a real deploy: one
+ * `kill -TERM -<pgid>` produced two SIGTERMs about 50ms apart. Without this
+ * window the second delivery is read as "the operator insisted" and the deploy
+ * is abandoned, which is the exact failure this module exists to prevent.
+ *
+ * 2s is far longer than a delivery burst (tens of ms) and far shorter than a
+ * deliberate repeat (a human running `kill` twice, or a supervisor's
+ * SIGTERM-then-escalate cycle), so both intents stay distinguishable.
+ */
+export const SIGNAL_COALESCE_MS = 2_000;
+
+/**
  * Decide how to answer a signal that arrives while CloudFormation is still
  * converging. This is the whole "decouple the CLI lifecycle from the in-flight
  * deploy" policy, kept pure so it can be asserted directly.
@@ -66,21 +89,26 @@ export const STREAM_FLUSH_GRACE_MS = 2_000;
  *   away (a backgrounded `npm run deploy &`, a closed SSH session). The deploy
  *   is server-side work that is already paid for; killing the CLI here is what
  *   produced the phantom failures, so we keep streaming instead.
- * - `SIGTERM` → `defer` the first time, `abort` after that. A lone SIGTERM is
- *   almost always process-group collateral (a harness reaping the parent shell,
- *   a supervisor tidying up) rather than a deliberate "stop the deploy", so the
- *   first one only warns. An operator who really wants to stop sends it again.
- *   A SIGKILL follow-up (`docker stop`, most CI cancels) is uncatchable and
- *   still ends the process immediately, so this cannot wedge a shutdown.
+ * - `SIGTERM` → `defer` the first time. A lone SIGTERM is almost always
+ *   process-group collateral (a harness reaping the parent shell, a supervisor
+ *   tidying up) rather than a deliberate "stop the deploy", so it only warns.
+ *   Repeats inside {@link SIGNAL_COALESCE_MS} are duplicate *deliveries* of that
+ *   same signal (the group delivers it, then `tsx` relays it) and are coalesced
+ *   into the first. A SIGTERM after that window is a deliberate repeat and
+ *   aborts. A SIGKILL follow-up (`docker stop`, most CI cancels) is uncatchable
+ *   and still ends the process immediately, so this cannot wedge a shutdown.
  * - `SIGINT` → always `abort`. Ctrl-C is unambiguous, interactive intent, so it
  *   stays responsive on the first press.
  *
  * @param signal - the signal received.
- * @param termAlreadyDeferred - whether a SIGTERM has already been deferred.
+ * @param msSinceFirstDeferral - ms since the first SIGTERM was deferred, or
+ *   `null` when none has been deferred yet.
+ * @param coalesceWindowMs - see {@link SIGNAL_COALESCE_MS}.
  */
 export function decideSignalResponse(
   signal: NodeJS.Signals,
-  termAlreadyDeferred: boolean,
+  msSinceFirstDeferral: number | null,
+  coalesceWindowMs: number = SIGNAL_COALESCE_MS,
 ): DeploySignalResponse {
   if (signal === 'SIGINT') {
     return {
@@ -94,13 +122,23 @@ export function decideSignalResponse(
       action: 'defer',
       message:
         '⚠️  Ignoring SIGHUP: the deploy is still running and CloudFormation is still converging. Streaming continues; send SIGTERM twice to abort.',
+      coalesced: msSinceFirstDeferral !== null && msSinceFirstDeferral < coalesceWindowMs,
     };
   }
-  if (signal === 'SIGTERM' && !termAlreadyDeferred) {
+  if (signal === 'SIGTERM' && msSinceFirstDeferral === null) {
     return {
       action: 'defer',
       message:
         '⚠️  Ignoring SIGTERM: the deploy is still running and CloudFormation is still converging. Send SIGTERM again to abort (the stack update continues server-side either way).',
+    };
+  }
+  if (signal === 'SIGTERM' && msSinceFirstDeferral !== null && msSinceFirstDeferral < coalesceWindowMs) {
+    // Same signal reaching us twice (process group + a wrapper's relay), not a
+    // second request — keep deploying and stay quiet about the duplicate.
+    return {
+      action: 'defer',
+      message: '',
+      coalesced: true,
     };
   }
   return {
@@ -284,7 +322,7 @@ export async function runStreaming(
   const startedAt = now();
   let lastOutputAt = startedAt;
   let aborting = false;
-  let termDeferred = false;
+  let firstDeferralAt: number | null = null;
   let exitObserved = false;
 
   const child: ChildProcess = spawnCommand(command, args, {
@@ -358,11 +396,18 @@ export async function runStreaming(
       // there is nothing left to defer or abort, and reporting an abort here
       // would turn a successful deploy into a failure.
       if (exitObserved) return;
-      const { action, message } = decideSignalResponse(signal, termDeferred);
+      const { action, message, coalesced } = decideSignalResponse(
+        signal,
+        firstDeferralAt === null ? null : now() - firstDeferralAt,
+      );
       if (action === 'defer') {
-        if (signal === 'SIGTERM') termDeferred = true;
-        lastOutputAt = now();
-        stdout.write(`${message}\n`);
+        if (signal === 'SIGTERM' && firstDeferralAt === null) firstDeferralAt = now();
+        // A coalesced duplicate is the same signal arriving twice (process group
+        // plus a wrapper relay); log it once, not once per delivery.
+        if (!coalesced) {
+          lastOutputAt = now();
+          stdout.write(`${message}\n`);
+        }
         return;
       }
       if (aborting) return; // already tearing down; a repeat signal is a no-op

--- a/packages/core/src/scripts/deploy.ts
+++ b/packages/core/src/scripts/deploy.ts
@@ -9,7 +9,7 @@ import { ensureSecrets, loadProductionEnv } from './ensure-secrets.js';
 import { applyExternalMigrations } from './external-migrations-step.js';
 import { trackCommand } from '../telemetry/trackCommand.js';
 import { getCdkTelemetryEnv } from './cdk-telemetry-env.js';
-import { runSync } from './run-command.js';
+import { runStreaming, buildCdkDeployArgs } from './deploy-stream.js';
 
 export interface DeployOptions {
   cdkAppPath: string;
@@ -57,18 +57,18 @@ export async function deploy(options: DeployOptions) {
     console.log('   (This may take a few minutes on first deploy)');
     console.log('   - Backend API (Lambda + API Gateway)');
     console.log('   - Frontend hosting (S3 + CloudFront)');
-    
+    console.log('   Streaming CloudFormation events below; the deploy keeps running if this');
+    console.log('   process is backgrounded (press Ctrl-C, or send SIGTERM twice, to abort).');
+
     try {
-      runSync(
+      await runStreaming(
         "npx",
-        [
-          "cdk", "deploy",
-          "--require-approval", "never",
-          "--outputs-file", ".blocks-sandbox/outputs.json",
-          "--context", `projectRoot=${options.projectRoot}`,
-        ],
+        buildCdkDeployArgs({
+          projectRoot: options.projectRoot,
+          outputsFile: '.blocks-sandbox/outputs.json',
+        }),
         {
-          stdio: 'inherit',
+          label: 'cdk deploy',
           cwd: options.projectRoot,
           env: {
             ...process.env,
@@ -78,7 +78,11 @@ export async function deploy(options: DeployOptions) {
         }
       );
     } catch (error) {
-      console.error('\n❌ Deployment failed.');
+      // Terminal status on stdout: a caller that only captures stdout (the case
+      // that produced phantom failures) must still be able to tell a failed
+      // deploy from a killed process. The error itself still surfaces on stderr
+      // via the entrypoint's `console.error(error)`.
+      console.log('\n❌ Deployment failed.');
       throw error;
     }
     

--- a/packages/core/src/scripts/deploy.ts
+++ b/packages/core/src/scripts/deploy.ts
@@ -78,10 +78,13 @@ export async function deploy(options: DeployOptions) {
         }
       );
     } catch (error) {
-      // Terminal status on stdout: a caller that only captures stdout (the case
+      // Terminal verdict on stdout: a caller that only captures stdout (the case
       // that produced phantom failures) must still be able to tell a failed
-      // deploy from a killed process. The error itself still surfaces on stderr
-      // via the entrypoint's `console.error(error)`.
+      // deploy from a killed process. This banner deliberately moved off stderr,
+      // so grepping stderr for this exact string no longer matches — the failure
+      // *reason* is still there. The CDK CLI keeps error-level output on stderr
+      // even under `--ci`, and the entrypoint prints the error itself with
+      // `console.error(error)`.
       console.log('\n❌ Deployment failed.');
       throw error;
     }


### PR DESCRIPTION
Fixes #222

## What was wrong

Two separate problems made a production deploy unobservable, and made a deploy
that had actually succeeded look like a failure. Consumers then re-ran it, which
is where the 2-3x cost in the issue comes from.

**1. Nothing on stdout for the whole CloudFormation phase.** The CDK CLI routes
every non-error log line (all stack activity included) to stderr unless CI mode
is on. Its io host picks the stream like this:

```js
selectStreamFromLevel(level) {
  switch (level) {
    case "error":  return process.stderr;
    case "result": return process.stdout;
    default:       return this.isCI ? process.stdout : process.stderr;
  }
}
```

So `npm run deploy > deploy.log` captured zero bytes while the stack converged.
Verified against the real CLI (aws-cdk 2.1122.0), deploying a pre-synthesized
assembly pinned to the all-zeros account so nothing can actually be created:

```
$ cdk deploy --progress events --no-ci ...   ->  stdout=0B    stderr=131B
$ cdk deploy --progress events --ci    ...   ->  stdout=29B   stderr=102B
```

**2. A backgrounded deploy was killed while CloudFormation kept going.**
`cdk deploy` ran through a blocking `spawnSync`, with the child in this process's
own group and no signal handling. A process-group SIGTERM (a harness reaping a
backgrounded job, a parent shell going away) killed the CLI with exit 143, took
the CDK child with it, and CloudFormation carried on server-side and finished.
The caller was left with a dead process, no output, and no terminal status.

## The fix

`packages/core/src/scripts/deploy-stream.ts` runs the CloudFormation phase and
owns its lifecycle:

- `--ci` so CDK log lines (progress included) land on stdout, errors still on
  stderr, and `--progress events` so it is one line per resource transition
  rather than a progress bar that needs a TTY.
- Output is piped and relayed line by line as it arrives, with lines reassembled
  across chunk boundaries, so nothing is buffered until exit.
- An idle heartbeat prints elapsed time while a slow resource is converging, so
  stdout is never silent for minutes.
- The CDK CLI is spawned in its own process group (POSIX) with stdin ignored, so
  a group signal aimed at the parent shell cannot kill it behind our back and a
  background run cannot be stopped by SIGTTIN.
- Signal policy: one SIGTERM, or any SIGHUP, does not abandon a converging
  deploy. It logs why and keeps streaming. Ctrl-C, or a second SIGTERM, aborts
  and reaps the whole CDK process tree through the existing
  `terminateProcessTree` helper. SIGKILL is uncatchable, so a `docker stop` or a
  CI cancel that escalates still stops immediately.
- The terminal status is printed on stdout for success and failure, so a caller
  that only captures stdout can tell them apart.

No new flags on `npm run deploy`, and no change to the deploy contract otherwise.

## Behaviour change worth knowing

Because the CDK CLI's output is now piped through this process, interactive runs
get event lines instead of the redrawing progress bar (the bar needs a TTY, which
a piped child does not have, and it was never usable in a log file anyway). Every
event is still shown, as it happens.

## Verification

`packages/core/src/scripts/deploy-stream.test.ts`, 23 tests, real child processes
and real signals, no mocks:

- Streaming is proven causally rather than by timing: the child prints one line
  and then blocks until the test writes a file, which the test only does after it
  has seen that line on stdout. If output were buffered until exit, the test
  deadlocks.
- Backgrounded deploy under a group SIGTERM, end to end through three real
  processes (test -> deploy wrapper -> fake cdk): the wrapper keeps streaming,
  reports that it is ignoring the signal, is still alive afterwards, the deploy
  runs to completion, and it exits 0 with the terminal status on stdout.
- A repeated group SIGTERM aborts, exits non-zero, and the cdk child is reaped
  rather than orphaned.
- A control test pins the old shape (blocking `spawnSync`, shared process group,
  no signal handling) and asserts it dies on the first group SIGTERM with the
  in-flight deploy cut short, so the passing tests above are not vacuous.
- The real CDK CLI stream routing is asserted against the installed CLI (see the
  numbers above), skipped if the CLI is not installed. No credentials, no network
  and no mutation: the probe uses a pre-synthesized assembly pinned to the
  all-zeros account, which can never resolve.
- Idle heartbeat, stderr staying on stderr, exit-code propagation, line assembly
  across chunk boundaries and CRLF, and the argv contract (dropping `--ci` or
  `--progress events` fails the suite).

Local runs:

```
npm run build:packages                 -> pass
npm test -w packages/core              -> 622 tests, 622 pass, 0 fail
npm run check:api                      -> All API reports are up-to-date
npm run check:exports-consistency      -> consistent
changeset-guard validate-structure     -> 8 changesets structurally valid
changeset-guard verify-coverage        -> all changed packages covered
changeset-guard block-major            -> no major bumps
changeset-guard verify-umbrella (#274) -> umbrella bumped alongside re-exported siblings
```

The changeset bumps `@aws-blocks/core` and `@aws-blocks/blocks` (the umbrella
re-exports core, so it has to ship with it).

`npm run lint` could not run on this machine (the bundled biome binary needs a
newer glibc), so lint is left to CI.

Backgrounded repro, before and after, with stdout redirected to a log:

```
log bytes 1.2s in (streamed, not buffered until exit): 405
sending group SIGTERM to pgid 5774 (the reap that used to kill the deploy)
alive 600ms after SIGTERM: true
final exit code=0 signal=null
CloudFormation phase ran to completion (cfn-done marker): true
terminal status file: complete
```

with the log itself showing the deploy carrying on through the signal:

```
ProbeStack | 5/20 | CREATE_IN_PROGRESS | AWS::Lambda::Function | ApiHandler
Ignoring SIGTERM: the deploy is still running and CloudFormation is still converging. Send SIGTERM again to abort (the stack update continues server-side either way).
ProbeStack | 6/20 | CREATE_IN_PROGRESS | AWS::Lambda::Function | ApiHandler
...
ProbeStack | CREATE_COMPLETE | AWS::CloudFormation::Stack | ProbeStack

Deployment complete!
```

## Not in this change

`npm run sandbox` has the same output plumbing and would benefit from the same
treatment, but the sandbox is a foreground dev loop with its own supervisor, so
it is left alone here to keep this focused on the reported production deploy bug.

## Follow-up after validating against a real AWS account

I deployed a freshly scaffolded app (create-blocks-app, backend template, wired to
this branch's build through a local registry) to a real account and it exposed a
gap in the first version of the signal policy, now fixed in the second commit.

One `kill -TERM -<pgid>` reaches the deploy CLI **twice**. `npm run deploy` runs
npm -> sh -> tsx -> node: the process group delivers SIGTERM to the node process,
then tsx relays the SIGTERM it received to its own child about 50ms later. The
original "second SIGTERM aborts" rule therefore fired on the duplicate delivery
and abandoned a deploy nobody had asked to stop:

```
api-app-...-prod |  0/15 | UPDATE_IN_PROGRESS | AWS::CloudFormation::Stack | api-app-...-prod User Initiated
⚠️  Ignoring SIGTERM: the deploy is still running ...
🛑 Received SIGTERM while deploying. Stopping the CDK CLI ...
❌ Deployment failed.
```

A standalone experiment confirmed the mechanism and that it is safe to hold on:
a script hosted by tsx saw 2 SIGTERMs from 1 `kill`, and tsx did not escalate to
SIGKILL when the child kept ignoring them (the script ran to completion).

SIGTERMs inside a 2s window are now treated as duplicate deliveries of the same
request: the deploy keeps streaming and the deferral is logged once. A SIGTERM
after that window is still a deliberate repeat and aborts, and Ctrl-C is still
immediate. Same scenario re-run on the real account after the fix:

```
t=30s first CloudFormation event on stdout (1521B) -> sending group SIGTERM
t=33s 3s after SIGTERM: stdout=1822B, deferral logged=true
t=44s npm wrapper: exitCode=0 signalCode=null
deploy reported success on stdout: true
```

with the log showing the deploy carrying straight on through the signal:

```
api-app-...-prod |  0/15 | UPDATE_IN_PROGRESS      | AWS::CloudFormation::Stack | ... User Initiated
⚠️  Ignoring SIGTERM: the deploy is still running and CloudFormation is still converging. ...
api-app-...-prod |  1/15 | UPDATE_COMPLETE         | AWS::Lambda::Function      | Handler
api-app-...-prod |  3/15 | UPDATE_COMPLETE         | AWS::CloudFormation::Stack | api-app-...-prod
✅ Deployment complete!
📡 API URL: https://<id>.execute-api.us-west-2.amazonaws.com/prod/aws-blocks/api
```

The stack finished UPDATE_COMPLETE and the API served the new handler code, so
the update that was signalled mid-flight really did apply.

### Real-account before and after on stdout

First deploy of the app (39 resources), stdout and stderr captured separately:

```
stdout 26353B (119 CloudFormation event lines), stderr 241B, exit 0
t=030s stdout=6659B  cfn_event_lines=30
t=050s stdout=11998B cfn_event_lines=59
t=080s stdout=25195B cfn_event_lines=116     <- streamed during the deploy
```

The same stack with the old flag set versus the new one:

```
cdk deploy --no-ci  ->  stdout=109B   (only the stack ARN)  stderr=686B (progress, status, outputs)
cdk deploy --ci     ->  stdout=554B   (progress, status, outputs)  stderr=241B
```

Teardown: `npm run destroy` exited 0, the stack no longer exists, and no
buckets, functions, APIs, parameters or log groups were left behind.
