### PR TITLE
fix(swift): disable wrapIfStatementBodies to unbreak SwiftFormat

### DIFF
--- a/native/swift/.swiftformat
+++ b/native/swift/.swiftformat
@@ -129,6 +129,7 @@
 --disable sortImports
 --disable wrapPropertyBodies
 --disable wrapFunctionBodies
+--disable wrapIfStatementBodies
 --disable simplifyGenericConstraints
 --disable redundantThrows
 --disable noForceUnwrapInTests


### PR DESCRIPTION
## Summary

The `Native SDK Swift / SwiftFormat` check has been red on **every branch** since early July, independent of PR content. This is a one-line config fix. **No Swift sources are reformatted.**

```diff
  --disable sortImports
  --disable wrapPropertyBodies
  --disable wrapFunctionBodies
+ --disable wrapIfStatementBodies
  --disable simplifyGenericConstraints
```

## Root cause

SwiftFormat **0.62.0** (released 2026-07-06) changed its rule set:

> Split `wrapConditionalBodies` rule into `wrapIfStatementBodies`, `wrapIfExpressionBodies`, `wrapGuardStatementBodies`

`native/swift/.swiftformat` never named `wrapIfStatementBodies` (neither `--enable` nor `--disable`), so the new rule fell through to the **tool default** and began flagging 9 pre-existing files. Because the workflow installs the formatter unpinned:

```yaml
- name: Install SwiftFormat
  run: brew install swiftformat
```

…the check turned red with no repo change, on all branches at once. That matches the observed history: every `native-sdk-swift.yml` run from 2026-07-16 onward failed, including PRs that touch **zero** Swift files (e.g. a dependabot `next` npm bump, which failed with the same rule and a byte-identical list of 9 files).

## Why disable rather than reformat

The rule is disabled next to the sibling body-wrapping rules already turned off — `wrapPropertyBodies` and `wrapFunctionBodies` — so this is consistent with how the file already treats this rule family, and with the ~60 other rules it manages explicitly. It keeps the code's existing, intentional formatting as the style.

The alternative — accepting the autofix — would reformat 9 files across `BlocksCodegen`, `BlocksRuntime`, the demo app, a plugin, and a test target, purely to satisfy a rule the repo never opted into.

## Verification

Ran the exact workflow command (`swiftformat --lint .` from `native/swift/`) with SwiftFormat **0.62.1**, the same minor the CI runner installs:

| State | Result |
|---|---|
| Before (config from `main`) | `9/63 files require formatting, 5 files skipped` — **exit 1** |
| After (this change) | `0/63 files require formatting, 5 files skipped` — **exit 0** |

Files changed: `native/swift/.swiftformat` only (+1 line). `git status` confirms **0** `.swift` files modified, so `SwiftLint` and the macOS/iOS build-and-test jobs are unaffected.

## Formatter pinning: recommended, not done here

Pinning would prevent recurrence, but there is no clean way to do it with the current install method: SwiftFormat publishes **no versioned Homebrew formula** (`versioned_formulae: []`), so `brew install swiftformat@0.62` does not exist. Pinning would mean switching to a different install mechanism (downloading a release artifact, or Mint/SPM), and the sibling `swiftlint` step is unpinned the same way — so changing one tool's strategy in isolation seemed out of scope for a red-CI fix.

Suggested as a follow-up, for whoever owns the Swift toolchain: pin both `swiftformat` and `swiftlint` to explicit versions via release artifacts, and bump them deliberately. Happy to take that on as a separate PR.

## Changesets

None required, and none added. The native changeset gates only fire for `native/swift/Sources/**` or `native/swift/Package.swift` (and the Kotlin equivalents); this touches neither. Verified locally against all four JS guards:

```
✓ 11 changeset(s) are structurally valid.
✓ No publishable packages were changed.
✓ No major version bumps declared in changesets.
✓ No changeset here releases a package @aws-blocks/blocks re-exports.
```

Adding an `aws-blocks-swift` entry would queue a package release for what is purely a lint-config change, so it is deliberately omitted.