### PR TITLE
fix(test-apps): key OIDC sign-in records by userId instead of module state

### DIFF
--- a/test-apps/comprehensive/aws-blocks/index.ts
+++ b/test-apps/comprehensive/aws-blocks/index.ts
@@ -117,7 +117,37 @@ const authCMfa = new AuthCognito(scope, 'authCMfa', {
 
 // AuthOIDC - OIDC sign-in gate
 // Uses the stub IdP in mock runtime — no real IdP needed for local tests.
-let lastOidcSignInUser: { userId: string; email: string | null; provider: string } | null = null;
+//
+// ── Sign-in records (e2e read-back) ─────────────────────────────────────────
+//
+// `onSignIn` runs while the OIDC callback is being served; the e2e reads the
+// result back over a later, separate request. A module-level variable cannot
+// carry it: in a deployed environment those two requests may be served by
+// different Lambda instances, so the reader either sees its own `null` or the
+// record of whoever signed in last, on either instance. The second case is
+// worse than a failure because it can pass by accident.
+//
+// Persist to the shared KVStore keyed by `userId` and scoped per AuthOIDC
+// instance, and require `userId` on the read, so a test can only ask for the
+// sign-in it is actually waiting on.
+//
+// These keys are bounded, unlike the verification codes: the stub IdP returns a
+// fixed user per provider, so each sign-in overwrites its own record.
+
+const oidcProfiles = new KVStore(scope, 'oidc-profiles');
+
+type SignInRecord = { userId: string; email: string | null; provider: string };
+
+const signInKey = (instance: string, userId: string) => `signin:${instance}:${userId}`;
+
+async function recordSignIn(instance: string, user: SignInRecord): Promise<void> {
+  await oidcProfiles.put(signInKey(instance, user.userId), JSON.stringify(user));
+}
+
+async function readSignIn(instance: string, userId: string): Promise<SignInRecord | null> {
+  const raw = await oidcProfiles.get(signInKey(instance, userId));
+  return raw === null ? null : (JSON.parse(raw) as SignInRecord);
+}
 
 const oidcProviders = [
   stubIdp({ name: 'google', onAuthorize: (req) => req.users[0] }),
@@ -127,16 +157,13 @@ const oidcProviders = [
 const oidcAuth = new AuthOIDC(scope, 'oidc-auth', {
   providers: oidcProviders,
   onSignIn: async (user) => {
-    lastOidcSignInUser = { userId: user.userId, email: user.email, provider: user.provider };
+    await recordSignIn('oidc-auth', { userId: user.userId, email: user.email, provider: user.provider });
   },
 });
 
 // AuthOIDC (second instance) — exercises the onSignIn hook with a profile
 // upsert pattern and bearer-token auth for native clients. Uses custom paths
 // to avoid colliding with the first instance.
-const oidcProfiles = new KVStore(scope, 'oidc-profiles');
-let lastExtrasSignInUser: { userId: string; email: string | null; provider: string } | null = null;
-
 const oidcAuthExtras = new AuthOIDC(scope, 'oidc-auth-extras', {
   providers: [
     stubIdp({ name: 'google-extras', onAuthorize: (req) => req.users[0] }),
@@ -148,7 +175,7 @@ const oidcAuthExtras = new AuthOIDC(scope, 'oidc-auth-extras', {
   // alongside the user, and /aws-blocks/auth/extras/refresh renews tokens.
   allowBearerAuth: true,
   onSignIn: async (user) => {
-    lastExtrasSignInUser = { userId: user.userId, email: user.email, provider: user.provider };
+    await recordSignIn('oidc-auth-extras', { userId: user.userId, email: user.email, provider: user.provider });
     // Upsert profile — the canonical post-sign-in pattern.
     await oidcProfiles.put(`profile:${user.userId}`, JSON.stringify({
       userId: user.userId,
@@ -1193,8 +1220,17 @@ export const api = new ApiNamespace(scope, 'api', (context) => ({
     return { success: true };
   },
 
-  async oidcGetLastSignInUser() {
-    return lastOidcSignInUser;
+  /**
+   * Read back the sign-in record `onSignIn` wrote for `userId`, or `null` if
+   * that user has not signed in through this instance.
+   *
+   * `userId` is required. The hook fires on a different request than this read,
+   * so "whoever signed in last" is not a safe question to ask: the answer can
+   * be another user, or another AuthOIDC instance's user, and the test would
+   * pass on the wrong record.
+   */
+  async oidcGetLastSignInUser(userId: string) {
+    return await readSignIn('oidc-auth', userId);
   },
 
   async oidcGetProviders() {
@@ -1210,8 +1246,9 @@ export const api = new ApiNamespace(scope, 'api', (context) => ({
     return { userId: user.userId, email: user.email, name: user.name, provider: user.provider, sub: user.sub, iss: user.iss };
   },
 
-  async oidcExtrasGetLastSignInUser() {
-    return lastExtrasSignInUser;
+  /** Read back the sign-in record for `userId`. See `oidcGetLastSignInUser`. */
+  async oidcExtrasGetLastSignInUser(userId: string) {
+    return await readSignIn('oidc-auth-extras', userId);
   },
 
   async oidcExtrasGetProfile(userId: string) {

--- a/test-apps/comprehensive/aws-blocks/index.ts
+++ b/test-apps/comprehensive/aws-blocks/index.ts
@@ -37,11 +37,18 @@ function logCodeLocally(message: string): void {
 // than a missing one: report it as absent so the caller's poller keeps waiting
 // and times out on its own message, rather than failing the test with a JSON
 // syntax error. An empty string is treated the same way.
-function parseStoredRecord<T>(raw: string | null): T | null {
+//
+// Absent is not silent though: a corrupt record means a bad write, which is a
+// real bug and not the race the pollers exist to absorb, so warn with the key
+// that failed. The value and the parser message are deliberately left out — the
+// message quotes the input it choked on, and these records hold verification
+// codes, which must never reach CloudWatch (see `logCodeLocally` above).
+function parseStoredRecord<T>(key: string, raw: string | null): T | null {
   if (!raw) return null;
   try {
     return JSON.parse(raw) as T;
   } catch {
+    console.warn(`[test-app] ignoring unparseable record at "${key}" (${raw.length} bytes) — treating it as absent`);
     return null;
   }
 }
@@ -97,8 +104,8 @@ async function recordDeliveredCode(channel: string, value: DeliveredCode | Deliv
 }
 
 async function readDeliveredCode<T extends DeliveredCode>(channel: string, username: string): Promise<T | null> {
-  const raw = await store.get(codeKey(channel, username));
-  return parseStoredRecord<T>(raw);
+  const key = codeKey(channel, username);
+  return parseStoredRecord<T>(key, await store.get(key));
 }
 
 async function purgeDeliveredCodes(): Promise<number> {
@@ -200,8 +207,8 @@ async function recordSignIn(instance: string, user: SignInRecord): Promise<void>
 }
 
 async function readSignIn(instance: string, userId: string): Promise<SignInRecord | null> {
-  const raw = await oidcProfiles.get(signInKey(instance, userId));
-  return parseStoredRecord<SignInRecord>(raw);
+  const key = signInKey(instance, userId);
+  return parseStoredRecord<SignInRecord>(key, await oidcProfiles.get(key));
 }
 
 const oidcProviders = [

--- a/test-apps/comprehensive/aws-blocks/index.ts
+++ b/test-apps/comprehensive/aws-blocks/index.ts
@@ -33,6 +33,19 @@ function logCodeLocally(message: string): void {
   if (!isDeployedLambda) console.log(message);
 }
 
+// Shared by the record readers below. A record we cannot parse is worth no more
+// than a missing one: report it as absent so the caller's poller keeps waiting
+// and times out on its own message, rather than failing the test with a JSON
+// syntax error. An empty string is treated the same way.
+function parseStoredRecord<T>(raw: string | null): T | null {
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as T;
+  } catch {
+    return null;
+  }
+}
+
 // ============================================================================
 // Building Block Instances
 // ============================================================================
@@ -85,7 +98,7 @@ async function recordDeliveredCode(channel: string, value: DeliveredCode | Deliv
 
 async function readDeliveredCode<T extends DeliveredCode>(channel: string, username: string): Promise<T | null> {
   const raw = await store.get(codeKey(channel, username));
-  return raw === null ? null : (JSON.parse(raw) as T);
+  return parseStoredRecord<T>(raw);
 }
 
 async function purgeDeliveredCodes(): Promise<number> {
@@ -188,15 +201,7 @@ async function recordSignIn(instance: string, user: SignInRecord): Promise<void>
 
 async function readSignIn(instance: string, userId: string): Promise<SignInRecord | null> {
   const raw = await oidcProfiles.get(signInKey(instance, userId));
-  if (!raw) return null;
-  // A record we cannot parse is worth no more than a missing one: report it as
-  // "not signed in yet" and let the poller keep waiting or time out on its own
-  // message, rather than failing the test with a JSON syntax error.
-  try {
-    return JSON.parse(raw) as SignInRecord;
-  } catch {
-    return null;
-  }
+  return parseStoredRecord<SignInRecord>(raw);
 }
 
 const oidcProviders = [

--- a/test-apps/comprehensive/aws-blocks/index.ts
+++ b/test-apps/comprehensive/aws-blocks/index.ts
@@ -188,7 +188,15 @@ async function recordSignIn(instance: string, user: SignInRecord): Promise<void>
 
 async function readSignIn(instance: string, userId: string): Promise<SignInRecord | null> {
   const raw = await oidcProfiles.get(signInKey(instance, userId));
-  return raw === null ? null : (JSON.parse(raw) as SignInRecord);
+  if (!raw) return null;
+  // A record we cannot parse is worth no more than a missing one: report it as
+  // "not signed in yet" and let the poller keep waiting or time out on its own
+  // message, rather than failing the test with a JSON syntax error.
+  try {
+    return JSON.parse(raw) as SignInRecord;
+  } catch {
+    return null;
+  }
 }
 
 const oidcProviders = [

--- a/test-apps/comprehensive/test/oidc-auth.test.ts
+++ b/test-apps/comprehensive/test/oidc-auth.test.ts
@@ -6,6 +6,7 @@ import assert from 'node:assert';
 import { readFileSync } from 'node:fs';
 import { isBlocksError } from '@aws-blocks/core';
 import type { api as apiType } from 'aws-blocks';
+import { signInPoller } from './poll-for-signin.js';
 
 const NotAuthenticated = 'NotAuthenticatedException';
 
@@ -44,6 +45,47 @@ async function rpcCall(
   });
   const body = await resp.json();
   return { status: resp.status, result: body.result, error: body.error };
+}
+
+/** Wait for the sign-in record the first AuthOIDC instance wrote for `userId`. */
+const pollOidcSignIn = (api: typeof apiType, userId: string) =>
+  signInPoller('oidcGetLastSignInUser', (id) => api.oidcGetLastSignInUser(id))(userId);
+
+/** Wait for the sign-in record the `extras` AuthOIDC instance wrote for `userId`. */
+const pollExtrasSignIn = (api: typeof apiType, userId: string) =>
+  signInPoller('oidcExtrasGetLastSignInUser', (id) => api.oidcExtrasGetLastSignInUser(id))(userId);
+
+/**
+ * Drive a full stub-IdP sign-in and return the resulting session, including the
+ * `userId` it authenticated as. Tests need that id to read back anything the
+ * `onSignIn` hook recorded, since those records are keyed per user.
+ *
+ * @param signinPath Path segment before `/signin`, e.g. `signin` for the first
+ *        instance or `extras/signin` for the second.
+ * @param requireAuthMethod The instance's `requireAuth` RPC, used to resolve the
+ *        session back to a `userId`.
+ */
+async function signInVia(
+  baseUrl: string,
+  signinPath: string,
+  provider: string,
+  requireAuthMethod: string,
+): Promise<{ userId: string; sessionCookies: string[] }> {
+  const signinResp = await fetch(`${baseUrl}/aws-blocks/auth/${signinPath}/${provider}`, { redirect: 'manual' });
+  assert.strictEqual(signinResp.status, 302, `signin kickoff should 302, got ${signinResp.status}`);
+  const cookies = collectCookies(signinResp);
+
+  const authResp = await fetch(signinResp.headers.get('location')!, { redirect: 'manual' });
+  const cbResp = await fetch(authResp.headers.get('location')!, {
+    redirect: 'manual',
+    headers: { cookie: cookies.join('; ') },
+  });
+  assert.strictEqual(cbResp.status, 302, `callback should 302, got ${cbResp.status}`);
+  const sessionCookies = mergeCookies(cookies, collectCookies(cbResp));
+
+  const meCall = await rpcCall(baseUrl, 'api', requireAuthMethod, [], { cookies: sessionCookies });
+  assert.strictEqual(meCall.status, 200, `${requireAuthMethod} should succeed after sign-in`);
+  return { userId: meCall.result.userId, sessionCookies };
 }
 
 export function oidcAuthTests(getApi: () => typeof apiType) {
@@ -230,17 +272,84 @@ export function oidcAuthTests(getApi: () => typeof apiType) {
         const authResp = await fetch(authorizeUrl, { redirect: 'manual' });
         const callbackUrl = authResp.headers.get('location')!;
 
-        await fetch(callbackUrl, {
+        const cbResp = await fetch(callbackUrl, {
           redirect: 'manual',
           headers: { cookie: cookies.join('; ') },
         });
+        const sessionCookies = mergeCookies(cookies, collectCookies(cbResp));
+
+        // Who did we just sign in as? The hook record is keyed by userId, so we
+        // need the session's own id to look it up rather than asking for
+        // whichever sign-in happened to be most recent.
+        const meCall = await rpcCall(baseUrl, 'api', 'oidcRequireAuth', [], { cookies: sessionCookies });
+        assert.strictEqual(meCall.status, 200);
+        const me = meCall.result;
 
         // Verify the hook fired
-        const lastUser = await api.oidcGetLastSignInUser();
-        assert.ok(lastUser, 'onSignIn should have been called');
-        assert.strictEqual(lastUser!.provider, 'google');
-        assert.ok(lastUser!.userId, 'Should have userId');
-        assert.strictEqual(lastUser!.email, 'google-user@stub.invalid');
+        const lastUser = await pollOidcSignIn(api, me.userId);
+        assert.strictEqual(lastUser.provider, 'google');
+        assert.strictEqual(lastUser.userId, me.userId);
+        assert.strictEqual(lastUser.email, 'google-user@stub.invalid');
+
+        // Cleanup: sign out
+        await fetch(`${baseUrl}/aws-blocks/auth/signout`, {
+          method: 'POST',
+          headers: { cookie: sessionCookies.join('; ') },
+        });
+      });
+
+      // ── Sign-in read-back durability (regression, #284) ──────────────────
+      //
+      // The record used to live in a module-level variable, so only the Lambda
+      // instance that served the callback could see it. A reader on any other
+      // instance got its own `null`, or the previous sign-in it had handled —
+      // and because the assertions only checked `provider`, a leftover record
+      // from the same provider would pass while proving nothing.
+
+      test('sign-in record is keyed per user, not a shared "last sign-in" slot', async () => {
+        const baseUrl = getBaseUrl();
+        const api = getApi();
+
+        const { userId, sessionCookies } = await signInVia(baseUrl, 'signin', 'google', 'oidcRequireAuth');
+        await pollOidcSignIn(api, userId);
+
+        // Asking for a user who never signed in must not hand back somebody
+        // else's record. With a single module-level slot this returned the user
+        // above, which is the bug.
+        assert.strictEqual(
+          await api.oidcGetLastSignInUser(`${userId}-never-signed-in`),
+          null,
+          'unknown userId should read as null, not the most recent sign-in',
+        );
+
+        await fetch(`${baseUrl}/aws-blocks/auth/signout`, {
+          method: 'POST',
+          headers: { cookie: sessionCookies.join('; ') },
+        });
+      });
+
+      test('each AuthOIDC instance keeps its own sign-in records', async () => {
+        const baseUrl = getBaseUrl();
+        const api = getApi();
+
+        const first = await signInVia(baseUrl, 'signin', 'google', 'oidcRequireAuth');
+        const second = await signInVia(baseUrl, 'extras/signin', 'google-extras', 'oidcExtrasRequireAuth');
+
+        // Each instance answers for its own user...
+        assert.strictEqual((await pollOidcSignIn(api, first.userId)).provider, 'google');
+        assert.strictEqual((await pollExtrasSignIn(api, second.userId)).provider, 'google-extras');
+
+        // ...and does not answer for the other instance's user. The later
+        // sign-in also must not have clobbered the earlier record.
+        assert.strictEqual(await api.oidcGetLastSignInUser(second.userId), null);
+        assert.strictEqual(await api.oidcExtrasGetLastSignInUser(first.userId), null);
+
+        for (const [path, session] of [['signout', first], ['extras/signout', second]] as const) {
+          await fetch(`${baseUrl}/aws-blocks/auth/${path}`, {
+            method: 'POST',
+            headers: { cookie: session.sessionCookies.join('; ') },
+          });
+        }
       });
     });
 
@@ -415,9 +524,9 @@ export function oidcAuthTests(getApi: () => typeof apiType) {
         assert.ok(me.userId);
 
         // Verify onSignIn fired and profile was upserted
-        const lastUser = await api.oidcExtrasGetLastSignInUser();
-        assert.ok(lastUser, 'onSignIn should have fired');
-        assert.strictEqual(lastUser!.provider, 'google-extras');
+        const lastUser = await pollExtrasSignIn(api, me.userId);
+        assert.strictEqual(lastUser.provider, 'google-extras');
+        assert.strictEqual(lastUser.userId, me.userId);
 
         const profile = await api.oidcExtrasGetProfile(me.userId);
         assert.ok(profile, 'Profile should have been upserted');

--- a/test-apps/comprehensive/test/oidc-auth.test.ts
+++ b/test-apps/comprehensive/test/oidc-auth.test.ts
@@ -85,7 +85,17 @@ async function signInVia(
 
   const meCall = await rpcCall(baseUrl, 'api', requireAuthMethod, [], { cookies: sessionCookies });
   assert.strictEqual(meCall.status, 200, `${requireAuthMethod} should succeed after sign-in`);
-  return { userId: meCall.result.userId, sessionCookies };
+
+  // Every caller keys a sign-in record read on this id. A missing or non-string
+  // one would still build a key (`signin:instance:undefined`), so the poller
+  // would wait out its full timeout and report "no record" for what is really a
+  // broken requireAuth response. Fail here instead, where the cause is obvious.
+  const userId = meCall.result?.userId;
+  assert.ok(
+    typeof userId === 'string' && userId.length > 0,
+    `${requireAuthMethod} should return a non-empty string userId, got ${JSON.stringify(meCall.result)}`,
+  );
+  return { userId, sessionCookies };
 }
 
 export function oidcAuthTests(getApi: () => typeof apiType) {

--- a/test-apps/comprehensive/test/poll-for-signin.ts
+++ b/test-apps/comprehensive/test/poll-for-signin.ts
@@ -16,7 +16,6 @@
  * belong to that `userId` before it is returned.
  *
  * Sibling of `poll-for-code.ts`, which does the same job for verification codes.
- * Worth folding the two into one generic poller once both have landed.
  */
 
 /** Shape of the sign-in record the backend hands back. */

--- a/test-apps/comprehensive/test/poll-for-signin.ts
+++ b/test-apps/comprehensive/test/poll-for-signin.ts
@@ -1,0 +1,84 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Shared sign-in-record poller for the AuthOIDC e2e suites.
+ *
+ * `onSignIn` fires while the OIDC callback is being served, and the test reads
+ * the record back over a later, separate request. Two ways to get that wrong:
+ *
+ * 1. Read once. The write can still be in flight, so the read returns null.
+ * 2. Ask for "the last sign-in" with no key. Another user, or another AuthOIDC
+ *    instance's user, satisfies that instantly and the assertions run against
+ *    the wrong record, which can pass by accident.
+ *
+ * Both are designed out here: `userId` is required, and the record is checked to
+ * belong to that `userId` before it is returned.
+ *
+ * Sibling of `poll-for-code.ts`, which does the same job for verification codes.
+ * Worth folding the two into one generic poller once both have landed.
+ */
+
+/** Shape of the sign-in record the backend hands back. */
+export interface SignInRecord {
+	userId: string;
+	email: string | null;
+	provider: string;
+}
+
+/** A backend `*GetLastSignInUser` method, scoped to one AuthOIDC instance. */
+export type SignInReader = (userId: string) => Promise<SignInRecord | null>;
+
+export interface PollForSignInOptions {
+	/** How long to wait before giving up. Defaults to 15s. */
+	maxMs?: number;
+	/** Gap between reads. Defaults to 200ms. */
+	intervalMs?: number;
+}
+
+/**
+ * Poll `read` until the sign-in record for `userId` is available, then return it.
+ *
+ * @param label Method name used in the timeout message, e.g. `oidcGetLastSignInUser`.
+ * @throws If no record appears within `maxMs`, or if a record arrives for a
+ *         different `userId` (a backend keying bug, not a race).
+ */
+export async function pollForSignIn(
+	label: string,
+	read: SignInReader,
+	userId: string,
+	options: PollForSignInOptions = {},
+): Promise<SignInRecord> {
+	const { maxMs = 15000, intervalMs = 200 } = options;
+	const start = Date.now();
+	let seen: SignInRecord | null = null;
+
+	while (Date.now() - start < maxMs) {
+		seen = await read(userId);
+		if (seen) {
+			if (seen.userId !== userId) {
+				throw new Error(
+					`${label}(${userId}) returned a record for "${seen.userId}" — sign-ins are not keyed per user`,
+				);
+			}
+			return seen;
+		}
+		await new Promise((resolve) => global.setTimeout(resolve, intervalMs));
+	}
+
+	throw new Error(`${label}(${userId}) returned no record after ${maxMs}ms`);
+}
+
+/**
+ * Bind {@link pollForSignIn} to one instance's reader so suites can call
+ * `poll(userId)` without repeating the label.
+ *
+ * @example
+ * ```typescript
+ * const pollSignIn = signInPoller('oidcGetLastSignInUser', (id) => api.oidcGetLastSignInUser(id));
+ * const record = await pollSignIn(me.userId);
+ * ```
+ */
+export function signInPoller(label: string, read: SignInReader) {
+	return (userId: string, options?: PollForSignInOptions) => pollForSignIn(label, read, userId, options);
+}


### PR DESCRIPTION
## What

`AuthOIDC`'s `onSignIn` hooks in the comprehensive test app recorded the signed-in user into module-level variables:

```ts
let lastOidcSignInUser: { userId: string; email: string | null; provider: string } | null = null;
```

The hook runs while the OIDC callback is being served. The e2e reads the result back over a later, separate request. In a deployed environment those two can land on different Lambda instances, so the reader either sees its own `null` or the record of whoever signed in last on whichever instance answered.

The second case is the one that bothers me more than a plain failure. The old assertions only checked `provider`, so a leftover record from the same provider would pass while proving nothing about the sign-in the test had just performed.

Same class as the verification-code flake in #278, different flow. No red builds have been pinned on this one yet, so this is prevention.

## How

Sign-in records go to the existing `oidc-profiles` KVStore under `signin:<instance>:<userId>`, and `userId` is now **required** on `oidcGetLastSignInUser` and `oidcExtrasGetLastSignInUser`. "Give me whoever signed in last" no longer type checks:

```
test/__noarg-probe.ts(3,23): error TS2554: Expected 1 arguments, but got 0.
test/__noarg-probe.ts(4,23): error TS2554: Expected 1 arguments, but got 0.
```

That is a live gate, not just a convention: `test:e2e:local` runs `tsc --noEmit` in its before-hook.

I reused `oidc-profiles` instead of adding a store. It already holds the per-user profile the second instance upserts, which the code comments call the canonical post-sign-in pattern, and no code scans it, only keyed get/put. The keys are also bounded here, unlike the verification codes: the stub IdP returns a fixed user per provider, so each sign-in overwrites its own record rather than piling up. That is why there is no purge method in this one.

The two consumers now resolve their own `userId` from the session via `requireAuth` and poll for that record rather than reading once. The polling lives in `test/poll-for-signin.ts`, a sibling of the `poll-for-code.ts` that #278 adds. Worth folding the two into one generic poller once both have landed; I kept them separate here so this PR does not depend on that one.

## Tests

Two new tests, both with a control run showing they bite. Restoring module-level semantics (a per-instance `Record` holding the last sign-in, which is exactly what the old code did) makes both fail:

```
not ok 1 - sign-in record is keyed per user, not a shared "last sign-in" slot
    unknown userId should read as null, not the most recent sign-in
not ok 2 - each AuthOIDC instance keeps its own sign-in records
    Expected values to be strictly equal:
    - null
# tests 2 / # pass 0 / # fail 2
```

With the fix both pass, along with the rest of the OIDC suite:

```
ok 1 - onSignIn fires on successful sign-in
ok 2 - sign-in record is keyed per user, not a shared "last sign-in" slot
ok 3 - each AuthOIDC instance keeps its own sign-in records
ok 1 - sign-in flow works and onSignIn upserts profile
ok 2 - second sign-in updates profile, does not duplicate
ok 14 - AuthOIDC
```

Also added sign-out cleanup to the `onSignIn fires` test, which previously left its session open.

Ran locally on Node 22: `npm run build`, `npm run test:unit` (0 fail across every workspace), the comprehensive e2e local, `check:api`, `check:exports-consistency`, and all three changeset guards. `verify-coverage` reports no publishable packages changed, so no changeset is needed here.

The e2e shows 372 pass / 2 fail. Both failures are `cli-client.test.ts` shelling out to `npm` and hitting my host's CodeArtifact registry with an expired token, `E401`. They are unrelated to this change and pass in CI.

Fixes #284
