### PR TITLE
fix(bb-auth-cognito): enable PreventUserExistenceErrors (close username enumeration oracle)

### DIFF
--- a/.changeset/cognito-prevent-user-enumeration.md
+++ b/.changeset/cognito-prevent-user-enumeration.md
@@ -1,0 +1,5 @@
+---
+"@aws-blocks/bb-auth-cognito": patch
+---
+
+Enable `PreventUserExistenceErrors` on the Cognito user pool client. Sign-in and forgot-password responses now return a uniform error regardless of whether the username exists, closing the account-enumeration oracle that Cognito exposes by default (distinct `UserNotFoundException` vs. wrong-password errors).

--- a/packages/bb-auth-cognito/README.md
+++ b/packages/bb-auth-cognito/README.md
@@ -521,6 +521,8 @@ Cognito scales automatically. Default quotas: 40 sign-ups/sec, 120 sign-ins/sec 
 
 AWS Blocks auth follows the BFF pattern: the browser sends `{username, password}` to the customer's Lambda over TLS; Lambda forwards to Cognito. The customer's Lambda is inside the user's trust boundary by design — same as `AuthBasic`, `AuthOIDC`, NextAuth, Devise, and every server-mediated auth library. Cognito tokens never reach the browser — instead, the BB issues an opaque HMAC-signed session cookie that maps to a server-side `SessionRecord` in a nested `KVStore`.
 
+The user pool client sets `PreventUserExistenceErrors: ENABLED`, so sign-in and forgot-password responses return a uniform error whether or not the username exists — closing the account-enumeration oracle Cognito exposes by default.
+
 See the auth-cognito technical design (see source repo) for the full architecture and mock-vs-AWS parity notes.
 
 ## Cookies and sessions

--- a/packages/bb-auth-cognito/src/index.cdk.test.ts
+++ b/packages/bb-auth-cognito/src/index.cdk.test.ts
@@ -132,6 +132,15 @@ describe('AuthCognito (CDK) — user pool client', () => {
 		});
 	});
 
+	test('client enables PreventUserExistenceErrors (no username enumeration oracle)', () => {
+		const template = synth((stack) => {
+			new AuthCognito(scope(stack), 'auth');
+		});
+		template.hasResourceProperties('AWS::Cognito::UserPoolClient', {
+			PreventUserExistenceErrors: 'ENABLED',
+		});
+	});
+
 	test('hosted-UI / OAuth flows are disabled (no implicit grant, no placeholder callback)', () => {
 		const template = synth((stack) => {
 			new AuthCognito(scope(stack), 'auth');

--- a/packages/bb-auth-cognito/src/index.cdk.ts
+++ b/packages/bb-auth-cognito/src/index.cdk.ts
@@ -238,6 +238,12 @@ export class AuthCognito<const O extends AuthCognitoOptions = AuthCognitoOptions
 		this.userPoolClient = new cognito.UserPoolClient(this, 'client', {
 			userPool: this.userPool,
 			generateSecret: false,
+			// Return a uniform error for "user doesn't exist" and "wrong
+			// password" so sign-in / forgot-password responses can't be used to
+			// enumerate which usernames are registered. Without this, Cognito
+			// leaks a distinct UserNotFoundException, which is an account-
+			// enumeration oracle. Amazon's recommended posture is ENABLED.
+			preventUserExistenceErrors: true,
 			// SDK + session-cookie auth only; the hosted UI is never used.
 			// Off by default CDK would enable the implicit grant and a
 			// placeholder example.com callback — unused attack surface.


### PR DESCRIPTION
## What

Enable `preventUserExistenceErrors: true` on the Cognito `UserPoolClient` in `packages/bb-auth-cognito/src/index.cdk.ts`.

```diff
 this.userPoolClient = new cognito.UserPoolClient(this, 'client', {
   userPool: this.userPool,
   generateSecret: false,
+  // Return a uniform error for "user doesn't exist" and "wrong password"
+  // so sign-in / forgot-password responses can't enumerate registered
+  // usernames. Amazon's recommended posture is ENABLED.
+  preventUserExistenceErrors: true,
   disableOAuth: true,
   ...
```

## Why

Board bug-bash card (P1 / Security): **bb-auth-cognito: user enumeration via PreventUserExistenceErrors unset** — https://github.com/orgs/aws-amplify/projects/141/views/15?pane=issue&itemId=195532810

Cognito's default client returns a distinct `UserNotFoundException` for unknown usernames vs. a wrong-password error for known ones — a classic account-enumeration oracle on sign-in and forgot-password (reported 3× across bench rounds R6/R8). `PreventUserExistenceErrors: ENABLED` is Amazon's recommended setting.

## Mock parity

No mock change needed. The mock's **public sign-in path** already returns a uniform `NotAuthorized` ("Incorrect username or password") for both missing-user and wrong-password (`index.ts`), matching `ENABLED` behavior. The only user-existence-revealing throw (`UserNotFound`) is in the **privileged admin surface** (`buildAdminSurface`), which is inside the trust boundary by design — so local↔AWS behavior stays aligned.

## Testing

- **CDK regression test added** asserting the synthesized `AWS::Cognito::UserPoolClient` has `PreventUserExistenceErrors: ENABLED`. Verified **red on the prior code** (`Missing key 'PreventUserExistenceErrors'`), green with the fix.
- `npm run build` (full monorepo) — passes
- `npm test` in `packages/bb-auth-cognito` — 231 tests, 0 failures
- `biome lint --changed --since=origin/main` — clean
- README Security Model note added; no public API change (internal CDK prop).

## Changeset

Included (`@aws-blocks/bb-auth-cognito` patch).
