### PR TITLE
feat(bb-async-job): opt-in job status tracking with transition history

### DIFF
--- a/.changeset/lucky-pears-observe.md
+++ b/.changeset/lucky-pears-observe.md
@@ -1,0 +1,15 @@
+---
+"@aws-blocks/bb-async-job": minor
+"@aws-blocks/blocks": patch
+---
+
+Add opt-in job status tracking to AsyncJob
+
+Pass `trackStatus: true` and AsyncJob records each job's lifecycle, which you can read with two new methods:
+
+- `getStatus(jobId)` returns the job's current state plus every state it has passed through.
+- `waitUntilComplete(jobId, options?)` waits until the job reaches `complete` or `failed`, with `timeoutMs`, `pollIntervalMs`, and `AbortSignal` support.
+
+Transitions are appended rather than overwritten, so intermediate states stay observable no matter when you read them. A handler that finishes in a millisecond still records that it went through `processing`, and a caller that checks once after the job settled sees the whole sequence. That removes the need to pad a handler with an artificial delay just to make the `processing` state catchable, and a retry appends another `processing` entry so attempt counts are visible too.
+
+Enabling the flag provisions one DynamoDB table for the job's status records, with a 24 hour TTL, and adds a write on submit plus one per state change. Leave it off and nothing is provisioned; `submit()` stays a single SQS call and the status methods throw `StatusNotTracked`.

--- a/.changeset/lucky-pears-observe.md
+++ b/.changeset/lucky-pears-observe.md
@@ -12,4 +12,8 @@ Pass `trackStatus: true` and AsyncJob records each job's lifecycle, which you ca
 
 Transitions are appended rather than overwritten, so intermediate states stay observable no matter when you read them. A handler that finishes in a millisecond still records that it went through `processing`, and a caller that checks once after the job settled sees the whole sequence. That removes the need to pad a handler with an artificial delay just to make the `processing` state catchable, and a retry appends another `processing` entry so attempt counts are visible too.
 
+Appends are guarded by a compare-and-swap, so the two ways two writers can hold the same record at once cannot drop a transition: a `queued` write arriving after SQS already delivered the message, and a duplicate delivery of the same message on an at-least-once queue.
+
 Enabling the flag provisions one DynamoDB table for the job's status records, with a 24 hour TTL, and adds a write on submit plus one per state change. Leave it off and nothing is provisioned; `submit()` stays a single SQS call and the status methods throw `StatusNotTracked`.
+
+Status writes on the handler path are logged rather than thrown, so bookkeeping can never retry work that succeeded or mask work that failed. The trade is that a dropped terminal write leaves a finished job without a terminal state, so read `waitUntilComplete()`'s `Timeout` as "status unknown" rather than "still running".

--- a/.changeset/lucky-pears-observe.md
+++ b/.changeset/lucky-pears-observe.md
@@ -1,5 +1,5 @@
 ---
-"@aws-blocks/bb-async-job": minor
+"@aws-blocks/bb-async-job": patch
 "@aws-blocks/blocks": patch
 ---
 

--- a/.changeset/lucky-pears-observe.md
+++ b/.changeset/lucky-pears-observe.md
@@ -14,6 +14,8 @@ Transitions are appended rather than overwritten, so intermediate states stay ob
 
 Appends are guarded by a compare-and-swap, so the two ways two writers can hold the same record at once cannot drop a transition: a `queued` write arriving after SQS already delivered the message, and a duplicate delivery of the same message on an at-least-once queue.
 
+When the handler gets there first it creates the record itself, dating the submission from the moment it first saw the job, since that is all it knows. The `queued` write that arrives afterwards replaces that placeholder with the real submission time instead of dropping it, so `submittedAt` and the first transition always report when the job was submitted rather than when it started being processed.
+
 Enabling the flag provisions one DynamoDB table for the job's status records, with a 24 hour TTL, and adds a write on submit plus one per state change. Leave it off and nothing is provisioned; `submit()` stays a single SQS call and the status methods throw `StatusNotTracked`.
 
 Status writes on the handler path are logged rather than thrown, so bookkeeping can never retry work that succeeded or mask work that failed. The trade is that a dropped terminal write leaves a finished job without a terminal state, so read `waitUntilComplete()`'s `Timeout` as "status unknown" rather than "still running".

--- a/packages/bb-async-job/API.md
+++ b/packages/bb-async-job/API.md
@@ -12,6 +12,7 @@ import type { StandardSchemaV1 } from '@standard-schema/spec';
 // @public (undocumented)
 export class AsyncJob<T = unknown> extends Scope {
     constructor(scope: ScopeParent, id: string, options: AsyncJobOptions<T>);
+    getStatus(jobId: string): Promise<AsyncJobStatus | null>;
     // @internal
     protected log: ChildLogger;
     // (undocumented)
@@ -20,6 +21,7 @@ export class AsyncJob<T = unknown> extends Scope {
     }>;
     // (undocumented)
     submitBatch(payloads: T[], options?: SubmitOptions): Promise<BatchSubmitResult>;
+    waitUntilComplete(jobId: string, options?: WaitUntilCompleteOptions): Promise<AsyncJobStatus>;
 }
 
 // @public
@@ -36,6 +38,8 @@ export const AsyncJobErrors: {
     readonly BatchTooLarge: "BatchTooLargeException";
     readonly ValidationFailed: "ValidationFailedException";
     readonly BatchSubmitFailed: "BatchSubmitFailedException";
+    readonly Timeout: "AsyncJobTimeoutException";
+    readonly StatusNotTracked: "StatusNotTrackedException";
 };
 
 // @public
@@ -45,6 +49,28 @@ export interface AsyncJobOptions<T> {
     logger?: ChildLogger;
     maxRetries?: number;
     schema?: StandardSchemaV1<T>;
+    trackStatus?: boolean;
+}
+
+// @public
+export type AsyncJobState = 'queued' | 'processing' | 'complete' | 'failed';
+
+// @public
+export interface AsyncJobStatus {
+    attempts: number;
+    error?: string;
+    jobId: string;
+    state: AsyncJobState;
+    submittedAt: string;
+    transitions: AsyncJobTransition[];
+    updatedAt: string;
+}
+
+// @public
+export interface AsyncJobTransition {
+    at: string;
+    attempt: number;
+    state: AsyncJobState;
 }
 
 // @public
