### PR TITLE
fix(bb-agent): preserve chunks while loading history

### DIFF
--- a/.changeset/quiet-oranges-stream.md
+++ b/.changeset/quiet-oranges-stream.md
@@ -1,0 +1,5 @@
+---
+'@aws-blocks/bb-agent': patch
+---
+
+fix(bb-agent): preserve streamed chunks while restoring a conversation

--- a/packages/bb-agent/src/index.hooks.ts
+++ b/packages/bb-agent/src/index.hooks.ts
@@ -106,20 +106,43 @@ export function useChat(options: UseChatOptions): ChatInstance {
 	let activeSub: { unsubscribe(): void } | null = null;
 	let assistantId: string | null = null;
 	let assistantText = '';
+	let loadingHistory = false;
+	let bufferedChunks: AgentStreamChunk[] = [];
 
 	/** Handle a chunk from the Realtime subscription. */
 	function handleChunk(chunk: AgentStreamChunk) {
+		if (loadingHistory) {
+			bufferedChunks.push(chunk);
+			return;
+		}
+		applyChunk(chunk);
+	}
+
+	function ensureAssistantMessage() {
+		if (assistantId) return;
+		const message: ChatMessage = { id: nextId(), role: 'assistant', content: '' };
+		assistantId = message.id;
+		assistantText = '';
+		messages = [...messages, message];
+		options.onMessagesChange?.(messages);
+	}
+
+	function applyChunk(chunk: AgentStreamChunk, skipTextUpdate = false) {
 		options.onChunk?.(chunk);
 
-		if (chunk.type === 'text-delta' && chunk.text && assistantId) {
+		if (chunk.type === 'text-delta' && chunk.text && !skipTextUpdate) {
+			ensureAssistantMessage();
 			assistantText += chunk.text;
 			messages = messages.map(m => m.id === assistantId ? { ...m, content: assistantText } : m);
 			options.onMessagesChange?.(messages);
 		}
 
 		if (chunk.type === 'done') {
-			if (chunk.text && assistantId) {
-				messages = messages.map(m => m.id === assistantId ? { ...m, content: chunk.text! } : m);
+			const text = chunk.text;
+			if (text && !skipTextUpdate) {
+				ensureAssistantMessage();
+				assistantText = text;
+				messages = messages.map(m => m.id === assistantId ? { ...m, content: text } : m);
 				options.onMessagesChange?.(messages);
 			}
 			loading = false;
@@ -225,22 +248,45 @@ export function useChat(options: UseChatOptions): ChatInstance {
 
 		async loadConversation(id: string) {
 			conversationId = id;
+			assistantId = null;
+			assistantText = '';
+			bufferedChunks = [];
+			loadingHistory = true;
 
-			// 1. Subscribe FIRST — catch any in-flight chunks
-			await ensureSubscribed(id);
+			try {
+				// 1. Subscribe FIRST — catch any in-flight chunks
+				await ensureSubscribed(id);
 
-			// 2. THEN load history from DB
-			// TODO: buffer chunks received between subscribe and history load, then deduplicate/merge
-			const { messages: history } = await options.api.getConversation(id);
-			messages = history
-				.filter(m => m.role === 'user' || m.role === 'assistant' || m.role === 'approval')
-				.map(m => ({
-					id: nextId(),
-					role: m.role as 'user' | 'assistant' | 'approval',
-					content: m.content,
-					metadata: m.metadata,
-				}));
-			options.onMessagesChange?.(messages);
+				// 2. THEN load history from DB. Chunks can arrive while this request is in flight,
+				// so replay them after the history establishes the message list they extend.
+				const { messages: history } = await options.api.getConversation(id);
+				messages = history
+					.filter(m => m.role === 'user' || m.role === 'assistant' || m.role === 'approval')
+					.map(m => ({
+						id: nextId(),
+						role: m.role as 'user' | 'assistant' | 'approval',
+						content: m.content,
+						metadata: m.metadata,
+					}));
+				options.onMessagesChange?.(messages);
+
+				const chunks = bufferedChunks;
+				bufferedChunks = [];
+				loadingHistory = false;
+
+				const completion = [...chunks].reverse().find(chunk => chunk.type === 'done' && chunk.text);
+				const latestMessage = messages.at(-1);
+				const historyAlreadyHasCompletion = completion?.text !== undefined
+					&& latestMessage?.role === 'assistant'
+					&& latestMessage.content === completion.text;
+
+				for (const chunk of chunks) {
+					applyChunk(chunk, historyAlreadyHasCompletion && (chunk.type === 'text-delta' || chunk.type === 'done'));
+				}
+			} finally {
+				loadingHistory = false;
+				bufferedChunks = [];
+			}
 
 			// Check for pending interrupts (e.g., user left mid-approval)
 			if (options.api.getPendingInterrupts) {

--- a/packages/bb-agent/src/index.test.ts
+++ b/packages/bb-agent/src/index.test.ts
@@ -737,8 +737,128 @@ describe('model-factory', () => {
 // ── useChat ──────────────────────────────────────────────────────────────────
 
 import { useChat } from './index.hooks.js';
+import type { AgentStreamChunk } from './types.js';
 
 describe('useChat', () => {
+	test('replays chunks received while loading a conversation', async () => {
+		let chunkHandler: ((chunk: AgentStreamChunk) => void) | undefined;
+		let resolveHistory: ((value: { messages: Array<{ role: string; content: string }> }) => void) | undefined;
+		const history = new Promise<{ messages: Array<{ role: string; content: string }> }>((resolve) => {
+			resolveHistory = resolve;
+		});
+
+		const chat = useChat({
+			api: {
+				sendMessage: async () => {},
+				createConversation: async () => ({ conversationId: 'conv-1' }),
+				getConversation: async () => history,
+			},
+			subscribe: async (_channelId, handler) => {
+				chunkHandler = handler;
+				return { unsubscribe() {}, established: Promise.resolve() };
+			},
+		});
+
+		const loading = chat.loadConversation('conv-1');
+		await Promise.resolve();
+		await Promise.resolve();
+		assert.ok(chunkHandler, 'subscription should be ready before loading history');
+
+		chunkHandler({ type: 'text-delta', text: 'Live ' });
+		chunkHandler({ type: 'done', text: 'Live response' });
+		assert.ok(resolveHistory, 'history request should be in flight');
+		resolveHistory({ messages: [{ role: 'user', content: 'Prompt' }] });
+
+		await loading;
+
+		assert.deepStrictEqual(
+			chat.getMessages().map(({ role, content }) => ({ role, content })),
+			[
+				{ role: 'user', content: 'Prompt' },
+				{ role: 'assistant', content: 'Live response' },
+			],
+		);
+	});
+
+	test('does not duplicate a completion already returned in conversation history', async () => {
+		let chunkHandler: ((chunk: AgentStreamChunk) => void) | undefined;
+		let resolveHistory: ((value: { messages: Array<{ role: string; content: string }> }) => void) | undefined;
+		const history = new Promise<{ messages: Array<{ role: string; content: string }> }>((resolve) => {
+			resolveHistory = resolve;
+		});
+
+		const chat = useChat({
+			api: {
+				sendMessage: async () => {},
+				createConversation: async () => ({ conversationId: 'conv-1' }),
+				getConversation: async () => history,
+			},
+			subscribe: async (_channelId, handler) => {
+				chunkHandler = handler;
+				return { unsubscribe() {}, established: Promise.resolve() };
+			},
+		});
+
+		const loading = chat.loadConversation('conv-1');
+		await Promise.resolve();
+		await Promise.resolve();
+		assert.ok(chunkHandler, 'subscription should be ready before loading history');
+
+		chunkHandler({ type: 'text-delta', text: 'Live ' });
+		chunkHandler({ type: 'done', text: 'Live response' });
+		assert.ok(resolveHistory, 'history request should be in flight');
+		resolveHistory({
+			messages: [
+				{ role: 'user', content: 'Prompt' },
+				{ role: 'assistant', content: 'Live response' },
+			],
+		});
+
+		await loading;
+
+		assert.deepStrictEqual(
+			chat.getMessages().map(({ role, content }) => ({ role, content })),
+			[
+				{ role: 'user', content: 'Prompt' },
+				{ role: 'assistant', content: 'Live response' },
+			],
+		);
+	});
+
+	test('processes new chunks after loading a conversation fails to subscribe', async () => {
+		let chunkHandler: ((chunk: AgentStreamChunk) => void) | undefined;
+		let subscribeAttempts = 0;
+
+		const chat = useChat({
+			api: {
+				sendMessage: async () => {},
+				createConversation: async () => ({ conversationId: 'conv-1' }),
+				getConversation: async () => ({ messages: [] }),
+			},
+			subscribe: async (_channelId, handler) => {
+				subscribeAttempts++;
+				chunkHandler = handler;
+				return {
+					unsubscribe() {},
+					established: subscribeAttempts < 3 ? Promise.reject(new Error('subscription failed')) : Promise.resolve(),
+				};
+			},
+		});
+
+		await assert.rejects(() => chat.loadConversation('conv-1'), /subscription failed/);
+		await chat.sendMessage('Prompt');
+		assert.ok(chunkHandler, 'a later subscription should provide a chunk handler');
+		chunkHandler({ type: 'done', text: 'Live response' });
+
+		assert.deepStrictEqual(
+			chat.getMessages().map(({ role, content }) => ({ role, content })),
+			[
+				{ role: 'user', content: 'Prompt' },
+				{ role: 'assistant', content: 'Live response' },
+			],
+		);
+	});
+
 	test('onError is called when error chunk arrives', async () => {
 		let chunkHandler: (chunk: any) => void;
 		let errorReceived: string | undefined;


### PR DESCRIPTION
## Problem

**Issue #, if available:** N/A

Opening a persisted Agent conversation while a response is still streaming can lose chunks received after the Realtime subscription is established but before `getConversation()` returns. At that point no assistant message has been created yet, and the subsequent history assignment overwrites the visible message list.

## Changes

- Buffer Realtime chunks while `loadConversation()` retrieves history, then replay them after history initializes the message list.
- Create an assistant message when replayed text arrives without an existing stream placeholder.
- Avoid duplicating an assistant completion when the history request already includes the same final response.
- Add focused regression tests for both timing outcomes.

## Validation

- Confirmed the new regression test fails before the fix: the restored conversation retained only the user message.
- `npm run build`
- `npm test`
- `npm run lint`
- `npm run lint:deps`
- `npm run test:e2e:local`

## Checklist

- [x] PR description included
- [x] Tests are changed or added
- [x] Relevant documentation reviewed; no update required because this fixes the already documented loading flow without changing the public API.

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._