### PR TITLE
fix(bb-data): make unconfigured-connection error intent-aware (Supabase/external path)

### DIFF
--- a/.changeset/bb-data-external-conn-error.md
+++ b/.changeset/bb-data-external-conn-error.md
@@ -1,0 +1,5 @@
+---
+"@aws-blocks/bb-data": patch
+---
+
+Make the unconfigured-connection error in the Database runtime intent-aware. When neither an Aurora cluster is provisioned nor an external `connectionString` connection is supplied, the error now names both paths — the provisioned Aurora database (`BLOCKS_*_CLUSTER_ARN` / `SECRET_ARN`) and `Database.fromExisting({ connectionString })` for external databases (Supabase/Neon/etc.) — instead of surfacing an Aurora-only message.

--- a/packages/bb-data/src/index.aws.test.ts
+++ b/packages/bb-data/src/index.aws.test.ts
@@ -63,3 +63,26 @@ describe('Database (aws runtime): _initBase forwards conn.ssl to the pool', () =
     assert.deepStrictEqual(ssl, { minVersion: 'TLSv1.2', rejectUnauthorized: true });
   });
 });
+
+/**
+ * When no connection is configured and no Aurora ARNs are injected, `_initBase`
+ * falls through to the Data API branch and throws. The message must guide *both*
+ * intents — a provisioned Aurora database and an external `fromExisting` connection
+ * (Supabase/Neon/etc.) — so an external-DB user isn't shown an Aurora-only error
+ * with no hint about the connectionString path. See aws-amplify/amplify-backend#3238.
+ */
+describe('Database (aws runtime): unconfigured connection error is intent-aware', () => {
+  test('error names both the Aurora provisioning and the fromExisting external path', async () => {
+    const scope = new Scope(`cfg-test-${Math.random().toString(36).slice(2)}`);
+    const db = new Database(scope, 'db', {});
+    await assert.rejects(
+      () => db.getEngine(),
+      (err: Error) => {
+        assert.match(err.message, /Supabase|external database/i, 'should mention the external-DB path');
+        assert.match(err.message, /fromExisting/, 'should point at Database.fromExisting({ connectionString })');
+        assert.match(err.message, /CLUSTER_ARN/, 'should still cover the provisioned Aurora path');
+        return true;
+      },
+    );
+  });
+});

--- a/packages/bb-data/src/index.aws.ts
+++ b/packages/bb-data/src/index.aws.ts
@@ -91,9 +91,16 @@ export class Database extends Scope {
     const database = conn?.database || this.options?.databaseName || process.env[`${ENV_VAR_PREFIX}_${envName}_DATABASE`] || envName;
 
     if (!resourceArn || !resolvedSecretArn) {
+      // This branch is the Aurora Data API path — reached only when no external
+      // `connectionString` connection was configured (those route to PgClientEngine
+      // in `_initBase`). The message covers both intents so a user who *meant* to
+      // connect to an external database (Supabase/Neon/etc.) but whose wiring never
+      // reached this class isn't left staring at an Aurora-only error.
       throw new Error(
-        `Missing environment variables: ${ENV_VAR_PREFIX}_${envName}_CLUSTER_ARN and/or ${ENV_VAR_PREFIX}_${envName}_SECRET_ARN. ` +
-        `These are injected by the CDK layer — ensure the Database is provisioned.`
+        `Database is not configured. For a provisioned Aurora database, the CDK layer ` +
+        `injects ${ENV_VAR_PREFIX}_${envName}_CLUSTER_ARN and ${ENV_VAR_PREFIX}_${envName}_SECRET_ARN — ` +
+        `ensure the Database is provisioned. For an external database (Supabase/Neon/etc.), ` +
+        `pass a connection via Database.fromExisting({ connectionString }).`
       );
     }
 


### PR DESCRIPTION
## What

Make the Database runtime's unconfigured-connection error **intent-aware** (`packages/bb-data/src/index.aws.ts`).

The Aurora Data API branch threw an Aurora-only message whenever no connection resolved:

> `Missing environment variables: BLOCKS_{id}_CLUSTER_ARN and/or BLOCKS_{id}_SECRET_ARN. These are injected by the CDK layer — ensure the Database is provisioned.`

A user who intended an **external database** (Supabase/Neon/etc.) but whose `Database.fromExisting({ connectionString })` wiring never reached this class was left staring at an Aurora-only error with no hint about the `connectionString` path. The message now names **both** intents.

```diff
-        `Missing environment variables: ${PREFIX}_${envName}_CLUSTER_ARN and/or ${PREFIX}_${envName}_SECRET_ARN. ` +
-        `These are injected by the CDK layer — ensure the Database is provisioned.`
+        `Database is not configured. For a provisioned Aurora database, the CDK layer ` +
+        `injects ${PREFIX}_${envName}_CLUSTER_ARN and ${PREFIX}_${envName}_SECRET_ARN — ` +
+        `ensure the Database is provisioned. For an external database (Supabase/Neon/etc.), ` +
+        `pass a connection via Database.fromExisting({ connectionString }).`
```

## Why

Polish / DX fix from the AWS Blocks bug-bash board. Not a functional bug on a correctly-generated Supabase app (those route to `PgClientEngine` before this branch), but the Aurora-centric message is confusing if a misconfiguration routes an external-DB user down the Data API branch.

Fixes **aws-amplify/amplify-backend#3238** (P3 / DX).

## Testing

- **Regression test added** (`index.aws.test.ts`) asserting the error names both the Aurora provisioning path (`CLUSTER_ARN`) and the external `fromExisting`/Supabase path. Verified it **fails on the old message** and **passes with the fix** (true red→green).
- `npm run build` (full monorepo) — passes
- `npm test` in `packages/bb-data` — 370 tests, 0 failures
- `biome lint --changed --since=origin/main` — clean on the changed files

## Changeset

Included (`@aws-blocks/bb-data` patch).