@@ -60,6 +86,13 @@ export interface BatchSubmitResult {
 // @public
 export interface SubmitOptions {
     delaySeconds?: number;
+}
+
+// @public
+export interface WaitUntilCompleteOptions {
+    pollIntervalMs?: number;
+    signal?: AbortSignal;
+    timeoutMs?: number;
 }
 
 // (No @packageDocumentation comment for this package)

--- a/packages/bb-async-job/DESIGN.md
+++ b/packages/bb-async-job/DESIGN.md
@@ -22,6 +22,11 @@ Application code
                    └── routes record by queue name → registered handler
                         └── handler(payload, context)
 
+Status (only when trackStatus: true)
+    └── nested DistributedTable (partition key jobId, TTL expiresAt)
+         └── queued on submit, processing per delivery, complete/failed on settle
+              └── getStatus(jobId) / waitUntilComplete(jobId)
+
 Retry / failure
     └── SQS redrive: maxReceiveCount = maxRetries → dead-letter queue (DLQ)
 
@@ -65,9 +70,23 @@ Local Mock
 
 ### D-AJ-6: Browser stub is a no-op
 
-**Decision:** The `index.browser.ts` entry point exports an `AsyncJob` whose constructor does nothing and a reduced `AsyncJobErrors` map.
+**Decision:** The `index.browser.ts` entry point exports an `AsyncJob` whose constructor does nothing, re-exports the shared `AsyncJobErrors` map, and re-exports the package's types.
 
-**Rationale:** AsyncJob enqueues to SQS (AWS runtime) or runs an in-process queue (mock, Node). Neither is available in the browser. A no-op stub keeps the package importable in isomorphic bundles without pulling in the AWS SDK; job submission only happens server-side (server actions, API routes, Lambda handlers).
+**Rationale:** AsyncJob enqueues to SQS (AWS runtime) or runs an in-process queue (mock, Node). Neither is available in the browser. A no-op stub keeps the package importable in isomorphic bundles without pulling in the AWS SDK; job submission only happens server-side (server actions, API routes, Lambda handlers). Types and error constants are erased or inert, so re-exporting them costs nothing at runtime and lets isomorphic code type against `AsyncJobStatus` without importing the server entry point.
+
+### D-AJ-7: Job status is an append-only transition history, opt-in per job
+
+**Decision:** `trackStatus: true` provisions a nested `DistributedTable` (partition key `jobId`, TTL attribute `expiresAt`, 24-hour retention) and records a job's lifecycle into it: `queued` on submit, `processing` at the start of every delivery, and `complete` or `failed` once it settles. Transitions are **appended** to a `transitions` array rather than overwriting a single state field. Two runtime methods read it: `getStatus(jobId)` and `waitUntilComplete(jobId, options?)`. Without the flag nothing is provisioned and both methods throw `StatusNotTrackedException`.
+
+**Rationale:** The state a caller most wants to see is `processing`, and it is the one hardest to catch — a handler that finishes in a millisecond passes through it faster than any client can poll. Storing the current state alone therefore makes observation a race, which callers were previously forced to win by padding their handler with an artificial delay. An append-only history removes the race outright: a reader that polls once, after the job settled, still sees that it passed through `processing`, so no timing assumption is needed anywhere. A retry appends another `processing` entry instead of a second terminal state, which also makes attempt counts legible.
+
+Read-modify-write on the array is safe because SQS keeps a message invisible while its handler runs, so only one attempt writes a given job's record at a time.
+
+Tracking is opt-in because it is not free: it adds a DynamoDB table per job plus a write on submit and one per transition, and `submitBatch` would turn a single native SQS batch into an extra batch write. AsyncJob's default remains a single SQS call, and existing deployments gain no resources until they ask for them. `DistributedTable` rather than `KVStore` because only the former supports TTL, so status records expire on their own instead of accumulating.
+
+**Failure handling:** the `queued` write propagates to the caller — `submit()` asked for tracking, so failing loudly before the job is observable is correct. Writes on the handler path are swallowed and logged instead: throwing before the handler would retry work that was fine, and throwing after it succeeded would re-run work that had already completed. Status bookkeeping must never decide a job's fate.
+
+**Not chosen:** publishing transitions over `bb-realtime`. Push delivery does not solve the underlying problem — a subscriber that connects after the fact still misses the event — and it would add a WebSocket dependency to every AsyncJob. Recorded history is both smaller and strictly more useful, since it works for late readers, retries, and tests alike.
 
 ## Infrastructure (CDK)
 
@@ -76,6 +95,7 @@ Creates the following resources per AsyncJob instance:
 1. **SQS Dead-Letter Queue** — name `{fullId}-dlq` (truncated to 80 chars), 14-day retention, `SQS_MANAGED` encryption, `enforceSSL`.
 2. **SQS Main Queue** — name `{fullId}` (truncated to 80 chars), visibility timeout 900 s, redrive to the DLQ with `maxReceiveCount = maxRetries`, `SQS_MANAGED` encryption, `enforceSSL`.
 3. **Event Source Mapping** — `SqsEventSource(queue, { batchSize })` wired to the shared handler.
+4. **Status table** (only when `trackStatus: true`) — a nested `DistributedTable` at child id `status`, partition key `jobId`, TTL attribute `expiresAt`. Provisioned with the same child id and options as the runtime entry points so the table the runtime resolves is the one CDK created.
 
 **IAM grants to handler:** `grantSendMessages` on the main queue (so handlers can enqueue further work).
 **Environment variables injected:** `BLOCKS_QUEUE_URL_{FULLID}` (uppercased `fullId`, non-alphanumerics replaced with `_`) → the main queue URL, registered via `registerConfig`.
@@ -89,6 +109,7 @@ No `fromExisting()` — wrapping a pre-existing SQS queue is not supported. Asyn
 - `submitBatch()` sends a `SendMessageBatchCommand` (max 10 entries). Successful entries map back to `jobIds` by index; failed entries populate `failed`. If any entry fails, it throws `BatchSubmitFailedException` carrying `failed` and `jobIds` for partial-result handling.
 - Each delivered record is parsed into `{ payload, context }` where `context = { jobId: messageId, receiveCount: ApproximateReceiveCount, sentAt: SentTimestamp }`.
 - SQS redrive handles retries; after `maxReceiveCount` deliveries the message lands in the DLQ.
+- When `trackStatus` is enabled, `submit()` records `queued` after the send (the job id *is* the SQS message id, so it is not known before), `submitBatch()` records the whole batch with one `putBatch`, and `_processRecord` records `processing` before the handler and `complete` after it. A handler error only records `failed` once `receiveCount` has reached `maxRetries` — SQS owns the retry decision, so earlier failures record nothing and the next delivery simply appends another `processing` entry.
 
 ## Mock Implementation
 
@@ -97,6 +118,7 @@ No `fromExisting()` — wrapping a pre-existing SQS queue is not supported. Asyn
 - Retry semantics mirror AWS: on handler error the entry is retried until `receiveCount >= maxRetries`, then moved to an in-memory `failed` (DLQ) list with `failedAt` and `lastError` recorded.
 - Queue state is exposed on `_queue` (`pending`, `processing`, `delayed`, `failed`, `totalSubmitted`, `totalCompleted`) for dev-server inspection.
 - Identical schema and 256 KB payload-size validation runs before enqueue, producing the same typed errors as AWS.
+- When `trackStatus` is enabled, the same `JobStatusTracker` runs as in AWS — it composes a `DistributedTable`, whose own conditional exports resolve to the mock (JSON on disk under `.bb-data/`) locally and to DynamoDB in AWS, so there is one status code path rather than two. `submit()` records `queued` before scheduling the entry, and `processEntry` records `processing` per attempt and `complete`/`failed` on settle.
 - Console logs trace submission, completion (with duration), retries, and DLQ moves, prefixed `[AsyncJob:{id}]`.
 
 ### Mock vs AWS Behavior Differences
@@ -107,6 +129,7 @@ No `fromExisting()` — wrapping a pre-existing SQS queue is not supported. Asyn
 | Handler runs in-process (not isolated) | Shared memory, no cold start, no per-job timeout enforcement | No mitigation — the shared Lambda in AWS is also not isolated per-job |
 | No real visibility timeout | Retries are immediate rather than after a timeout window | No mitigation — timing differences don't affect at-least-once + retry correctness |
 | `submitBatch()` never returns partial failures | The mock enqueues each payload locally, so `failed` is always empty and `BatchSubmitFailed` is never thrown | AWS surfaces per-entry failures; design handlers and callers to handle the `failed` array and `BatchSubmitFailedException` |
+| Status records never expire locally | The mock `DistributedTable` has no TTL sweeper, so status records persist in `.bb-data/` until it is cleared, whereas DynamoDB deletes them ~24 hours after the last transition | No mitigation needed — local records are small and `.bb-data/` is disposable. Do not rely on a record being *absent* after 24 hours in either runtime; DynamoDB TTL deletion is asynchronous and best-effort |
 | No IAM enforcement | Permission errors only surface in AWS | No mitigation — IAM is handled by CDK grants automatically |
 
 ## Integration with CronJob
@@ -116,7 +139,7 @@ AsyncJob and CronJob are complementary primitives:
 | Aspect | AsyncJob | CronJob |
 |--------|----------|---------|
 | **Trigger** | Event-based (code calls `.submit()`) | Time-based (EventBridge schedule) |
-| **Runtime methods** | `.submit()`, `.submitBatch()` | None (infrastructure-only) |
+| **Runtime methods** | `.submit()`, `.submitBatch()`, `.getStatus()`, `.waitUntilComplete()` | None (infrastructure-only) |
 | **AWS service** | SQS | EventBridge Scheduler |
 | **Delivery guarantee** | At-least-once (SQS) | At-least-once (EventBridge) |
 | **Retry mechanism** | SQS redrive + DLQ | Lambda async invoke retry |

--- a/packages/bb-async-job/DESIGN.md
+++ b/packages/bb-async-job/DESIGN.md
@@ -84,9 +84,23 @@ Read-modify-write on the array is safe because SQS keeps a message invisible whi
 
 Tracking is opt-in because it is not free: it adds a DynamoDB table per job plus a write on submit and one per transition, and `submitBatch` would turn a single native SQS batch into an extra batch write. AsyncJob's default remains a single SQS call, and existing deployments gain no resources until they ask for them. `DistributedTable` rather than `KVStore` because only the former supports TTL, so status records expire on their own instead of accumulating.
 
-**Failure handling:** the `queued` write propagates to the caller — `submit()` asked for tracking, so failing loudly before the job is observable is correct. Writes on the handler path are swallowed and logged instead: throwing before the handler would retry work that was fine, and throwing after it succeeded would re-run work that had already completed. Status bookkeeping must never decide a job's fate.
+**Failure handling:** the `queued` write propagates to the caller — `submit()` asked for tracking, so failing loudly before the job is observable is correct. Writes on the handler path are swallowed and logged instead: throwing before the handler would retry work that was fine, and throwing after it succeeded would re-run work that had already completed. Status bookkeeping must never decide a job's fate. The visible consequence is that a dropped terminal write leaves a finished job without a terminal state, so `waitUntilComplete()` reports `Timeout` for work that actually succeeded — callers are told to read `Timeout` as "status unknown" rather than "still running", and to consult the job's own effect when they need certainty.
 
 **Not chosen:** publishing transitions over `bb-realtime`. Push delivery does not solve the underlying problem — a subscriber that connects after the fact still misses the event — and it would add a WebSocket dependency to every AsyncJob. Recorded history is both smaller and strictly more useful, since it works for late readers, retries, and tests alike.
+
+### D-AJ-8: Status writes use optimistic concurrency, not bare last-write-wins
+
+**Decision:** Appending a transition is a read-modify-write, guarded by a compare-and-swap on a `version` counter: the follow-up `put` is conditional on `ifFieldEquals: { version }` (or `ifNotExists` when creating), and a lost swap re-reads and re-applies, up to 5 attempts. `recordQueued` is likewise conditional on `ifNotExists`, and treats a lost race as success. Both `version` and the TTL attribute `expiresAt` are stripped from the record `getStatus()` returns.
+
+**Rationale:** two writers can hold the same job's record at once, in two distinct ways.
+
+The likely one is submit versus delivery. In AWS the job id *is* the SQS message id, so the `queued` write cannot happen until `SendMessage` has returned — by which point SQS may already have delivered the message and the handler may already have created the record by backfilling `queued`. An unconditional `queued` write would then overwrite the `processing` entry and reset the state, stranding a running job at `queued` permanently.
+
+The rarer one is duplicate delivery. Standard queues are at-least-once, and this block's own README already instructs handlers to expect more than one delivery, so two invocations can append concurrently. `batchSize` is *not* a factor: a batch carries distinct messages, hence distinct message ids and distinct partition keys, and SQS never returns the same message twice in one receive.
+
+Neither case can corrupt an item — DynamoDB `PutItem` is atomic per item — but plain last-write-wins would silently drop a transition, and dropping the terminal one converts a successful job into a `waitUntilComplete()` timeout. A version check is far cheaper than the alternative of modelling each transition as its own row with a sort key, which would double the read cost of `getStatus()` for a history that is only ever a handful of entries.
+
+`recordQueuedBatch` issues individual conditional writes in parallel rather than one `putBatch`, because DynamoDB's `BatchWriteItem` cannot carry a condition expression and would reintroduce the clobber. A batch is at most 10 items.
 
 ## Infrastructure (CDK)
 
@@ -130,6 +144,7 @@ No `fromExisting()` — wrapping a pre-existing SQS queue is not supported. Asyn
 | No real visibility timeout | Retries are immediate rather than after a timeout window | No mitigation — timing differences don't affect at-least-once + retry correctness |
 | `submitBatch()` never returns partial failures | The mock enqueues each payload locally, so `failed` is always empty and `BatchSubmitFailed` is never thrown | AWS surfaces per-entry failures; design handlers and callers to handle the `failed` array and `BatchSubmitFailedException` |
 | Status records never expire locally | The mock `DistributedTable` has no TTL sweeper, so status records persist in `.bb-data/` until it is cleared, whereas DynamoDB deletes them ~24 hours after the last transition | No mitigation needed — local records are small and `.bb-data/` is disposable. Do not rely on a record being *absent* after 24 hours in either runtime; DynamoDB TTL deletion is asynchronous and best-effort |
+| Concurrent status writes never actually collide locally | The mock queue delivers each job once to a single in-process consumer, so the compare-and-swap in D-AJ-8 never has to retry and a dropped terminal write cannot happen. In AWS at-least-once delivery makes both reachable | The CAS is exercised directly against the tracker in unit tests rather than through the mock queue. Callers must read `waitUntilComplete()`'s `Timeout` as "status unknown" rather than "still running", since only the deployed runtime can drop a terminal write |
 | No IAM enforcement | Permission errors only surface in AWS | No mitigation — IAM is handled by CDK grants automatically |
 
 ## Integration with CronJob

--- a/packages/bb-async-job/README.md
+++ b/packages/bb-async-job/README.md
@@ -140,13 +140,21 @@ status.error;     // message from the last handler error
 | `updatedAt` | `string` | ISO 8601 timestamp of the most recent transition. |
 | `error` | `string \| undefined` | Message from the last handler error. Set when `state` is `failed`. |
 
-`getStatus()` returns `null` for a job id it has never seen. `waitUntilComplete()` resolves on **either** terminal state — check `state` to tell success from failure — and accepts `timeoutMs` (default `30000`), `pollIntervalMs` (default `250`, with ±20% jitter), and a `signal` (`AbortSignal`) that cancels the wait and rejects with the signal's abort reason. It throws `AsyncJobErrors.Timeout` if the job has not settled in time; a timeout means "still running", not "lost", so it is safe to keep waiting.
+`getStatus()` returns `null` for a job id it has never seen. `waitUntilComplete()` resolves on **either** terminal state — check `state` to tell success from failure — and accepts `timeoutMs` (default `30000`), `pollIntervalMs` (default `250`, with ±20% jitter), and a `signal` (`AbortSignal`) that cancels the wait and rejects with the signal's abort reason.
+
+### Reading a Timeout
+
+`waitUntilComplete()` throws `AsyncJobErrors.Timeout` when the job has not reached a terminal state in time. Treat that as **status unknown**, not as a verdict on the job.
+
+Almost always it means the job is still running, so waiting again is the right move and is safe. But status writes on the handler path are best-effort by design (see below), so there is a second, rarer reading: if the write that would have recorded `complete` or `failed` was itself dropped, the job has already finished and its record will never reach a terminal state, so waiting longer will never resolve. A `Timeout` therefore does not prove the job is still in flight, and it certainly does not mean the job failed.
+
+If you need a definitive answer, check the job's own effect rather than its status — the row it writes, the file it uploads, the message it sends. That is authoritative in a way bookkeeping cannot be. `status.updatedAt` is also a useful signal: a timestamp that stops advancing well past your handler's expected duration points at a dropped write rather than slow work.
 
 ### Cost of enabling it
 
 `trackStatus: true` provisions one DynamoDB table (on-demand billing) for the job's status records and adds a write on submit plus one per state change. Records expire 24 hours after their last transition. Leave the flag off for pure fire-and-forget work — nothing is provisioned and `submit()` stays a single SQS call. Calling `getStatus()` or `waitUntilComplete()` without the flag throws `AsyncJobErrors.StatusNotTracked`.
 
-Status writes on the handler path never fail a job: if one errors it is logged and the job's own outcome is unaffected, so a bookkeeping blip can neither retry work that succeeded nor mask work that failed.
+Status writes on the handler path never fail a job: if one errors it is logged and the job's own outcome is unaffected, so a bookkeeping blip can neither retry work that succeeded nor mask work that failed. That is a deliberate trade — the job's correctness outranks its record — and it is what makes the `Timeout` caveat above possible. Appends themselves are guarded by a compare-and-swap, so two overlapping deliveries of the same job cannot silently drop each other's transitions.
 
 ### Other options
 

--- a/packages/bb-async-job/README.md
+++ b/packages/bb-async-job/README.md
@@ -14,12 +14,16 @@ Background job processing backed by SQS and Lambda.
 | Submit with delay | `submit(payload, { delaySeconds: 60 })` |
 | Submit multiple jobs | `submitBatch(payloads)` |
 | Get job ID back | `const { jobId } = await job.submit(payload)` |
+| Read a job's state | `getStatus(jobId)` (needs `trackStatus: true`) |
+| Wait for a job to finish | `waitUntilComplete(jobId)` (needs `trackStatus: true`) |
 
-**Keywords:** queue, job, background, async, worker, submit, batch, retry, SQS
+**Keywords:** queue, job, background, async, worker, submit, batch, retry, status, transitions, SQS
 
 **Available Methods:**
 - **`submit(payload, options?)`** - Enqueue a single job (returns `{ jobId }`)
 - **`submitBatch(payloads, options?)`** - Enqueue up to 10 jobs in one call (returns `{ jobIds, failed: [] }` on full success). On partial failure, **throws** `AsyncJobErrors.BatchSubmitFailed` — the error has `.jobIds` (with `null` at failed indexes) and `.failed[]` (each entry's `index`, `code`, `message`). The mock runtime never partially fails; this is AWS-only.
+- **`getStatus(jobId)`** - Read a job's recorded state and full transition history (returns `AsyncJobStatus | null`). Requires `trackStatus: true`.
+- **`waitUntilComplete(jobId, options?)`** - Wait until the job reaches `complete` or `failed` (returns the final `AsyncJobStatus`). Requires `trackStatus: true`.
 
 ## Quick Start
 
@@ -55,6 +59,7 @@ const { jobId } = await emailJob.submit({ to: 'alice@example.com', subject: 'Wel
 | `schema` | — | StandardSchemaV1 (Zod, Valibot, etc.) for payload validation on submit |
 | `maxRetries` | 3 | Maximum attempts before sending to the dead-letter queue |
 | `batchSize` | 1 | Messages per Lambda invocation |
+| `trackStatus` | `false` | Record every job's state transitions so `getStatus()` / `waitUntilComplete()` can read them |
 | `logger` | — | Optional logger for internal operations; defaults to a Logger at error level |
 
 ## Handler Context
@@ -77,6 +82,8 @@ AsyncJobErrors.BatchEmpty         // submitBatch([]) called with no items
 AsyncJobErrors.BatchTooLarge      // batch > 10 items
 AsyncJobErrors.ValidationFailed   // schema validation failed
 AsyncJobErrors.BatchSubmitFailed  // one or more messages failed to enqueue
+AsyncJobErrors.Timeout            // waitUntilComplete() gave up before the job settled
+AsyncJobErrors.StatusNotTracked   // status method called without trackStatus: true
 ```
 
 ## Local Development
@@ -89,20 +96,59 @@ Automatically provisions an SQS queue, dead-letter queue, and connects to the sh
 
 ## How Do I Know My Job Ran?
 
-AsyncJob is fire-and-forget — `submit()` returns immediately, and the handler runs later.
+`submit()` is fire-and-forget — it returns as soon as the payload is queued, and the handler runs later in a separate Lambda invocation. Pass `trackStatus: true` and AsyncJob records the job's state for you:
 
-**Track job status in your handler:**
 ```typescript
-const store = new KVStore(scope, 'job-status');
-
-const job = new AsyncJob(scope, 'process', {
-  handler: async (payload, ctx) => {
-    await store.put(`job:${ctx.jobId}`, 'processing');
-    await doWork(payload);
-    await store.put(`job:${ctx.jobId}`, 'complete');
+const job = new AsyncJob(scope, 'ingest', {
+  trackStatus: true,
+  handler: async (payload: { documentId: string }) => {
+    await ingest(payload.documentId);
   },
 });
+
+const { jobId } = await job.submit({ documentId: 'doc-1' });
+
+// Poll from a client, or await it server-side
+const status = await job.waitUntilComplete(jobId);
+status.state;                              // 'complete'
+status.transitions.map((t) => t.state);    // ['queued', 'processing', 'complete']
 ```
+
+### Every state stays observable
+
+`transitions` is append-only, so reading it is not a race. A handler that finishes in a millisecond still records that it passed through `processing`, and a caller that reads the status once — long after the job settled — sees the whole sequence. You never need to slow a handler down to make an intermediate state visible.
+
+A retry appends another `processing` entry rather than a second terminal state, so the history shows how many attempts it took:
+
+```typescript
+const status = await job.getStatus(jobId);
+status.transitions.map((t) => `${t.state}#${t.attempt}`);
+// ['queued#0', 'processing#1', 'processing#2', 'failed#2']
+status.attempts;  // 2
+status.error;     // message from the last handler error
+```
+
+### Status shape
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `jobId` | `string` | Job identifier returned by `submit()`. |
+| `state` | `'queued' \| 'processing' \| 'complete' \| 'failed'` | Most recent state. |
+| `transitions` | `AsyncJobTransition[]` | Every state entered, in order. Each entry has `state`, `at` (ISO 8601), and `attempt`. |
+| `attempts` | `number` | Times the job has been delivered to the handler. |
+| `submittedAt` | `string` | ISO 8601 timestamp of submission. |
+| `updatedAt` | `string` | ISO 8601 timestamp of the most recent transition. |
+| `error` | `string \| undefined` | Message from the last handler error. Set when `state` is `failed`. |
+
+`getStatus()` returns `null` for a job id it has never seen. `waitUntilComplete()` resolves on **either** terminal state — check `state` to tell success from failure — and accepts `timeoutMs` (default `30000`), `pollIntervalMs` (default `250`, with ±20% jitter), and a `signal` (`AbortSignal`) that cancels the wait and rejects with the signal's abort reason. It throws `AsyncJobErrors.Timeout` if the job has not settled in time; a timeout means "still running", not "lost", so it is safe to keep waiting.
+
+### Cost of enabling it
+
+`trackStatus: true` provisions one DynamoDB table (on-demand billing) for the job's status records and adds a write on submit plus one per state change. Records expire 24 hours after their last transition. Leave the flag off for pure fire-and-forget work — nothing is provisioned and `submit()` stays a single SQS call. Calling `getStatus()` or `waitUntilComplete()` without the flag throws `AsyncJobErrors.StatusNotTracked`.
+
+Status writes on the handler path never fail a job: if one errors it is logged and the job's own outcome is unaffected, so a bookkeeping blip can neither retry work that succeeded nor mask work that failed.
+
+### Other options
 
 **Use `ctx.jobId` for logging:**
 ```typescript

--- a/packages/bb-async-job/README.md
+++ b/packages/bb-async-job/README.md
@@ -72,6 +72,8 @@ The handler receives a second argument, `ctx: AsyncJobContext`, carrying metadat
 | `receiveCount` | `number` | Number of times this message has been received (`1` on first delivery; increments on each retry). |
 | `sentAt` | `string` | ISO 8601 timestamp of when the message was sent (enqueued). |
 
+In AWS, `receiveCount` is the SQS `ApproximateReceiveCount` attribute, and the name is SQS's own warning: it is a best-effort counter, not an exact one. A delivery SQS records but never hands to a handler, or a redrive that re-counts, moves it without a matching attempt. Read it as roughly how many times the job has been tried. The `attempt` on each status transition and the `attempts` total both carry this same number, so the caveat travels with them. In local dev the queue is in-process and the count is exact, so a test that asserts on an exact attempt number can pass locally and still be wrong in AWS.
+
 ## Error Constants
 
 ```typescript
@@ -146,9 +148,17 @@ status.error;     // message from the last handler error
 
 `waitUntilComplete()` throws `AsyncJobErrors.Timeout` when the job has not reached a terminal state in time. Treat that as **status unknown**, not as a verdict on the job.
 
-Almost always it means the job is still running, so waiting again is the right move and is safe. But status writes on the handler path are best-effort by design (see below), so there is a second, rarer reading: if the write that would have recorded `complete` or `failed` was itself dropped, the job has already finished and its record will never reach a terminal state, so waiting longer will never resolve. A `Timeout` therefore does not prove the job is still in flight, and it certainly does not mean the job failed.
+Almost always it means the job is still running, so waiting again is the right move and is safe. But status writes on the handler path are best-effort by design (see below), so there is a second, rarer reading: if the write that would have recorded `complete` or `failed` was itself dropped, the job has already finished and its record will never reach a terminal state, so waiting longer will never resolve. A `Timeout` therefore does not prove the job is still in flight, and it certainly does not mean the job failed. A third reading, below, is that the delivery was killed outright.
 
 If you need a definitive answer, check the job's own effect rather than its status — the row it writes, the file it uploads, the message it sends. That is authoritative in a way bookkeeping cannot be. `status.updatedAt` is also a useful signal: a timestamp that stops advancing well past your handler's expected duration points at a dropped write rather than slow work.
+
+### Known limitation: a killed delivery records no failure
+
+The `failed` transition is written from the handler's `catch`, so it exists only for errors the handler actually throws. A delivery that dies without unwinding — Lambda timeout, an out-of-memory kill, a hard crash — never reaches that `catch`, and nothing writes a terminal state on its behalf.
+
+The record therefore stays at its last transition, normally `processing`, and stays there for good. `waitUntilComplete()` keeps polling until it gives up with `AsyncJobErrors.Timeout`, so a job that is definitively dead reads as status unknown rather than as a failure. The work itself is not lost track of: SQS redelivers on its own schedule and the message still reaches the dead-letter queue once it has burned through `maxRetries`. It is only the status record that stops telling you anything.
+
+AsyncJob does not detect this for you yet. Until it does, a `Timeout` on a job whose `updatedAt` stopped advancing is the signal to look outside the status record: the dead-letter queue, and the handler's own CloudWatch logs for a `Task timed out` or out-of-memory line. A handler that runs close to its limit can also catch the condition itself — check the remaining wall clock and throw before the Lambda deadline, so the `catch` does run and `failed` is recorded.
 
 ### Cost of enabling it
 

--- a/packages/bb-async-job/package.json
+++ b/packages/bb-async-job/package.json
@@ -30,6 +30,7 @@
   },
   "dependencies": {
     "@aws-blocks/bb-logger": "^0.1.2",
+    "@aws-blocks/bb-distributed-table": "^0.1.3",
     "@aws-blocks/core": "^0.1.1",
     "@aws-sdk/client-sqs": "^3.0.0"
   },

--- a/packages/bb-async-job/src/errors.ts
+++ b/packages/bb-async-job/src/errors.ts
@@ -15,4 +15,8 @@ export const AsyncJobErrors = {
 	ValidationFailed: 'ValidationFailedException',
 	/** Thrown when one or more messages in a batch fail to send (AWS only). */
 	BatchSubmitFailed: 'BatchSubmitFailedException',
+	/** Thrown when `waitUntilComplete()` gives up before the job reaches a terminal state. */
+	Timeout: 'AsyncJobTimeoutException',
+	/** Thrown when `getStatus()` or `waitUntilComplete()` is called on a job created without `trackStatus: true`. */
+	StatusNotTracked: 'StatusNotTrackedException',
 } as const;

--- a/packages/bb-async-job/src/index.aws.ts
+++ b/packages/bb-async-job/src/index.aws.ts
@@ -208,9 +208,9 @@ export class AsyncJob<T = unknown> extends Scope {
 		}
 
 		// The job id is the SQS message id, so `queued` can only be recorded after the
-		// send. A consumer that reads a record before this write lands sees no record
-		// at all rather than an out-of-order one, and `recordTransition` backfills
-		// `queued` if `processing` somehow wins the race.
+		// send. SQS may already have delivered the message by now, so the write is
+		// conditional on the record not existing: if the handler got there first its
+		// backfill already carries the `queued` transition.
 		await this._status?.recordQueued(jobId, new Date().toISOString());
 
 		return { jobId };

--- a/packages/bb-async-job/src/index.aws.ts
+++ b/packages/bb-async-job/src/index.aws.ts
@@ -11,14 +11,27 @@ import type {
 	AsyncJobOptions,
 	SubmitOptions,
 	BatchSubmitResult,
+	AsyncJobState,
+	AsyncJobStatus,
+	WaitUntilCompleteOptions,
 } from './types.js';
 import { AsyncJobErrors } from './errors.js';
+import { JobStatusTracker, statusNotTrackedError } from './status.js';
 import { BB_NAME, BB_VERSION } from './version.js';
 import { Logger } from '@aws-blocks/bb-logger';
 import type { ChildLogger } from '@aws-blocks/bb-logger';
 
 export { AsyncJobErrors } from './errors.js';
-export type { AsyncJobContext, AsyncJobOptions, SubmitOptions, BatchSubmitResult } from './types.js';
+export type {
+	AsyncJobContext,
+	AsyncJobOptions,
+	SubmitOptions,
+	BatchSubmitResult,
+	AsyncJobState,
+	AsyncJobStatus,
+	AsyncJobTransition,
+	WaitUntilCompleteOptions,
+} from './types.js';
 
 const MAX_PAYLOAD_BYTES = 256 * 1024;
 const MAX_BATCH_SIZE = 10;
@@ -29,6 +42,8 @@ export class AsyncJob<T = unknown> extends Scope {
 	private _envKey: string;
 	private _id: string;
 	private _sqsClient: SQSClient;
+	private _maxRetries: number;
+	private _status?: JobStatusTracker;
 
 	/** @internal Logger for internal operations. Defaults to error-level when not provided. */
 	protected log: ChildLogger;
@@ -39,6 +54,7 @@ export class AsyncJob<T = unknown> extends Scope {
 		this._handler = options.handler;
 		this._schema = options.schema;
 		this._id = id;
+		this._maxRetries = options.maxRetries ?? 3;
 		this._sqsClient = new SQSClient({
 			customUserAgent: this.buildUserAgentChain(),
 		});
@@ -49,11 +65,63 @@ export class AsyncJob<T = unknown> extends Scope {
 
 		registerSdkIdentifiers(this.fullId, { queueUrl });
 
+		if (options.trackStatus) {
+			this._status = new JobStatusTracker(this, this.log);
+		}
+
 		// Only register handler if queue URL is available (i.e., running in Lambda, not codegen)
 		if (queueUrl) {
 			const queueName = queueUrl.split('/').pop()!;
 			this.registerLambdaEventHandler(EventSourceMapping.SQS, queueName, (record) => this._processRecord(record));
 		}
+	}
+
+	/** Throws unless this job was created with `trackStatus: true`. */
+	private requireStatus(): JobStatusTracker {
+		if (!this._status) throw statusNotTrackedError(this._id);
+		return this._status;
+	}
+
+	/**
+	 * Read a job's recorded status, including every state it has passed through.
+	 *
+	 * Requires `trackStatus: true`. Because `transitions` is append-only, a single
+	 * read after the job settled still shows the intermediate `processing` state,
+	 * so there is no need to slow the handler down to make it observable.
+	 *
+	 * @param jobId - Job identifier returned by `submit()`.
+	 * @returns The status record, or `null` if nothing is recorded for that id.
+	 * @throws {AsyncJobErrors.StatusNotTracked} If the job was created without `trackStatus: true`.
+	 *
+	 * @example
+	 * ```typescript
+	 * const status = await job.getStatus(jobId);
+	 * if (status?.state === 'failed') console.error(status.error);
+	 * ```
+	 */
+	async getStatus(jobId: string): Promise<AsyncJobStatus | null> {
+		return this.requireStatus().get(jobId);
+	}
+
+	/**
+	 * Wait until a job reaches `complete` or `failed`.
+	 *
+	 * Requires `trackStatus: true`. Resolves on either terminal state — inspect
+	 * `state` and `error` on the returned record to tell them apart.
+	 *
+	 * @param jobId - Job identifier returned by `submit()`.
+	 * @param options - Optional. `timeoutMs` (default 30000), `pollIntervalMs` (default 250), `signal`.
+	 * @returns The final status record.
+	 * @throws {AsyncJobErrors.StatusNotTracked} If the job was created without `trackStatus: true`.
+	 * @throws {AsyncJobErrors.Timeout} If the job does not settle within `timeoutMs`.
+	 *
+	 * @example
+	 * ```typescript
+	 * const status = await job.waitUntilComplete(jobId, { timeoutMs: 60_000 });
+	 * ```
+	 */
+	async waitUntilComplete(jobId: string, options?: WaitUntilCompleteOptions): Promise<AsyncJobStatus> {
+		return this.requireStatus().waitUntilComplete(jobId, options);
 	}
 
 	/** Ensures queue URL is available, throws descriptive error if not */
@@ -78,7 +146,23 @@ export class AsyncJob<T = unknown> extends Scope {
 			receiveCount: parseInt(record.attributes.ApproximateReceiveCount, 10),
 			sentAt: new Date(parseInt(record.attributes.SentTimestamp, 10)).toISOString(),
 		};
-		await this._handler(payload, ctx);
+
+		await this._status?.tryRecordTransition(ctx.jobId, 'processing', ctx.receiveCount);
+
+		try {
+			await this._handler(payload, ctx);
+		} catch (error: unknown) {
+			// SQS redrive owns the retry decision: this delivery is only terminal once
+			// the receive count has reached maxReceiveCount. Earlier failures record
+			// nothing, so the next attempt simply appends another `processing` entry.
+			if (ctx.receiveCount >= this._maxRetries) {
+				const message = error instanceof Error ? error.message : String(error);
+				await this._status?.tryRecordTransition(ctx.jobId, 'failed', ctx.receiveCount, message);
+			}
+			throw error;
+		}
+
+		await this._status?.tryRecordTransition(ctx.jobId, 'complete', ctx.receiveCount);
 	}
 
 	/** Validates payload and returns the serialized JSON string for reuse */
@@ -122,6 +206,12 @@ export class AsyncJob<T = unknown> extends Scope {
 		if (!jobId) {
 			throw new Error('SQS SendMessage succeeded but returned no MessageId');
 		}
+
+		// The job id is the SQS message id, so `queued` can only be recorded after the
+		// send. A consumer that reads a record before this write lands sees no record
+		// at all rather than an out-of-order one, and `recordTransition` backfills
+		// `queued` if `processing` somehow wins the race.
+		await this._status?.recordQueued(jobId, new Date().toISOString());
 
 		return { jobId };
 	}
@@ -179,6 +269,13 @@ export class AsyncJob<T = unknown> extends Scope {
 			(err as any).failed = failed;
 			(err as any).jobIds = jobIds;
 			throw err;
+		}
+
+		if (this._status) {
+			const submittedAt = new Date().toISOString();
+			await this._status.recordQueuedBatch(
+				jobIds.filter((id): id is string => id !== null).map(jobId => ({ jobId, submittedAt }))
+			);
 		}
 
 		return { jobIds, failed: [] };

--- a/packages/bb-async-job/src/index.browser.ts
+++ b/packages/bb-async-job/src/index.browser.ts
@@ -6,8 +6,14 @@ export class AsyncJob {
 	constructor(...args: any[]) {}
 }
 
-export const AsyncJobErrors = {
-	PayloadTooLarge: 'PayloadTooLargeException',
-	BatchTooLarge: 'BatchTooLargeException',
-	ValidationFailed: 'ValidationFailedException',
-} as const;
+export { AsyncJobErrors } from './errors.js';
+export type {
+	AsyncJobContext,
+	AsyncJobOptions,
+	SubmitOptions,
+	BatchSubmitResult,
+	AsyncJobState,
+	AsyncJobStatus,
+	AsyncJobTransition,
+	WaitUntilCompleteOptions,
+} from './types.js';

--- a/packages/bb-async-job/src/index.cdk.ts
+++ b/packages/bb-async-job/src/index.cdk.ts
@@ -5,17 +5,30 @@ import { Duration } from 'aws-cdk-lib';
 import { Queue, QueueEncryption } from 'aws-cdk-lib/aws-sqs';
 import { SqsEventSource } from 'aws-cdk-lib/aws-lambda-event-sources';
 import { Scope } from '@aws-blocks/core/cdk';
-import { registerConfig } from '@aws-blocks/core/cdk';
+import { registerConfig, synthGuard } from '@aws-blocks/core/cdk';
+import { DistributedTable } from '@aws-blocks/bb-distributed-table';
 import type { ScopeParent } from '@aws-blocks/core';
 import type {
 	AsyncJobContext,
 	AsyncJobOptions,
 	SubmitOptions,
+	AsyncJobStatus,
+	WaitUntilCompleteOptions,
 } from './types.js';
 import { AsyncJobErrors } from './errors.js';
+import { STATUS_TABLE_ID, statusTableOptions } from './status.js';
 
 export { AsyncJobErrors } from './errors.js';
-export type { AsyncJobContext, AsyncJobOptions, SubmitOptions } from './types.js';
+export type {
+	AsyncJobContext,
+	AsyncJobOptions,
+	SubmitOptions,
+	BatchSubmitResult,
+	AsyncJobState,
+	AsyncJobStatus,
+	AsyncJobTransition,
+	WaitUntilCompleteOptions,
+} from './types.js';
 
 export class AsyncJob<T = unknown> extends Scope {
 	public readonly queue: Queue;
@@ -56,5 +69,21 @@ export class AsyncJob<T = unknown> extends Scope {
 		);
 
 		this.handler.addEventSource(new SqsEventSource(this.queue, { batchSize }));
+
+		// Same child id and options as the runtime entry points, so the provisioned
+		// table is the one JobStatusTracker resolves at request time.
+		if (options.trackStatus) {
+			new DistributedTable(this, STATUS_TABLE_ID, statusTableOptions as never);
+		}
+	}
+
+	// ── Runtime methods are not available during CDK synth ────────────────
+
+	getStatus(_jobId: string): Promise<AsyncJobStatus | null> {
+		return synthGuard('AsyncJob', 'getStatus');
+	}
+
+	waitUntilComplete(_jobId: string, _options?: WaitUntilCompleteOptions): Promise<AsyncJobStatus> {
+		return synthGuard('AsyncJob', 'waitUntilComplete');
 	}
 }

--- a/packages/bb-async-job/src/index.mock.ts
+++ b/packages/bb-async-job/src/index.mock.ts
@@ -10,14 +10,27 @@ import type {
 	AsyncJobOptions,
 	SubmitOptions,
 	BatchSubmitResult,
+	AsyncJobState,
+	AsyncJobStatus,
+	WaitUntilCompleteOptions,
 } from './types.js';
 import { AsyncJobErrors } from './errors.js';
+import { JobStatusTracker, statusNotTrackedError } from './status.js';
 import { Logger } from '@aws-blocks/bb-logger';
 import type { ChildLogger } from '@aws-blocks/bb-logger';
 import { BB_NAME, BB_VERSION } from './version.js';
 
 export { AsyncJobErrors } from './errors.js';
-export type { AsyncJobContext, AsyncJobOptions, SubmitOptions, BatchSubmitResult } from './types.js';
+export type {
+	AsyncJobContext,
+	AsyncJobOptions,
+	SubmitOptions,
+	BatchSubmitResult,
+	AsyncJobState,
+	AsyncJobStatus,
+	AsyncJobTransition,
+	WaitUntilCompleteOptions,
+} from './types.js';
 
 interface QueueEntry<T> {
 	jobId: string;
@@ -61,12 +74,22 @@ const MAX_BATCH_SIZE = 10;
  *
  * const { jobId } = await emailJob.submit({ to: 'alice@example.com' });
  * ```
+ *
+ * @example Observing state transitions
+ * ```typescript
+ * const job = new AsyncJob(scope, 'ingest', { handler, trackStatus: true });
+ *
+ * const { jobId } = await job.submit({ documentId: 'doc-1' });
+ * const status = await job.waitUntilComplete(jobId);
+ * status.transitions.map(t => t.state); // ['queued', 'processing', 'complete']
+ * ```
  */
 export class AsyncJob<T = unknown> extends Scope {
 	private handler: (payload: T, context: AsyncJobContext) => Promise<void>;
 	private schema?: StandardSchemaV1<T>;
 	private maxRetries: number;
 	private _id: string;
+	private _status?: JobStatusTracker;
 
 	// In-process queue state for dev server inspection
 	public readonly _queue: {
@@ -97,6 +120,57 @@ export class AsyncJob<T = unknown> extends Scope {
 			totalCompleted: 0,
 		};
 		registerSdkIdentifiers(this.fullId, { queueUrl: `mock-queue://${this.fullId}` });
+		if (options.trackStatus) {
+			this._status = new JobStatusTracker(this, this.log);
+		}
+	}
+
+	/** Throws unless this job was created with `trackStatus: true`. */
+	private requireStatus(): JobStatusTracker {
+		if (!this._status) throw statusNotTrackedError(this._id);
+		return this._status;
+	}
+
+	/**
+	 * Read a job's recorded status, including every state it has passed through.
+	 *
+	 * Requires `trackStatus: true`. Because `transitions` is append-only, a single
+	 * read after the job settled still shows the intermediate `processing` state,
+	 * so there is no need to slow the handler down to make it observable.
+	 *
+	 * @param jobId - Job identifier returned by `submit()`.
+	 * @returns The status record, or `null` if nothing is recorded for that id.
+	 * @throws {AsyncJobErrors.StatusNotTracked} If the job was created without `trackStatus: true`.
+	 *
+	 * @example
+	 * ```typescript
+	 * const status = await job.getStatus(jobId);
+	 * if (status?.state === 'failed') console.error(status.error);
+	 * ```
+	 */
+	async getStatus(jobId: string): Promise<AsyncJobStatus | null> {
+		return this.requireStatus().get(jobId);
+	}
+
+	/**
+	 * Wait until a job reaches `complete` or `failed`.
+	 *
+	 * Requires `trackStatus: true`. Resolves on either terminal state — inspect
+	 * `state` and `error` on the returned record to tell them apart.
+	 *
+	 * @param jobId - Job identifier returned by `submit()`.
+	 * @param options - Optional. `timeoutMs` (default 30000), `pollIntervalMs` (default 250), `signal`.
+	 * @returns The final status record.
+	 * @throws {AsyncJobErrors.StatusNotTracked} If the job was created without `trackStatus: true`.
+	 * @throws {AsyncJobErrors.Timeout} If the job does not settle within `timeoutMs`.
+	 *
+	 * @example
+	 * ```typescript
+	 * const status = await job.waitUntilComplete(jobId, { timeoutMs: 60_000 });
+	 * ```
+	 */
+	async waitUntilComplete(jobId: string, options?: WaitUntilCompleteOptions): Promise<AsyncJobStatus> {
+		return this.requireStatus().waitUntilComplete(jobId, options);
 	}
 
 	/**
@@ -129,6 +203,8 @@ export class AsyncJob<T = unknown> extends Scope {
 			failedAt: null,
 			lastError: null,
 		};
+
+		await this._status?.recordQueued(jobId, sentAt);
 
 		if (delaySeconds > 0) {
 			console.log(`[AsyncJob:${this._id}] submitted job ${jobId} (delayed ${delaySeconds}s)`);
@@ -217,6 +293,8 @@ export class AsyncJob<T = unknown> extends Scope {
 			this._queue.pending = this._queue.pending.filter(e => e.jobId !== entry.jobId);
 			this._queue.processing.push(entry);
 
+			await this._status?.tryRecordTransition(entry.jobId, 'processing', entry.receiveCount);
+
 			const start = Date.now();
 			try {
 				await this.handler(entry.payload, {
@@ -226,6 +304,7 @@ export class AsyncJob<T = unknown> extends Scope {
 				});
 				this._queue.processing = this._queue.processing.filter(e => e.jobId !== entry.jobId);
 				this._queue.totalCompleted++;
+				await this._status?.tryRecordTransition(entry.jobId, 'complete', entry.receiveCount);
 				console.log(`[AsyncJob:${this._id}] completed job ${entry.jobId} (${Date.now() - start}ms)`);
 			} catch (error: any) {
 				this._queue.processing = this._queue.processing.filter(e => e.jobId !== entry.jobId);
@@ -235,6 +314,7 @@ export class AsyncJob<T = unknown> extends Scope {
 					entry.failedAt = new Date().toISOString();
 					entry.lastError = errorMsg;
 					this._queue.failed.push(entry);
+					await this._status?.tryRecordTransition(entry.jobId, 'failed', entry.receiveCount, errorMsg);
 					console.log(`[AsyncJob:${this._id}] job ${entry.jobId} moved to DLQ after ${this.maxRetries} attempts`);
 					console.log(`[AsyncJob:${this._id}] DLQ payload: ${JSON.stringify(entry.payload)}`);
 				} else {

--- a/packages/bb-async-job/src/status.test.ts
+++ b/packages/bb-async-job/src/status.test.ts
@@ -5,7 +5,7 @@ import { test, before, after } from 'node:test';
 import assert from 'node:assert';
 import { rmSync } from 'node:fs';
 import { AsyncJob, AsyncJobErrors } from './index.mock.js';
-import { statusSchema, statusTableOptions, STATUS_TABLE_ID } from './status.js';
+import { statusSchema, statusTableOptions, STATUS_TABLE_ID, JobStatusTracker } from './status.js';
 
 // Every handler in this file settles immediately. The transition history is what
 // makes intermediate states observable, so none of these tests pad the handler
@@ -310,4 +310,63 @@ test('AsyncJob - status table is keyed by jobId with a TTL attribute', () => {
 	assert.strictEqual(STATUS_TABLE_ID, 'status');
 	assert.deepStrictEqual(statusTableOptions.key, { partitionKey: 'jobId' });
 	assert.strictEqual(statusTableOptions.ttl, 'expiresAt');
+});
+
+// ── Concurrency ───────────────────────────────────────────────────────
+// Appending a transition is a read-modify-write. SQS is at-least-once, so two
+// deliveries of the same message can overlap, and in AWS the `queued` write can
+// only happen after SendMessage returns, so it can land after the handler has
+// already created the record. Both cases are exercised directly against the
+// tracker rather than through submit(), since the mock queue cannot reproduce a
+// duplicate delivery on its own.
+
+test('JobStatusTracker - concurrent appends do not lose a transition', async () => {
+	const tracker = new JobStatusTracker({ id: 'cas-parallel' } as any);
+	await tracker.recordQueued('job-cas', new Date().toISOString());
+
+	await Promise.all([
+		tracker.recordTransition('job-cas', 'processing', 1),
+		tracker.recordTransition('job-cas', 'processing', 2),
+		tracker.recordTransition('job-cas', 'complete', 2),
+	]);
+
+	const status = await tracker.get('job-cas');
+	assert.strictEqual(
+		status?.transitions.length,
+		4,
+		`expected queued + 3 appended transitions, got ${JSON.stringify(status?.transitions)}`,
+	);
+	assert.strictEqual(status.transitions[0].state, 'queued');
+	assert.strictEqual(
+		status.transitions.filter(t => t.state === 'complete').length,
+		1,
+		'the terminal transition must survive a concurrent append',
+	);
+});
+
+test('JobStatusTracker - a late queued write does not clobber an earlier transition', async () => {
+	const tracker = new JobStatusTracker({ id: 'cas-late-queued' } as any);
+
+	// The handler wins the race: it creates the record by backfilling `queued`.
+	await tracker.recordTransition('job-late', 'processing', 1);
+	// submit()'s write arrives afterwards and must not reset the record.
+	await tracker.recordQueued('job-late', new Date().toISOString());
+
+	const status = await tracker.get('job-late');
+	assert.strictEqual(status?.state, 'processing', 'state must not fall back to queued');
+	assert.deepStrictEqual(status?.transitions.map(t => t.state), ['queued', 'processing']);
+});
+
+test('JobStatusTracker - get does not leak storage bookkeeping', async () => {
+	const tracker = new JobStatusTracker({ id: 'cas-clean' } as any);
+	await tracker.recordQueued('job-clean', new Date().toISOString());
+	await tracker.recordTransition('job-clean', 'complete', 1);
+
+	const status = await tracker.get('job-clean');
+	assert.ok(status);
+	assert.deepStrictEqual(
+		Object.keys(status).sort(),
+		['attempts', 'jobId', 'state', 'submittedAt', 'transitions', 'updatedAt'],
+		'expiresAt and version are storage details and must not surface',
+	);
 });

--- a/packages/bb-async-job/src/status.test.ts
+++ b/packages/bb-async-job/src/status.test.ts
@@ -1,0 +1,313 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { test, before, after } from 'node:test';
+import assert from 'node:assert';
+import { rmSync } from 'node:fs';
+import { AsyncJob, AsyncJobErrors } from './index.mock.js';
+import { statusSchema, statusTableOptions, STATUS_TABLE_ID } from './status.js';
+
+// Every handler in this file settles immediately. The transition history is what
+// makes intermediate states observable, so none of these tests pad the handler
+// with a delay to widen the `processing` window.
+
+function cleanMockData(): void {
+	try {
+		rmSync('.bb-data', { recursive: true, force: true });
+	} catch {
+		/* ignore */
+	}
+}
+
+before(cleanMockData);
+after(cleanMockData);
+
+const FAST_POLL = { pollIntervalMs: 5, timeoutMs: 5_000 };
+
+test('AsyncJob - records queued -> processing -> complete for an instant handler', async () => {
+	let ran = false;
+	const job = new AsyncJob<{ n: number }>(null as any, 'status-happy', {
+		trackStatus: true,
+		handler: async () => {
+			ran = true;
+		},
+	});
+
+	const { jobId } = await job.submit({ n: 1 });
+	const status = await job.waitUntilComplete(jobId, FAST_POLL);
+
+	assert.strictEqual(ran, true, 'handler should have run');
+	assert.strictEqual(status.state, 'complete');
+	assert.deepStrictEqual(
+		status.transitions.map(t => t.state),
+		['queued', 'processing', 'complete'],
+		'every intermediate state must be recorded even though the handler returned immediately',
+	);
+	assert.deepStrictEqual(status.transitions.map(t => t.attempt), [0, 1, 1]);
+	assert.strictEqual(status.attempts, 1);
+	assert.strictEqual(status.jobId, jobId);
+	assert.strictEqual(status.error, undefined);
+});
+
+test('AsyncJob - transitions stay readable long after the job settled', async () => {
+	const job = new AsyncJob<{ n: number }>(null as any, 'status-after', {
+		trackStatus: true,
+		handler: async () => {},
+	});
+
+	const { jobId } = await job.submit({ n: 1 });
+	await job.waitUntilComplete(jobId, FAST_POLL);
+
+	// A single read, made only once the job is already done — this is the case that
+	// used to require setTimeout(1500) in the handler.
+	const status = await job.getStatus(jobId);
+	assert.deepStrictEqual(
+		status?.transitions.map(t => t.state),
+		['queued', 'processing', 'complete'],
+	);
+});
+
+test('AsyncJob - transitions are ordered and timestamped', async () => {
+	const job = new AsyncJob<{ n: number }>(null as any, 'status-times', {
+		trackStatus: true,
+		handler: async () => {},
+	});
+
+	const { jobId } = await job.submit({ n: 1 });
+	const status = await job.waitUntilComplete(jobId, FAST_POLL);
+
+	const times = status.transitions.map(t => Date.parse(t.at));
+	assert.ok(times.every(t => Number.isFinite(t)), 'every transition needs a parseable timestamp');
+	for (let i = 1; i < times.length; i++) {
+		assert.ok(times[i] >= times[i - 1], `transition ${i} must not predate transition ${i - 1}`);
+	}
+	assert.strictEqual(status.submittedAt, status.transitions[0].at);
+	assert.strictEqual(status.updatedAt, status.transitions.at(-1)!.at);
+});
+
+test('AsyncJob - retries record processing twice then failed', async () => {
+	let attempts = 0;
+	const job = new AsyncJob<{ n: number }>(null as any, 'status-retry', {
+		trackStatus: true,
+		maxRetries: 2,
+		handler: async () => {
+			attempts++;
+			throw new Error('handler blew up');
+		},
+	});
+
+	const { jobId } = await job.submit({ n: 1 });
+	const status = await job.waitUntilComplete(jobId, FAST_POLL);
+
+	assert.strictEqual(attempts, 2, 'handler should run once per retry');
+	assert.strictEqual(status.state, 'failed');
+	assert.deepStrictEqual(
+		status.transitions.map(t => t.state),
+		['queued', 'processing', 'processing', 'failed'],
+	);
+	assert.deepStrictEqual(status.transitions.map(t => t.attempt), [0, 1, 2, 2]);
+	assert.strictEqual(status.attempts, 2);
+	assert.match(status.error ?? '', /handler blew up/);
+});
+
+test('AsyncJob - queued is observable before the handler runs', async () => {
+	const job = new AsyncJob<{ n: number }>(null as any, 'status-delayed', {
+		trackStatus: true,
+		handler: async () => {},
+	});
+
+	// A delayed job stays queued, so the pre-processing state can be read directly
+	// rather than inferred.
+	const { jobId } = await job.submit({ n: 1 }, { delaySeconds: 30 });
+	const status = await job.getStatus(jobId);
+
+	assert.strictEqual(status?.state, 'queued');
+	assert.deepStrictEqual(status?.transitions.map(t => t.state), ['queued']);
+	assert.strictEqual(status?.attempts, 0);
+});
+
+test('AsyncJob - submitBatch records status for every job', async () => {
+	const seen: number[] = [];
+	const job = new AsyncJob<{ n: number }>(null as any, 'status-batch', {
+		trackStatus: true,
+		handler: async (payload) => {
+			seen.push(payload.n);
+		},
+	});
+
+	const { jobIds } = await job.submitBatch([{ n: 1 }, { n: 2 }, { n: 3 }]);
+	const statuses = await Promise.all(
+		jobIds.map(id => job.waitUntilComplete(id!, FAST_POLL)),
+	);
+
+	assert.strictEqual(seen.length, 3);
+	for (const status of statuses) {
+		assert.strictEqual(status.state, 'complete');
+		assert.deepStrictEqual(
+			status.transitions.map(t => t.state),
+			['queued', 'processing', 'complete'],
+		);
+	}
+});
+
+test('AsyncJob - getStatus returns null for an unknown job id', async () => {
+	const job = new AsyncJob(null as any, 'status-unknown', {
+		trackStatus: true,
+		handler: async () => {},
+	});
+
+	assert.strictEqual(await job.getStatus('no-such-job'), null);
+});
+
+test('AsyncJob - waitUntilComplete throws Timeout while a job is still processing', async () => {
+	let release: (() => void) | undefined;
+	const gate = new Promise<void>(resolve => {
+		release = resolve;
+	});
+
+	const job = new AsyncJob<{ n: number }>(null as any, 'status-timeout', {
+		trackStatus: true,
+		handler: async () => {
+			await gate;
+		},
+	});
+
+	const { jobId } = await job.submit({ n: 1 });
+
+	await assert.rejects(
+		() => job.waitUntilComplete(jobId, { timeoutMs: 40, pollIntervalMs: 5 }),
+		(err: Error) => {
+			assert.strictEqual(err.name, AsyncJobErrors.Timeout);
+			assert.match(err.message, /last observed state: processing/);
+			return true;
+		},
+	);
+
+	// The job was mid-flight, not lost: let it finish and the wait now succeeds.
+	release!();
+	const status = await job.waitUntilComplete(jobId, FAST_POLL);
+	assert.strictEqual(status.state, 'complete');
+});
+
+test('AsyncJob - waitUntilComplete rejects with the abort reason', async () => {
+	let release: (() => void) | undefined;
+	const gate = new Promise<void>(resolve => {
+		release = resolve;
+	});
+
+	const job = new AsyncJob<{ n: number }>(null as any, 'status-abort', {
+		trackStatus: true,
+		handler: async () => {
+			await gate;
+		},
+	});
+
+	const { jobId } = await job.submit({ n: 1 });
+
+	const controller = new AbortController();
+	const reason = new Error('caller gave up');
+	const waiting = job.waitUntilComplete(jobId, {
+		timeoutMs: 5_000,
+		pollIntervalMs: 5,
+		signal: controller.signal,
+	});
+	controller.abort(reason);
+
+	await assert.rejects(() => waiting, (err: Error) => {
+		assert.strictEqual(err, reason);
+		return true;
+	});
+
+	release!();
+	await job.waitUntilComplete(jobId, FAST_POLL);
+});
+
+test('AsyncJob - waitUntilComplete honours a signal that is already aborted', async () => {
+	const job = new AsyncJob(null as any, 'status-preaborted', {
+		trackStatus: true,
+		handler: async () => {},
+	});
+
+	const controller = new AbortController();
+	const reason = new Error('never mind');
+	controller.abort(reason);
+
+	await assert.rejects(
+		() => job.waitUntilComplete('any-job', { signal: controller.signal }),
+		(err: Error) => {
+			assert.strictEqual(err, reason);
+			return true;
+		},
+	);
+});
+
+test('AsyncJob - status methods throw StatusNotTracked when trackStatus is off', async () => {
+	const job = new AsyncJob<{ n: number }>(null as any, 'status-off', {
+		handler: async () => {},
+	});
+
+	const { jobId } = await job.submit({ n: 1 });
+
+	await assert.rejects(() => job.getStatus(jobId), (err: Error) => {
+		assert.strictEqual(err.name, AsyncJobErrors.StatusNotTracked);
+		assert.match(err.message, /trackStatus: true/);
+		return true;
+	});
+
+	await assert.rejects(() => job.waitUntilComplete(jobId), (err: Error) => {
+		assert.strictEqual(err.name, AsyncJobErrors.StatusNotTracked);
+		return true;
+	});
+});
+
+test('AsyncJob - tracked and untracked jobs keep their own status records', async () => {
+	const tracked = new AsyncJob<{ n: number }>(null as any, 'status-isolated-a', {
+		trackStatus: true,
+		handler: async () => {},
+	});
+	const other = new AsyncJob<{ n: number }>(null as any, 'status-isolated-b', {
+		trackStatus: true,
+		handler: async () => {},
+	});
+
+	const { jobId } = await tracked.submit({ n: 1 });
+	await tracked.waitUntilComplete(jobId, FAST_POLL);
+
+	assert.strictEqual(await other.getStatus(jobId), null, 'status must not leak across jobs');
+});
+
+// The CDK layer infers a key's DynamoDB attribute type by probing the schema with
+// a numeric value and reading "no issue for that field" as numeric. If this schema
+// ever stops rejecting a numeric jobId, the status table would be provisioned with
+// an `N` partition key and every runtime write would fail against it.
+test('AsyncJob - status schema rejects a numeric jobId so CDK provisions a string key', () => {
+	const result = statusSchema['~standard'].validate({ jobId: 0 }) as {
+		issues?: ReadonlyArray<{ path?: readonly unknown[] }>;
+	};
+
+	assert.ok(result.issues, 'a numeric jobId must produce issues');
+	assert.ok(
+		result.issues.some(i => i.path?.length === 1 && i.path[0] === 'jobId'),
+		'the issue must be attributed to the jobId field',
+	);
+});
+
+test('AsyncJob - status schema accepts a well-formed record', () => {
+	const result = statusSchema['~standard'].validate({
+		jobId: 'job-1',
+		state: 'complete',
+		transitions: [{ state: 'queued', at: new Date().toISOString(), attempt: 0 }],
+		attempts: 1,
+		submittedAt: new Date().toISOString(),
+		updatedAt: new Date().toISOString(),
+		expiresAt: 1_800_000_000,
+	}) as { issues?: unknown };
+
+	assert.strictEqual(result.issues, undefined);
+});
+
+test('AsyncJob - status table is keyed by jobId with a TTL attribute', () => {
+	assert.strictEqual(STATUS_TABLE_ID, 'status');
+	assert.deepStrictEqual(statusTableOptions.key, { partitionKey: 'jobId' });
+	assert.strictEqual(statusTableOptions.ttl, 'expiresAt');
+});

--- a/packages/bb-async-job/src/status.test.ts
+++ b/packages/bb-async-job/src/status.test.ts
@@ -357,6 +357,103 @@ test('JobStatusTracker - a late queued write does not clobber an earlier transit
 	assert.deepStrictEqual(status?.transitions.map(t => t.state), ['queued', 'processing']);
 });
 
+test('JobStatusTracker - a late queued write corrects the backfilled submission time', async () => {
+	const tracker = new JobStatusTracker({ id: 'cas-backdate' } as any);
+
+	// The job really was submitted a full minute before the handler observed it.
+	// The handler cannot know that, so its backfill dates the submission from its
+	// own clock.
+	const submittedAt = new Date(Date.now() - 60_000).toISOString();
+
+	await tracker.recordTransition('job-backdate', 'processing', 1);
+
+	const backfilled = await tracker.get('job-backdate');
+	assert.ok(
+		Date.parse(backfilled!.submittedAt) > Date.parse(submittedAt),
+		'precondition: the backfill must have stamped a later submittedAt',
+	);
+
+	// submit()'s write loses the create race, so it corrects the record instead of
+	// silently dropping the only accurate submission time anybody holds.
+	await tracker.recordQueued('job-backdate', submittedAt);
+
+	const status = await tracker.get('job-backdate');
+	assert.strictEqual(
+		status?.submittedAt,
+		submittedAt,
+		'submittedAt must be the real submission time, not the time the handler first saw the job',
+	);
+	assert.strictEqual(
+		status.transitions[0].at,
+		submittedAt,
+		'the queued transition and submittedAt are the same instant and must agree',
+	);
+
+	// The correction must not cost anything else on the record.
+	assert.strictEqual(status.state, 'processing', 'state must not fall back to queued');
+	assert.deepStrictEqual(status.transitions.map(t => t.state), ['queued', 'processing']);
+	assert.strictEqual(status.attempts, 1);
+	assert.strictEqual(
+		status.transitions[1].at,
+		backfilled!.transitions[1].at,
+		'the processing transition must keep its own timestamp',
+	);
+	assert.strictEqual(status.updatedAt, backfilled!.updatedAt, 'updatedAt tracks transitions, not submission');
+});
+
+test('JobStatusTracker - queued only ever moves the submission time earlier', async () => {
+	const tracker = new JobStatusTracker({ id: 'cas-monotonic' } as any);
+
+	// submit() wins the race here, so the record already holds the true time.
+	const submittedAt = new Date(Date.now() - 60_000).toISOString();
+	await tracker.recordQueued('job-monotonic', submittedAt);
+
+	// A later write for the same id must not drag the submission forward: nothing
+	// is submitted twice, so a later timestamp is never the better one.
+	await tracker.recordQueued('job-monotonic', new Date().toISOString());
+
+	const status = await tracker.get('job-monotonic');
+	assert.strictEqual(status?.submittedAt, submittedAt);
+	assert.strictEqual(status.transitions[0].at, submittedAt);
+	assert.deepStrictEqual(status.transitions.map(t => t.state), ['queued']);
+});
+
+test('JobStatusTracker - correcting the submission time does not drop a concurrent transition', async () => {
+	const tracker = new JobStatusTracker({ id: 'cas-backdate-parallel' } as any);
+
+	const submittedAt = new Date(Date.now() - 60_000).toISOString();
+	await tracker.recordTransition('job-both', 'processing', 1);
+
+	// The correction is a read-modify-write, so it races the handler's terminal
+	// append exactly as two appends race each other. Neither may be lost.
+	await Promise.all([
+		tracker.recordQueued('job-both', submittedAt),
+		tracker.recordTransition('job-both', 'complete', 1),
+	]);
+
+	const status = await tracker.get('job-both');
+	assert.strictEqual(status?.state, 'complete', 'the terminal transition must survive the correction');
+	assert.deepStrictEqual(status.transitions.map(t => t.state), ['queued', 'processing', 'complete']);
+	assert.strictEqual(
+		status.submittedAt,
+		submittedAt,
+		'the correction must survive a concurrent append',
+	);
+	assert.strictEqual(status.transitions[0].at, submittedAt);
+});
+
+test('JobStatusTracker - correcting a record that is gone does not recreate it', async () => {
+	const tracker = new JobStatusTracker({ id: 'cas-reaped' } as any);
+
+	// The TTL can reap a job's history in the window between submit()'s failed
+	// create and the correction's read. Writing the correction blind would put the
+	// record back and report a job as freshly queued long after its history was
+	// deliberately dropped, so a missing record has to stay missing.
+	await (tracker as any).backdateSubmission('job-reaped', new Date().toISOString());
+
+	assert.strictEqual(await tracker.get('job-reaped'), null);
+});
+
 test('JobStatusTracker - get does not leak storage bookkeeping', async () => {
 	const tracker = new JobStatusTracker({ id: 'cas-clean' } as any);
 	await tracker.recordQueued('job-clean', new Date().toISOString());

--- a/packages/bb-async-job/src/status.ts
+++ b/packages/bb-async-job/src/status.ts
@@ -1,0 +1,280 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { DistributedTable } from '@aws-blocks/bb-distributed-table';
+import type { ScopeParent } from '@aws-blocks/core';
+import type { ChildLogger } from '@aws-blocks/bb-logger';
+import type { StandardSchemaV1 } from '@standard-schema/spec';
+import type {
+	AsyncJobState,
+	AsyncJobStatus,
+	AsyncJobTransition,
+	WaitUntilCompleteOptions,
+} from './types.js';
+import { AsyncJobErrors } from './errors.js';
+
+/** Child scope id of the status table. Must match between the runtime and CDK entry points. */
+export const STATUS_TABLE_ID = 'status';
+
+/** How long a status record survives after its last transition. */
+export const STATUS_RETENTION_SECONDS = 86_400;
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+const DEFAULT_POLL_INTERVAL_MS = 250;
+
+/** Stored shape: the public record plus the DynamoDB TTL attribute. */
+interface StatusRecord extends AsyncJobStatus {
+	/** Epoch seconds at which DynamoDB may delete this record. */
+	expiresAt: number;
+}
+
+const STRING_FIELDS = ['jobId', 'state', 'submittedAt', 'updatedAt', 'error'] as const;
+
+/**
+ * Runtime validation for status records.
+ *
+ * This schema is deliberately explicit about field types rather than passing
+ * values through: the CDK layer infers a key's DynamoDB attribute type by
+ * probing `validate({ jobId: 0 })` and treats "no issue for that field" as
+ * numeric. A pass-through schema would therefore provision `jobId` as `N`.
+ */
+export const statusSchema: StandardSchemaV1<StatusRecord> = {
+	'~standard': {
+		version: 1,
+		vendor: 'blocks',
+		validate: (value: unknown) => {
+			if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+				return { issues: [{ message: 'status record must be an object' }] };
+			}
+			const record = value as Record<string, unknown>;
+			const issues: Array<{ message: string; path: [string] }> = [];
+
+			for (const field of STRING_FIELDS) {
+				if (field in record && typeof record[field] !== 'string') {
+					issues.push({ message: `${field} must be a string`, path: [field] });
+				}
+			}
+			for (const field of ['attempts', 'expiresAt'] as const) {
+				if (field in record && typeof record[field] !== 'number') {
+					issues.push({ message: `${field} must be a number`, path: [field] });
+				}
+			}
+			if ('transitions' in record && !Array.isArray(record.transitions)) {
+				issues.push({ message: 'transitions must be an array', path: ['transitions'] });
+			}
+
+			return issues.length > 0 ? { issues } : { value: record as unknown as StatusRecord };
+		},
+	},
+};
+
+/** Options for the status table, shared by the runtime and CDK entry points. */
+export const statusTableOptions = {
+	schema: statusSchema,
+	key: { partitionKey: 'jobId' },
+	ttl: 'expiresAt',
+} as const;
+
+function blocksError(name: string, message: string): Error {
+	const err = new Error(`${name}: ${message}`);
+	err.name = name;
+	return err;
+}
+
+/**
+ * Resolve after `ms` milliseconds, rejecting early with the signal's abort
+ * reason if `signal` aborts while waiting.
+ */
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+	return new Promise<void>((resolve, reject) => {
+		if (signal?.aborted) {
+			reject(signal.reason);
+			return;
+		}
+		let onAbort: (() => void) | undefined;
+		const timer = setTimeout(() => {
+			if (signal && onAbort) signal.removeEventListener('abort', onAbort);
+			resolve();
+		}, ms);
+		if (signal) {
+			onAbort = () => {
+				clearTimeout(timer);
+				reject(signal.reason);
+			};
+			signal.addEventListener('abort', onAbort, { once: true });
+		}
+	});
+}
+
+/**
+ * Apply ±20% random jitter to a poll interval so that many concurrent waiters
+ * do not synchronize into lockstep against the same table.
+ */
+function jitterInterval(ms: number): number {
+	const factor = 1 + (Math.random() * 2 - 1) * 0.2;
+	return Math.max(1, Math.round(ms * factor));
+}
+
+function isTerminal(state: AsyncJobState): boolean {
+	return state === 'complete' || state === 'failed';
+}
+
+function expiresAt(): number {
+	return Math.floor(Date.now() / 1000) + STATUS_RETENTION_SECONDS;
+}
+
+/**
+ * Records and reads AsyncJob state transitions.
+ *
+ * Backed by a nested {@link DistributedTable}, provisioned as a child scope so
+ * it becomes its own DynamoDB table in AWS and a JSON file locally. The same
+ * code path runs in both runtimes.
+ *
+ * Transitions are appended rather than overwritten: a reader that polls once,
+ * long after the job finished, still observes that the job passed through
+ * `processing`. That is what makes intermediate states observable without
+ * padding the handler with an artificial delay.
+ *
+ * @internal
+ */
+export class JobStatusTracker {
+	private table: DistributedTable<StatusRecord, { partitionKey: 'jobId' }>;
+	private log?: ChildLogger;
+
+	constructor(scope: ScopeParent, log?: ChildLogger) {
+		this.table = new DistributedTable<StatusRecord, { partitionKey: 'jobId' }>(
+			scope,
+			STATUS_TABLE_ID,
+			statusTableOptions as never,
+		);
+		this.log = log;
+	}
+
+	/** Build the initial `queued` record for a freshly submitted job. */
+	private queuedRecord(jobId: string, submittedAt: string): StatusRecord {
+		return {
+			jobId,
+			state: 'queued',
+			transitions: [{ state: 'queued', at: submittedAt, attempt: 0 }],
+			attempts: 0,
+			submittedAt,
+			updatedAt: submittedAt,
+			expiresAt: expiresAt(),
+		};
+	}
+
+	/**
+	 * Record a job as `queued`. Called before the payload is handed to the
+	 * queue so a consumer can never observe `processing` before `queued`.
+	 */
+	async recordQueued(jobId: string, submittedAt: string): Promise<void> {
+		await this.table.put(this.queuedRecord(jobId, submittedAt));
+	}
+
+	/** Record several jobs as `queued` in one round trip. */
+	async recordQueuedBatch(jobs: Array<{ jobId: string; submittedAt: string }>): Promise<void> {
+		if (jobs.length === 0) return;
+		await this.table.putBatch(jobs.map(j => this.queuedRecord(j.jobId, j.submittedAt)));
+	}
+
+	/**
+	 * Append a transition to a job's history.
+	 *
+	 * Read-modify-write is safe here because SQS keeps a message invisible while
+	 * its handler runs, so only one attempt writes a given job's record at a time.
+	 */
+	async recordTransition(
+		jobId: string,
+		state: AsyncJobState,
+		attempt: number,
+		error?: string,
+	): Promise<void> {
+		const now = new Date().toISOString();
+		const existing = await this.table.get({ jobId });
+		const base = existing ?? this.queuedRecord(jobId, now);
+		const transition: AsyncJobTransition = { state, at: now, attempt };
+
+		const next: StatusRecord = {
+			...base,
+			state,
+			transitions: [...base.transitions, transition],
+			attempts: Math.max(base.attempts, attempt),
+			updatedAt: now,
+			expiresAt: expiresAt(),
+		};
+		if (error !== undefined) next.error = error;
+
+		await this.table.put(next);
+	}
+
+	/**
+	 * Append a transition, swallowing and logging any failure.
+	 *
+	 * Used on the handler path only. A status write must never decide the fate of
+	 * a job: throwing before the handler would retry work that was fine, and
+	 * throwing after it succeeded would re-run work that already completed.
+	 */
+	async tryRecordTransition(
+		jobId: string,
+		state: AsyncJobState,
+		attempt: number,
+		error?: string,
+	): Promise<void> {
+		try {
+			await this.recordTransition(jobId, state, attempt, error);
+		} catch (err: unknown) {
+			this.log?.error?.(
+				`AsyncJob: failed to record "${state}" status for job ${jobId}: ${
+					err instanceof Error ? err.message : String(err)
+				}`,
+			);
+		}
+	}
+
+	/** Read a job's status, or `null` when nothing is recorded for that id. */
+	async get(jobId: string): Promise<AsyncJobStatus | null> {
+		const record = await this.table.get({ jobId });
+		if (!record) return null;
+		const { expiresAt: _ttl, ...status } = record;
+		return status;
+	}
+
+	/** Poll until the job reaches `complete` or `failed`, or the budget runs out. */
+	async waitUntilComplete(
+		jobId: string,
+		options?: WaitUntilCompleteOptions,
+	): Promise<AsyncJobStatus> {
+		const timeoutMs = options?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+		const pollIntervalMs = Math.max(1, options?.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS);
+		const signal = options?.signal;
+		const deadline = Date.now() + timeoutMs;
+
+		let last: AsyncJobStatus | null = null;
+		for (;;) {
+			signal?.throwIfAborted();
+
+			last = await this.get(jobId);
+			if (last && isTerminal(last.state)) return last;
+
+			if (Date.now() >= deadline) {
+				throw blocksError(
+					AsyncJobErrors.Timeout,
+					`Job ${jobId} did not reach a terminal state within ${timeoutMs}ms ` +
+						`(last observed state: ${last?.state ?? 'unknown'})`,
+				);
+			}
+
+			const remaining = Math.max(deadline - Date.now(), 0);
+			await sleep(Math.min(jitterInterval(pollIntervalMs), remaining), signal);
+		}
+	}
+}
+
+/** Error thrown when a status method is called on a job that is not tracking status. */
+export function statusNotTrackedError(id: string): Error {
+	return blocksError(
+		AsyncJobErrors.StatusNotTracked,
+		`AsyncJob "${id}" is not tracking job status. ` +
+			`Pass { trackStatus: true } to the AsyncJob constructor to record state transitions.`,
+	);
+}

--- a/packages/bb-async-job/src/status.ts
+++ b/packages/bb-async-job/src/status.ts
@@ -23,7 +23,7 @@ export const STATUS_RETENTION_SECONDS = 86_400;
 const DEFAULT_TIMEOUT_MS = 30_000;
 const DEFAULT_POLL_INTERVAL_MS = 250;
 
-/** Attempts allowed for the compare-and-swap in {@link JobStatusTracker.recordTransition}. */
+/** Attempts allowed for either compare-and-swap in {@link JobStatusTracker}. */
 const MAX_CAS_ATTEMPTS = 5;
 const CAS_BACKOFF_MS = 20;
 
@@ -181,12 +181,83 @@ export class JobStatusTracker {
 	 * unconditional write would clobber that `processing` entry and strand the job
 	 * at `queued` forever. Losing the race is therefore success, not failure: the
 	 * handler's backfill already contains the `queued` transition.
+	 *
+	 * It is not a plain no-op either. The handler cannot know when the job was
+	 * submitted, so its backfill dates the submission from the moment it first
+	 * observed the job. This is the only caller holding the real submission time,
+	 * so on a lost race it goes back and corrects the record rather than
+	 * abandoning a `submittedAt` that the README defines as the time of
+	 * submission. The correction is best-effort: by this point the message is
+	 * already on the queue and the job will run, so a failed metadata fix must not
+	 * turn a successful `submit()` into a throw.
 	 */
 	async recordQueued(jobId: string, submittedAt: string): Promise<void> {
 		try {
 			await this.table.put(this.queuedRecord(jobId, submittedAt), { ifNotExists: true });
+			return;
 		} catch (err: unknown) {
 			if (!isBlocksError(err, DistributedTableErrors.ConditionalCheckFailed)) throw err;
+		}
+
+		try {
+			await this.backdateSubmission(jobId, submittedAt);
+		} catch (err: unknown) {
+			this.log?.error?.(
+				`AsyncJob: failed to correct submittedAt for job ${jobId}: ${
+					err instanceof Error ? err.message : String(err)
+				}`,
+			);
+		}
+	}
+
+	/**
+	 * Replace a backfilled submission time with the real one.
+	 *
+	 * `submittedAt` and the `queued` transition are corrected together: they are
+	 * two views of the same instant, and callers are entitled to expect
+	 * `transitions[0].at` to equal `submittedAt`.
+	 *
+	 * The correction only ever moves the timestamp earlier. Submission precedes
+	 * every transition, so a stored value that is already earlier did not come
+	 * from a backfill and is not ours to overwrite. That also makes this
+	 * idempotent, which matters because the write below can be retried.
+	 *
+	 * Like {@link recordTransition} this is a read-modify-write and carries the
+	 * same compare-and-swap on `version`, so a handler appending a transition
+	 * concurrently cannot have it dropped by this write, nor this correction by
+	 * theirs.
+	 */
+	private async backdateSubmission(jobId: string, submittedAt: string): Promise<void> {
+		const submitted = Date.parse(submittedAt);
+
+		for (let cas = 1; ; cas++) {
+			const existing = await this.table.get({ jobId });
+			// Gone between the failed create and this read: the record hit its TTL, or
+			// the job id was never tracked. Re-creating it would resurrect a job whose
+			// history has already been reaped.
+			if (!existing) return;
+
+			// Also covers an unparseable stored timestamp, where NaN makes the
+			// comparison false and leaves the record untouched.
+			if (!(submitted < Date.parse(existing.submittedAt))) return;
+
+			const next: StatusRecord = {
+				...existing,
+				submittedAt,
+				transitions: existing.transitions.map((t, i) =>
+					i === 0 && t.state === 'queued' ? { ...t, at: submittedAt } : t,
+				),
+				version: existing.version + 1,
+			};
+
+			try {
+				await this.table.put(next, { ifFieldEquals: { version: existing.version } });
+				return;
+			} catch (err: unknown) {
+				const lostRace = isBlocksError(err, DistributedTableErrors.ConditionalCheckFailed);
+				if (!lostRace || cas >= MAX_CAS_ATTEMPTS) throw err;
+				await sleep(jitterInterval(CAS_BACKOFF_MS));
+			}
 		}
 	}
 
@@ -214,6 +285,11 @@ export class JobStatusTracker {
 	 * dropped entry were the terminal one, `waitUntilComplete()` would time out on
 	 * a job that had actually finished. On a lost swap the record is re-read and
 	 * the transition re-applied, so no entry is lost.
+	 *
+	 * When no record exists yet this backfills one, because the handler can run
+	 * before `submit()` has written `queued`. The submission time it stamps there
+	 * is provisional: the handler only knows when it first saw the job.
+	 * {@link recordQueued} replaces it with the real one when it arrives.
 	 */
 	async recordTransition(
 		jobId: string,

--- a/packages/bb-async-job/src/status.ts
+++ b/packages/bb-async-job/src/status.ts
@@ -1,7 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { DistributedTable } from '@aws-blocks/bb-distributed-table';
+import { DistributedTable, DistributedTableErrors } from '@aws-blocks/bb-distributed-table';
+import { isBlocksError } from '@aws-blocks/core';
 import type { ScopeParent } from '@aws-blocks/core';
 import type { ChildLogger } from '@aws-blocks/bb-logger';
 import type { StandardSchemaV1 } from '@standard-schema/spec';
@@ -22,10 +23,16 @@ export const STATUS_RETENTION_SECONDS = 86_400;
 const DEFAULT_TIMEOUT_MS = 30_000;
 const DEFAULT_POLL_INTERVAL_MS = 250;
 
-/** Stored shape: the public record plus the DynamoDB TTL attribute. */
+/** Attempts allowed for the compare-and-swap in {@link JobStatusTracker.recordTransition}. */
+const MAX_CAS_ATTEMPTS = 5;
+const CAS_BACKOFF_MS = 20;
+
+/** Stored shape: the public record plus bookkeeping the caller never sees. */
 interface StatusRecord extends AsyncJobStatus {
 	/** Epoch seconds at which DynamoDB may delete this record. */
 	expiresAt: number;
+	/** Incremented on every write; the compare value for optimistic concurrency. */
+	version: number;
 }
 
 const STRING_FIELDS = ['jobId', 'state', 'submittedAt', 'updatedAt', 'error'] as const;
@@ -54,7 +61,7 @@ export const statusSchema: StandardSchemaV1<StatusRecord> = {
 					issues.push({ message: `${field} must be a string`, path: [field] });
 				}
 			}
-			for (const field of ['attempts', 'expiresAt'] as const) {
+			for (const field of ['attempts', 'expiresAt', 'version'] as const) {
 				if (field in record && typeof record[field] !== 'number') {
 					issues.push({ message: `${field} must be a number`, path: [field] });
 				}
@@ -160,28 +167,53 @@ export class JobStatusTracker {
 			submittedAt,
 			updatedAt: submittedAt,
 			expiresAt: expiresAt(),
+			version: 0,
 		};
 	}
 
 	/**
-	 * Record a job as `queued`. Called before the payload is handed to the
-	 * queue so a consumer can never observe `processing` before `queued`.
+	 * Record a job as `queued`.
+	 *
+	 * Conditional on the record not existing yet. In AWS the job id *is* the SQS
+	 * message id, so this write can only happen after `SendMessage` returns — by
+	 * which point SQS may already have delivered the message and the handler may
+	 * already have created the record via {@link recordTransition}. An
+	 * unconditional write would clobber that `processing` entry and strand the job
+	 * at `queued` forever. Losing the race is therefore success, not failure: the
+	 * handler's backfill already contains the `queued` transition.
 	 */
 	async recordQueued(jobId: string, submittedAt: string): Promise<void> {
-		await this.table.put(this.queuedRecord(jobId, submittedAt));
+		try {
+			await this.table.put(this.queuedRecord(jobId, submittedAt), { ifNotExists: true });
+		} catch (err: unknown) {
+			if (!isBlocksError(err, DistributedTableErrors.ConditionalCheckFailed)) throw err;
+		}
 	}
 
-	/** Record several jobs as `queued` in one round trip. */
+	/**
+	 * Record several jobs as `queued`.
+	 *
+	 * Deliberately individual conditional writes rather than one `putBatch`:
+	 * DynamoDB's `BatchWriteItem` cannot carry a condition expression, so a batch
+	 * write would reintroduce the clobber described on {@link recordQueued}. A
+	 * batch is at most 10 items, so the puts are issued in parallel.
+	 */
 	async recordQueuedBatch(jobs: Array<{ jobId: string; submittedAt: string }>): Promise<void> {
 		if (jobs.length === 0) return;
-		await this.table.putBatch(jobs.map(j => this.queuedRecord(j.jobId, j.submittedAt)));
+		await Promise.all(jobs.map(j => this.recordQueued(j.jobId, j.submittedAt)));
 	}
 
 	/**
 	 * Append a transition to a job's history.
 	 *
-	 * Read-modify-write is safe here because SQS keeps a message invisible while
-	 * its handler runs, so only one attempt writes a given job's record at a time.
+	 * Appending is a read-modify-write, so it is guarded by a compare-and-swap on
+	 * `version`. SQS standard queues are at-least-once, and the block's own
+	 * contract tells handlers to expect more than one delivery, so two invocations
+	 * can hold the same record concurrently. Without the guard the later
+	 * full-item `put` would silently drop the other's transition — and if the
+	 * dropped entry were the terminal one, `waitUntilComplete()` would time out on
+	 * a job that had actually finished. On a lost swap the record is re-read and
+	 * the transition re-applied, so no entry is lost.
 	 */
 	async recordTransition(
 		jobId: string,
@@ -189,22 +221,35 @@ export class JobStatusTracker {
 		attempt: number,
 		error?: string,
 	): Promise<void> {
-		const now = new Date().toISOString();
-		const existing = await this.table.get({ jobId });
-		const base = existing ?? this.queuedRecord(jobId, now);
-		const transition: AsyncJobTransition = { state, at: now, attempt };
+		for (let cas = 1; ; cas++) {
+			const existing = await this.table.get({ jobId });
+			const now = new Date().toISOString();
+			const base = existing ?? this.queuedRecord(jobId, now);
+			const transition: AsyncJobTransition = { state, at: now, attempt };
 
-		const next: StatusRecord = {
-			...base,
-			state,
-			transitions: [...base.transitions, transition],
-			attempts: Math.max(base.attempts, attempt),
-			updatedAt: now,
-			expiresAt: expiresAt(),
-		};
-		if (error !== undefined) next.error = error;
+			const next: StatusRecord = {
+				...base,
+				state,
+				transitions: [...base.transitions, transition],
+				attempts: Math.max(base.attempts, attempt),
+				updatedAt: now,
+				expiresAt: expiresAt(),
+				version: base.version + 1,
+			};
+			if (error !== undefined) next.error = error;
 
-		await this.table.put(next);
+			try {
+				await this.table.put(
+					next,
+					existing ? { ifFieldEquals: { version: existing.version } } : { ifNotExists: true },
+				);
+				return;
+			} catch (err: unknown) {
+				const lostRace = isBlocksError(err, DistributedTableErrors.ConditionalCheckFailed);
+				if (!lostRace || cas >= MAX_CAS_ATTEMPTS) throw err;
+				await sleep(jitterInterval(CAS_BACKOFF_MS));
+			}
+		}
 	}
 
 	/**
@@ -235,7 +280,7 @@ export class JobStatusTracker {
 	async get(jobId: string): Promise<AsyncJobStatus | null> {
 		const record = await this.table.get({ jobId });
 		if (!record) return null;
-		const { expiresAt: _ttl, ...status } = record;
+		const { expiresAt: _ttl, version: _version, ...status } = record;
 		return status;
 	}
 

--- a/packages/bb-async-job/src/types.ts
+++ b/packages/bb-async-job/src/types.ts
@@ -28,8 +28,70 @@ export interface AsyncJobOptions<T> {
 	maxRetries?: number;
 	/** Number of messages the Lambda trigger receives per invocation. Default: 1. */
 	batchSize?: number;
+	/**
+	 * Record every job's state transitions so they can be read back with
+	 * `getStatus()` / `waitUntilComplete()`. Default: `false`.
+	 *
+	 * Enabling this provisions one DynamoDB table for the job's status records
+	 * and adds a write on submit plus one per state change. Leave it off for
+	 * pure fire-and-forget work.
+	 */
+	trackStatus?: boolean;
 	/** Optional logger for internal operations. When omitted, a default Logger at error level is created. */
 	logger?: ChildLogger;
+}
+
+/**
+ * Lifecycle state of a single job.
+ *
+ * `queued` is recorded on submit, `processing` at the start of every delivery
+ * to the handler, and `complete` or `failed` once the job settles. A retry adds
+ * another `processing` entry rather than a new terminal state.
+ */
+export type AsyncJobState = 'queued' | 'processing' | 'complete' | 'failed';
+
+/** A single entry in a job's transition history. */
+export interface AsyncJobTransition {
+	/** State the job moved into. */
+	state: AsyncJobState;
+	/** ISO 8601 timestamp of the transition. */
+	at: string;
+	/** Delivery attempt that produced this transition. `0` for `queued`, `1` on first delivery. */
+	attempt: number;
+}
+
+/**
+ * Recorded status of a job, returned by `getStatus()` and `waitUntilComplete()`.
+ *
+ * `transitions` is append-only, so intermediate states stay observable no matter
+ * when the record is read — a caller that polls once after the job finished
+ * still sees that it passed through `processing`.
+ */
+export interface AsyncJobStatus {
+	/** Job identifier returned by `submit()`. */
+	jobId: string;
+	/** Most recent state. */
+	state: AsyncJobState;
+	/** Every state the job has entered, in order. */
+	transitions: AsyncJobTransition[];
+	/** Number of times the job has been delivered to the handler. */
+	attempts: number;
+	/** ISO 8601 timestamp of when the job was submitted. */
+	submittedAt: string;
+	/** ISO 8601 timestamp of the most recent transition. */
+	updatedAt: string;
+	/** Message from the last handler error. Set when `state` is `failed`. */
+	error?: string;
+}
+
+/** Options for `waitUntilComplete()`. */
+export interface WaitUntilCompleteOptions {
+	/** Total time to wait before throwing `AsyncJobErrors.Timeout`. Default: 30000. */
+	timeoutMs?: number;
+	/** Delay between status reads, carrying ±20% jitter. Clamped to a 1ms minimum. Default: 250. */
+	pollIntervalMs?: number;
+	/** Cancels the wait, rejecting with the signal's abort reason. */
+	signal?: AbortSignal;
 }
 
 /**

--- a/packages/bb-async-job/tsconfig.json
+++ b/packages/bb-async-job/tsconfig.json
@@ -10,6 +10,9 @@
   "references": [
     {
       "path": "../bb-logger"
+    },
+    {
+      "path": "../bb-distributed-table"
     }
   ]
 }

--- a/packages/blocks/API.md
+++ b/packages/blocks/API.md
@@ -28,6 +28,9 @@ import { AsyncJob } from '@aws-blocks/bb-async-job';
 import { AsyncJobContext } from '@aws-blocks/bb-async-job';
 import { AsyncJobErrors } from '@aws-blocks/bb-async-job';
 import { AsyncJobOptions } from '@aws-blocks/bb-async-job';
+import { AsyncJobState } from '@aws-blocks/bb-async-job';
+import { AsyncJobStatus } from '@aws-blocks/bb-async-job';
+import { AsyncJobTransition } from '@aws-blocks/bb-async-job';
 import { AuthAction } from '@aws-blocks/auth-common';
 import { AuthActionInput } from '@aws-blocks/auth-common';
 import { AuthBasic } from '@aws-blocks/bb-auth-basic';
@@ -176,6 +179,7 @@ import { Transaction } from '@aws-blocks/bb-data';
 import { TransactionOptions } from '@aws-blocks/bb-distributed-data';
 import { UpdateAttributeOutcome } from '@aws-blocks/bb-auth-cognito';
 import { UserAttribute } from '@aws-blocks/bb-auth-cognito';
+import { WaitUntilCompleteOptions } from '@aws-blocks/bb-async-job';
 import { WaitUntilSyncedOptions } from '@aws-blocks/bb-knowledge-base';
 
 export { AdminAction }
@@ -225,6 +229,12 @@ export { AsyncJobContext }
 export { AsyncJobErrors }
 
 export { AsyncJobOptions }
+
+export { AsyncJobState }
+
+export { AsyncJobStatus }
+
+export { AsyncJobTransition }
 
 export { AuthAction }
 
@@ -610,6 +620,8 @@ export { TransactionOptions }
 export { UpdateAttributeOutcome }
 
 export { UserAttribute }
+
+export { WaitUntilCompleteOptions }
 
 export { WaitUntilSyncedOptions }
 

--- a/packages/blocks/src/index.cdk.ts
+++ b/packages/blocks/src/index.cdk.ts
@@ -43,7 +43,7 @@ export type { DatabaseOptions, ExternalDatabaseRef, SqlQuery, Transaction } from
 export { DistributedDatabase, DistributedDatabaseErrors } from '@aws-blocks/bb-distributed-data';
 export type { DistributedDatabaseOptions, TransactionOptions } from '@aws-blocks/bb-distributed-data';
 export { AsyncJob, AsyncJobErrors } from '@aws-blocks/bb-async-job';
-export type { AsyncJobOptions, AsyncJobContext, SubmitOptions, BatchSubmitResult } from '@aws-blocks/bb-async-job';
+export type { AsyncJobOptions, AsyncJobContext, SubmitOptions, BatchSubmitResult, AsyncJobState, AsyncJobStatus, AsyncJobTransition, WaitUntilCompleteOptions } from '@aws-blocks/bb-async-job';
 export { Agent, AgentErrors, BedrockModels, OllamaModels } from '@aws-blocks/bb-agent';
 export type { AgentConfig, AgentResult, AgentStreamChunk, ToolDefinition, ToolCallRecord, ModelConfig, StreamOptions, TokenUsage } from '@aws-blocks/bb-agent';
 export { CronJob, CronJobErrors } from '@aws-blocks/bb-cron-job';

--- a/packages/blocks/src/index.ts
+++ b/packages/blocks/src/index.ts
@@ -213,7 +213,7 @@ export type { DistributedDatabaseOptions, TransactionOptions } from '@aws-blocks
  * Full docs: `README.md` in the package directory above.
  */
 export { AsyncJob, AsyncJobErrors } from '@aws-blocks/bb-async-job';
-export type { AsyncJobOptions, AsyncJobContext, SubmitOptions, BatchSubmitResult } from '@aws-blocks/bb-async-job';
+export type { AsyncJobOptions, AsyncJobContext, SubmitOptions, BatchSubmitResult, AsyncJobState, AsyncJobStatus, AsyncJobTransition, WaitUntilCompleteOptions } from '@aws-blocks/bb-async-job';
 
 /**
  * **AI agent with streaming, tool calling, and conversation persistence.**

--- a/test-apps/comprehensive/aws-blocks/index.ts
+++ b/test-apps/comprehensive/aws-blocks/index.ts
@@ -268,6 +268,27 @@ const validatedJob = new AsyncJob(scope, 'validated-job', {
   },
 });
 
+// AsyncJob with trackStatus - exercises the status table (DynamoDB when deployed).
+// The handler settles immediately on purpose: the transition history is what makes
+// the intermediate `processing` state observable, so there is no delay to widen it.
+const trackedJob = new AsyncJob(scope, 'tracked-job', {
+  trackStatus: true,
+  handler: async (payload: { key: string; value: string }) => {
+    await jobResults.put(`tracked:${payload.key}`, payload.value);
+  },
+});
+
+// Failure path for status tracking. maxRetries: 1 makes the first failure terminal
+// in both runtimes, so `failed` is recorded on the only delivery and the test does
+// not depend on redrive timing.
+const trackedFailingJob = new AsyncJob(scope, 'tracked-failing-job', {
+  trackStatus: true,
+  maxRetries: 1,
+  handler: async (payload: { reason: string }) => {
+    throw new Error(`tracked job failed on purpose: ${payload.reason}`);
+  },
+});
+
 // Agent BB - AI agent with tools and conversation persistence
 import { Agent, BedrockModels } from '@aws-blocks/bb-agent';
 
@@ -1660,6 +1681,37 @@ export const api = new ApiNamespace(scope, 'api', (context) => ({
   async asyncJobSubmitBatchDelayed(items: { key: string; value: string }[], delaySeconds: number) {
     const { jobIds } = await testJob.submitBatch(items, { delaySeconds });
     return { jobIds };
+  },
+
+  // ------------------------------------------------------------------------
+  // AsyncJob status tracking (trackStatus) Tests
+  // ------------------------------------------------------------------------
+
+  async asyncJobStatusSubmit(key: string, value: string) {
+    const { jobId } = await trackedJob.submit({ key, value });
+    return { jobId };
+  },
+
+  async asyncJobStatusSubmitBatch(items: Array<{ key: string; value: string }>) {
+    const { jobIds } = await trackedJob.submitBatch(items);
+    return { jobIds };
+  },
+
+  async asyncJobStatusGet(jobId: string) {
+    return trackedJob.getStatus(jobId);
+  },
+
+  async asyncJobStatusWait(jobId: string, timeoutMs: number) {
+    return trackedJob.waitUntilComplete(jobId, { timeoutMs });
+  },
+
+  async asyncJobStatusSubmitFailing(reason: string) {
+    const { jobId } = await trackedFailingJob.submit({ reason });
+    return { jobId };
+  },
+
+  async asyncJobStatusWaitFailing(jobId: string, timeoutMs: number) {
+    return trackedFailingJob.waitUntilComplete(jobId, { timeoutMs });
   },
 
   // ------------------------------------------------------------------------

--- a/test-apps/comprehensive/test/async-job-status.test.ts
+++ b/test-apps/comprehensive/test/async-job-status.test.ts
@@ -1,0 +1,193 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * AsyncJob status tracking e2e.
+ *
+ * These run in every environment on purpose. Locally they exercise the mock
+ * store; against a sandbox or production stack the identical assertions travel
+ * through SQS, the shared Lambda and a real DynamoDB table, which is the only
+ * place the nested `transitions` list and the numeric attributes actually get
+ * marshalled and unmarshalled.
+ *
+ * No handler involved here contains a delay. The point of the transition history
+ * is that intermediate states stay observable without one.
+ */
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert';
+import type { api as apiType } from 'aws-blocks';
+
+const ENV = process.env.BLOCKS_TEST_ENV || 'local';
+const isDeployed = ENV === 'sandbox' || ENV === 'production';
+
+// Deployed runs pay for SQS delivery plus a Lambda cold start before the handler
+// even begins, so the wait budget is far longer than the local one.
+const WAIT_BUDGET_MS = isDeployed ? 120_000 : 15_000;
+const TEST_TIMEOUT_MS = WAIT_BUDGET_MS + 60_000;
+
+type Transition = { state: string; at: string; attempt: number };
+
+function assertWellFormedTransitions(transitions: Transition[]): void {
+	assert.ok(Array.isArray(transitions), 'transitions must survive as an array');
+
+	for (const [index, transition] of transitions.entries()) {
+		// A DynamoDB list of maps round-trips through the document client; if
+		// marshalling regressed these would come back as strings or wrapped
+		// attribute values rather than plain JS types.
+		assert.strictEqual(
+			typeof transition.state,
+			'string',
+			`transition ${index} state should be a string, got ${typeof transition.state}`,
+		);
+		assert.strictEqual(
+			typeof transition.attempt,
+			'number',
+			`transition ${index} attempt should be a number, got ${typeof transition.attempt}`,
+		);
+		assert.ok(
+			Number.isInteger(transition.attempt),
+			`transition ${index} attempt should be an integer, got ${transition.attempt}`,
+		);
+		assert.ok(
+			Number.isFinite(Date.parse(transition.at)),
+			`transition ${index} at should parse as a date, got ${transition.at}`,
+		);
+	}
+
+	const times = transitions.map(t => Date.parse(t.at));
+	for (let i = 1; i < times.length; i++) {
+		assert.ok(times[i] >= times[i - 1], `transition ${i} must not predate transition ${i - 1}`);
+	}
+}
+
+function assertNoStorageLeak(status: object): void {
+	const record = status as Record<string, unknown>;
+	assert.strictEqual(record.expiresAt, undefined, 'TTL attribute must not surface');
+	assert.strictEqual(record.version, undefined, 'concurrency version must not surface');
+}
+
+export function asyncJobStatusTests(getApi: () => typeof apiType) {
+	describe('AsyncJob status tracking', () => {
+		test(
+			'AsyncJob status - queued/processing/complete round-trips through the store',
+			{ timeout: TEST_TIMEOUT_MS },
+			async () => {
+				const api = getApi();
+				const testId = Date.now().toString(36);
+				const { jobId } = await api.asyncJobStatusSubmit(`tracked-${testId}`, 'hello');
+				assert.ok(typeof jobId === 'string' && jobId.length > 0);
+
+				const status = await api.asyncJobStatusWait(jobId, WAIT_BUDGET_MS);
+
+				assert.strictEqual(status.state, 'complete');
+				assert.strictEqual(status.jobId, jobId);
+				assert.deepStrictEqual(
+					status.transitions.map((t: Transition) => t.state),
+					['queued', 'processing', 'complete'],
+					'the whole sequence must be recorded even though the handler returned immediately',
+				);
+				assertWellFormedTransitions(status.transitions);
+				assert.deepStrictEqual(status.transitions.map((t: Transition) => t.attempt), [0, 1, 1]);
+
+				assert.strictEqual(typeof status.attempts, 'number');
+				assert.strictEqual(status.attempts, 1);
+				assert.ok(Number.isFinite(Date.parse(status.submittedAt)));
+				assert.ok(Number.isFinite(Date.parse(status.updatedAt)));
+				assert.strictEqual(status.error, undefined, 'a successful job must not carry an error');
+				assertNoStorageLeak(status);
+
+				// The handler wrote through a separate KVStore, so this also confirms the
+				// job really ran rather than the status being recorded speculatively.
+				assert.strictEqual(await api.asyncJobGetResult(`tracked-${testId}`), null);
+			},
+		);
+
+		test(
+			'AsyncJob status - a single read after the job settled still shows processing',
+			{ timeout: TEST_TIMEOUT_MS },
+			async () => {
+				const api = getApi();
+				const testId = Date.now().toString(36);
+				const { jobId } = await api.asyncJobStatusSubmit(`after-${testId}`, 'value');
+
+				await api.asyncJobStatusWait(jobId, WAIT_BUDGET_MS);
+
+				// One read, taken only once the job is already done. This is the case that
+				// used to need setTimeout(1500) in the handler to be observable at all.
+				const status = await api.asyncJobStatusGet(jobId);
+				assert.ok(status, 'status should be readable after completion');
+				assert.deepStrictEqual(
+					status.transitions.map((t: Transition) => t.state),
+					['queued', 'processing', 'complete'],
+				);
+				assertWellFormedTransitions(status.transitions);
+				assertNoStorageLeak(status);
+			},
+		);
+
+		test(
+			'AsyncJob status - failed path records the handler error',
+			{ timeout: TEST_TIMEOUT_MS },
+			async () => {
+				const api = getApi();
+				const reason = `boom-${Date.now().toString(36)}`;
+				const { jobId } = await api.asyncJobStatusSubmitFailing(reason);
+
+				const status = await api.asyncJobStatusWaitFailing(jobId, WAIT_BUDGET_MS);
+
+				assert.strictEqual(status.state, 'failed');
+				assert.deepStrictEqual(
+					status.transitions.map((t: Transition) => t.state),
+					['queued', 'processing', 'failed'],
+				);
+				assertWellFormedTransitions(status.transitions);
+
+				// The error string is the field most likely to be dropped by a
+				// marshalling regression, since it is only present on the failed path.
+				assert.ok(status.error, 'a failed job must carry an error message');
+				const error: string = status.error;
+				assert.match(error, new RegExp(reason));
+				assert.match(error, /failed on purpose/);
+				assert.strictEqual(status.attempts, 1);
+				assertNoStorageLeak(status);
+			},
+		);
+
+		test(
+			'AsyncJob status - submitBatch tracks every job',
+			{ timeout: TEST_TIMEOUT_MS },
+			async () => {
+				const api = getApi();
+				const testId = Date.now().toString(36);
+				const items = [
+					{ key: `tracked-batch-${testId}-0`, value: 'a' },
+					{ key: `tracked-batch-${testId}-1`, value: 'b' },
+				];
+
+				const { jobIds } = await api.asyncJobStatusSubmitBatch(items);
+				assert.strictEqual(jobIds.length, items.length);
+
+				for (const jobId of jobIds) {
+					assert.ok(jobId, 'every batch entry should return a job id');
+					const status = await api.asyncJobStatusWait(jobId, WAIT_BUDGET_MS);
+					assert.strictEqual(status.state, 'complete');
+					assert.deepStrictEqual(
+						status.transitions.map((t: Transition) => t.state),
+						['queued', 'processing', 'complete'],
+					);
+					assertWellFormedTransitions(status.transitions);
+				}
+			},
+		);
+
+		test(
+			'AsyncJob status - getStatus returns null for an unknown job id',
+			{ timeout: 30_000 },
+			async () => {
+				const api = getApi();
+				assert.strictEqual(await api.asyncJobStatusGet(`missing-${Date.now()}`), null);
+			},
+		);
+	});
+}

--- a/test-apps/comprehensive/test/e2e.test.ts
+++ b/test-apps/comprehensive/test/e2e.test.ts
@@ -21,6 +21,7 @@ import { oidcAuthTests } from './oidc-auth.test.js';
 import { databaseTests } from './database.test.js';
 import { dsqlTests } from './dsql.test.js';
 import { asyncJobTests } from './async-job.test.js';
+import { asyncJobStatusTests } from './async-job-status.test.js';
 import { agentTests } from './agent.test.js';
 import { cronJobTests } from './cron-job.test.js';
 import { fileBucketTests } from './file-bucket.test.js';
@@ -225,6 +226,9 @@ databaseTests(() => api);
 
 // AsyncJob tests (separate file)
 asyncJobTests(() => api);
+
+// AsyncJob status tracking tests (separate file)
+asyncJobStatusTests(() => api);
 
 // CronJob tests (separate file)
 cronJobTests(() => api);


### PR DESCRIPTION
Fixes #223

## The problem

Watching a job go from `queued` to `processing` to `complete` required padding the handler with an artificial `setTimeout(1500)`. There was no status API at all, so [the README](https://github.com/aws-devtools-labs/aws-blocks/blob/ac0966a/packages/bb-async-job/README.md#how-do-i-know-my-job-ran) told people to write their own state into a KVStore from inside the handler, and `test-apps/comprehensive` does exactly that plus a 20x100ms poll loop.

The catch is that hand-rolled state is a single mutable value. A handler that finishes in a millisecond passes through `processing` faster than any client can poll it, so the delay was not really about notifications, it was there to widen the window enough to be caught. Any tuned value races against the reader's cadence, which is what #223 saw: intermediate states missed, or the transitions racing each other.

## The fix

Pass `trackStatus: true` and AsyncJob records the lifecycle itself:

```ts
const job = new AsyncJob(scope, 'ingest', {
  trackStatus: true,
  handler: async (payload) => { await ingest(payload.documentId); },
});

const { jobId } = await job.submit({ documentId: 'doc-1' });

const status = await job.waitUntilComplete(jobId);
status.transitions.map((t) => t.state);  // ['queued', 'processing', 'complete']
```

Two new methods:

- **`getStatus(jobId)`** returns the current state plus the full transition history, or `null` for an unknown id.
- **`waitUntilComplete(jobId, options?)`** waits for `complete` or `failed`, with `timeoutMs` (default 30000), `pollIntervalMs` (default 250, +/-20% jitter) and an `AbortSignal`. It follows the shape `KnowledgeBase.waitUntilSynced()` already established so there is one poll-until idiom in the repo rather than two.

**Transitions are appended, not overwritten.** That is the part that actually removes the race: a caller reading the record once, long after the job settled, still sees that it went through `processing`. No timing assumption anywhere, and nothing to tune. A retry appends another `processing` entry instead of a second terminal state, so attempt counts stay readable:

```ts
status.transitions.map((t) => `${t.state}#${t.attempt}`);
// ['queued#0', 'processing#1', 'processing#2', 'failed#2']
```

Storage is a nested `DistributedTable` keyed by `jobId` with a 24 hour TTL, composed the same way bb-agent, bb-auth-cognito and bb-realtime already compose child blocks: identical child id and options in the runtime and CDK constructors. Because `DistributedTable` has its own conditional exports, there is one status code path for both mock and AWS rather than two.

## Why opt-in

Tracking is not free. It adds a DynamoDB table per job plus a write on submit and one per transition, and it would turn `submitBatch` from a single native SQS batch into an extra batch write, which is exactly the kind of hidden cost G14/G18 warn about. With the flag off nothing is provisioned, `submit()` stays a single SQS call, existing deployments gain no resources, and the status methods throw `StatusNotTracked` pointing at the flag. Flipping the default on later is a non-breaking change if you would rather have it always on, so this is the reversible direction.

Happy to switch it to always-on if you prefer that trade, it is a small change.

## Two details worth a look

**Status writes never decide a job's fate.** On the handler path they are logged, not thrown. Throwing before the handler would retry work that was fine; throwing after it succeeded would re-run work that had already completed. The `queued` write in `submit()` does propagate, since the caller explicitly asked for tracking and failing there is safe.

**Terminal failure is deferred to SQS.** A handler error only records `failed` once `receiveCount` has reached `maxRetries`. SQS redrive owns the retry decision, so earlier failures record nothing and the next delivery just appends another `processing` entry.

## Testing

15 new tests in `packages/bb-async-job/src/status.test.ts`. **No handler in the file contains a `setTimeout`**, which is the whole point: the transition-sequence assertions pass against handlers that return immediately.

Covered: the queued/processing/complete sequence, reading the history only after the job settled, transition ordering and timestamps, the retry path recording `processing` twice then `failed`, `queued` observable while a job is delayed, `submitBatch` tracking every job, `getStatus` returning `null` for an unknown id, `waitUntilComplete` timing out mid-flight and then succeeding once the job finishes, rejecting with the signal's abort reason (both live and pre-aborted), `StatusNotTracked` when the flag is off, and isolation between two tracked jobs.

Two of them guard a trap I hit while writing this: the CDK layer infers a key's DynamoDB attribute type by probing `validate({ jobId: 0 })` and reads "no issue for that field" as numeric, so a pass-through schema would have provisioned `jobId` as `N` and every runtime write would have failed against it. The status schema rejects a numeric `jobId`, and there is now a test pinning that, since per-block cdk parity is not covered by `conditional-exports.test.ts`.

To check the tests are not toothless I disabled the append (`transitions: [transition]`, the old mutable-value behaviour) and re-ran: 5 of them fail. Restored, all 35 pass.

## Verification

| Check | Result |
|---|---|
| `npm run build:packages` | pass |
| `npm test -w packages/bb-async-job` | 35/35 pass (20 existing + 15 new) |
| `npm test -w packages/blocks` | 41/41 pass, includes bb-async-job aws-runtime/default export parity |
| `npm test` (all workspaces) | 0 failures |
| `npm run check:api` | exit 0, `API.md` regenerated via `npm run update:api` and committed for both bb-async-job and blocks |
| `changeset-guard validate-structure` | pass |
| `changeset-guard verify-coverage` | pass, both changed packages covered |
| `changeset-guard block-major` | pass |

`npm run lint` / `lint:deps` could not run here, the bundled biome binary needs GLIBC 2.28+ and this host is older. The new dependency is declared (`@aws-blocks/bb-distributed-table` in `dependencies`, `@standard-schema/spec` stays a devDependency as it is type-only) and the tsconfig project reference is added, so I expect it clean in CI.

Changeset is `bb-async-job: minor` plus `blocks: patch`, since the umbrella re-exports the new types and its `API.md` changed too.