### PR TITLE
feat(core): stack-wide BlocksDefaults + presets (Infrastructure Options, step 1); adopt in bb-kv-store

### DIFF
--- a/.changeset/blocks-infrastructure-defaults.md
+++ b/.changeset/blocks-infrastructure-defaults.md
@@ -1,0 +1,20 @@
+---
+"@aws-blocks/core": minor
+"@aws-blocks/blocks": minor
+"@aws-blocks/bb-kv-store": patch
+"@aws-blocks/bb-data": patch
+"@aws-blocks/bb-distributed-data": patch
+"@aws-blocks/bb-distributed-table": patch
+"@aws-blocks/bb-knowledge-base": patch
+"@aws-blocks/create-blocks-app": patch
+---
+
+Add infrastructure `defaults` chosen once at the app entry point, replacing the per-block `sandboxMode` logic and the `RemovalPolicies`/`SandboxDisableDeletionProtection` mixin dance for removal-policy and deletion-protection.
+
+`@aws-blocks/core/cdk` now exports `BlocksDefaults` and the `BlocksPresets.sandbox` / `BlocksPresets.production` starting points. `BlocksStack.create` / `BlocksBackend.create` take a required `defaults` prop; start from a preset and override individual fields with a spread. `defaults` is anchored on the owning `BlocksStack`/`BlocksBackend` (resolved by walking up the construct tree, like `handler`/`executionRole`), so multiple backends in one stack each keep their own posture. Building Blocks read the resolved values via `scope.defaults`, and a per-block option always wins (`option ?? scope.defaults.field`).
+
+Adopted across the stateful Building Blocks: `bb-kv-store`, `bb-data`, `bb-distributed-data`, `bb-distributed-table`, and `bb-knowledge-base` now take their removal policy and deletion protection from `defaults` instead of reading the `sandboxMode` context themselves. (`bb-distributed-table` reads `defaults` directly for now; a richer per-block `protection` override lands with #282.)
+
+The `create-blocks-app` scaffolding templates are updated to pass `defaults: sandboxMode ? BlocksPresets.sandbox : BlocksPresets.production` (replacing the `RemovalPolicies`/`SandboxDisableDeletionProtection` mixin), so newly-generated apps satisfy the required prop.
+
+**Breaking:** `BlocksStack.create` / `BlocksBackend.create` now require a `defaults` field — pass `BlocksPresets.sandbox` or `BlocksPresets.production` (typically `sandboxMode ? BlocksPresets.sandbox : BlocksPresets.production`). The previously-shipped experimental `hardening` prop and its `resolve*` helpers are removed; log-retention, API throttling, access-logging and point-in-time-recovery move into `defaults` in follow-up, per-feature changes.

--- a/packages/bb-data/src/index.cdk.test.ts
+++ b/packages/bb-data/src/index.cdk.test.ts
@@ -14,12 +14,13 @@ function synthWithRemovalPolicy(removalPolicy?: cdk.RemovalPolicy): Template {
 }
 
 // These tests verify the contract that index.cdk.ts relies on:
-// - sandboxMode=true → passes removalPolicy=DESTROY → cluster is deletable
-// - no sandboxMode  → passes undefined → cluster is retained and protected
+// - removalPolicy=DESTROY → cluster is deletable (DeletionProtection=false)
+// - removalPolicy=RETAIN  → cluster is retained and protected
 //
-// The context→removalPolicy mapping in index.cdk.ts is verified via cdk synth
-// (see canary-publish-plan.md) because Database requires BlocksStack which can't
-// be unit-tested without bundling a full backend.
+// index.cdk.ts resolves the policy as `options.removalPolicy ?? this.defaults.removalPolicy`
+// (the stack-wide sandbox/production posture) and passes it to materialize();
+// that resolution is verified via cdk synth (see canary-publish-plan.md) because
+// Database requires BlocksStack which can't be unit-tested without a full backend.
 
 test('CDK: removalPolicy=DESTROY sets DeletionPolicy=Delete and DeletionProtection=false', () => {
   const template = synthWithRemovalPolicy(cdk.RemovalPolicy.DESTROY);

--- a/packages/bb-data/src/index.cdk.ts
+++ b/packages/bb-data/src/index.cdk.ts
@@ -33,8 +33,6 @@ export class Database extends Scope {
   constructor(scope: ScopeParent, id: string, options?: DatabaseOptions) {
     super(id, { parent: scope });
 
-    const isSandbox = cdk.Stack.of(this).node.tryGetContext('sandboxMode') === 'true';
-
     if (options?.connection) {
       // External database — skip provisioning, just grant permissions and inject env vars
       const conn = options.connection;
@@ -67,8 +65,11 @@ export class Database extends Scope {
       snapshot: cdk.RemovalPolicy.SNAPSHOT,
     } as const;
 
-    // In sandbox mode, default to DESTROY so sandbox:destroy can clean up.
-    const defaultRemovalPolicy = isSandbox ? cdk.RemovalPolicy.DESTROY : undefined;
+    // Removal policy: the per-block option wins, otherwise the stack-wide
+    // `defaults` (sandbox → DESTROY so sandbox:destroy can clean up; production
+    // → RETAIN). Deletion protection is derived from the resolved policy in
+    // materialize() (protected unless DESTROY).
+    const defaultRemovalPolicy = this.defaults.removalPolicy;
 
     const infra = materialize(this, this.fullId, {
       minCapacity: options?.minCapacity,
@@ -76,6 +77,9 @@ export class Database extends Scope {
       databaseName,
       migrationsPath: options?.migrationsPath ? resolve(options.migrationsPath) : undefined,
       removalPolicy: options?.removalPolicy ? REMOVAL_POLICY_MAP[options.removalPolicy] : defaultRemovalPolicy,
+      // Read independently from defaults (not derived from removalPolicy), so
+      // an override like `{ ...production, deletionProtection: false }` is honored.
+      deletionProtection: this.defaults.deletionProtection,
       postgresVersion: options?.postgresVersion,
     });
 

--- a/packages/bb-data/src/infra.ts
+++ b/packages/bb-data/src/infra.ts
@@ -35,6 +35,12 @@ export interface AuroraInfraConfig {
   migrationsPath?: string;
   /** CloudFormation removal policy for the Aurora cluster. @default RETAIN */
   removalPolicy?: cdk.RemovalPolicy;
+  /**
+   * Whether to enable RDS deletion protection. Resolved independently of
+   * `removalPolicy` so the stack-wide `defaults.deletionProtection` is honored.
+   * @default derived from removalPolicy (protected unless DESTROY)
+   */
+  deletionProtection?: boolean;
   /** Aurora PostgreSQL engine version, e.g. `'16.13'`. @default '16.13' */
   postgresVersion?: string;
 }
@@ -146,7 +152,9 @@ export function materialize(
     securityGroups: [securityGroup],
     defaultDatabaseName: databaseName,
     enableDataApi: true,
-    deletionProtection: removalPolicy !== cdk.RemovalPolicy.DESTROY,
+    // Read independently from defaults (falling back to the removalPolicy-derived
+    // value for direct materialize() callers that don't pass it).
+    deletionProtection: options.deletionProtection ?? removalPolicy !== cdk.RemovalPolicy.DESTROY,
     removalPolicy,
   });
 

--- a/packages/bb-data/src/types.ts
+++ b/packages/bb-data/src/types.ts
@@ -29,9 +29,11 @@ export interface DatabaseOptions {
    */
   rlsPolicy?: 'enforce';
   /**
-   * CloudFormation removal policy for the Aurora cluster.
-   * Use 'destroy' for dev/sandbox, 'retain' (default) for production to prevent data loss.
-   * @default 'retain'
+   * CloudFormation removal policy for the Aurora cluster. When omitted, the
+   * stack-wide `defaults` apply (`production` → RETAIN so data is preserved on
+   * `cdk destroy`; `sandbox` → DESTROY). Pass `'destroy'`/`'retain'`/`'snapshot'`
+   * to override for this one database. Deletion protection follows: on unless
+   * the cluster is being destroyed.
    */
   removalPolicy?: 'destroy' | 'retain' | 'snapshot';
   /**

--- a/packages/bb-distributed-data/src/index.cdk.test.ts
+++ b/packages/bb-distributed-data/src/index.cdk.test.ts
@@ -14,7 +14,7 @@ import { Template, Match } from 'aws-cdk-lib/assertions';
 import { mkdirSync, writeFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import type { ScopeParent } from '@aws-blocks/core';
-import { DEFAULT_NODE_RUNTIME } from '@aws-blocks/core/cdk';
+import { DEFAULT_NODE_RUNTIME, BlocksPresets } from '@aws-blocks/core/cdk';
 import { DistributedDatabase } from './index.cdk.js';
 
 const MIGRATIONS_DIR = '.bb-data/__test_cdk_migrations__';
@@ -60,18 +60,35 @@ test('CDK: cluster has DeletionProtectionEnabled=true by default', () => {
   });
 });
 
-test('CDK: removalPolicy=destroy disables deletion protection', () => {
-  const template = synth((stack) => {
-    new DistributedDatabase(scope(stack), 'mydsql', { removalPolicy: 'destroy' });
+test('CDK: per-block removalPolicy is independent of deletion protection', () => {
+  // Deletion protection is read from `defaults` independently of removalPolicy
+  // (consistent across all adopting blocks). Here: sandbox defaults (protection
+  // off) with a per-block `removalPolicy: 'retain'` override → the cluster is
+  // RETAINed on stack delete but not deletion-protected.
+  const app = new cdk.App();
+  const stack = new cdk.Stack(app, 'IndepStack');
+  const handler = new lambda.Function(stack, 'Handler', {
+    runtime: DEFAULT_NODE_RUNTIME,
+    handler: 'index.handler',
+    code: lambda.Code.fromInline('exports.handler = async () => {};'),
   });
-  template.hasResource('AWS::DSQL::Cluster', {
-    Properties: { DeletionProtectionEnabled: false },
-    DeletionPolicy: 'Delete',
-  });
+  (stack as any).handler = handler;
+  (stack as any).defaults = BlocksPresets.sandbox;
+  (globalThis as any).CURRENT_BLOCKS_STACK = stack;
+  try {
+    new DistributedDatabase(scope(stack), 'mydsql', { removalPolicy: 'retain' });
+    const template = Template.fromStack(stack);
+    template.hasResource('AWS::DSQL::Cluster', {
+      Properties: { DeletionProtectionEnabled: false },
+      DeletionPolicy: 'Retain',
+    });
+  } finally {
+    delete (globalThis as any).CURRENT_BLOCKS_STACK;
+  }
 });
 
-test('CDK: sandboxMode=true disables deletion protection', () => {
-  const app = new cdk.App({ context: { sandboxMode: 'true' } });
+test('CDK: sandbox defaults disable deletion protection', () => {
+  const app = new cdk.App();
   const stack = new cdk.Stack(app, 'SandboxStack');
   const handler = new lambda.Function(stack, 'Handler', {
     runtime: DEFAULT_NODE_RUNTIME,
@@ -79,6 +96,9 @@ test('CDK: sandboxMode=true disables deletion protection', () => {
     code: lambda.Code.fromInline('exports.handler = async () => {};'),
   });
   (stack as any).handler = handler;
+  // The cluster's removal/protection follows the stack-wide defaults (resolved
+  // via the globalThis fallback here), not the sandboxMode context.
+  (stack as any).defaults = BlocksPresets.sandbox;
   (globalThis as any).CURRENT_BLOCKS_STACK = stack;
   try {
     new DistributedDatabase(scope(stack), 'mydsql');

--- a/packages/bb-distributed-data/src/index.cdk.ts
+++ b/packages/bb-distributed-data/src/index.cdk.ts
@@ -24,19 +24,26 @@ export class DistributedDatabase extends Scope {
     super(id, { parent: scope });
 
     const stack = cdk.Stack.of(this);
-    const isSandbox = stack.node.tryGetContext('sandboxMode') === 'true';
     const envName = this.fullId.replace(ENV_SANITIZE, '_');
     const region = stack.region;
     const dbRole = sanitizeDbRoleName(this.fullId);
 
-    // DSQL Cluster — respect explicit removalPolicy; default to DESTROY in sandbox, RETAIN otherwise.
-    const shouldDestroy = options?.removalPolicy === 'destroy' || (!options?.removalPolicy && isSandbox);
-    const removalPolicy = shouldDestroy ? cdk.RemovalPolicy.DESTROY : cdk.RemovalPolicy.RETAIN;
+    // Removal policy and deletion protection are resolved independently from the
+    // stack-wide `defaults` (per-block `removalPolicy` option wins for that field).
+    // Reading `defaults.deletionProtection` directly — rather than deriving it
+    // from `removalPolicy` — keeps every adopting block consistent: the same
+    // `defaults` object yields the same posture no matter which block reads it.
+    const removalPolicy =
+      options?.removalPolicy === 'destroy'
+        ? cdk.RemovalPolicy.DESTROY
+        : options?.removalPolicy === 'retain'
+          ? cdk.RemovalPolicy.RETAIN
+          : this.defaults.removalPolicy;
 
     const cluster = new cdk.CfnResource(stack, `${this.fullId}DsqlCluster`, {
       type: 'AWS::DSQL::Cluster',
       properties: {
-        DeletionProtectionEnabled: removalPolicy !== cdk.RemovalPolicy.DESTROY,
+        DeletionProtectionEnabled: this.defaults.deletionProtection,
       },
     });
 

--- a/packages/bb-distributed-data/src/types.ts
+++ b/packages/bb-distributed-data/src/types.ts
@@ -9,8 +9,10 @@ export interface DistributedDatabaseOptions {
   /** Path to directory containing numbered .sql migration files. */
   migrationsPath?: string;
   /**
-   * CloudFormation removal policy.
-   * @default 'retain'
+   * CloudFormation removal policy for the DSQL cluster. When omitted, the
+   * stack-wide `defaults` apply (`production` → RETAIN, `sandbox` → DESTROY).
+   * Pass `'destroy'`/`'retain'` to override for this one database. Deletion
+   * protection follows: on unless the cluster is being destroyed.
    */
   removalPolicy?: 'destroy' | 'retain';
 	/** Optional logger for internal operations. When omitted, a default Logger at error level is created. */

--- a/packages/bb-distributed-table/src/index.cdk.test.ts
+++ b/packages/bb-distributed-table/src/index.cdk.test.ts
@@ -15,7 +15,7 @@ import assert from 'node:assert';
 import * as cdk from 'aws-cdk-lib';
 import type { Construct } from 'constructs';
 import { Template } from 'aws-cdk-lib/assertions';
-import { Scope, DEFAULT_NODE_RUNTIME } from '@aws-blocks/core/cdk';
+import { Scope, DEFAULT_NODE_RUNTIME, BlocksPresets, type BlocksDefaults } from '@aws-blocks/core/cdk';
 import { z } from 'zod';
 import { DistributedTable } from './index.cdk.js';
 
@@ -28,6 +28,7 @@ const userSchema = z.object({
 class StubBlocksStack extends cdk.Stack {
 	public readonly handler: cdk.aws_lambda.Function;
 	public readonly id: string;
+	public defaults: BlocksDefaults = BlocksPresets.production;
 	constructor(scope: Construct, id: string) {
 		super(scope, id);
 		this.id = id;
@@ -40,9 +41,10 @@ class StubBlocksStack extends cdk.Stack {
 	}
 }
 
-function setup(): { stack: StubBlocksStack; parent: Scope } {
+function setup(defaults: BlocksDefaults = BlocksPresets.production): { stack: StubBlocksStack; parent: Scope } {
 	const app = new cdk.App();
 	const stack = new StubBlocksStack(app, 'TestStack');
+	stack.defaults = defaults;
 	const parent = new Scope('app');
 	return { stack, parent };
 }
@@ -55,6 +57,28 @@ test('CDK: default DistributedTable provisions a DynamoDB table', () => {
 	});
 	const template = Template.fromStack(stack);
 	template.resourceCountIs('AWS::DynamoDB::Table', 1);
+});
+
+test('CDK: table adopts sandbox defaults (DESTROY, deletion protection off)', () => {
+	const { stack, parent } = setup(BlocksPresets.sandbox);
+	new DistributedTable(parent, 'users', {
+		schema: userSchema,
+		key: { partitionKey: 'userId', sortKey: 'createdAt' },
+	});
+	const template = Template.fromStack(stack);
+	template.hasResource('AWS::DynamoDB::Table', { DeletionPolicy: 'Delete' });
+	template.hasResourceProperties('AWS::DynamoDB::Table', { DeletionProtectionEnabled: false });
+});
+
+test('CDK: table adopts production defaults (RETAIN, deletion protection on)', () => {
+	const { stack, parent } = setup(BlocksPresets.production);
+	new DistributedTable(parent, 'users', {
+		schema: userSchema,
+		key: { partitionKey: 'userId', sortKey: 'createdAt' },
+	});
+	const template = Template.fromStack(stack);
+	template.hasResource('AWS::DynamoDB::Table', { DeletionPolicy: 'Retain' });
+	template.hasResourceProperties('AWS::DynamoDB::Table', { DeletionProtectionEnabled: true });
 });
 
 test('CDK: DistributedTable.fromExisting does NOT provision a table (regression)', () => {

--- a/packages/bb-distributed-table/src/index.cdk.ts
+++ b/packages/bb-distributed-table/src/index.cdk.ts
@@ -83,6 +83,11 @@ export class DistributedTable<T = any> extends Scope {
 			} : undefined,
 			billingMode: BillingMode.PAY_PER_REQUEST,
 			timeToLiveAttribute: config.ttl || undefined,
+			// Durability follows the stack-wide `defaults` (sandbox → DESTROY +
+			// no protection so a teardown is clean; production → RETAIN + protected).
+			// A richer per-block override lands with the `protection` option in #282.
+			removalPolicy: this.defaults.removalPolicy,
+			deletionProtection: this.defaults.deletionProtection,
 		});
 
 		this.table.grantReadWriteData(this.handler);

--- a/packages/bb-knowledge-base/README.md
+++ b/packages/bb-knowledge-base/README.md
@@ -49,7 +49,7 @@ const kb = new KnowledgeBase(scope, id, options)
 | `chunking` | `ChunkingConfig` | `{ strategy: 'semantic' }` | How documents are split into chunks. |
 | `embeddingDimensions` | `256 \| 512 \| 1024` | `1024` | Embedding model dimensions. |
 | `description` | `string` | — | Human-readable description for the knowledge base. |
-| `removalPolicy` | `'destroy' \| 'retain'` | `'retain'` | CDK removal behavior for BB-created data buckets (imported `s3://` URI sources are unaffected). Defaults to RETAIN (bucket and documents preserved on `cdk destroy`) unless sandbox mode. Pass `'destroy'` for ephemeral stacks — also enables `autoDeleteObjects`. |
+| `removalPolicy` | `'destroy' \| 'retain'` | stack `defaults` | CDK removal behavior for BB-created data buckets (imported `s3://` URI sources are unaffected). When omitted, follows the stack-wide `defaults` (`production` → RETAIN, `sandbox` → DESTROY). Pass `'destroy'` to drop the bucket on teardown for this KB — also enables `autoDeleteObjects`. |
 | `logger` | `ChildLogger` | — | Optional logger for internal operations. When omitted, a default Logger at error level is created. |
 
 ### Source Configuration

--- a/packages/bb-knowledge-base/src/index.cdk.test.ts
+++ b/packages/bb-knowledge-base/src/index.cdk.test.ts
@@ -28,7 +28,7 @@ import * as cdk from 'aws-cdk-lib';
 import type { Construct } from 'constructs';
 import { Template, Match } from 'aws-cdk-lib/assertions';
 import * as s3vectors from 'aws-cdk-lib/aws-s3vectors';
-import { Scope, DEFAULT_NODE_RUNTIME, finalizeConfigRegistry } from '@aws-blocks/core/cdk';
+import { Scope, DEFAULT_NODE_RUNTIME, finalizeConfigRegistry, BlocksPresets, type BlocksDefaults } from '@aws-blocks/core/cdk';
 import { KnowledgeBase } from './index.cdk.js';
 
 // Real local-folder source so BucketDeployment + sidecar generation synth.
@@ -45,6 +45,7 @@ const VECTOR_INDEX_TYPE = s3vectors.CfnIndex.CFN_RESOURCE_TYPE_NAME;
 class StubBlocksStack extends cdk.Stack {
   public readonly handler: cdk.aws_lambda.Function;
   public readonly id: string;
+  public defaults: BlocksDefaults = BlocksPresets.production;
   constructor(scope: Construct, id: string) {
     super(scope, id);
     this.id = id;
@@ -61,10 +62,13 @@ function buildStack(options: { removalPolicy?: 'destroy' | 'retain'; sandbox?: b
   stack: StubBlocksStack;
   kb: KnowledgeBase;
 } {
-  const app = new cdk.App(options.sandbox ? { context: { sandboxMode: 'true' } } : undefined);
+  const app = new cdk.App();
   // S3 bucket names must be lowercase; the data bucket derives its name from
   // the scope chain, so keep ids lowercase.
   const stack = new StubBlocksStack(app, 'teststack');
+  // Durability follows the stack-wide defaults (resolved via the globalThis
+  // fallback here), not the sandboxMode context.
+  if (options.sandbox) stack.defaults = BlocksPresets.sandbox;
   const parent = new Scope('app');
   const kb = new KnowledgeBase(parent, 'docs', {
     source: options.source ?? FIXTURES,
@@ -99,7 +103,7 @@ test("CDK: removalPolicy 'retain' keeps the data bucket + vector store and omits
   template.hasResource(VECTOR_INDEX_TYPE, { DeletionPolicy: 'Retain' });
 });
 
-test('CDK: sandboxMode context defaults the data bucket + vector store to destroy', () => {
+test('CDK: sandbox defaults make the data bucket + vector store destroy', () => {
   const template = synth({ sandbox: true });
 
   template.hasResource('AWS::S3::Bucket', { DeletionPolicy: 'Delete' });

--- a/packages/bb-knowledge-base/src/index.cdk.ts
+++ b/packages/bb-knowledge-base/src/index.cdk.ts
@@ -194,14 +194,15 @@ export class KnowledgeBase extends Scope {
 
 		// ── 1. S3 Data Bucket ──────────────────────────────────────────────
 
-		// In sandbox mode, default to DESTROY + autoDeleteObjects so a teardown
-		// can fully clean up without manual bucket emptying. An explicit
-		// `removalPolicy` from the customer always takes precedence. Computed
-		// up-front because it also drives the S3 Vectors resources' deletion
-		// policy (section 2) — keeping the data bucket and the vector store in
-		// sync on teardown.
-		const isSandbox = cdk.Stack.of(this).node.tryGetContext('sandboxMode') === 'true';
-		const destroy = options.removalPolicy === 'destroy' || (isSandbox && options.removalPolicy === undefined);
+		// Removal: an explicit `removalPolicy` from the customer always takes
+		// precedence; otherwise follow the stack-wide `defaults` (sandbox →
+		// DESTROY + autoDeleteObjects so a teardown fully cleans up without
+		// manual bucket emptying; production → RETAIN). Computed up-front because
+		// it also drives the S3 Vectors resources' deletion policy (section 2) —
+		// keeping the data bucket and the vector store in sync on teardown.
+		const destroy =
+			options.removalPolicy === 'destroy' ||
+			(options.removalPolicy === undefined && this.defaults.removalPolicy === cdk.RemovalPolicy.DESTROY);
 
 		let dataBucket: s3.IBucket;
 		let inclusionPrefixes: string[] | undefined;

--- a/packages/bb-knowledge-base/src/types.ts
+++ b/packages/bb-knowledge-base/src/types.ts
@@ -89,17 +89,13 @@ export interface KnowledgeBaseOptions {
 	description?: string;
 	/**
 	 * CDK removal behavior for the data bucket (only for BB-created
-	 * buckets; imported S3 URI sources are unaffected). When omitted,
-	 * CDK's default applies (RETAIN — the bucket and its documents are
-	 * preserved on `cdk destroy`).
+	 * buckets; imported S3 URI sources are unaffected). When omitted, the
+	 * stack-wide `defaults` apply (`production` → RETAIN so the bucket and its
+	 * documents are preserved on `cdk destroy`; `sandbox` → DESTROY).
 	 *
-	 * Pass `'destroy'` for sandbox / ephemeral stacks where the data
-	 * bucket should be dropped on teardown. This also enables
-	 * `autoDeleteObjects` so CloudFormation can empty the bucket before
-	 * deletion. Pass `'retain'` to set the policy explicitly.
-	 *
-	 * Templates that apply `RemovalPolicies.of(stack).destroy()` at the
-	 * top level override this setting.
+	 * Pass `'destroy'` to drop the data bucket on teardown for this one
+	 * knowledge base — this also enables `autoDeleteObjects` so CloudFormation
+	 * can empty the bucket before deletion. Pass `'retain'` to keep it.
 	 */
 	removalPolicy?: 'destroy' | 'retain';
 	/** Optional logger for internal operations. When omitted, a default Logger at error level is created. */

--- a/packages/bb-kv-store/API.md
+++ b/packages/bb-kv-store/API.md
@@ -55,6 +55,7 @@ export const KVStoreErrors: {
 
 // @public (undocumented)
 export interface KVStoreOptions<T = string> {
+    deletionProtection?: boolean;
     logger?: ChildLogger;
     removalPolicy?: 'destroy' | 'retain';
     schema?: StandardSchemaV1<T>;

--- a/packages/bb-kv-store/README.md
+++ b/packages/bb-kv-store/README.md
@@ -31,7 +31,7 @@ const store = new KVStore(scope, id, options?)
 | `schema` | `StandardSchemaV1` | Runtime validation schema (Zod, Valibot, ArkType, etc.). When provided, the value type `T` is inferred from the schema and every `put()` validates the value before writing. |
 | `table` | `ExternalTableRef` | Wrap an existing DynamoDB table instead of creating one. |
 | `logger` | `ChildLogger` | Optional logger for internal operations. When omitted, a default Logger at error level is created. |
-| `removalPolicy` | `'destroy' \| 'retain'` | CDK removal behavior for the underlying DynamoDB table. When omitted, CDK's default (RETAIN — data preserved on `cdk destroy`) applies; pass `'destroy'` for sandbox / ephemeral stacks. Ignored by the mock and browser runtimes. |
+| `removalPolicy` | `'destroy' \| 'retain'` | Removal behavior for the underlying DynamoDB table. When omitted, the stack-wide `defaults` (from `BlocksPresets.sandbox`/`production`, chosen at `BlocksStack.create`) apply — `production` retains data on `cdk destroy`, `sandbox` destroys it. Pass `'destroy'`/`'retain'` to override for this one store. The table's deletion protection also follows the stack `defaults`. Ignored by the mock and browser runtimes. |
 | `ttl` | `boolean` | Enable DynamoDB Time-to-Live so items written with an expiry are deleted automatically. Defaults to `false`. See [Expiring Items](#expiring-items-ttl). |
 
 ### Expiring Items (TTL)

--- a/packages/bb-kv-store/src/index.cdk.test.ts
+++ b/packages/bb-kv-store/src/index.cdk.test.ts
@@ -13,16 +13,20 @@ import assert from 'node:assert';
 import * as cdk from 'aws-cdk-lib';
 import type { Construct } from 'constructs';
 import { Template, Match } from 'aws-cdk-lib/assertions';
-import { Scope, DEFAULT_NODE_RUNTIME } from '@aws-blocks/core/cdk';
+import { Scope, DEFAULT_NODE_RUNTIME, BlocksPresets, type BlocksDefaults } from '@aws-blocks/core/cdk';
 import { KVStore } from './index.cdk.js';
 
 // Minimal BlocksStack-shaped parent. The production code path uses BlocksStack,
 // which exposes `handler` on a Lambda that lives inside a `cdk.Stack`. We
 // reproduce that here so KVStore can call grantReadWriteData(this.handler)
-// and still synth into a real stack.
+// and still synth into a real stack. It also carries `defaults` — Building
+// Blocks resolve `scope.defaults` by walking up to the owning
+// BlocksStack/BlocksBackend, falling back to `globalThis.CURRENT_BLOCKS_STACK`,
+// which is this stub in these tests.
 class StubBlocksStack extends cdk.Stack {
   public readonly handler: cdk.aws_lambda.Function;
   public readonly id: string;
+  public defaults: BlocksDefaults = BlocksPresets.production;
   constructor(scope: Construct, id: string) {
     super(scope, id);
     this.id = id;
@@ -35,9 +39,10 @@ class StubBlocksStack extends cdk.Stack {
   }
 }
 
-function setup(): { stack: StubBlocksStack; parent: Scope } {
+function setup(defaults: BlocksDefaults = BlocksPresets.production): { stack: StubBlocksStack; parent: Scope } {
   const app = new cdk.App();
   const stack = new StubBlocksStack(app, 'TestStack');
+  stack.defaults = defaults;
   const parent = new Scope('app');
   return { stack, parent };
 }
@@ -62,6 +67,42 @@ test('CDK: KVStore.fromExisting returns a branded ref', () => {
   const ref = KVStore.fromExisting('foo');
   assert.strictEqual(ref.tableName, 'foo');
   assert.strictEqual(ref.__brand, 'ExternalTableRef');
+});
+
+test('CDK: table adopts the sandbox defaults (DESTROY, deletion protection off)', () => {
+  const { stack, parent } = setup(BlocksPresets.sandbox);
+  new KVStore(parent, 'sessions');
+  const template = Template.fromStack(stack);
+  template.hasResource('AWS::DynamoDB::Table', { DeletionPolicy: 'Delete' });
+  template.hasResourceProperties('AWS::DynamoDB::Table', { DeletionProtectionEnabled: false });
+});
+
+test('CDK: table adopts the production defaults (RETAIN, deletion protection on)', () => {
+  const { stack, parent } = setup(BlocksPresets.production);
+  new KVStore(parent, 'sessions');
+  const template = Template.fromStack(stack);
+  template.hasResource('AWS::DynamoDB::Table', { DeletionPolicy: 'Retain' });
+  template.hasResourceProperties('AWS::DynamoDB::Table', { DeletionProtectionEnabled: true });
+});
+
+test('CDK: per-block removalPolicy overrides the resolved default', () => {
+  const { stack, parent } = setup(BlocksPresets.production);
+  new KVStore(parent, 'sessions', { removalPolicy: 'destroy' });
+  const template = Template.fromStack(stack);
+  // Per-block 'destroy' wins over the production RETAIN default; deletion
+  // protection still follows the default (no per-block option given for it).
+  template.hasResource('AWS::DynamoDB::Table', { DeletionPolicy: 'Delete' });
+  template.hasResourceProperties('AWS::DynamoDB::Table', { DeletionProtectionEnabled: true });
+});
+
+test('CDK: per-block deletionProtection overrides the resolved default', () => {
+  const { stack, parent } = setup(BlocksPresets.production);
+  new KVStore(parent, 'sessions', { deletionProtection: false });
+  const template = Template.fromStack(stack);
+  // Per-block false wins over the production (protected) default; removal
+  // policy still follows the default (RETAIN).
+  template.hasResourceProperties('AWS::DynamoDB::Table', { DeletionProtectionEnabled: false });
+  template.hasResource('AWS::DynamoDB::Table', { DeletionPolicy: 'Retain' });
 });
 
 test('CDK: calling a runtime data method throws an actionable error (not a cryptic TypeError)', () => {

--- a/packages/bb-kv-store/src/index.cdk.ts
+++ b/packages/bb-kv-store/src/index.cdk.ts
@@ -32,19 +32,24 @@ export class KVStore extends Scope {
 			// and grant the runtime Lambda read/write access.
 			this.table = Table.fromTableName(this, 'table', options.table.tableName);
 		} else {
+			// Resolve durability from the per-block option (a `'destroy'|'retain'`
+			// string, normalized to a CDK RemovalPolicy) falling back to the
+			// stack-wide `defaults`. The stack `defaults` replace the old
+			// `RemovalPolicies.of(stack).destroy()` + `SandboxDisableDeletionProtection`
+			// mixin dance — the sandbox posture now flows in through the chosen preset.
+			const removalPolicy =
+				options?.removalPolicy === 'destroy'
+					? RemovalPolicy.DESTROY
+					: options?.removalPolicy === 'retain'
+						? RemovalPolicy.RETAIN
+						: this.defaults.removalPolicy;
+
 			this.table = new Table(this, 'table', {
 				tableName: this.fullId.substring(0, 255),
 				partitionKey: { name: 'pk', type: AttributeType.STRING },
 				billingMode: BillingMode.PAY_PER_REQUEST,
-				// Default: CDK's RETAIN (undefined here). Customers opt into teardown
-				// via `{ removalPolicy: 'destroy' }`. Templates that apply
-				// `RemovalPolicies.of(stack).destroy()` under `sandboxMode` will
-				// override this at the stack layer regardless.
-				removalPolicy: options?.removalPolicy === 'destroy'
-					? RemovalPolicy.DESTROY
-					: options?.removalPolicy === 'retain'
-						? RemovalPolicy.RETAIN
-						: undefined,
+				removalPolicy,
+				deletionProtection: options?.deletionProtection ?? this.defaults.deletionProtection,
 				// Opt-in: enabling TTL on an already-deployed table is a live table
 				// update, so it must never happen implicitly.
 				timeToLiveAttribute: options?.ttl ? TTL_ATTRIBUTE : undefined,

--- a/packages/bb-kv-store/src/types.ts
+++ b/packages/bb-kv-store/src/types.ts
@@ -99,19 +99,24 @@ export interface KVStoreOptions<T = string> {
 	 */
 	logger?: ChildLogger;
 	/**
-	 * CDK removal behavior for the underlying DynamoDB table. When omitted,
-	 * CDK's default applies (RETAIN — data is preserved on `cdk destroy`).
-	 * Pass `'destroy'` for sandbox / ephemeral stacks where the table and
-	 * its contents should be dropped on teardown. Pass `'retain'` to set
-	 * the policy explicitly (identical to omitting it today, but robust
-	 * against stack-layer policy overrides).
-	 *
-	 * Templates that apply `RemovalPolicies.of(stack).destroy()` at the
-	 * top level (e.g. under `sandboxMode`) override this setting.
+	 * Removal behavior (via CDK/CloudFormation) for the underlying DynamoDB
+	 * table. When omitted, the stack-wide `defaults` apply (`production` retains
+	 * data on `cdk destroy`, `sandbox` destroys it). Pass `'destroy'` or
+	 * `'retain'` to override for this one store.
 	 *
 	 * Ignored by the mock and browser runtimes (no AWS resource to retain).
 	 */
 	removalPolicy?: 'destroy' | 'retain';
+	/**
+	 * Whether to block deletion of the underlying DynamoDB table. Unlike
+	 * `removalPolicy` (which only governs CDK/CloudFormation), deletion
+	 * protection also prevents deletion via the CLI, API, and AWS console.
+	 * When omitted, the stack-wide `defaults` apply (on in `production`, off in
+	 * `sandbox`). Pass `true`/`false` to override for this one store.
+	 *
+	 * Ignored by the mock and browser runtimes (no AWS resource to protect).
+	 */
+	deletionProtection?: boolean;
 	/**
 	 * Enable DynamoDB Time-to-Live on the underlying table so items written with
 	 * `put(key, value, { ttlSeconds })` (or `{ expiresAt }`) are deleted

--- a/packages/core/src/cdk/blocks-backend.test.ts
+++ b/packages/core/src/cdk/blocks-backend.test.ts
@@ -9,6 +9,7 @@ import * as cdk from 'aws-cdk-lib';
 import { Template, Match } from 'aws-cdk-lib/assertions';
 import { PolicyStatement } from 'aws-cdk-lib/aws-iam';
 import { BlocksBackend } from './blocks-backend.js';
+import { BlocksPresets } from './blocks-defaults.js';
 import { Scope } from './index.js';
 
 // Simulate the CDK condition being active (tests import CDK files directly)
@@ -32,11 +33,13 @@ describe('ESM cache-busting (multi-stage)', () => {
     const backend1 = await BlocksBackend.create(stack, 'Stage1', {
       backendHandlerPath: handlerPath,
       backendCDKPath: sideEffectBackendPath,
+      defaults: BlocksPresets.production,
     });
 
     const backend2 = await BlocksBackend.create(stack, 'Stage2', {
       backendHandlerPath: handlerPath,
       backendCDKPath: sideEffectBackendPath,
+      defaults: BlocksPresets.production,
     });
 
     const findMarker = (scope: cdk.aws_lambda_nodejs.NodejsFunction | any) =>
@@ -61,6 +64,7 @@ describe('synth shape (drop into existing stack)', () => {
     const backend = await BlocksBackend.create(parent, 'Blocks', {
       backendHandlerPath: handlerPath,
       backendCDKPath: sideEffectBackendPath,
+      defaults: BlocksPresets.production,
     });
 
     // Public surface mirrors BlocksStack.
@@ -82,10 +86,12 @@ describe('synth shape (drop into existing stack)', () => {
     await BlocksBackend.create(parent, 'BackendA', {
       backendHandlerPath: handlerPath,
       backendCDKPath: sideEffectBackendPath,
+      defaults: BlocksPresets.production,
     });
     await BlocksBackend.create(parent, 'BackendB', {
       backendHandlerPath: handlerPath,
       backendCDKPath: sideEffectBackendPath,
+      defaults: BlocksPresets.production,
     });
 
     const template = Template.fromStack(parent);
@@ -101,6 +107,7 @@ describe('shared execution role', () => {
     const backend = await BlocksBackend.create(parent, 'Blocks', {
       backendHandlerPath: handlerPath,
       backendCDKPath: sideEffectBackendPath,
+      defaults: BlocksPresets.production,
     });
 
     assert.ok(backend.executionRole, 'BlocksBackend should expose .executionRole');
@@ -113,6 +120,7 @@ describe('shared execution role', () => {
     await BlocksBackend.create(parent, 'Blocks', {
       backendHandlerPath: handlerPath,
       backendCDKPath: sideEffectBackendPath,
+      defaults: BlocksPresets.production,
     });
 
     const template = Template.fromStack(parent);
@@ -149,6 +157,7 @@ describe('shared execution role', () => {
     const backend = await BlocksBackend.create(parent, 'Blocks', {
       backendHandlerPath: handlerPath,
       backendCDKPath: sideEffectBackendPath,
+      defaults: BlocksPresets.production,
     });
 
     // Build nested Scopes under the backend (outer → inner), the same shape a
@@ -194,6 +203,7 @@ describe('CJS bundle: import.meta.url in the handler is shimmed (no Lambda-load 
       BlocksBackend.create(stack, 'blocks', {
         backendHandlerPath: importMetaHandlerPath,
         backendCDKPath: sideEffectBackendPath,
+        defaults: BlocksPresets.production,
       }),
     );
   });
@@ -207,6 +217,7 @@ describe('factory function support', () => {
     const backend = await BlocksBackend.create(stack, 'FactoryStage', {
       backendHandlerPath: handlerPath,
       backendCDKPath: factoryBackendPath,
+      defaults: BlocksPresets.production,
     });
 
     const marker = backend.node.tryFindChild('FactoryMarker');
@@ -222,6 +233,7 @@ describe('fullId is token-free (construct IDs / env-var keys)', () => {
     const backend = await BlocksBackend.create(stack, 'blocks', {
       backendHandlerPath: handlerPath,
       backendCDKPath: sideEffectBackendPath,
+      defaults: BlocksPresets.production,
     });
 
     assert.strictEqual(backend.fullId, 'TopLevelStack-blocks');
@@ -246,6 +258,7 @@ describe('fullId is token-free (construct IDs / env-var keys)', () => {
     const backend = await BlocksBackend.create(nested, 'blocks', {
       backendHandlerPath: handlerPath,
       backendCDKPath: sideEffectBackendPath,
+      defaults: BlocksPresets.production,
     });
 
     assert.ok(
@@ -266,6 +279,7 @@ describe('fullId is token-free (construct IDs / env-var keys)', () => {
     const backend = await BlocksBackend.create(nested, 'blocks', {
       backendHandlerPath: handlerPath,
       backendCDKPath: fullIdConstructBackendPath,
+      defaults: BlocksPresets.production,
     });
 
     // The construct ID is `${scope.fullId}Marker` → `ParentStack-blocks-blocks-dbMarker`.
@@ -293,6 +307,7 @@ describe('fullId is token-free (construct IDs / env-var keys)', () => {
     const backend = await BlocksBackend.create(nested, 'blocks', {
       backendHandlerPath: handlerPath,
       backendCDKPath: sideEffectBackendPath,
+      defaults: BlocksPresets.production,
     });
 
     const template = Template.fromStack(nested);
@@ -313,5 +328,45 @@ describe('fullId is token-free (construct IDs / env-var keys)', () => {
         `BLOCKS_STACK_NAME must be token-free, got: ${value}`,
       );
     }
+  });
+});
+
+describe('infrastructure defaults (backend-anchored)', () => {
+  test('each backend exposes its own defaults', async () => {
+    const app = new cdk.App();
+    const stack = new cdk.Stack(app, 'TwoBackendsStack');
+
+    const a = await BlocksBackend.create(stack, 'A', {
+      backendHandlerPath: handlerPath,
+      backendCDKPath: sideEffectBackendPath,
+      defaults: BlocksPresets.production,
+    });
+    const b = await BlocksBackend.create(stack, 'B', {
+      backendHandlerPath: handlerPath,
+      backendCDKPath: sideEffectBackendPath,
+      defaults: BlocksPresets.sandbox,
+    });
+
+    // Two backends in one stack must NOT clobber each other — defaults are
+    // anchored on the backend, not the shared stack.
+    assert.strictEqual(a.defaults, BlocksPresets.production);
+    assert.strictEqual(b.defaults, BlocksPresets.sandbox);
+  });
+
+  test('a nested block resolves its owning backend defaults via the tree-walk', async () => {
+    const app = new cdk.App();
+    const stack = new cdk.Stack(app, 'ResolveDefaultsStack');
+
+    const backend = await BlocksBackend.create(stack, 'Blocks', {
+      backendHandlerPath: handlerPath,
+      backendCDKPath: sideEffectBackendPath,
+      defaults: BlocksPresets.sandbox,
+    });
+
+    // A Scope under the backend resolves scope.defaults by walking up to it.
+    const outer = new Scope('outer');
+    const inner = new Scope('inner', { parent: outer });
+    assert.strictEqual(inner.defaults, backend.defaults);
+    assert.strictEqual(inner.defaults, BlocksPresets.sandbox);
   });
 });

--- a/packages/core/src/cdk/blocks-backend.ts
+++ b/packages/core/src/cdk/blocks-backend.ts
@@ -12,6 +12,7 @@ import { DEFAULT_NODE_RUNTIME } from './node-version.js';
 import { blocksNodejsBundling } from './bundling.js';
 import { addBlocksStackMetadata } from './stack-metadata.js';
 import { finalizeConfigRegistry, registerConfig } from './config-registry.js';
+import type { BlocksDefaults } from './blocks-defaults.js';
 import { BLOCKS_NAMESPACE, BLOCKS_RPC_PREFIX } from '../constants.js';
 import { registerBuiltinRoutes } from '../builtin-routes.js';
 
@@ -46,10 +47,29 @@ export function assertCdkConditionActive(): void {
 export interface BlocksBackendProps {
   backendHandlerPath: string;
   backendCDKPath: string;
+  /**
+   * Stack-wide infrastructure defaults applied to every Building Block (removal
+   * policy, deletion protection, …). See {@link BlocksDefaults}. Start from
+   * `BlocksPresets.sandbox` or `BlocksPresets.production` and override
+   * individual fields as needed. A per-block option always wins over the
+   * corresponding stack default.
+   */
+  defaults: BlocksDefaults;
 }
 
 /** Shared infra setup — creates Lambda + API Gateway on the given scope. */
 export function setupBlocksInfra(scope: Construct, props: BlocksBackendProps, id?: string) {
+  // Fail fast with an actionable message at the create() call site if `defaults`
+  // is missing (e.g. a plain-JS caller, `as any`, or a dynamically-built props
+  // object) — otherwise the first Building Block to read `scope.defaults` throws
+  // a cryptic `Cannot read properties of undefined (reading 'removalPolicy')`.
+  if (!props.defaults) {
+    throw new Error(
+      'BlocksStack/BlocksBackend requires a `defaults` field. Pass a posture from ' +
+      '`@aws-blocks/core/cdk` — typically `defaults: sandboxMode ? BlocksPresets.sandbox : BlocksPresets.production`.',
+    );
+  }
+
   // ── Shared execution role ──────────────────────────────────────────────
   // A single IAM role that every Building Block grants to. Provisioned here so
   // it exists before the backend module is imported (Building Blocks reach it
@@ -203,6 +223,8 @@ export class BlocksBackend extends Construct {
   public readonly backendHandlerPath: string;
   /** Shared IAM role assumed by all Blocks compute. Building Blocks grant to this role. */
   public readonly executionRole: iam.IRole;
+  /** Infrastructure defaults for Building Blocks created under this backend. */
+  public readonly defaults: BlocksDefaults;
 
   /**
    * The fullId used by child Scopes to compute their env var names,
@@ -242,6 +264,11 @@ export class BlocksBackend extends Construct {
 
     // Expose self to Building Blocks at CDK time
     (globalThis as any).CURRENT_BLOCKS_STACK = this;
+
+    // Store defaults on the backend (not the stack) so several BlocksBackends
+    // in one stack each keep their own posture; Building Blocks resolve them by
+    // walking up to their owning backend (see Scope.defaults).
+    this.defaults = props.defaults;
 
     const infra = setupBlocksInfra(this, props, id);
     this.handler = infra.handler;

--- a/packages/core/src/cdk/blocks-defaults.test.ts
+++ b/packages/core/src/cdk/blocks-defaults.test.ts
@@ -1,0 +1,25 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * BlocksPresets carry the expected posture. Resolution/anchoring (a block
+ * reading its owning backend's defaults, and two backends in one stack keeping
+ * separate postures) is covered in blocks-backend.test.ts, which has the
+ * fixtures to construct real backends.
+ */
+import { test, describe } from 'node:test';
+import assert from 'node:assert';
+import { RemovalPolicy } from 'aws-cdk-lib';
+import { BlocksPresets } from './blocks-defaults.js';
+
+describe('BlocksPresets', () => {
+	test('sandbox is disposable: DESTROY + deletion protection off', () => {
+		assert.strictEqual(BlocksPresets.sandbox.removalPolicy, RemovalPolicy.DESTROY);
+		assert.strictEqual(BlocksPresets.sandbox.deletionProtection, false);
+	});
+
+	test('production is durable: RETAIN + deletion protection on', () => {
+		assert.strictEqual(BlocksPresets.production.removalPolicy, RemovalPolicy.RETAIN);
+		assert.strictEqual(BlocksPresets.production.deletionProtection, true);
+	});
+});

--- a/packages/core/src/cdk/blocks-defaults.ts
+++ b/packages/core/src/cdk/blocks-defaults.ts
@@ -1,0 +1,49 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { RemovalPolicy } from 'aws-cdk-lib';
+
+/**
+ * Default values for every Amazon-authored Building Block created within a
+ * `BlocksStack` or `BlocksBackend`. A per-block option always overrides the
+ * corresponding default (`option ?? scope.defaults.field`).
+ *
+ * Start from {@link BlocksPresets} and override individual fields as needed.
+ */
+export interface BlocksDefaults {
+	/**
+	 * What happens to a stateful resource (table, bucket, user pool) when the
+	 * stack is deleted, via CDK/CloudFormation: `RETAIN` keeps the resource (and
+	 * its data) behind; `DESTROY` tears it down. Applies only to CDK/CloudFormation
+	 * deletions.
+	 */
+	removalPolicy: RemovalPolicy;
+
+	/**
+	 * Whether to block deletion of a stateful resource. Unlike `removalPolicy`,
+	 * this guards against deletion through **any** path — CDK/CloudFormation as
+	 * well as the CLI, API, and AWS console — until it is turned off.
+	 */
+	deletionProtection: boolean;
+}
+
+/**
+ * Prepared starting points for {@link BlocksDefaults}. Pick one and override
+ * individual fields with a spread:
+ *
+ * ```ts
+ * defaults: { ...BlocksPresets.production, deletionProtection: false }
+ * ```
+ */
+export const BlocksPresets = {
+	/** Disposable development stacks: tear down cleanly, no delete guard. */
+	sandbox: {
+		removalPolicy: RemovalPolicy.DESTROY,
+		deletionProtection: false,
+	},
+	/** Durable, protected posture for permanent deployments. */
+	production: {
+		removalPolicy: RemovalPolicy.RETAIN,
+		deletionProtection: true,
+	},
+} satisfies Record<string, BlocksDefaults>;

--- a/packages/core/src/cdk/blocks-stack.test.ts
+++ b/packages/core/src/cdk/blocks-stack.test.ts
@@ -7,7 +7,7 @@ import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import * as cdk from 'aws-cdk-lib';
 import { BlocksBackend } from './blocks-backend.js';
-import { BlocksStack, Scope } from './index.js';
+import { BlocksStack, BlocksPresets, Scope } from './index.js';
 
 // Simulate the CDK condition being active (tests import CDK files directly)
 before(() => {
@@ -26,11 +26,13 @@ describe('ESM cache-busting (multi-stage)', () => {
     const stack1 = await BlocksStack.create(app, 'PipelineStage1', {
       backendHandlerPath: handlerPath,
       backendCDKPath: sideEffectBackendPath,
+      defaults: BlocksPresets.production,
     });
 
     const stack2 = await BlocksStack.create(app, 'PipelineStage2', {
       backendHandlerPath: handlerPath,
       backendCDKPath: sideEffectBackendPath,
+      defaults: BlocksPresets.production,
     });
 
     const findMarker = (scope: any) => scope.node.tryFindChild('SideEffectMarker');
@@ -53,6 +55,7 @@ describe('factory function support', () => {
     const stack = await BlocksStack.create(app, 'FactoryBlocksStack', {
       backendHandlerPath: handlerPath,
       backendCDKPath: factoryBackendPath,
+      defaults: BlocksPresets.production,
     });
 
     const marker = stack.node.tryFindChild('FactoryMarker');
@@ -68,6 +71,7 @@ describe('legacy side-effect mode (no default export)', () => {
     const backend = await BlocksBackend.create(stack, 'LegacyStage', {
       backendHandlerPath: handlerPath,
       backendCDKPath: sideEffectBackendPath,
+      defaults: BlocksPresets.production,
     });
 
     const marker = backend.node.tryFindChild('SideEffectMarker');
@@ -88,6 +92,7 @@ describe('shared execution role (BlocksStack)', () => {
     const stack = await BlocksStack.create(app, 'StackRoleStack', {
       backendHandlerPath: handlerPath,
       backendCDKPath: sideEffectBackendPath,
+      defaults: BlocksPresets.production,
     });
 
     assert.ok(stack.executionRole, 'BlocksStack should expose a populated .executionRole');
@@ -100,6 +105,7 @@ describe('executionRole globalThis fallback', () => {
     const stack = await BlocksStack.create(app, 'FallbackStack', {
       backendHandlerPath: handlerPath,
       backendCDKPath: sideEffectBackendPath,
+      defaults: BlocksPresets.production,
     });
 
     // A Scope whose construct-tree ancestry has no BlocksStack/BlocksBackend
@@ -132,6 +138,7 @@ describe('assertCdkConditionActive', () => {
         BlocksStack.create(app, 'MissingConditionStack', {
           backendHandlerPath: handlerPath,
           backendCDKPath: sideEffectBackendPath,
+          defaults: BlocksPresets.production,
         }),
         (err: Error) => {
           assert.ok(err.message.includes('Missing --conditions=cdk'), `Expected condition error, got: ${err.message}`);

--- a/packages/core/src/cdk/index.ts
+++ b/packages/core/src/cdk/index.ts
@@ -15,12 +15,17 @@ import {
 import { setupBlocksInfra, BlocksBackend, assertCdkConditionActive } from './blocks-backend.js';
 import { addBlocksStackMetadata } from './stack-metadata.js';
 import { finalizeConfigRegistry } from './config-registry.js';
+import { type BlocksDefaults, BlocksPresets } from './blocks-defaults.js';
 
 export { BlocksBackend, type BlocksBackendProps } from './blocks-backend.js';
 export { DEFAULT_NODE_RUNTIME } from './node-version.js';
 export { blocksNodejsBundling } from './bundling.js';
 export { SandboxDisableDeletionProtection } from './mixins.js';
 export { registerConfig, finalizeConfigRegistry } from './config-registry.js';
+export {
+  type BlocksDefaults,
+  BlocksPresets,
+} from './blocks-defaults.js';
 export { synthGuard } from './synth-guard.js';
 export type { ScopeOptions } from '../index.js';
 export { ApiError, isBlocksError, hasAuthError, DEFAULT_API_ERROR_NAME } from '../errors.js';
@@ -33,11 +38,14 @@ export class BlocksStack extends cdk.Stack implements BaseBlocksStack {
   public readonly backendHandlerPath: string;
   /** Shared IAM role assumed by all Blocks compute. Building Blocks grant to this role. */
   public readonly executionRole: cdk.aws_iam.IRole;
+  /** Infrastructure defaults for Building Blocks created under this stack. */
+  public readonly defaults: BlocksDefaults;
 
   private constructor(scope: Construct, id: string, props: BlocksStackProps) {
     super(scope, id, props);
     this.id = id;
     this.backendHandlerPath = props.backendHandlerPath;
+    this.defaults = props.defaults;
 
     // Set globalThis so Building Blocks attach directly to this stack
     (globalThis as any).CURRENT_BLOCKS_STACK = this;
@@ -131,6 +139,41 @@ export class Scope extends Construct {
 
   get fullId(): string {
     return computeScopeFullId(this);
+  }
+
+  /**
+   * The stack-wide infrastructure {@link BlocksDefaults} registered by
+   * `BlocksStack.create` / `BlocksBackend.create`. Read these in a Building
+   * Block's CDK constructor to resolve a durability value, letting a per-block
+   * option override:
+   *
+   * ```ts
+   * const removalPolicy = options?.removalPolicy ?? this.defaults.removalPolicy;
+   * ```
+   */
+  get defaults(): BlocksDefaults {
+    // Resolve the same way as handler/executionRole: walk up to the owning
+    // BlocksStack/BlocksBackend and read its defaults, so several backends in
+    // one stack each keep their own posture. Falls back to the ambient stack,
+    // then to the production preset when none was registered.
+    let current: Construct = this;
+    while (current.node.scope) {
+        current = current.node.scope as Construct;
+        if (current instanceof BlocksStack || current instanceof BlocksBackend) {
+            return current.defaults;
+        }
+    }
+    const ambient = ((globalThis as any).CURRENT_BLOCKS_STACK as { defaults?: BlocksDefaults } | undefined)?.defaults;
+    if (ambient) return ambient;
+    // No owning BlocksStack/BlocksBackend in the tree and none ambient — this is
+    // usually a deliberate test stub, but could be a real misconfiguration (a
+    // block built outside any Blocks backend). Fall back to the safe production
+    // posture, and log so it's debuggable if it fires unexpectedly.
+    console.warn(
+      `[Blocks] Scope "${this.id}" resolved infrastructure defaults with no owning ` +
+      'BlocksStack/BlocksBackend in scope; falling back to BlocksPresets.production.',
+    );
+    return BlocksPresets.production;
   }
 
   protected buildUserAgentChain(): [string, string][] {

--- a/packages/core/src/cdk/mixins.ts
+++ b/packages/core/src/cdk/mixins.ts
@@ -31,6 +31,12 @@ const DELETION_PROTECTION_PROPERTIES = ['deletionProtection', 'deletionProtectio
  * `DeleteTable` while deletion protection is enabled, regardless of the
  * CloudFormation `DeletionPolicy`.
  *
+ * @deprecated Prefer the stack-wide `defaults` prop on `BlocksStack`/`BlocksBackend`
+ * (`defaults: BlocksPresets.sandbox` / `.production`, or `sandboxMode ? … : …`).
+ * Amazon-authored Building Blocks now read removal policy + deletion protection
+ * from `defaults`, so this mixin is no longer needed; it is retained only for
+ * backward compatibility.
+ *
  * @example
  * ```ts
  * import { RemovalPolicies, Mixins } from 'aws-cdk-lib';

--- a/packages/core/src/common/index.ts
+++ b/packages/core/src/common/index.ts
@@ -3,6 +3,7 @@
 
 import type { StackProps } from 'aws-cdk-lib';
 import type { Construct } from 'constructs';
+import type { BlocksDefaults } from '../cdk/blocks-defaults.js';
 import { CORE_VERSION } from '../version.js';
 import { OFFICIAL_BB_NAMES } from './official-bb-names.generated.js';
 export { OFFICIAL_BB_NAMES } from './official-bb-names.generated.js';
@@ -325,6 +326,14 @@ export function computeScopeFullId(scope: { id: string; parent?: any }) {
 export interface BlocksStackProps extends StackProps {
   backendHandlerPath: string;
   backendCDKPath: string;
+  /**
+   * Stack-wide infrastructure defaults applied to every Building Block (removal
+   * policy, deletion protection, …). Start from `BlocksPresets.sandbox` or
+   * `BlocksPresets.production` and override individual fields as needed. Any
+   * field a block also exposes as a per-block option is overridden by that
+   * option. See `BlocksDefaults` in `@aws-blocks/core/cdk`.
+   */
+  defaults: BlocksDefaults;
 }
 
 export class BlocksStack {

--- a/packages/core/src/index.cdk.ts
+++ b/packages/core/src/index.cdk.ts
@@ -10,6 +10,10 @@ export { registerSdkIdentifiers, getSdkIdentifiers, getAllSdkIdentifiers, _reset
 export { getConfig, getConfigSync, preloadConfig, loadConfigToProcessEnv, _resetConfigCache } from './common/config.js';
 export { BlocksStack, Scope, SandboxDisableDeletionProtection, BlocksBackend, registerConfig, finalizeConfigRegistry, synthGuard, DEFAULT_NODE_RUNTIME, blocksNodejsBundling, type BlocksBackendProps } from './cdk/index.js';
 export {
+  type BlocksDefaults,
+  BlocksPresets,
+} from './cdk/index.js';
+export {
   Hosting,
   type HostingProps,
   type BlocksStackApi,

--- a/packages/create-blocks-app/templates/amplify/aws-blocks/index.cdk.ts
+++ b/packages/create-blocks-app/templates/amplify/aws-blocks/index.cdk.ts
@@ -4,8 +4,7 @@
  * This file is imported by amplify/blocks.ts to wire Blocks into the Amplify backend.
  * It is NOT a standalone CDK app — Amplify's `ampx` CLI orchestrates synthesis.
  */
-import { BlocksBackend, SandboxDisableDeletionProtection } from '@aws-blocks/blocks/cdk';
-import { RemovalPolicies, Mixins } from 'aws-cdk-lib';
+import { BlocksBackend, BlocksPresets } from '@aws-blocks/blocks/cdk';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import type { Stack } from 'aws-cdk-lib';
@@ -26,13 +25,8 @@ export async function createBlocksBackend(stack: Stack, sandboxMode: boolean) {
   const blocks = await BlocksBackend.create(stack, 'blocks', {
     backendHandlerPath: join(__dirname, 'index.handler.ts'),
     backendCDKPath: join(__dirname, 'index.ts'),
+    defaults: sandboxMode ? BlocksPresets.sandbox : BlocksPresets.production,
   });
-
-  // In sandbox mode, make all resources deletable so teardown succeeds cleanly.
-  if (sandboxMode) {
-    RemovalPolicies.of(stack).destroy();
-    Mixins.of(stack).apply(new SandboxDisableDeletionProtection());
-  }
 
   return blocks;
 }

--- a/packages/create-blocks-app/templates/auth-cognito/aws-blocks/index.cdk.ts
+++ b/packages/create-blocks-app/templates/auth-cognito/aws-blocks/index.cdk.ts
@@ -1,7 +1,6 @@
 import * as cdk from 'aws-cdk-lib';
-import { RemovalPolicies, Mixins } from 'aws-cdk-lib';
 
-import { Hosting, BlocksStack, SandboxDisableDeletionProtection } from '@aws-blocks/blocks/cdk';
+import { Hosting, BlocksStack, BlocksPresets } from '@aws-blocks/blocks/cdk';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import { getStackName } from '@aws-blocks/blocks/scripts';
@@ -16,17 +15,11 @@ const projectRoot = app.node.tryGetContext('projectRoot') || process.cwd();
 const stackName = getStackName({ sandbox: sandboxMode, projectRoot });
 export const blocksStack = await BlocksStack.create(app, stackName, {
   backendHandlerPath: join(__dirname, 'index.handler.ts'),
-  backendCDKPath: join(__dirname, 'index.ts')
+  backendCDKPath: join(__dirname, 'index.ts'),
+  defaults: sandboxMode ? BlocksPresets.sandbox : BlocksPresets.production,
 });
 
 if (sandboxMode) {
-  // Make all resources deletable so sandbox:destroy can clean up the entire stack.
-  // This overrides removal policies and deletion protection (e.g. RDS) for every
-  // resource in the stack, including any you add below.
-  // Remove these lines if you want to manage teardown behavior yourself.
-  RemovalPolicies.of(blocksStack).destroy();
-  Mixins.of(blocksStack).apply(new SandboxDisableDeletionProtection());
-
   // Tell the runtime that cookies need cross-domain attributes (frontend on
   // localhost, API on API Gateway — different registrable domains).
   blocksStack.handler.addEnvironment('BLOCKS_SANDBOX', 'true');}

--- a/packages/create-blocks-app/templates/backend/aws-blocks/index.cdk.ts
+++ b/packages/create-blocks-app/templates/backend/aws-blocks/index.cdk.ts
@@ -1,7 +1,6 @@
 import * as cdk from 'aws-cdk-lib';
-import { RemovalPolicies, Mixins } from 'aws-cdk-lib';
 
-import { BlocksStack, SandboxDisableDeletionProtection } from '@aws-blocks/blocks/cdk';
+import { BlocksStack, BlocksPresets } from '@aws-blocks/blocks/cdk';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import { getStackName } from '@aws-blocks/blocks/scripts';
@@ -16,17 +15,11 @@ const projectRoot = app.node.tryGetContext('projectRoot') || process.cwd();
 const stackName = getStackName({ sandbox: sandboxMode, projectRoot });
 export const blocksStack = await BlocksStack.create(app, stackName, {
   backendHandlerPath: join(__dirname, 'index.handler.ts'),
-  backendCDKPath: join(__dirname, 'index.ts')
+  backendCDKPath: join(__dirname, 'index.ts'),
+  defaults: sandboxMode ? BlocksPresets.sandbox : BlocksPresets.production,
 });
 
 if (sandboxMode) {
-  // Make all resources deletable so sandbox:destroy can clean up the entire stack.
-  // This overrides removal policies and deletion protection (e.g. RDS) for every
-  // resource in the stack, including any you add below.
-  // Remove these lines if you want to manage teardown behavior yourself.
-  RemovalPolicies.of(blocksStack).destroy();
-  Mixins.of(blocksStack).apply(new SandboxDisableDeletionProtection());
-
   // Tell the runtime that cookies need cross-domain attributes (frontend on
   // localhost, API on API Gateway — different registrable domains).
   blocksStack.handler.addEnvironment('BLOCKS_SANDBOX', 'true');}

--- a/packages/create-blocks-app/templates/bare/aws-blocks/index.cdk.ts
+++ b/packages/create-blocks-app/templates/bare/aws-blocks/index.cdk.ts
@@ -1,7 +1,6 @@
 import * as cdk from 'aws-cdk-lib';
-import { RemovalPolicies, Mixins } from 'aws-cdk-lib';
 
-import { Hosting, BlocksStack, SandboxDisableDeletionProtection } from '@aws-blocks/blocks/cdk';
+import { Hosting, BlocksStack, BlocksPresets } from '@aws-blocks/blocks/cdk';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import { getStackName } from '@aws-blocks/blocks/scripts';
@@ -16,17 +15,11 @@ const projectRoot = app.node.tryGetContext('projectRoot') || process.cwd();
 const stackName = getStackName({ sandbox: sandboxMode, projectRoot });
 export const blocksStack = await BlocksStack.create(app, stackName, {
   backendHandlerPath: join(__dirname, 'index.handler.ts'),
-  backendCDKPath: join(__dirname, 'index.ts')
+  backendCDKPath: join(__dirname, 'index.ts'),
+  defaults: sandboxMode ? BlocksPresets.sandbox : BlocksPresets.production,
 });
 
 if (sandboxMode) {
-  // Make all resources deletable so sandbox:destroy can clean up the entire stack.
-  // This overrides removal policies and deletion protection (e.g. RDS) for every
-  // resource in the stack, including any you add below.
-  // Remove these lines if you want to manage teardown behavior yourself.
-  RemovalPolicies.of(blocksStack).destroy();
-  Mixins.of(blocksStack).apply(new SandboxDisableDeletionProtection());
-
   // Tell the runtime that cookies need cross-domain attributes (frontend on
   // localhost, API on API Gateway — different registrable domains).
   blocksStack.handler.addEnvironment('BLOCKS_SANDBOX', 'true');}

--- a/packages/create-blocks-app/templates/default/aws-blocks/index.cdk.ts
+++ b/packages/create-blocks-app/templates/default/aws-blocks/index.cdk.ts
@@ -1,7 +1,6 @@
 import * as cdk from 'aws-cdk-lib';
-import { RemovalPolicies, Mixins } from 'aws-cdk-lib';
 
-import { Hosting, BlocksStack, SandboxDisableDeletionProtection } from '@aws-blocks/blocks/cdk';
+import { Hosting, BlocksStack, BlocksPresets } from '@aws-blocks/blocks/cdk';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import { getStackName } from '@aws-blocks/blocks/scripts';
@@ -16,17 +15,11 @@ const projectRoot = app.node.tryGetContext('projectRoot') || process.cwd();
 const stackName = getStackName({ sandbox: sandboxMode, projectRoot });
 export const blocksStack = await BlocksStack.create(app, stackName, {
   backendHandlerPath: join(__dirname, 'index.handler.ts'),
-  backendCDKPath: join(__dirname, 'index.ts')
+  backendCDKPath: join(__dirname, 'index.ts'),
+  defaults: sandboxMode ? BlocksPresets.sandbox : BlocksPresets.production,
 });
 
 if (sandboxMode) {
-  // Make all resources deletable so sandbox:destroy can clean up the entire stack.
-  // This overrides removal policies and deletion protection (e.g. RDS) for every
-  // resource in the stack, including any you add below.
-  // Remove these lines if you want to manage teardown behavior yourself.
-  RemovalPolicies.of(blocksStack).destroy();
-  Mixins.of(blocksStack).apply(new SandboxDisableDeletionProtection());
-
   // Tell the runtime that cookies need cross-domain attributes (frontend on
   // localhost, API on API Gateway — different registrable domains).
   blocksStack.handler.addEnvironment('BLOCKS_SANDBOX', 'true');

--- a/packages/create-blocks-app/templates/demo/aws-blocks/index.cdk.ts
+++ b/packages/create-blocks-app/templates/demo/aws-blocks/index.cdk.ts
@@ -1,7 +1,6 @@
 import * as cdk from 'aws-cdk-lib';
-import { RemovalPolicies, Mixins } from 'aws-cdk-lib';
 
-import { Hosting, BlocksStack, SandboxDisableDeletionProtection } from '@aws-blocks/blocks/cdk';
+import { Hosting, BlocksStack, BlocksPresets } from '@aws-blocks/blocks/cdk';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import { getStackName } from '@aws-blocks/blocks/scripts';
@@ -16,17 +15,11 @@ const projectRoot = app.node.tryGetContext('projectRoot') || process.cwd();
 const stackName = getStackName({ sandbox: sandboxMode, projectRoot });
 export const blocksStack = await BlocksStack.create(app, stackName, {
   backendHandlerPath: join(__dirname, 'index.handler.ts'),
-  backendCDKPath: join(__dirname, 'index.ts')
+  backendCDKPath: join(__dirname, 'index.ts'),
+  defaults: sandboxMode ? BlocksPresets.sandbox : BlocksPresets.production,
 });
 
 if (sandboxMode) {
-  // Make all resources deletable so sandbox:destroy can clean up the entire stack.
-  // This overrides removal policies and deletion protection (e.g. RDS) for every
-  // resource in the stack, including any you add below.
-  // Remove these lines if you want to manage teardown behavior yourself.
-  RemovalPolicies.of(blocksStack).destroy();
-  Mixins.of(blocksStack).apply(new SandboxDisableDeletionProtection());
-
   // Tell the runtime that cookies need cross-domain attributes (frontend on
   // localhost, API on API Gateway — different registrable domains).
   blocksStack.handler.addEnvironment('BLOCKS_SANDBOX', 'true');}

--- a/packages/create-blocks-app/templates/nextjs/aws-blocks/index.cdk.ts
+++ b/packages/create-blocks-app/templates/nextjs/aws-blocks/index.cdk.ts
@@ -1,7 +1,6 @@
 import * as cdk from 'aws-cdk-lib';
-import { RemovalPolicies, Mixins } from 'aws-cdk-lib';
 
-import { Hosting, BlocksStack, SandboxDisableDeletionProtection } from '@aws-blocks/blocks/cdk';
+import { Hosting, BlocksStack, BlocksPresets } from '@aws-blocks/blocks/cdk';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import { getStackName } from '@aws-blocks/blocks/scripts';
@@ -16,17 +15,9 @@ const projectRoot = app.node.tryGetContext('projectRoot') || process.cwd();
 const stackName = getStackName({ sandbox: sandboxMode, projectRoot });
 export const blocksStack = await BlocksStack.create(app, stackName, {
   backendHandlerPath: join(__dirname, 'index.handler.ts'),
-  backendCDKPath: join(__dirname, 'index.ts')
+  backendCDKPath: join(__dirname, 'index.ts'),
+  defaults: sandboxMode ? BlocksPresets.sandbox : BlocksPresets.production,
 });
-
-if (sandboxMode) {
-  // Make all resources deletable so sandbox:destroy can clean up the entire stack.
-  // This overrides removal policies and deletion protection (e.g. RDS) for every
-  // resource in the stack, including any you add below.
-  // Remove these lines if you want to manage teardown behavior yourself.
-  RemovalPolicies.of(blocksStack).destroy();
-  Mixins.of(blocksStack).apply(new SandboxDisableDeletionProtection());
-}
 
 // Add Next.js SSR hosting only when deploying (not in sandbox mode)
 if (!sandboxMode) {

--- a/packages/create-blocks-app/templates/react/aws-blocks/index.cdk.ts
+++ b/packages/create-blocks-app/templates/react/aws-blocks/index.cdk.ts
@@ -1,7 +1,6 @@
 import * as cdk from 'aws-cdk-lib';
-import { RemovalPolicies, Mixins } from 'aws-cdk-lib';
 
-import { Hosting, BlocksStack, SandboxDisableDeletionProtection } from '@aws-blocks/blocks/cdk';
+import { Hosting, BlocksStack, BlocksPresets } from '@aws-blocks/blocks/cdk';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import { getStackName } from '@aws-blocks/blocks/scripts';
@@ -16,17 +15,11 @@ const projectRoot = app.node.tryGetContext('projectRoot') || process.cwd();
 const stackName = getStackName({ sandbox: sandboxMode, projectRoot });
 export const blocksStack = await BlocksStack.create(app, stackName, {
   backendHandlerPath: join(__dirname, 'index.handler.ts'),
-  backendCDKPath: join(__dirname, 'index.ts')
+  backendCDKPath: join(__dirname, 'index.ts'),
+  defaults: sandboxMode ? BlocksPresets.sandbox : BlocksPresets.production,
 });
 
 if (sandboxMode) {
-  // Make all resources deletable so sandbox:destroy can clean up the entire stack.
-  // This overrides removal policies and deletion protection (e.g. RDS) for every
-  // resource in the stack, including any you add below.
-  // Remove these lines if you want to manage teardown behavior yourself.
-  RemovalPolicies.of(blocksStack).destroy();
-  Mixins.of(blocksStack).apply(new SandboxDisableDeletionProtection());
-
   // Tell the runtime that cookies need cross-domain attributes (frontend on
   // localhost, API on API Gateway — different registrable domains).
   blocksStack.handler.addEnvironment('BLOCKS_SANDBOX', 'true');

--- a/test-apps/amplify-gen2/aws-blocks/index.cdk.ts
+++ b/test-apps/amplify-gen2/aws-blocks/index.cdk.ts
@@ -4,8 +4,7 @@
  * This file is imported by amplify/blocks.ts to wire Blocks into the Amplify backend.
  * It is NOT a standalone CDK app — Amplify's `ampx` CLI orchestrates synthesis.
  */
-import { BlocksBackend, SandboxDisableDeletionProtection } from '@aws-blocks/blocks/cdk';
-import { RemovalPolicies, Mixins } from 'aws-cdk-lib';
+import { BlocksBackend, BlocksPresets } from '@aws-blocks/blocks/cdk';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import type { Stack } from 'aws-cdk-lib';
@@ -26,13 +25,8 @@ export async function createBlocksBackend(stack: Stack, sandboxMode: boolean) {
   const blocks = await BlocksBackend.create(stack, 'blocks', {
     backendHandlerPath: join(__dirname, 'index.handler.ts'),
     backendCDKPath: join(__dirname, 'index.ts'),
+    defaults: sandboxMode ? BlocksPresets.sandbox : BlocksPresets.production,
   });
-
-  // In sandbox/CI mode, make all resources deletable so teardown doesn't leave orphans.
-  if (sandboxMode) {
-    RemovalPolicies.of(stack).destroy();
-    Mixins.of(stack).apply(new SandboxDisableDeletionProtection());
-  }
 
   return blocks;
 }

--- a/test-apps/auth-cognito-passkeys/aws-blocks/index.cdk.ts
+++ b/test-apps/auth-cognito-passkeys/aws-blocks/index.cdk.ts
@@ -1,6 +1,5 @@
 import * as cdk from 'aws-cdk-lib';
-import { RemovalPolicies, Mixins } from 'aws-cdk-lib';
-import { BlocksStack, SandboxDisableDeletionProtection } from '@aws-blocks/blocks/cdk';
+import { BlocksStack, BlocksPresets } from '@aws-blocks/blocks/cdk';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import { getSandboxId } from './scripts/sandbox-id.js';
@@ -19,9 +18,5 @@ const stackName = sandboxMode
 export const blocksStack = await BlocksStack.create(app, stackName, {
   backendHandlerPath: join(__dirname, 'index.handler.ts'),
   backendCDKPath: join(__dirname, 'index.ts'),
+  defaults: sandboxMode ? BlocksPresets.sandbox : BlocksPresets.production,
 });
-
-if (sandboxMode) {
-  RemovalPolicies.of(blocksStack).destroy();
-  Mixins.of(blocksStack).apply(new SandboxDisableDeletionProtection());
-}

--- a/test-apps/comprehensive/aws-blocks/index.cdk.ts
+++ b/test-apps/comprehensive/aws-blocks/index.cdk.ts
@@ -2,8 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import * as cdk from 'aws-cdk-lib';
-import { RemovalPolicies, Mixins } from 'aws-cdk-lib';
-import { BlocksStack, SandboxDisableDeletionProtection } from '@aws-blocks/blocks/cdk';
+import { BlocksStack, BlocksPresets } from '@aws-blocks/blocks/cdk';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import { getSandboxId } from './scripts/sandbox-id.js';
@@ -32,7 +31,13 @@ const stackName = sandboxMode
 
 export const blocksStack = await BlocksStack.create(app, stackName, {
   backendHandlerPath: join(__dirname, 'index.handler.ts'),
-  backendCDKPath: join(__dirname, 'index.ts')
+  backendCDKPath: join(__dirname, 'index.ts'),
+  // E2E test stacks must be fully deletable regardless of deploy mode, so pass
+  // the sandbox preset (DESTROY + no deletion protection) unconditionally. This
+  // replaces the previous `RemovalPolicies.of(...).destroy()` +
+  // `SandboxDisableDeletionProtection` mixin. A production app would use
+  // `sandboxMode ? BlocksPresets.sandbox : BlocksPresets.production`.
+  defaults: BlocksPresets.sandbox,
 });
 
 // Propagate E2E_FROM_EMAIL to the Lambda runtime so the EmailClient BB
@@ -40,11 +45,6 @@ export const blocksStack = await BlocksStack.create(app, stackName, {
 if (process.env.E2E_FROM_EMAIL) {
   blocksStack.handler.addEnvironment('E2E_FROM_EMAIL', process.env.E2E_FROM_EMAIL);
 }
-
-// E2E test stacks must be fully deletable regardless of deploy mode.
-// Production apps would only apply these in sandbox mode.
-RemovalPolicies.of(blocksStack).destroy();
-Mixins.of(blocksStack).apply(new SandboxDisableDeletionProtection());
 
 // Tag every taggable resource in the stack for easy identification and cleanup
 cdk.Tags.of(blocksStack).add('blocks:purpose', 'e2e-test');

--- a/test-apps/extending-blocks-guide-blocksbackend/aws-blocks/index.cdk.ts
+++ b/test-apps/extending-blocks-guide-blocksbackend/aws-blocks/index.cdk.ts
@@ -9,9 +9,8 @@
  * exercised by `test-apps/extending-blocks-guide/`.
  */
 import * as cdk from 'aws-cdk-lib';
-import { RemovalPolicies, Mixins } from 'aws-cdk-lib';
 import * as sqs from 'aws-cdk-lib/aws-sqs';
-import { BlocksBackend, SandboxDisableDeletionProtection } from '@aws-blocks/blocks/cdk';
+import { BlocksBackend, BlocksPresets } from '@aws-blocks/blocks/cdk';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import { getSandboxId } from './scripts/sandbox-id.js';
@@ -51,6 +50,10 @@ class MyExistingStack extends cdk.Stack {
     stack.blocks = await BlocksBackend.create(stack, 'BlocksApi', {
       backendHandlerPath: join(__dirname, 'index.handler.ts'),
       backendCDKPath: join(__dirname, 'index.ts'),
+      // Disposable CI test stack: force the sandbox posture (DESTROY, no deletion
+      // protection) so teardown works in every deploy mode. A real app would use
+      // `sandboxMode ? BlocksPresets.sandbox : BlocksPresets.production`.
+      defaults: BlocksPresets.sandbox,
     });
 
     // Wire IAM + env on the BlocksBackend's handler — same surface as BlocksStack.
@@ -67,7 +70,3 @@ class MyExistingStack extends cdk.Stack {
 }
 
 export const stack = await MyExistingStack.build(app, stackName);
-
-// E2E test stacks must be fully deletable.
-RemovalPolicies.of(stack).destroy();
-Mixins.of(stack).apply(new SandboxDisableDeletionProtection());

--- a/test-apps/extending-blocks-guide/aws-blocks/index.cdk.ts
+++ b/test-apps/extending-blocks-guide/aws-blocks/index.cdk.ts
@@ -2,10 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import * as cdk from 'aws-cdk-lib';
-import { RemovalPolicies, Mixins } from 'aws-cdk-lib';
 import * as sqs from 'aws-cdk-lib/aws-sqs';
 import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
-import { BlocksStack, SandboxDisableDeletionProtection } from '@aws-blocks/blocks/cdk';
+import { BlocksStack, BlocksPresets } from '@aws-blocks/blocks/cdk';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import { getSandboxId } from './scripts/sandbox-id.js';
@@ -29,11 +28,11 @@ process.env.BLOCKS_LEGACY_USERS_TABLE = legacyUsersTableName;
 export const blocksStack = await BlocksStack.create(app, stackName, {
   backendHandlerPath: join(__dirname, 'index.handler.ts'),
   backendCDKPath: join(__dirname, 'index.ts'),
+  // Disposable CI test stack: force the sandbox posture (DESTROY, no deletion
+  // protection) so teardown works in every deploy mode. A real app would use
+  // `sandboxMode ? BlocksPresets.sandbox : BlocksPresets.production`.
+  defaults: BlocksPresets.sandbox,
 });
-
-// E2E test stacks must be fully deletable.
-RemovalPolicies.of(blocksStack).destroy();
-Mixins.of(blocksStack).apply(new SandboxDisableDeletionProtection());
 
 // Pattern 1 fixture: an SQS queue we'll send to via raw SDK.
 const externalQueue = new sqs.Queue(blocksStack, 'external-queue');

--- a/test-apps/hosting-spa/aws-blocks/index.cdk.ts
+++ b/test-apps/hosting-spa/aws-blocks/index.cdk.ts
@@ -2,8 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import * as cdk from 'aws-cdk-lib';
-import { RemovalPolicies, Mixins } from 'aws-cdk-lib';
-import { Hosting, BlocksStack, SandboxDisableDeletionProtection } from '@aws-blocks/blocks/cdk';
+import { Hosting, BlocksStack, BlocksPresets } from '@aws-blocks/blocks/cdk';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import { getSandboxId } from './scripts/sandbox-id.js';
@@ -24,11 +23,11 @@ const stackName = sandboxMode
 export const blocksStack = await BlocksStack.create(app, stackName, {
   backendHandlerPath: join(__dirname, 'index.handler.ts'),
   backendCDKPath: join(__dirname, 'index.ts'),
+  // Disposable CI test stack: force the sandbox posture (DESTROY, no deletion
+  // protection) so teardown works in every deploy mode. A real app would use
+  // `sandboxMode ? BlocksPresets.sandbox : BlocksPresets.production`.
+  defaults: BlocksPresets.sandbox,
 });
-
-// E2E test stacks must be fully deletable.
-RemovalPolicies.of(blocksStack).destroy();
-Mixins.of(blocksStack).apply(new SandboxDisableDeletionProtection());
 
 // Hosting — SPA (static site served via CloudFront)
 new Hosting(blocksStack, 'Hosting', {

--- a/test-apps/hosting-ssr-astro-default404/aws-blocks/index.cdk.ts
+++ b/test-apps/hosting-ssr-astro-default404/aws-blocks/index.cdk.ts
@@ -2,8 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import * as cdk from 'aws-cdk-lib';
-import { RemovalPolicies, Mixins } from 'aws-cdk-lib';
-import { Hosting, BlocksStack, SandboxDisableDeletionProtection } from '@aws-blocks/blocks/cdk';
+import { Hosting, BlocksStack, BlocksPresets } from '@aws-blocks/blocks/cdk';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import { getSandboxId } from './scripts/sandbox-id.js';
@@ -24,10 +23,11 @@ const stackName = sandboxMode
 export const blocksStack = await BlocksStack.create(app, stackName, {
   backendHandlerPath: join(__dirname, 'index.handler.ts'),
   backendCDKPath: join(__dirname, 'index.ts'),
+  // Disposable CI test stack: force the sandbox posture (DESTROY, no deletion
+  // protection) so teardown works in every deploy mode. A real app would use
+  // `sandboxMode ? BlocksPresets.sandbox : BlocksPresets.production`.
+  defaults: BlocksPresets.sandbox,
 });
-
-RemovalPolicies.of(blocksStack).destroy();
-Mixins.of(blocksStack).apply(new SandboxDisableDeletionProtection());
 
 // Astro static (multi-page) deploy. No `compute` block: a static Astro site
 // has no SSR Lambda — every route is prerendered to its own index.html and

--- a/test-apps/hosting-ssr-astro/aws-blocks/index.cdk.ts
+++ b/test-apps/hosting-ssr-astro/aws-blocks/index.cdk.ts
@@ -2,8 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import * as cdk from 'aws-cdk-lib';
-import { RemovalPolicies, Mixins } from 'aws-cdk-lib';
-import { Hosting, BlocksStack, SandboxDisableDeletionProtection } from '@aws-blocks/blocks/cdk';
+import { Hosting, BlocksStack, BlocksPresets } from '@aws-blocks/blocks/cdk';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import { getSandboxId } from './scripts/sandbox-id.js';
@@ -24,10 +23,11 @@ const stackName = sandboxMode
 export const blocksStack = await BlocksStack.create(app, stackName, {
   backendHandlerPath: join(__dirname, 'index.handler.ts'),
   backendCDKPath: join(__dirname, 'index.ts'),
+  // Disposable CI test stack: force the sandbox posture (DESTROY, no deletion
+  // protection) so teardown works in every deploy mode. A real app would use
+  // `sandboxMode ? BlocksPresets.sandbox : BlocksPresets.production`.
+  defaults: BlocksPresets.sandbox,
 });
-
-RemovalPolicies.of(blocksStack).destroy();
-Mixins.of(blocksStack).apply(new SandboxDisableDeletionProtection());
 
 // Astro static (multi-page) deploy. No `compute` block: a static Astro site
 // has no SSR Lambda — every route is prerendered to its own index.html and

--- a/test-apps/hosting-ssr-nuxt/aws-blocks/index.cdk.ts
+++ b/test-apps/hosting-ssr-nuxt/aws-blocks/index.cdk.ts
@@ -2,8 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import * as cdk from 'aws-cdk-lib';
-import { RemovalPolicies, Mixins } from 'aws-cdk-lib';
-import { Hosting, BlocksStack, SandboxDisableDeletionProtection } from '@aws-blocks/blocks/cdk';
+import { Hosting, BlocksStack, BlocksPresets } from '@aws-blocks/blocks/cdk';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import { getSandboxId } from './scripts/sandbox-id.js';
@@ -24,10 +23,11 @@ const stackName = sandboxMode
 export const blocksStack = await BlocksStack.create(app, stackName, {
   backendHandlerPath: join(__dirname, 'index.handler.ts'),
   backendCDKPath: join(__dirname, 'index.ts'),
+  // Disposable CI test stack: force the sandbox posture (DESTROY, no deletion
+  // protection) so teardown works in every deploy mode. A real app would use
+  // `sandboxMode ? BlocksPresets.sandbox : BlocksPresets.production`.
+  defaults: BlocksPresets.sandbox,
 });
-
-RemovalPolicies.of(blocksStack).destroy();
-Mixins.of(blocksStack).apply(new SandboxDisableDeletionProtection());
 
 new Hosting(blocksStack, 'Hosting', {
   root: join(__dirname, '..'),

--- a/test-apps/hosting-ssr-sveltekit/aws-blocks/index.cdk.ts
+++ b/test-apps/hosting-ssr-sveltekit/aws-blocks/index.cdk.ts
@@ -2,8 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import * as cdk from 'aws-cdk-lib';
-import { RemovalPolicies, Mixins } from 'aws-cdk-lib';
-import { Hosting, BlocksStack, SandboxDisableDeletionProtection } from '@aws-blocks/blocks/cdk';
+import { Hosting, BlocksStack, BlocksPresets } from '@aws-blocks/blocks/cdk';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import { getSandboxId } from './scripts/sandbox-id.js';
@@ -24,10 +23,11 @@ const stackName = sandboxMode
 export const blocksStack = await BlocksStack.create(app, stackName, {
   backendHandlerPath: join(__dirname, 'index.handler.ts'),
   backendCDKPath: join(__dirname, 'index.ts'),
+  // Disposable CI test stack: force the sandbox posture (DESTROY, no deletion
+  // protection) so teardown works in every deploy mode. A real app would use
+  // `sandboxMode ? BlocksPresets.sandbox : BlocksPresets.production`.
+  defaults: BlocksPresets.sandbox,
 });
-
-RemovalPolicies.of(blocksStack).destroy();
-Mixins.of(blocksStack).apply(new SandboxDisableDeletionProtection());
 
 // SvelteKit SSR deploy. The Blocks SvelteKit adapter runs @sveltejs/adapter-node
 // on Lambda via the Lambda Web Adapter (http-server compute). `api: blocksStack`

--- a/test-apps/hosting-ssr/aws-blocks/index.cdk.ts
+++ b/test-apps/hosting-ssr/aws-blocks/index.cdk.ts
@@ -2,8 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import * as cdk from 'aws-cdk-lib';
-import { RemovalPolicies, Mixins } from 'aws-cdk-lib';
-import { Hosting, BlocksStack, SandboxDisableDeletionProtection } from '@aws-blocks/blocks/cdk';
+import { Hosting, BlocksStack, BlocksPresets } from '@aws-blocks/blocks/cdk';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import { getSandboxId } from './scripts/sandbox-id.js';
@@ -24,11 +23,11 @@ const stackName = sandboxMode
 export const blocksStack = await BlocksStack.create(app, stackName, {
   backendHandlerPath: join(__dirname, 'index.handler.ts'),
   backendCDKPath: join(__dirname, 'index.ts'),
+  // Disposable CI test stack: force the sandbox posture (DESTROY, no deletion
+  // protection) so teardown works in every deploy mode. A real app would use
+  // `sandboxMode ? BlocksPresets.sandbox : BlocksPresets.production`.
+  defaults: BlocksPresets.sandbox,
 });
-
-// E2E test stacks must be fully deletable.
-RemovalPolicies.of(blocksStack).destroy();
-Mixins.of(blocksStack).apply(new SandboxDisableDeletionProtection());
 
 // Hosting — Next.js SSR (CloudFront + Lambda)
 new Hosting(blocksStack, 'Hosting', {

--- a/test-apps/native-bindings/aws-blocks/index.cdk.ts
+++ b/test-apps/native-bindings/aws-blocks/index.cdk.ts
@@ -11,8 +11,7 @@
 // Minimal variant of the comprehensive app's index.cdk.ts (no sandbox-id salt).
 
 import * as cdk from 'aws-cdk-lib';
-import { RemovalPolicies, Mixins } from 'aws-cdk-lib';
-import { BlocksStack, SandboxDisableDeletionProtection } from '@aws-blocks/blocks/cdk';
+import { BlocksStack, BlocksPresets } from '@aws-blocks/blocks/cdk';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
@@ -33,6 +32,10 @@ const stackName =
 export const blocksStack = await BlocksStack.create(app, stackName, {
   backendHandlerPath: join(__dirname, 'index.handler.ts'),
   backendCDKPath: join(__dirname, 'index.ts'),
+  // Disposable CI test stack: force the sandbox posture (DESTROY, no deletion
+  // protection) so teardown works in every deploy mode. A real app would use
+  // `sandboxMode ? BlocksPresets.sandbox : BlocksPresets.production`.
+  defaults: BlocksPresets.sandbox,
 });
 
 // Tag for the scheduled stack janitor (cleanup-stacks.yml). It only deletes
@@ -40,8 +43,3 @@ export const blocksStack = await BlocksStack.create(app, stackName, {
 // (failed `npm run destroy`) matches the bb-test- prefix but is skipped and
 // accumulates forever. Mirrors every other e2e test-app's index.cdk.ts.
 cdk.Tags.of(blocksStack).add('blocks:purpose', 'e2e-native-bindings');
-
-// E2E stacks must be fully deletable so the CI teardown (`npm run destroy`)
-// can't leave a stuck DELETE_FAILED stack or deletion-protected resources behind.
-RemovalPolicies.of(blocksStack).destroy();
-Mixins.of(blocksStack).apply(new SandboxDisableDeletionProtection());

--- a/test-apps/pipeline/aws-blocks/index.cdk.ts
+++ b/test-apps/pipeline/aws-blocks/index.cdk.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import * as cdk from 'aws-cdk-lib';
-import { BlocksStack } from '@aws-blocks/core/cdk';
+import { BlocksStack, BlocksPresets } from '@aws-blocks/core/cdk';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 
@@ -15,4 +15,5 @@ const stackName = sandboxMode ? 'pipeline-test-sandbox' : 'pipeline-test-prod';
 await BlocksStack.create(app, stackName, {
   backendHandlerPath: join(__dirname, 'index.handler.ts'),
   backendCDKPath: join(__dirname, 'index.ts'),
+  defaults: sandboxMode ? BlocksPresets.sandbox : BlocksPresets.production,
 });

--- a/test-apps/telemetry/aws-blocks/index.cdk.ts
+++ b/test-apps/telemetry/aws-blocks/index.cdk.ts
@@ -2,8 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import * as cdk from 'aws-cdk-lib';
-import { RemovalPolicies, Mixins } from 'aws-cdk-lib';
-import { BlocksStack, SandboxDisableDeletionProtection } from '@aws-blocks/blocks/cdk';
+import { BlocksStack, BlocksPresets } from '@aws-blocks/blocks/cdk';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import { randomUUID } from 'node:crypto';
@@ -34,10 +33,11 @@ const stackName = sandboxMode
 export const blocksStack = await BlocksStack.create(app, stackName, {
   backendHandlerPath: join(__dirname, 'index.ts'),
   backendCDKPath: join(__dirname, 'index.ts'),
+  // Disposable CI test stack: force the sandbox posture (DESTROY, no deletion
+  // protection) so teardown works in every deploy mode. A real app would use
+  // `sandboxMode ? BlocksPresets.sandbox : BlocksPresets.production`.
+  defaults: BlocksPresets.sandbox,
 });
-
-RemovalPolicies.of(blocksStack).destroy();
-Mixins.of(blocksStack).apply(new SandboxDisableDeletionProtection());
 
 cdk.Tags.of(blocksStack).add('blocks:purpose', 'telemetry-e2e');
 cdk.Tags.of(blocksStack).add('blocks:deploy-mode', sandboxMode ? 'sandbox' : 'production');


### PR DESCRIPTION
## Summary

Introduces a single, explicit `defaults` object passed to `BlocksStack.create()` / `BlocksBackend.create()`, chosen once at the app entry point and read by every stateful Building Block. It replaces the per-block `sandboxMode` logic and the `RemovalPolicies` / `SandboxDisableDeletionProtection` mixin/aspect dance for the removal-policy / deletion-protection knobs.

The remaining infra knobs (log retention, API throttling, access logging, PITR, secrets backend, VPC, compute) fit the same `defaults` object and land in follow-up PRs, each with its own API review.

> Supersedes this PR's original experimental `hardening` prop.

## Approach

Two-tier resolution, highest precedence first:

```
per-block option  >  scope.defaults
```

i.e. `options.field ?? scope.defaults.field` — no hidden fallback below the stack default; the app always picks a posture explicitly, starting from a preset:

```ts
await BlocksStack.create(app, stackName, {
  backendHandlerPath: join(__dirname, 'index.handler.ts'),
  backendCDKPath: join(__dirname, 'index.ts'),
  defaults: sandboxMode ? BlocksPresets.sandbox : BlocksPresets.production,
});

// override a single field
defaults: { ...BlocksPresets.production, deletionProtection: false }
```

`defaults` is **anchored on the owning `BlocksStack`/`BlocksBackend`** and resolved by walking up the construct tree (the same way `handler` and `executionRole` resolve), so several backends in one stack each keep their own posture without clobbering each other.

## Changes

**`@aws-blocks/core` (minor):**
- New `blocks-defaults.ts`: the `BlocksDefaults` interface (`removalPolicy: RemovalPolicy`, `deletionProtection: boolean`) and `BlocksPresets.sandbox` / `BlocksPresets.production`.
- `Scope` gains a `defaults` getter (tree-walk to the owning backend); `BlocksStack`/`BlocksBackend` expose `defaults` and take it as a **required** prop.
- Removed the experimental `hardening` prop and its `resolve*` helpers.

**`@aws-blocks/blocks` (minor):** re-exports the new `/cdk` surface.

**Building Block adopters (patch):** `bb-kv-store`, `bb-data`, `bb-distributed-data`, `bb-distributed-table`, and `bb-knowledge-base` now take their removal policy + deletion protection from `defaults` instead of reading the `sandboxMode` context themselves. `bb-kv-store` also exposes `deletionProtection?` as a per-block override (matching `removalPolicy`). `bb-distributed-table` reads `defaults` directly for now — a richer per-block `protection` override lands with #282.

**Templates + test-apps:** every `create()` call site now passes `defaults`; the `RemovalPolicies`/`SandboxDisableDeletionProtection` mixin lines are gone. E2E apps set `defaults: BlocksPresets.sandbox` (disposable), customer templates use `sandboxMode ? sandbox : production`.

## Breaking change

`BlocksStack.create` / `BlocksBackend.create` now **require** a `defaults` field. Migration is one line: pass `BlocksPresets.sandbox` / `BlocksPresets.production` (typically the `sandboxMode ? …` ternary).

## Testing

- Core: `BlocksPresets` posture; backend-anchored resolution (two backends in one stack keep separate defaults; a nested block resolves its owning backend's defaults via the tree-walk).
- Adopters: CDK synth tests that each BB's table/cluster/bucket takes sandbox (DESTROY + protection off) vs production (RETAIN + protection on) from `defaults`, and that per-block options override.
- **Teardown verified via synth:** synthesizing `test-apps/comprehensive` with `defaults: BlocksPresets.sandbox` yields **DeletionPolicy=Delete + DeletionProtection=false** across all 29 DynamoDB tables, the RDS cluster, the DSQL cluster, and all 11 S3 buckets — i.e. the whole stack is disposable through the mechanism, no mixin. (Deploy+destroy is exercised by the E2E Sandbox/Production CI jobs.)
- `npm run build` · `npm run lint` · `npm test` (0 failures) · `npm run lint:deps` all green; API reports regenerated.

## Open questions for reviewers

- **Version bump** — a required prop is a hard compile break; kept at `minor` to match convention but flagged Breaking. Bump to `major` if the policy is semver-strict.
- **`removalPolicy` + `deletionProtection` as two fields** can encode a contradiction; #282 merged the equivalent DDB knobs into one `protection` enum. Worth deciding whether `defaults` should follow suit before more blocks adopt.

## Related (secure-defaults bug bash)
- #163 / #326 — core REST API throttling + access logging (future `defaults` adopters)
- #282 — bb-distributed-table durability (`protection`, PITR, encryption)
- #304 — bb-file-bucket enforceSSL + access logging

## Follow-ups (not in this PR)
`defaults.logRetention` · `defaults.throttling` (re-adopting bb-realtime's WS throttle/access-logs) · `defaults.accessLogging` · `defaults.pointInTimeRecovery` · `defaults.secretsStore` · `vpc` · `compute`; a shared `scope.resolveDefault(key, override)` helper once the per-property fallback repeats; reconciling bb-distributed-table's `protection` (#282) with `defaults`.
