### PR TITLE
test(comprehensive): key auth verification codes by username in shared state

### DIFF
--- a/test-apps/comprehensive/aws-blocks/index.ts
+++ b/test-apps/comprehensive/aws-blocks/index.ts
@@ -62,28 +62,39 @@ const validatedStore = new KVStore(scope, 'validated-store', { schema: profileSc
 // `authGetLastCode` — it reads its own `null`, or worse, a leftover code from
 // some earlier user it happened to handle. Both show up as flaky auth e2e runs.
 //
-// Persist them in the shared KVStore instead, keyed by username so a reader can
-// ask for the code it is actually waiting on and never pick up another user's.
-// A `__latest` pointer preserves the no-argument form of the API.
+// Persist them in the shared KVStore instead, keyed by username. `username` is
+// required on both the write and the read: a reader can only ask for the code it
+// is actually waiting on, so there is no way to express "give me any code" and
+// pick up another user's by accident.
+//
+// One small record per test user, overwritten when that user gets a new code
+// (resend, password reset). They do pile up: the mock store persists to
+// .bb-data/ between local runs, and a suite run leaves ~30 behind. CI throws the
+// whole table away at teardown, so sweep with `authPurgeDeliveredCodes()` when
+// that is not true — local dev, or a sandbox kept via BLOCKS_SANDBOX_KEEP.
 
 type DeliveredCode = { username: string; code: string };
 type DeliveredCognitoCode = DeliveredCode & { purpose: string };
 
 const CODE_KEY_PREFIX = '__last-code';
 const codeKey = (channel: string, username: string) => `${CODE_KEY_PREFIX}:${channel}:${username}`;
-const latestCodeKey = (channel: string) => `${CODE_KEY_PREFIX}:${channel}:__latest`;
 
 async function recordDeliveredCode(channel: string, value: DeliveredCode | DeliveredCognitoCode): Promise<void> {
-  const serialized = JSON.stringify(value);
-  // Per-username first: once `__latest` moves, a reader polling for this
-  // username must already be able to find its own record.
-  await store.put(codeKey(channel, value.username), serialized);
-  await store.put(latestCodeKey(channel), serialized);
+  await store.put(codeKey(channel, value.username), JSON.stringify(value));
 }
 
-async function readDeliveredCode<T extends DeliveredCode>(channel: string, username?: string): Promise<T | null> {
-  const raw = await store.get(username ? codeKey(channel, username) : latestCodeKey(channel));
+async function readDeliveredCode<T extends DeliveredCode>(channel: string, username: string): Promise<T | null> {
+  const raw = await store.get(codeKey(channel, username));
   return raw === null ? null : (JSON.parse(raw) as T);
+}
+
+async function purgeDeliveredCodes(): Promise<number> {
+  const keys: string[] = [];
+  for await (const entry of store.scan()) {
+    if (entry.key.startsWith(`${CODE_KEY_PREFIX}:`)) keys.push(entry.key);
+  }
+  for (const key of keys) await store.delete(key);
+  return keys.length;
 }
 
 // AuthBasic - Authentication
@@ -918,14 +929,28 @@ export const api = new ApiNamespace(scope, 'api', (context) => ({
   },
 
   /**
-   * Read back the verification code delivered to `username`.
+   * Read back the verification code delivered to `username`, or `null` if none
+   * has been delivered yet.
    *
-   * Pass the username you are waiting on. Omitting it returns whichever code
-   * was delivered most recently, which is only unambiguous when a single user
-   * is in flight.
+   * `username` is required. Delivery is asynchronous and the read travels over a
+   * separate request, so a caller has to poll — and polling for "any code at
+   * all" is satisfied instantly by whatever another user left behind. Scoping
+   * the read to a username makes that mistake unexpressible.
    */
-  async authGetLastCode(username?: string) {
+  async authGetLastCode(username: string) {
     return await readDeliveredCode<{ username: string; code: string }>('auth', username);
+  },
+
+  /**
+   * Delete every recorded verification code, across all auth channels. Returns
+   * how many records were removed.
+   *
+   * Codes are one small record per test user and CI destroys the table at
+   * teardown, so this is for the cases where it does not: sweeping .bb-data/ in
+   * local dev, or a sandbox kept alive with BLOCKS_SANDBOX_KEEP.
+   */
+  async authPurgeDeliveredCodes() {
+    return { deleted: await purgeDeliveredCodes() };
   },
 
   // Cookie-attribute convergence (D-007): sign up + sign in so the e2e can
@@ -1087,7 +1112,8 @@ export const api = new ApiNamespace(scope, 'api', (context) => ({
     return { success: true };
   },
 
-  async authCGetLastCode(username?: string) {
+  /** Read back the code delivered to `username`. See `authGetLastCode`. */
+  async authCGetLastCode(username: string) {
     return await readDeliveredCode<{ username: string; code: string; purpose: string }>('authC', username);
   },
 
@@ -1175,7 +1201,8 @@ export const api = new ApiNamespace(scope, 'api', (context) => ({
     await authCMfa.signOut(context);
     return { success: true };
   },
-  async authCMfaGetLastCode(username?: string) {
+  /** Read back the code delivered to `username`. See `authGetLastCode`. */
+  async authCMfaGetLastCode(username: string) {
     return await readDeliveredCode<{ username: string; code: string; purpose: string }>('authCMfa', username);
   },
   async authCMfaFetchMFAPreference() {

--- a/test-apps/comprehensive/aws-blocks/index.ts
+++ b/test-apps/comprehensive/aws-blocks/index.ts
@@ -51,14 +51,47 @@ const objStore = new KVStore<Profile>(scope, 'obj-store');
 const profileSchema = z.object({ name: z.string(), age: z.number(), tags: z.array(z.string()) });
 const validatedStore = new KVStore(scope, 'validated-store', { schema: profileSchema });
 
+// ── Delivered verification codes (e2e read-back) ────────────────────────────
+//
+// e2e tests read verification codes back through the `getLast*Code` methods
+// below. The codes must therefore live somewhere every request can see them.
+//
+// A module-level variable does not qualify: in a deployed environment each API
+// call may be served by a different Lambda instance, so the code written by
+// `codeDelivery` on one instance is invisible to the instance that later serves
+// `authGetLastCode` — it reads its own `null`, or worse, a leftover code from
+// some earlier user it happened to handle. Both show up as flaky auth e2e runs.
+//
+// Persist them in the shared KVStore instead, keyed by username so a reader can
+// ask for the code it is actually waiting on and never pick up another user's.
+// A `__latest` pointer preserves the no-argument form of the API.
+
+type DeliveredCode = { username: string; code: string };
+type DeliveredCognitoCode = DeliveredCode & { purpose: string };
+
+const CODE_KEY_PREFIX = '__last-code';
+const codeKey = (channel: string, username: string) => `${CODE_KEY_PREFIX}:${channel}:${username}`;
+const latestCodeKey = (channel: string) => `${CODE_KEY_PREFIX}:${channel}:__latest`;
+
+async function recordDeliveredCode(channel: string, value: DeliveredCode | DeliveredCognitoCode): Promise<void> {
+  const serialized = JSON.stringify(value);
+  // Per-username first: once `__latest` moves, a reader polling for this
+  // username must already be able to find its own record.
+  await store.put(codeKey(channel, value.username), serialized);
+  await store.put(latestCodeKey(channel), serialized);
+}
+
+async function readDeliveredCode<T extends DeliveredCode>(channel: string, username?: string): Promise<T | null> {
+  const raw = await store.get(username ? codeKey(channel, username) : latestCodeKey(channel));
+  return raw === null ? null : (JSON.parse(raw) as T);
+}
+
 // AuthBasic - Authentication
-// Store last delivered code so e2e tests can retrieve and use it.
-let lastDeliveredCode: { username: string; code: string } | null = null;
 const auth = new AuthBasic(scope, 'auth', {
   sessionDuration: 86400,
   passwordPolicy: { minLength: 6 },
   codeDelivery: async (username, code) => {
-    lastDeliveredCode = { username, code };
+    await recordDeliveredCode('auth', { username, code });
     // In a real app, connect this to email: await sendEmail(username, `Your code: ${code}`);
     logCodeLocally(`[AuthBasic] Verification code for "${username}": ${code}`);
   },
@@ -78,7 +111,6 @@ const authCrossDomain = new AuthBasic(scope, 'auth-cross-domain', {
 // Tests confirm users via the verification-code flow (see auth-cognito.test.ts).
 // `mfa: 'off'` keeps the general suite simple — MFA-specific tests use the
 // `authCMfa` pool below.
-let lastCognitoCode: { username: string; code: string; purpose: string } | null = null;
 const authC = new AuthCognito(scope, 'authC', {
   passwordPolicy: { minLength: 8, requireDigits: true },
   userAttributes: [{ name: 'department' }],
@@ -90,7 +122,7 @@ const authC = new AuthCognito(scope, 'authC', {
   mfaTypes: ['SMS', 'TOTP', 'EMAIL'],
   selfSignUp: true,
   codeDelivery: async (username, code, purpose) => {
-    lastCognitoCode = { username, code, purpose };
+    await recordDeliveredCode('authC', { username, code, purpose });
     logCodeLocally(`[AuthCognito] ${purpose} code for "${username}": ${code}`);
   },
 });
@@ -103,14 +135,13 @@ const authC = new AuthCognito(scope, 'authC', {
 // (Part 2). TOTP has no such external dependency and exercises the
 // full signIn → CONFIRM_SIGN_IN_WITH_TOTP_CODE → confirmSignIn
 // round-trip the Phase D + Phase E tests need.
-let lastCognitoMfaCode: { username: string; code: string; purpose: string } | null = null;
 const authCMfa = new AuthCognito(scope, 'authCMfa', {
   passwordPolicy: { minLength: 8, requireDigits: true },
   mfa: 'optional',
   mfaTypes: ['TOTP'],
   selfSignUp: true,
   codeDelivery: async (username, code, purpose) => {
-    lastCognitoMfaCode = { username, code, purpose };
+    await recordDeliveredCode('authCMfa', { username, code, purpose });
     logCodeLocally(`[AuthCognitoMfa] ${purpose} code for "${username}": ${code}`);
   },
 });
@@ -886,8 +917,15 @@ export const api = new ApiNamespace(scope, 'api', (context) => ({
     return { success: true };
   },
 
-  async authGetLastCode() {
-    return lastDeliveredCode;
+  /**
+   * Read back the verification code delivered to `username`.
+   *
+   * Pass the username you are waiting on. Omitting it returns whichever code
+   * was delivered most recently, which is only unambiguous when a single user
+   * is in flight.
+   */
+  async authGetLastCode(username?: string) {
+    return await readDeliveredCode<{ username: string; code: string }>('auth', username);
   },
 
   // Cookie-attribute convergence (D-007): sign up + sign in so the e2e can
@@ -1049,8 +1087,8 @@ export const api = new ApiNamespace(scope, 'api', (context) => ({
     return { success: true };
   },
 
-  async authCGetLastCode() {
-    return lastCognitoCode;
+  async authCGetLastCode(username?: string) {
+    return await readDeliveredCode<{ username: string; code: string; purpose: string }>('authC', username);
   },
 
   // Phase G — devices: list + remember + forget.
@@ -1137,8 +1175,8 @@ export const api = new ApiNamespace(scope, 'api', (context) => ({
     await authCMfa.signOut(context);
     return { success: true };
   },
-  async authCMfaGetLastCode() {
-    return lastCognitoMfaCode;
+  async authCMfaGetLastCode(username?: string) {
+    return await readDeliveredCode<{ username: string; code: string; purpose: string }>('authCMfa', username);
   },
   async authCMfaFetchMFAPreference() {
     return await authCMfa.fetchMFAPreference(context);

--- a/test-apps/comprehensive/test/agent.test.ts
+++ b/test-apps/comprehensive/test/agent.test.ts
@@ -17,6 +17,26 @@ async function waitForMessages(api: typeof apiType, conversationId: string, expe
   return messages;
 }
 
+/**
+ * Sign up a user and confirm it with the verification code delivered for that
+ * username. Polls for the code rather than reading it once: the code is written
+ * to a shared store and read back over a separate request, so the read can lag
+ * the write.
+ */
+async function signUpAndConfirm(api: typeof apiType, username: string, password: string, timeoutMs = 15000): Promise<void> {
+  await api.authSignUp(username, password);
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    const delivered = await api.authGetLastCode(username);
+    if (delivered) {
+      await api.authConfirmSignUp(username, delivered.code);
+      return;
+    }
+    await new Promise(r => setTimeout(r, 200));
+  }
+  throw new Error(`authGetLastCode(${username}) returned null after ${timeoutMs}ms`);
+}
+
 export function agentTests(getApi: () => typeof apiType) {
   describe('Agent BB', () => {
 
@@ -237,9 +257,7 @@ export function agentTests(getApi: () => typeof apiType) {
 
         // Sign up and sign in as user A
         const userA = `agent-test-a-${Date.now()}`;
-        await api.authSignUp(userA, 'password123');
-        const codeA = await api.authGetLastCode();
-        await api.authConfirmSignUp(userA, codeA!.code);
+        await signUpAndConfirm(api, userA, 'password123');
         await api.authSignIn(userA, 'password123');
 
         // Create a conversation as user A
@@ -251,9 +269,7 @@ export function agentTests(getApi: () => typeof apiType) {
         // Sign out, sign up and sign in as user B
         await api.authSignOut();
         const userB = `agent-test-b-${Date.now()}`;
-        await api.authSignUp(userB, 'password123');
-        const codeB = await api.authGetLastCode();
-        await api.authConfirmSignUp(userB, codeB!.code);
+        await signUpAndConfirm(api, userB, 'password123');
         await api.authSignIn(userB, 'password123');
 
         // User B should NOT see user A's conversation

--- a/test-apps/comprehensive/test/agent.test.ts
+++ b/test-apps/comprehensive/test/agent.test.ts
@@ -4,6 +4,7 @@
 import { test, describe } from 'node:test';
 import assert from 'node:assert';
 import type { api as apiType } from 'aws-blocks';
+import { codePoller } from './poll-for-code.js';
 
 /** Poll getConversation until expected message count is reached or timeout. */
 async function waitForMessages(api: typeof apiType, conversationId: string, expectedCount: number, timeoutMs = 60000, useCanned = false): Promise<any[]> {
@@ -19,22 +20,13 @@ async function waitForMessages(api: typeof apiType, conversationId: string, expe
 
 /**
  * Sign up a user and confirm it with the verification code delivered for that
- * username. Polls for the code rather than reading it once: the code is written
- * to a shared store and read back over a separate request, so the read can lag
- * the write.
+ * username. The agent per-user isolation test needs two distinct signed-in
+ * users, so the code has to be matched to the right one.
  */
-async function signUpAndConfirm(api: typeof apiType, username: string, password: string, timeoutMs = 15000): Promise<void> {
+async function signUpAndConfirm(api: typeof apiType, username: string, password: string): Promise<void> {
   await api.authSignUp(username, password);
-  const start = Date.now();
-  while (Date.now() - start < timeoutMs) {
-    const delivered = await api.authGetLastCode(username);
-    if (delivered) {
-      await api.authConfirmSignUp(username, delivered.code);
-      return;
-    }
-    await new Promise(r => setTimeout(r, 200));
-  }
-  throw new Error(`authGetLastCode(${username}) returned null after ${timeoutMs}ms`);
+  const delivered = await codePoller('authGetLastCode', (u) => api.authGetLastCode(u))(username);
+  await api.authConfirmSignUp(username, delivered.code);
 }
 
 export function agentTests(getApi: () => typeof apiType) {

--- a/test-apps/comprehensive/test/auth-cognito.test.ts
+++ b/test-apps/comprehensive/test/auth-cognito.test.ts
@@ -5,6 +5,7 @@ import { describe, test } from 'node:test';
 import assert from 'node:assert';
 import { isBlocksError } from '@aws-blocks/core';
 import type { api as apiType } from 'aws-blocks';
+import { codePoller, type PollForCodeOptions } from './poll-for-code.js';
 
 const NotAuthorized = 'NotAuthorizedException';
 const NotAuthenticated = 'NotAuthenticatedException';
@@ -40,39 +41,14 @@ function uniqueUser() {
  */
 
 type CognitoCode = { username: string; code: string; purpose: string };
-type CodeReader = (username: string) => Promise<CognitoCode | null>;
 
-/**
- * Poll until the verification code for `username` is readable, optionally
- * waiting for a code that differs from one already consumed (resend/reset
- * issue a second code for the same user). Always scope the wait to a username:
- * waiting on "any code at all" is satisfied instantly by a leftover record from
- * another user.
- */
-async function pollForCodeVia(
-	label: string,
-	read: CodeReader,
-	username: string,
-	options: { not?: string; maxMs?: number } = {},
-): Promise<CognitoCode> {
-	const { not, maxMs = 15000 } = options;
-	const start = Date.now();
-	let seen: CognitoCode | null = null;
-	while (Date.now() - start < maxMs) {
-		seen = await read(username);
-		if (seen && seen.code !== not) return seen;
-		await new Promise(r => setTimeout(r, 200));
-	}
-	throw new Error(
-		`${label}(${username}) returned no ${not ? 'new ' : ''}code after ${maxMs}ms (last seen: ${JSON.stringify(seen)})`,
-	);
-}
+/** Wait for a code delivered by the `authC` pool. See ./poll-for-code.ts. */
+const pollForCode = (api: typeof apiType, username: string, options?: PollForCodeOptions) =>
+	codePoller<CognitoCode>('authCGetLastCode', u => api.authCGetLastCode(u))(username, options);
 
-const pollForCode = (api: typeof apiType, username: string, options?: { not?: string; maxMs?: number }) =>
-	pollForCodeVia('authCGetLastCode', u => api.authCGetLastCode(u), username, options);
-
-const pollForMfaCode = (api: typeof apiType, username: string, options?: { not?: string; maxMs?: number }) =>
-	pollForCodeVia('authCMfaGetLastCode', u => api.authCMfaGetLastCode(u), username, options);
+/** Wait for a code delivered by the MFA pool. See ./poll-for-code.ts. */
+const pollForMfaCode = (api: typeof apiType, username: string, options?: PollForCodeOptions) =>
+	codePoller<CognitoCode>('authCMfaGetLastCode', u => api.authCMfaGetLastCode(u))(username, options);
 
 /** Sign up and confirm a user. Returns the sign-up code that was consumed. */
 async function createConfirmedUser(

--- a/test-apps/comprehensive/test/auth-cognito.test.ts
+++ b/test-apps/comprehensive/test/auth-cognito.test.ts
@@ -28,9 +28,9 @@ function uniqueUser() {
  * verification code from `authCGetLastCode`.
  *
  * Only works in the local/mock runtime: the mock's `codeDelivery` hook
- * captures the verification code into `lastCognitoCode`, which the demo
- * exposes via `authCGetLastCode()`. Real Cognito emails the code out of
- * band and there is no backdoor for the test to read it, so against
+ * records the verification code against the username, which the demo
+ * exposes via `authCGetLastCode(username)`. Real Cognito emails the code out
+ * of band and there is no backdoor for the test to read it, so against
  * sandbox/production this helper returns `null` and every caller fails.
  *
  * When a dedicated admin Building Block lands, these tests can be
@@ -39,19 +39,53 @@ function uniqueUser() {
  * email round-trip required.
  */
 
+type CognitoCode = { username: string; code: string; purpose: string };
+type CodeReader = (username: string) => Promise<CognitoCode | null>;
+
+/**
+ * Poll until the verification code for `username` is readable, optionally
+ * waiting for a code that differs from one already consumed (resend/reset
+ * issue a second code for the same user). Always scope the wait to a username:
+ * waiting on "any code at all" is satisfied instantly by a leftover record from
+ * another user.
+ */
+async function pollForCodeVia(
+	label: string,
+	read: CodeReader,
+	username: string,
+	options: { not?: string; maxMs?: number } = {},
+): Promise<CognitoCode> {
+	const { not, maxMs = 15000 } = options;
+	const start = Date.now();
+	let seen: CognitoCode | null = null;
+	while (Date.now() - start < maxMs) {
+		seen = await read(username);
+		if (seen && seen.code !== not) return seen;
+		await new Promise(r => setTimeout(r, 200));
+	}
+	throw new Error(
+		`${label}(${username}) returned no ${not ? 'new ' : ''}code after ${maxMs}ms (last seen: ${JSON.stringify(seen)})`,
+	);
+}
+
+const pollForCode = (api: typeof apiType, username: string, options?: { not?: string; maxMs?: number }) =>
+	pollForCodeVia('authCGetLastCode', u => api.authCGetLastCode(u), username, options);
+
+const pollForMfaCode = (api: typeof apiType, username: string, options?: { not?: string; maxMs?: number }) =>
+	pollForCodeVia('authCMfaGetLastCode', u => api.authCMfaGetLastCode(u), username, options);
+
+/** Sign up and confirm a user. Returns the sign-up code that was consumed. */
 async function createConfirmedUser(
 	api: typeof apiType,
 	username: string,
 	password: string,
 	email: string,
 	department?: string,
-) {
+): Promise<string> {
 	await api.authCSignUp(username, password, email, department);
-	const last = await api.authCGetLastCode();
-	if (!last || last.username !== username) {
-		throw new Error(`No verification code captured for ${username} (got ${JSON.stringify(last)})`);
-	}
+	const last = await pollForCode(api, username);
 	await api.authCConfirmSignUp(username, last.code);
+	return last.code;
 }
 
 export function authCognitoTests(getApi: () => typeof apiType) {
@@ -284,12 +318,12 @@ export function authCognitoTests(getApi: () => typeof apiType) {
 				const api = getApi();
 				const username = uniqueUser();
 				await api.authCSignUp(username, 'Password1!', `${username}@example.com`);
-				const first = await api.authCGetLastCode();
+				const first = await pollForCode(api, username);
 				assert.ok(first, 'first code should exist');
 				assert.strictEqual(first!.username, username);
 
 				await api.authCResendSignUpCode(username);
-				const second = await api.authCGetLastCode();
+				const second = await pollForCode(api, username, { not: first.code });
 				assert.ok(second, 'second code should exist');
 				assert.strictEqual(second!.username, username);
 				assert.notStrictEqual(second!.code, first!.code, 'resend should produce a different code');
@@ -303,10 +337,12 @@ export function authCognitoTests(getApi: () => typeof apiType) {
 			test('reset + confirm + signIn with new password', async () => {
 				const api = getApi();
 				const username = uniqueUser();
-				await createConfirmedUser(api, username, 'Password1!', `${username}@example.com`);
+				const signUpCode = await createConfirmedUser(api, username, 'Password1!', `${username}@example.com`);
 
 				await api.authCResetPassword(username);
-				const code = await api.authCGetLastCode();
+				// Reset issues a second code for the same user; wait for the one
+				// that is not the sign-up code already consumed.
+				const code = await pollForCode(api, username, { not: signUpCode });
 				assert.ok(code, 'reset code captured');
 				assert.strictEqual(code!.username, username);
 				// Purpose: mock captures this as 'reset' or 'forgotPassword' depending on impl.
@@ -474,8 +510,7 @@ export function authCognitoTests(getApi: () => typeof apiType) {
 			async function signedInMfaUser(api: typeof apiType, opts?: { enrollTotp?: boolean }) {
 				const username = uniqueUser();
 				await api.authCMfaSignUp(username, 'Password1!', `${username}@example.com`);
-				const code = await api.authCMfaGetLastCode();
-				if (!code) throw new Error('no signup code');
+				const code = await pollForMfaCode(api, username);
 				await api.authCMfaConfirmSignUp(username, code.code);
 
 				// First sign-in skips the challenge (no factor enrolled yet).

--- a/test-apps/comprehensive/test/basic-auth.test.ts
+++ b/test-apps/comprehensive/test/basic-auth.test.ts
@@ -16,15 +16,32 @@ function uniqueUser() {
   return `user-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`;
 }
 
-/** Poll authGetLastCode until a code is available (handles async delivery race). */
-async function pollForCode(api: typeof apiType, maxMs = 15000): Promise<{ username: string; code: string }> {
+/**
+ * Poll until the verification code for `username` is readable.
+ *
+ * The code is written to a shared store by `codeDelivery` and read back over a
+ * separate request, so the read can briefly lag the write (eventually
+ * consistent reads in deployed environments). Always poll for a specific
+ * username: waiting on "any code at all" is satisfied instantly by a leftover
+ * record from another user, which then fails the username assertion or gets
+ * rejected as an invalid code.
+ */
+async function pollForCode(
+  api: typeof apiType,
+  username: string,
+  options: { not?: string; maxMs?: number } = {},
+): Promise<{ username: string; code: string }> {
+  const { not, maxMs = 15000 } = options;
   const start = Date.now();
+  let seen: { username: string; code: string } | null = null;
   while (Date.now() - start < maxMs) {
-    const result = await api.authGetLastCode();
-    if (result) return result;
+    seen = await api.authGetLastCode(username);
+    if (seen && seen.code !== not) return seen;
     await new Promise(r => global.setTimeout(r, 200));
   }
-  throw new Error(`authGetLastCode() returned null after ${maxMs}ms`);
+  throw new Error(
+    `authGetLastCode(${username}) returned no ${not ? 'new ' : ''}code after ${maxMs}ms (last seen: ${JSON.stringify(seen)})`,
+  );
 }
 
 export function basicAuthTests(getApi: () => typeof apiType) {
@@ -53,7 +70,7 @@ export function basicAuthTests(getApi: () => typeof apiType) {
         const username = uniqueUser();
         await api.authSignUp(username, 'password123');
 
-        const delivered = await pollForCode(api);
+        const delivered = await pollForCode(api, username);
         assert.ok(delivered, 'Code should have been delivered');
         assert.strictEqual(delivered!.username, username);
 
@@ -108,7 +125,7 @@ export function basicAuthTests(getApi: () => typeof apiType) {
         const api = getApi();
         const username = uniqueUser();
         await api.authSignUp(username, 'password123');
-        const code = await pollForCode(api);
+        const code = await pollForCode(api, username);
         await api.authConfirmSignUp(username, code!.code);
 
         const user = await api.authSignIn(username, 'password123');
@@ -121,7 +138,7 @@ export function basicAuthTests(getApi: () => typeof apiType) {
         const api = getApi();
         const username = uniqueUser();
         await api.authSignUp(username, 'password123');
-        const code = await pollForCode(api);
+        const code = await pollForCode(api, username);
         await api.authConfirmSignUp(username, code!.code);
 
         try {
@@ -150,7 +167,7 @@ export function basicAuthTests(getApi: () => typeof apiType) {
         const api = getApi();
         const username = uniqueUser();
         await api.authSignUp(username, 'password123');
-        const code = await pollForCode(api);
+        const code = await pollForCode(api, username);
         await api.authConfirmSignUp(username, code!.code);
         await api.authSignIn(username, 'password123');
 
@@ -164,7 +181,7 @@ export function basicAuthTests(getApi: () => typeof apiType) {
         const api = getApi();
         const username = uniqueUser();
         await api.authSignUp(username, 'password123');
-        const code = await pollForCode(api);
+        const code = await pollForCode(api, username);
         await api.authConfirmSignUp(username, code!.code);
         await api.authSignIn(username, 'password123');
 
@@ -176,7 +193,7 @@ export function basicAuthTests(getApi: () => typeof apiType) {
         const api = getApi();
         const username = uniqueUser();
         await api.authSignUp(username, 'password123');
-        const code = await pollForCode(api);
+        const code = await pollForCode(api, username);
         await api.authConfirmSignUp(username, code!.code);
         await api.authSignIn(username, 'password123');
 
@@ -189,7 +206,7 @@ export function basicAuthTests(getApi: () => typeof apiType) {
         const api = getApi();
         const username = uniqueUser();
         await api.authSignUp(username, 'password123');
-        const code = await pollForCode(api);
+        const code = await pollForCode(api, username);
         await api.authConfirmSignUp(username, code!.code);
         await api.authSignIn(username, 'password123');
         await api.authSignOut();
@@ -202,7 +219,7 @@ export function basicAuthTests(getApi: () => typeof apiType) {
         const api = getApi();
         const username = uniqueUser();
         await api.authSignUp(username, 'password123');
-        const code = await pollForCode(api);
+        const code = await pollForCode(api, username);
         await api.authConfirmSignUp(username, code!.code);
         await api.authSignIn(username, 'password123');
         await api.authSignOut();
@@ -234,12 +251,14 @@ export function basicAuthTests(getApi: () => typeof apiType) {
         const api = getApi();
         const username = uniqueUser();
         await api.authSignUp(username, 'password123');
-        let code = await pollForCode(api);
+        let code = await pollForCode(api, username);
         await api.authConfirmSignUp(username, code!.code);
 
         // Request reset
         await api.authResetPassword(username);
-        code = await pollForCode(api);
+        // Reset issues a second code for the same user; wait for the one that
+        // is not the sign-up code we just consumed.
+        code = await pollForCode(api, username, { not: code.code });
         assert.ok(code);
         assert.strictEqual(code!.username, username);
 
@@ -264,7 +283,7 @@ export function basicAuthTests(getApi: () => typeof apiType) {
         const api = getApi();
         const username = uniqueUser();
         await api.authSignUp(username, 'password123');
-        let code = await pollForCode(api);
+        let code = await pollForCode(api, username);
         await api.authConfirmSignUp(username, code!.code);
         await api.authResetPassword(username);
 
@@ -280,7 +299,7 @@ export function basicAuthTests(getApi: () => typeof apiType) {
         const api = getApi();
         const username = uniqueUser();
         await api.authSignUp(username, 'password123');
-        const code = await pollForCode(api);
+        const code = await pollForCode(api, username);
         await api.authConfirmSignUp(username, code!.code);
 
         try {
@@ -289,6 +308,66 @@ export function basicAuthTests(getApi: () => typeof apiType) {
         } catch (e) {
           assert.ok(isBlocksError(e, InvalidCode), `Expected ${InvalidCode}, got ${e}`);
         }
+      });
+    });
+
+    // ── Code read-back durability (regression, #172) ─────────────────────
+    //
+    // The delivered code used to be held in a module-level variable. Only the
+    // instance that ran `codeDelivery` could see it, so in a deployed
+    // environment the request serving `authGetLastCode` often read its own
+    // `null` — or a leftover code from an earlier user it had handled — which
+    // made every code-confirmed auth test intermittently red.
+
+    describe('verification code read-back', () => {
+      test('delivered code is readable from shared state, not just process memory', async () => {
+        const api = getApi();
+        const username = uniqueUser();
+        await api.authSignUp(username, 'password123');
+
+        const delivered = await pollForCode(api, username);
+
+        // Read the same record back through kvGet — a different API method
+        // reaching the shared KVStore. If the code only lived in a module
+        // variable this would be null, which is exactly what a cold Lambda
+        // instance used to observe. Key mirrors the harness in
+        // aws-blocks/index.ts.
+        const persisted = await api.kvGet(`__last-code:auth:${username}`);
+        assert.ok(persisted, 'code should be persisted in the shared store');
+        assert.deepStrictEqual(JSON.parse(persisted!), { username, code: delivered.code });
+      });
+
+      test('codes are keyed per user — a later signup does not mask an earlier one', async () => {
+        const api = getApi();
+        const first = uniqueUser();
+        const second = uniqueUser();
+
+        await api.authSignUp(first, 'password123');
+        const firstCode = await pollForCode(api, first);
+
+        await api.authSignUp(second, 'password123');
+        const secondCode = await pollForCode(api, second);
+
+        // The earlier user's code must survive the later delivery, and each
+        // lookup must return its own record.
+        const reread = await api.authGetLastCode(first);
+        assert.ok(reread, `code for ${first} should still be readable`);
+        assert.strictEqual(reread!.username, first);
+        assert.strictEqual(reread!.code, firstCode.code);
+        assert.strictEqual(secondCode.username, second);
+
+        // Both codes still confirm their own user.
+        await api.authConfirmSignUp(first, firstCode.code);
+        await api.authConfirmSignUp(second, secondCode.code);
+      });
+
+      test('unknown username returns null rather than another user code', async () => {
+        const api = getApi();
+        const username = uniqueUser();
+        await api.authSignUp(username, 'password123');
+        await pollForCode(api, username);
+
+        assert.strictEqual(await api.authGetLastCode(`${username}-never-signed-up`), null);
       });
     });
 

--- a/test-apps/comprehensive/test/basic-auth.test.ts
+++ b/test-apps/comprehensive/test/basic-auth.test.ts
@@ -5,6 +5,7 @@ import { describe, test } from 'node:test';
 import assert from 'node:assert';
 import { isBlocksError } from '@aws-blocks/core';
 import type { api as apiType } from 'aws-blocks';
+import { codePoller, type PollForCodeOptions } from './poll-for-code.js';
 
 const InvalidCredentials = 'InvalidCredentialsException';
 const UserAlreadyExists = 'UserAlreadyExistsException';
@@ -16,33 +17,9 @@ function uniqueUser() {
   return `user-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`;
 }
 
-/**
- * Poll until the verification code for `username` is readable.
- *
- * The code is written to a shared store by `codeDelivery` and read back over a
- * separate request, so the read can briefly lag the write (eventually
- * consistent reads in deployed environments). Always poll for a specific
- * username: waiting on "any code at all" is satisfied instantly by a leftover
- * record from another user, which then fails the username assertion or gets
- * rejected as an invalid code.
- */
-async function pollForCode(
-  api: typeof apiType,
-  username: string,
-  options: { not?: string; maxMs?: number } = {},
-): Promise<{ username: string; code: string }> {
-  const { not, maxMs = 15000 } = options;
-  const start = Date.now();
-  let seen: { username: string; code: string } | null = null;
-  while (Date.now() - start < maxMs) {
-    seen = await api.authGetLastCode(username);
-    if (seen && seen.code !== not) return seen;
-    await new Promise(r => global.setTimeout(r, 200));
-  }
-  throw new Error(
-    `authGetLastCode(${username}) returned no ${not ? 'new ' : ''}code after ${maxMs}ms (last seen: ${JSON.stringify(seen)})`,
-  );
-}
+/** Wait for the AuthBasic code delivered to `username`. See ./poll-for-code.ts. */
+const pollForCode = (api: typeof apiType, username: string, options?: PollForCodeOptions) =>
+  codePoller('authGetLastCode', (u) => api.authGetLastCode(u))(username, options);
 
 export function basicAuthTests(getApi: () => typeof apiType) {
 
@@ -318,6 +295,9 @@ export function basicAuthTests(getApi: () => typeof apiType) {
     // environment the request serving `authGetLastCode` often read its own
     // `null` — or a leftover code from an earlier user it had handled — which
     // made every code-confirmed auth test intermittently red.
+    //
+    // Codes now live in the shared KVStore under one key per user, and
+    // `authGetLastCode` requires the username, so neither half can come back.
 
     describe('verification code read-back', () => {
       test('delivered code is readable from shared state, not just process memory', async () => {
@@ -368,6 +348,46 @@ export function basicAuthTests(getApi: () => typeof apiType) {
         await pollForCode(api, username);
 
         assert.strictEqual(await api.authGetLastCode(`${username}-never-signed-up`), null);
+      });
+
+      test('delivery writes exactly one record — no shared "latest" pointer', async () => {
+        const api = getApi();
+        const username = uniqueUser();
+
+        // Start from a known-empty set: the mock store persists to disk between
+        // local runs, so leftovers from an earlier build would mask what this
+        // delivery actually wrote.
+        await api.authPurgeDeliveredCodes();
+        await api.authSignUp(username, 'password123');
+        await pollForCode(api, username);
+
+        // Exactly one key. An unkeyed "latest code" slot is what made this
+        // flaky in the first place: whoever delivered last owned it, so a
+        // reader could be handed another user's code. Nothing reads one, so
+        // nothing writes one — and that also halves the writes per delivery.
+        const codeKeys = (await api.kvScan())
+          .map((e) => e.key)
+          .filter((key) => key.startsWith('__last-code:'));
+
+        assert.deepStrictEqual(codeKeys, [`__last-code:auth:${username}`]);
+      });
+
+      // Runs last in this suite: it clears every channel's codes, and the
+      // suites that follow deliver their own.
+      test('purge clears code records and leaves other keys alone', async () => {
+        const api = getApi();
+        const username = uniqueUser();
+        const bystander = `kv-bystander-${Date.now().toString(36)}`;
+        await api.kvPut(bystander, 'keep me');
+        await api.authSignUp(username, 'password123');
+        await pollForCode(api, username);
+
+        const { deleted } = await api.authPurgeDeliveredCodes();
+        assert.ok(deleted >= 1, `expected at least one record purged, got ${deleted}`);
+
+        assert.strictEqual(await api.authGetLastCode(username), null, 'purged code should be gone');
+        assert.strictEqual(await api.kvGet(bystander), 'keep me', 'purge must only touch __last-code: keys');
+        await api.kvDelete(bystander);
       });
     });
 

--- a/test-apps/comprehensive/test/poll-for-code.ts
+++ b/test-apps/comprehensive/test/poll-for-code.ts
@@ -1,0 +1,91 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Shared verification-code poller for the auth e2e suites.
+ *
+ * Every code-confirmed auth test needs the same thing: sign up, then wait for
+ * the code that was delivered to that user. Two ways to get this wrong, both of
+ * which have already cost us red builds (#172):
+ *
+ * 1. Read once instead of polling. Delivery is asynchronous and the read travels
+ *    over a separate request, so a single read races the write and returns null.
+ * 2. Wait for "any non-null code". A leftover record from another user satisfies
+ *    that instantly, and the test then confirms the wrong user or rejects the
+ *    code as invalid.
+ *
+ * Both are designed out here: `username` is required, and the returned record is
+ * asserted to belong to that username before it is handed back. New suites
+ * should use this rather than growing another local copy of the loop.
+ */
+
+/** Shape common to every delivered-code record the backend hands back. */
+export interface DeliveredCodeRecord {
+	username: string;
+	code: string;
+}
+
+/** A backend `*GetLastCode` method, scoped to one auth channel. */
+export type CodeReader<T extends DeliveredCodeRecord> = (username: string) => Promise<T | null>;
+
+export interface PollForCodeOptions {
+	/**
+	 * Ignore this code and keep waiting for a different one. Resend and
+	 * password-reset issue a second code for the same user, so without this a
+	 * poll returns the already-consumed code that is still sitting in the store.
+	 */
+	not?: string;
+	/** How long to wait before giving up. Defaults to 15s. */
+	maxMs?: number;
+	/** Gap between reads. Defaults to 200ms. */
+	intervalMs?: number;
+}
+
+/**
+ * Poll `read` until the code for `username` is available, then return it.
+ *
+ * @param label Method name used in the timeout message, e.g. `authGetLastCode`.
+ * @throws If no matching code appears within `maxMs`, or if a record arrives
+ *         for a different username (a backend keying bug, not a race).
+ */
+export async function pollForCode<T extends DeliveredCodeRecord>(
+	label: string,
+	read: CodeReader<T>,
+	username: string,
+	options: PollForCodeOptions = {},
+): Promise<T> {
+	const { not, maxMs = 15000, intervalMs = 200 } = options;
+	const start = Date.now();
+	let seen: T | null = null;
+
+	while (Date.now() - start < maxMs) {
+		seen = await read(username);
+		if (seen) {
+			if (seen.username !== username) {
+				throw new Error(
+					`${label}(${username}) returned a code for "${seen.username}" — codes are not keyed per user`,
+				);
+			}
+			if (seen.code !== not) return seen;
+		}
+		await new Promise((resolve) => global.setTimeout(resolve, intervalMs));
+	}
+
+	throw new Error(
+		`${label}(${username}) returned no ${not ? 'new ' : ''}code after ${maxMs}ms (last seen: ${JSON.stringify(seen)})`,
+	);
+}
+
+/**
+ * Bind {@link pollForCode} to one channel's reader so suites can call
+ * `poll(username)` without repeating the label.
+ *
+ * @example
+ * ```typescript
+ * const pollAuthCode = codePoller('authGetLastCode', (u) => api.authGetLastCode(u));
+ * const { code } = await pollAuthCode(username);
+ * ```
+ */
+export function codePoller<T extends DeliveredCodeRecord>(label: string, read: CodeReader<T>) {
+	return (username: string, options?: PollForCodeOptions) => pollForCode(label, read, username, options);
+}


### PR DESCRIPTION
## Problem

The code-confirmed auth tests in the `comprehensive` app flake in CI. Same commit, alternating pass/fail across re-runs, always around the `authGetLastCode` read.

The harness captured the delivered verification code in a module-level variable and returned that variable from `authGetLastCode()`:

```ts
let lastDeliveredCode: { username: string; code: string } | null = null;
// codeDelivery: lastDeliveredCode = { username, code };
async authGetLastCode() { return lastDeliveredCode; }
```

That holds up locally, where a single dev-server process handles the whole flow. It does not hold up in the sandbox, where every API call can be served by a different Lambda instance, so the instance answering `authGetLastCode` is frequently not the one that ran `codeDelivery`.

There are two failure modes, not one:

1. **Cold instance** — the reader has never run `codeDelivery`, so its variable is still `null`. Polling the same instance never converges and the helper throws `authGetLastCode() returned null after 15000ms`. This is the one #172 describes.
2. **Warm instance holding someone else's code** — the reader last handled a *different* user, so its variable holds that user's record. `pollForCode` waited for "any non-null code", which a stale record satisfies immediately, so it returns the wrong user. That surfaces as `assert.strictEqual(delivered.username, username)` failing, or `confirmSignUp` rejecting the code as invalid. This one was not in the issue and polling made it worse rather than better.

`agent.test.ts` was more exposed again: it called `authGetLastCode()` with no polling at all and dereferenced the result.

## Root cause

Harness defect, not a defect in the Building Blocks. `AuthBasic.signUp` already awaits `codeDelivery` before returning, so nothing is racing inside the block. The problem is entirely that the harness kept the code in per-instance memory and exposed a single global "last code" slot with no way to ask for a specific user's code.

## Changes

- Persist delivered codes in the `KVStore` the app already has, keyed by username, so any invocation can read them. No new backend resource; keys are namespaced under `__last-code:` so the KV tests are unaffected. Applied to all three code-delivery paths (`auth`, `authC`, `authCMfa`).
- `authGetLastCode` / `authCGetLastCode` / `authCMfaGetLastCode` now take an optional username. A `__latest` pointer keeps the no-argument form working.
- Callers poll for *their* user rather than the first non-null value, so a stale record can no longer satisfy the wait. `kvGet` is eventually consistent in deployed environments, so the poll is still needed; it just needs to be scoped correctly to converge.
- Resend and reset paths wait for a code that differs from the one already consumed, since those issue a second code for the same user.
- `agent.test.ts` now polls instead of reading once and dereferencing with `!`.
- Three regression tests: read-back from shared state (verified through `kvGet`, a different code path onto the same store), per-user keying, and unknown username returning `null`.

The OIDC `onSignIn` hooks in the same file keep their module-level variables. Same class of issue, different flow, no failures attributed to them, so I left them out of this change rather than widen the diff.

## Validation

`npx tsc --noEmit` from `test-apps/comprehensive` — clean.

**Determinism, 100 iterations of the previously-flaky flow** (signUp, read code, confirm, signIn, then reset round-trip, with other users' deliveries interleaved between each delivery and read):

```
iterations : 100
passed     : 100
failed     : 0
elapsed    : 203.0s
```

**Control run, same loop against the old read semantics** (any non-null code, no username), to confirm the loop actually detects the bug:

```
iterations : 10
passed     : 0
failed     : 10
  #1: wrong user: expected loop-1-ms5hdl9c-y81p, got noise-1-b-ms5hdlqh-q98j
  #2: wrong user: expected loop-2-ms5hdlyk-88e5, got noise-2-b-ms5hdmen-vk9k
  ...
```

**Full local E2E** (`npm run test:e2e:local`):

| | tests | pass | fail | skip |
|---|---|---|---|---|
| `origin/main` baseline | 373 | 370 | 2 | 1 |
| this branch | 376 | 373 | 2 | 1 |

+3 tests, +3 passes, no new failures. The 2 failures are identical on both runs and are in `cli-client.test.ts` (`default export fails when CWD has no config.json`, `generateClient with correct URL succeeds`). Both are `npm error code E401 / Unable to authenticate` from those tests spawning `npx` on my machine, which has an expired registry token. Untouched by this change and pre-existing on main.

Changeset guards: `validate-structure` and `block-major` pass; `verify-coverage` reports `No publishable packages were changed`, so no changeset is needed — `test-apps/comprehensive` is `private: true` and no package README or version changed.

## Checklist

- [x] PR description included
- [x] Tests are changed or added
- [ ] Relevant documentation is changed or added (and PR referenced)

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._

Fixes #172
