### PR TITLE
fix(core): drop redundant --hotswap flag from cdk watch in sandbox

### DIFF
--- a/.changeset/sandbox-redundant-hotswap.md
+++ b/.changeset/sandbox-redundant-hotswap.md
@@ -1,0 +1,5 @@
+---
+"@aws-blocks/core": patch
+---
+
+Remove the redundant `--hotswap` flag from the `cdk watch` invocation in `npm run sandbox`. `cdk watch` already performs hotswap deployments by default, so passing the flag explicitly was redundant and emitted a duplicate-option warning on some `aws-cdk` CLI versions.

--- a/packages/core/src/scripts/sandbox.ts
+++ b/packages/core/src/scripts/sandbox.ts
@@ -150,8 +150,6 @@ export async function startSandbox(options: SandboxOptions) {
   console.log(`\n   Open http://localhost:${clientPort}\n`);
 
   const cdkWatch = spawnCommand("npx", [
-    // `cdk watch` already hotswaps by default, so passing `--hotswap` is
-    // redundant and emits a duplicate-option warning on some aws-cdk versions.
     "cdk", "watch",
     `--outputs-file`, `${outDir}/outputs.json`,
     `--context`, `projectRoot=${process.cwd()}`,

--- a/packages/core/src/scripts/sandbox.ts
+++ b/packages/core/src/scripts/sandbox.ts
@@ -150,7 +150,9 @@ export async function startSandbox(options: SandboxOptions) {
   console.log(`\n   Open http://localhost:${clientPort}\n`);
 
   const cdkWatch = spawnCommand("npx", [
-    "cdk", "watch", "--hotswap",
+    // `cdk watch` already hotswaps by default, so passing `--hotswap` is
+    // redundant and emits a duplicate-option warning on some aws-cdk versions.
+    "cdk", "watch",
     `--outputs-file`, `${outDir}/outputs.json`,
     `--context`, `projectRoot=${process.cwd()}`,
     `--context`, `sandboxMode=true`,


### PR DESCRIPTION
## What

Remove the redundant `--hotswap` flag from the `cdk watch` invocation in `npm run sandbox` (`packages/core/src/scripts/sandbox.ts`).

`cdk watch` **already performs hotswap deployments by default** ([aws-cdk docs](https://docs.aws.amazon.com/cdk/v2/guide/cli.html#cli-deploy-watch)), so passing `--hotswap` explicitly is redundant. On some `aws-cdk` CLI versions it also emits a benign duplicate/unknown-option warning that surfaces to users as `[CDK Watch] ...` on stderr.

```diff
   const cdkWatch = spawnCommand("npx", [
-    "cdk", "watch", "--hotswap",
+    // `cdk watch` already hotswaps by default, so passing `--hotswap` is
+    // redundant and emits a duplicate-option warning on some aws-cdk versions.
+    "cdk", "watch",
     `--outputs-file`, `${outDir}/outputs.json`,
```

## Why

Cosmetic dev-experience fix — removes misleading warning output during `npm run sandbox`. No behavior change: hotswap remains the deploy mode for `cdk watch`.

Source: AWS Blocks bug-bash board — [board card](https://github.com/orgs/aws-amplify/projects/141/views/15?pane=issue&itemId=203197131) · [amplify-backend#3249](https://github.com/aws-amplify/amplify-backend/issues/3249) (P3 / DX).

## Testing

- `npm run build` (full monorepo) — passes
- `npm test` in `packages/core` — passes
- `biome lint --changed --since=origin/main` — clean on the changed file

## Changeset

Included (`@aws-blocks/core` patch).
