### PR TITLE
fix(core): return a JSON usage hint for dev-server 404s on the API path

### DIFF
--- a/.changeset/dev-server-404-usage-hint.md
+++ b/.changeset/dev-server-404-usage-hint.md
@@ -1,0 +1,5 @@
+---
+"@aws-blocks/core": patch
+---
+
+Return a JSON usage hint instead of an empty body when a dev-server request doesn't match `POST /aws-blocks/api`. Opening the endpoint in a browser (a GET) or hitting a REST-style URL previously returned a bare 404 with no body; it now responds with `{ error, expected: { method: 'POST', path: '/aws-blocks/api' } }`, and says so explicitly when the path was right but the method was wrong.

--- a/packages/core/src/scripts/dev-server-rpc.test.ts
+++ b/packages/core/src/scripts/dev-server-rpc.test.ts
@@ -112,4 +112,58 @@ startDevServer({ backendPath: '${join(tempDir, 'backend.ts').replace(/\\/g, '/')
     assert.ok(stdout.includes('[rpc-ok] testApi.pingVoid'), `Missing verbose success log. stdout: ${stdout}`);
     assert.ok(!stdout.includes('[rpc-err]'), `Unexpected RPC error log. stdout: ${stdout}`);
   });
+
+  it('returns a JSON usage hint (not an empty body) for a GET on the API path', async () => {
+    const port = await getAvailablePort();
+    tempDir = join(tmpdir(), `dev-404-test-${process.pid}-${Date.now()}`);
+    mkdirSync(tempDir, { recursive: true });
+    writeFileSync(join(tempDir, 'backend.ts'), `
+export const testApi = {
+  pingVoid: async () => undefined,
+};
+`);
+    writeFileSync(join(tempDir, 'preload.mjs'), `
+if (!process.loadEnvFile) {
+  process.loadEnvFile = () => { throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' }); };
+}
+`);
+    writeFileSync(join(tempDir, 'run-dev.ts'), `
+import { startDevServer } from '${join(__dirname, 'dev-server.js').replace(/\\/g, '/')}';
+startDevServer({ backendPath: '${join(tempDir, 'backend.ts').replace(/\\/g, '/')}', port: ${port} });
+`);
+
+    const tsxBin = join(__dirname, '..', '..', '..', '..', 'node_modules', '.bin', 'tsx');
+    devProcess = spawn(tsxBin, ['--import', join(tempDir, 'preload.mjs'), join(tempDir, 'run-dev.ts')], {
+      cwd: tempDir,
+      env: { ...process.env, AWS_BLOCKS_DISABLE_TELEMETRY: '1', BLOCKS_DEV_QUIET: '1' },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    let stdout = '';
+    let stderr = '';
+    devProcess.stdout?.on('data', chunk => { stdout += chunk.toString(); });
+    devProcess.stderr?.on('data', chunk => { stderr += chunk.toString(); });
+
+    // A GET on the API path (e.g. opening it in a browser) hits the API handler
+    // but not the POST branch — the exact case that used to return an empty 404.
+    const deadline = Date.now() + 15_000;
+    let response: Response | undefined;
+    let lastError: unknown;
+    while (!response && Date.now() < deadline) {
+      try {
+        response = await fetch(`http://127.0.0.1:${port}/aws-blocks/api`, { method: 'GET' });
+      } catch (error) {
+        lastError = error;
+        await new Promise(resolve => setTimeout(resolve, 100));
+      }
+    }
+
+    assert.ok(response, `Dev server did not respond: ${String(lastError)}\nstdout: ${stdout}\nstderr: ${stderr}`);
+    assert.strictEqual(response.status, 404);
+    assert.strictEqual(response.headers.get('content-type'), 'application/json');
+    const payload = await response.json() as { error?: string; expected?: { method?: string; path?: string } };
+    assert.match(payload.error ?? '', /POST/, `404 body should hint at the POST requirement: ${JSON.stringify(payload)}`);
+    assert.strictEqual(payload.expected?.method, 'POST');
+    assert.strictEqual(payload.expected?.path, '/aws-blocks/api');
+  });
 });

--- a/packages/core/src/scripts/dev-server.ts
+++ b/packages/core/src/scripts/dev-server.ts
@@ -1244,6 +1244,20 @@ function handleApiRequest(
     return;
   }
 
-  res.writeHead(404);
-  res.end();
+  // Anything that reaches here didn't match `POST /aws-blocks/api`. Returning a
+  // bare empty 404 leaves a developer poking at the endpoint (e.g. opening it in
+  // a browser, which sends a GET, or trying a REST-style URL) with no feedback.
+  // Reply with a small JSON hint pointing at the one supported shape. When the
+  // path was right but the method wasn't, say so explicitly.
+  const wrongMethodOnApi = url.pathname === BLOCKS_RPC_PREFIX;
+  const message = wrongMethodOnApi
+    ? `The AWS Blocks JSON-RPC API expects POST, not ${method}.`
+    : 'Not found. The AWS Blocks JSON-RPC API is served at POST /aws-blocks/api.';
+  res.writeHead(404, { 'Content-Type': 'application/json' });
+  res.end(
+    JSON.stringify({
+      error: message,
+      expected: { method: 'POST', path: BLOCKS_RPC_PREFIX },
+    }),
+  );
 }


### PR DESCRIPTION
## What

The dev-server API handler (`handleApiRequest` in `packages/core/src/scripts/dev-server.ts`) replied to any request that didn't match `POST /aws-blocks/api` with a bare `res.writeHead(404); res.end()` — an **empty body**. Now it returns a small JSON usage hint:

```json
{ "error": "Not found. The AWS Blocks JSON-RPC API is served at POST /aws-blocks/api.",
  "expected": { "method": "POST", "path": "/aws-blocks/api" } }
```

When the path was right but the method wasn't (e.g. a browser GET on the endpoint), the message says so explicitly:
`"The AWS Blocks JSON-RPC API expects POST, not GET."`

## Why

Board bug-bash card (P3 / DX): **core: 404 returns empty body with no JSON-RPC usage hint** — https://github.com/orgs/aws-amplify/projects/141/views/15?pane=issue&itemId=195535001

New users hitting the endpoint with a REST-style URL or opening it in a browser got zero feedback about what went wrong or how to call it.

## Scope / safety

- **Dev-server only.** No change to the production Lambda handler. Scoped strictly to the `handleApiRequest` trailing 404 (the other dev-server 404 at ~L899 is intentionally left alone — it's touched by open PRs #250/#164).
- Verified this region (dev-server.ts >L1000) is not modified by any open PR, so no merge conflict.

## Testing

- **e2e regression test added** to `dev-server-rpc.test.ts`: spawns the dev server, GETs `/aws-blocks/api`, and asserts a 404 with `Content-Type: application/json` and the hint body. **Verified red on the prior empty-404 code**, green with the fix.
- `npm run build` (full monorepo) — passes
- `dev-server-rpc` suite — 2/2 pass
- `biome lint --changed --since=origin/main` — clean

## Changeset

Included (`@aws-blocks/core` patch).
