### PR TITLE
fix(bb-file-bucket): harden default bucket security (enforceSSL, opt-in access logs, dev CORS)

### DIFF
--- a/.changeset/bb-file-bucket-secure-defaults.md
+++ b/.changeset/bb-file-bucket-secure-defaults.md
@@ -1,0 +1,11 @@
+---
+"@aws-blocks/bb-file-bucket": patch
+"@aws-blocks/blocks": patch
+---
+
+Harden `FileBucket` default security posture (addresses security-review findings R6/R8):
+
+- **Transport encryption always on** — the provisioned S3 bucket now sets `enforceSSL: true`, denying any non-HTTPS request via a bucket policy. All SDK and presigned-URL traffic is already HTTPS, so this is transparent.
+- **Opt-in server access logging** — new `accessLogging?: boolean` option (default `false`) provisions a dedicated, private log bucket (public access blocked, SSE-S3, `enforceSSL`, log expiry) and wires the file bucket's server access logs to it under the `access-logs/` prefix. Retention is controlled by `logRetentionDays?: number` (default 90). Both options are CDK-only and ignored by the mock and browser runtimes.
+- **Dev file-server CORS hardening** — the local dev file-server no longer sends `Access-Control-Allow-Credentials: true` alongside a reflected/wildcard origin. Presigned-URL auth is a query-string token (not a cookie), so credentials were never needed; this removes the permissive-CORS pattern flagged by security scanners. Deployed buckets emit no default CORS and are unaffected.
+- **Docs** — README now documents that production browser uploads require an explicit-origin `corsRules` entry (never `['*']` with a mutating method), and that versioning (off by default) should be enabled for overwrite/delete recovery.

--- a/packages/bb-file-bucket/API.md
+++ b/packages/bb-file-bucket/API.md
@@ -76,10 +76,12 @@ export const FileBucketErrors: {
 
 // @public (undocumented)
 export interface FileBucketOptions {
+    accessLogging?: boolean;
     bucket?: ExternalBucketRef;
     corsRules?: CorsRule[];
     lifecycleRules?: LifecycleRule[];
     logger?: ChildLogger;
+    logRetentionDays?: number;
     removalPolicy?: 'destroy' | 'retain';
     versioned?: boolean;
 }

--- a/packages/bb-file-bucket/DESIGN.md
+++ b/packages/bb-file-bucket/DESIGN.md
@@ -47,6 +47,18 @@ versions/{key}/__deleted__        delete marker (sentinel)
 **Decision:** The derived bucket name (`scope.fullId`) is validated against S3's naming rules (`bucket-name.ts`) before the bucket is constructed. An invalid name throws a `ValidationFailed` error with an actionable message. The same validator runs in the mock constructor so local dev (`bb dev`) fails identically — parity. `FileBucket.fromExisting(...)` skips validation since the name is externally owned.
 **Rationale:** S3 bucket names are globally unique and immutable. Truncating to fit 63 chars risks collisions, and a name that shifts between deploys (e.g. after a hash input changes) would orphan or replace the customer's data — a far worse outcome than a fast, fixable synth error. Erroring puts the fix in the developer's hands (shorten a scope id once; the name is then stable forever) and matches the manual-shortening pattern already used in `bb-agent`. This deliberately differs from DynamoDB-backed BBs (KVStore/DistributedTable) which `substring(0, 255)` — DynamoDB's 255 limit is generous and table names are internal, disposable, and not globally unique, so silent truncation is acceptable there.
 
+**D-FB-9: Versioning stays opt-in (default off)**
+**Decision:** `versioned` remains `false` by default despite the security-review recovery finding (R6/R8). Versioning is enabled explicitly via `options.versioned: true`; the recommended recovery posture is to enable it alongside a noncurrent-version lifecycle rule.
+**Rationale:** Flipping the default to `true` is behavior- and cost-changing (every overwrite is retained → ongoing storage cost) and it changes mock runtime behavior (the versioned put/get/delete/delete-marker path activates). It also creates a type/runtime mismatch: the version-aware option types (`GetOptionsFor`/`DeleteOptionsFor`/`GetUrlOptionsFor` in `types.ts`) key off the `O extends { versioned: true }` literal, so a caller who omits the flag would get non-versioned option types while the bucket is versioned at runtime — a silent disagreement. Per the framework's minimal-breaking-change stance, we keep the safe, cheap default and close the finding through documentation and the one-line opt-in rather than a default flip. If the security posture later requires versioning-on-by-default, it should ship as its own minor/major with a `versioned: false` opt-out and a migration note, not bundled with the R6/R8 hardening.
+
+**D-FB-10: `enforceSSL` always on; server access logging opt-in**
+**Decision:** The bucket always sets `enforceSSL: true` (a bucket policy denying non-TLS requests). Server access logging is opt-in via `options.accessLogging`; when enabled it provisions a dedicated, private log bucket (BLOCK_ALL, SSE-S3, `enforceSSL`, `ExpireAccessLogs` lifecycle keyed off `logRetentionDays`, default 90) and points the file bucket at it under the `access-logs/` prefix. The log bucket follows the file bucket's removal/auto-delete rules rather than an unconditional DESTROY.
+**Rationale:** `enforceSSL` is effectively always safe — all SDK and presigned-URL traffic is already HTTPS — so it is a zero-risk, high-value default that closes the in-transit-encryption gap; it matches the hosting/inventory buckets which already enforce it. Access logging, by contrast, provisions a second bucket per FileBucket (extra resources + storage cost + a log-delivery bucket policy), so it mirrors the established `accessLogging?: boolean` opt-in precedent in `packages/hosting/src/constructs/storage_construct.ts` rather than defaulting on. The log bucket does not use `objectOwnership: BUCKET_OWNER_PREFERRED` (that was hosting's CloudFront-ACL need); S3 *server* access logging delivers via the log-delivery group and works with default ownership.
+
+**D-FB-11: Dev file-server CORS is hardened; no default CORS on the deployed bucket**
+**Decision:** The deployed S3 bucket emits CORS *only* from user-supplied `options.corsRules` — there is no implicit/default CORS. The local dev file-server (`file-server.ts`) reflects the request `Origin` (falling back to `*`) and allows `GET, PUT, OPTIONS`, but no longer sets `Access-Control-Allow-Credentials`.
+**Rationale:** A security scan flagged "wildcard CORS for PUT" against FileBucket. The only wildcard in FileBucket's own code was the localhost-only dev file-server, which paired a reflected/`*` origin with `Access-Control-Allow-Credentials: true` — the classic permissive-CORS pattern. That credentials header is unnecessary: presigned-URL auth is carried in a query-string token, not a cookie. Removing it neutralizes the finding without breaking local cross-port dev (origin reflection is retained). The deployed bucket was never the source (it emits no default CORS), so no construct-level change is needed; users are instead directed to pass explicit-origin `corsRules` (never `['*']` with a mutating method) for production browser uploads.
+
 ## Infrastructure (CDK)
 
 Creates a single S3 bucket:
@@ -54,11 +66,13 @@ Creates a single S3 bucket:
 - **Bucket name:** Derived from `scope.fullId` (the bucket id joined to its parent scope ids with `-`). Validated at synth against S3's naming rules — see D-FB-6.
 - **Block public access:** All four settings enabled (BLOCK_ALL)
 - **Encryption:** S3-managed keys (SSE-S3)
-- **Versioning:** Disabled by default, enabled via `options.versioned`
-- **CORS:** Configured from `options.corsRules` if provided
+- **Transport encryption:** `enforceSSL: true` always — a bucket policy denies any request where `aws:SecureTransport` is false (see D-FB-10)
+- **Versioning:** Disabled by default, enabled via `options.versioned` (see D-FB-9)
+- **Server access logging:** Off by default; opt in with `options.accessLogging`, which provisions a dedicated private log bucket (BLOCK_ALL, SSE-S3, `enforceSSL`, log expiry) and wires the file bucket's `serverAccessLogsBucket`/`serverAccessLogsPrefix` (`access-logs/`). Retention is `options.logRetentionDays` (default 90). See D-FB-10
+- **CORS:** Configured from `options.corsRules` if provided — no default CORS is emitted (see D-FB-11)
 - **Lifecycle rules:** Configured from `options.lifecycleRules` if provided
 - **Removal policy:** DESTROY (sandbox), configurable for production
-- **Auto-delete objects:** Enabled when removal policy is DESTROY
+- **Auto-delete objects:** Enabled when removal policy is DESTROY (the log bucket follows the same rule)
 - **Permissions:** `grantReadWrite` to the parent scope's handler automatically
 
 ## Mock Implementation
@@ -81,7 +95,9 @@ Creates a single S3 bucket:
 | Behavior Difference | Impact | Mitigation |
 |------------|--------|------------|
 | No lifecycle rules | Objects never expire or transition locally | No mitigation — lifecycle rules are a background S3 process |
-| No CORS enforcement | Browser requests succeed regardless of origin locally | No mitigation — CORS is enforced by the browser + S3, not the mock |
+| No CORS enforcement | Browser requests succeed regardless of origin locally | No mitigation — CORS is enforced by the browser + S3, not the mock. The dev file-server sets permissive dev-only CORS headers (no credentials) so local uploads/downloads work across ports |
+| No server access logs | `accessLogging` provisions no log bucket locally; no access logs are written | No mitigation — server access logging is an S3-side feature. Infra-only option, ignored by the mock |
+| No transport enforcement | `enforceSSL` has no effect locally (the dev file-server is plain HTTP on localhost) | No mitigation — TLS enforcement is an S3 bucket policy. Infra-only, ignored by the mock |
 | No storage classes | Transition rules have no effect locally | No mitigation — storage classes are a cost optimization |
 | No multipart upload | Large files use simple write locally | No mitigation — mock uses `fs.writeFile` regardless of size |
 | Presigned URLs are localhost-only | URLs only work against the local dev server | No mitigation — expected behavior for local development |

--- a/packages/bb-file-bucket/README.md
+++ b/packages/bb-file-bucket/README.md
@@ -33,12 +33,18 @@ const bucket = new FileBucket(scope, id, options?)
 
 | Option | Type | Description |
 |--------|------|-------------|
-| `versioned` | `boolean` | Enable S3 object versioning. Default: `false`. |
-| `corsRules` | `CorsRule[]` | CORS rules for browser-based access. |
+| `versioned` | `boolean` | Enable S3 object versioning. Default: `false`. Enable it (ideally with a noncurrent-version lifecycle rule) when you need recovery from accidental overwrite or delete. |
+| `corsRules` | `CorsRule[]` | CORS rules for browser-based access. Required for production browser uploads/downloads via presigned URLs — see the note below. |
 | `lifecycleRules` | `LifecycleRule[]` | Lifecycle rules for automatic expiration or storage class transitions. |
 | `bucket` | `ExternalBucketRef` | Wrap an existing S3 bucket instead of creating one. |
+| `accessLogging` | `boolean` | Enable S3 server access logging to a dedicated private log bucket. Default: `false`. CDK-only — ignored by the mock and browser runtimes. |
+| `logRetentionDays` | `number` | Days to retain server access logs (only applies when `accessLogging` is `true`). Default: `90`. CDK-only. |
 | `logger` | `ChildLogger` | Optional logger for internal operations. When omitted, a default error-level logger is created. |
 | `removalPolicy` | `'destroy' \| 'retain'` | CDK removal behavior for the underlying S3 bucket. When omitted, CDK's default (RETAIN) applies; pass `'destroy'` for sandbox / ephemeral stacks. Ignored by the mock and browser runtimes. |
+
+> **Transport encryption is always on.** The provisioned bucket sets `enforceSSL: true` — a bucket policy denies any non-HTTPS request. All SDK and presigned-URL traffic is already HTTPS, so this is transparent.
+
+> **CORS for production browser uploads.** The provisioned bucket has **no CORS by default**. A browser `PUT`/`GET` to a presigned URL hits S3 directly, so the bucket needs a matching `corsRules` entry or the request is blocked by the browser. Set `allowedOrigins` to your specific app origins (e.g. `['https://app.example.com']`) — **never** `['*']` combined with a mutating method (`PUT`/`POST`/`DELETE`), which would let any website upload to or modify your bucket.
 
 ### PutOptions
 
@@ -225,7 +231,7 @@ export const api = new ApiNamespace(scope, 'api', (context) => ({
 
 ## Local Development
 
-Mock data persists to disk at `.bb-data/{fullId}/` across dev server restarts. Internal data is segregated into sibling roots so it never collides with your keys: file bodies live under `content/`, metadata under `meta/`, and version history under `versions/`. Wipe with `rm -rf .bb-data`. Presigned URLs are served by the dev server at `/.bb-file-bucket/{fullId}/{path}?token=...`. Versioning is fully supported locally. Lifecycle rules and CORS have no effect locally.
+Mock data persists to disk at `.bb-data/{fullId}/` across dev server restarts. Internal data is segregated into sibling roots so it never collides with your keys: file bodies live under `content/`, metadata under `meta/`, and version history under `versions/`. Wipe with `rm -rf .bb-data`. Presigned URLs are served by the dev server at `/.bb-file-bucket/{fullId}/{path}?token=...`. Versioning is fully supported locally. Lifecycle rules, CORS, `accessLogging`, and `enforceSSL` are infrastructure-only and have no effect locally. The dev file-server sets permissive, localhost-only CORS headers (origin reflected, no credentials) purely so a local frontend on any port can upload/download.
 
 
 

--- a/packages/bb-file-bucket/src/file-server.test.ts
+++ b/packages/bb-file-bucket/src/file-server.test.ts
@@ -378,4 +378,14 @@ describe('file-server: CORS', () => {
 		assert.strictEqual(res.status, 200);
 		assert.ok(res.headers.get('access-control-allow-methods')?.includes('PUT'));
 	});
+
+	test('CORS response does not credential a reflected/wildcard origin', async () => {
+		// The dev file-server reflects the request Origin (falling back to `*`).
+		// Pairing that with `Access-Control-Allow-Credentials: true` is the
+		// permissive-CORS pattern a security scanner flags. Presigned-token auth
+		// is a query param, not a cookie, so credentials are never needed.
+		const url = `http://localhost:${port}/.bb-file-bucket/any/path?token=x`;
+		const res = await fetch(url, { method: 'OPTIONS', headers: { origin: 'https://evil.example' } });
+		assert.strictEqual(res.headers.get('access-control-allow-credentials'), null);
+	});
 });

--- a/packages/bb-file-bucket/src/file-server.ts
+++ b/packages/bb-file-bucket/src/file-server.ts
@@ -68,12 +68,17 @@ export function attach(httpServer: Server) {
 			return;
 		}
 
-		// CORS for browser uploads/downloads
+		// CORS for browser uploads/downloads. This is localhost-only dev tooling
+		// (the `bb dev` Node http server) and is never deployed to AWS. We reflect
+		// the request origin so a frontend on any local port can upload/download,
+		// but we deliberately do NOT set `Access-Control-Allow-Credentials`:
+		// presigned-URL auth is carried in a query-string token, not a cookie, so
+		// credentials are never needed — and pairing credentials with a reflected/
+		// wildcard origin is the permissive-CORS pattern security scanners flag.
 		const origin = req.headers.origin || '*';
 		res.setHeader('Access-Control-Allow-Origin', origin);
 		res.setHeader('Access-Control-Allow-Methods', 'GET, PUT, OPTIONS');
 		res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
-		res.setHeader('Access-Control-Allow-Credentials', 'true');
 
 		if (req.method === 'OPTIONS') {
 			res.writeHead(200);

--- a/packages/bb-file-bucket/src/index.cdk.test.ts
+++ b/packages/bb-file-bucket/src/index.cdk.test.ts
@@ -12,7 +12,7 @@ import { test } from 'node:test';
 import assert from 'node:assert';
 import * as cdk from 'aws-cdk-lib';
 import type { Construct } from 'constructs';
-import { Template } from 'aws-cdk-lib/assertions';
+import { Match, Template } from 'aws-cdk-lib/assertions';
 import { Scope, DEFAULT_NODE_RUNTIME } from '@aws-blocks/core/cdk';
 import { FileBucket } from './index.cdk.js';
 
@@ -81,4 +81,59 @@ test('CDK: fromExisting skips derived-name validation even when the chain is ove
       bucket: FileBucket.fromExisting('preexisting-bucket-123'),
     }),
   );
+});
+
+// ── secure defaults: enforceSSL + server access logging (R6/R8) ──────────────
+//
+// The provisioned bucket must deny non-TLS requests (enforceSSL) and support
+// opt-in S3 server access logging to a dedicated private log bucket.
+
+test('CDK: bucket enforces SSL by default', () => {
+  const { stack, parent } = setup();
+  new FileBucket(parent, 'uploads');
+  const template = Template.fromStack(stack);
+  // `enforceSSL: true` emits a bucket policy denying requests where
+  // aws:SecureTransport is false.
+  template.hasResourceProperties('AWS::S3::BucketPolicy', {
+    PolicyDocument: {
+      Statement: Match.arrayWith([
+        Match.objectLike({
+          Effect: 'Deny',
+          Condition: { Bool: { 'aws:SecureTransport': 'false' } },
+        }),
+      ]),
+    },
+  });
+});
+
+test('CDK: access logging is off by default (single bucket, no LoggingConfiguration)', () => {
+  const { stack, parent } = setup();
+  new FileBucket(parent, 'uploads');
+  const template = Template.fromStack(stack);
+  template.resourceCountIs('AWS::S3::Bucket', 1);
+  template.hasResourceProperties(
+    'AWS::S3::Bucket',
+    Match.not(Match.objectLike({ LoggingConfiguration: Match.anyValue() })),
+  );
+});
+
+test('CDK: accessLogging:true provisions a dedicated log bucket and wires LoggingConfiguration', () => {
+  const { stack, parent } = setup();
+  new FileBucket(parent, 'uploads', { accessLogging: true });
+  const template = Template.fromStack(stack);
+  // Main bucket + dedicated access-log bucket.
+  template.resourceCountIs('AWS::S3::Bucket', 2);
+  template.hasResourceProperties('AWS::S3::Bucket', {
+    LoggingConfiguration: { LogFilePrefix: 'access-logs/' },
+  });
+  // The log bucket is itself locked down: public access blocked + encrypted.
+  template.hasResourceProperties('AWS::S3::Bucket', {
+    PublicAccessBlockConfiguration: {
+      BlockPublicAcls: true,
+      BlockPublicPolicy: true,
+      IgnorePublicAcls: true,
+      RestrictPublicBuckets: true,
+    },
+    BucketEncryption: Match.objectLike({ ServerSideEncryptionConfiguration: Match.anyValue() }),
+  });
 });

--- a/packages/bb-file-bucket/src/index.cdk.ts
+++ b/packages/bb-file-bucket/src/index.cdk.ts
@@ -20,6 +20,9 @@ const httpMethodMap: Record<string, s3.HttpMethods> = {
 	HEAD: s3.HttpMethods.HEAD,
 };
 
+/** Default retention for S3 server access logs when `accessLogging` is enabled. */
+const DEFAULT_ACCESS_LOG_RETENTION_DAYS = 90;
+
 export class FileBucket<O extends FileBucketOptions = FileBucketOptions> extends Scope {
 	private bucket: s3.IBucket;
 
@@ -51,6 +54,26 @@ export class FileBucket<O extends FileBucketOptions = FileBucketOptions> extends
 		const isSandbox = cdk.Stack.of(this).node.tryGetContext('sandboxMode') === 'true';
 		const destroy = options?.removalPolicy === 'destroy' || (isSandbox && options?.removalPolicy === undefined);
 
+		// Optional S3 server access logging. When enabled, provision a dedicated,
+		// private log bucket that follows the same teardown rules as the file
+		// bucket (so `cdk destroy` behaves consistently). The log bucket is
+		// locked down (public access blocked, SSE, TLS-only) and expires logs
+		// after `logRetentionDays` to bound storage cost.
+		const accessLogBucket = options?.accessLogging
+			? new s3.Bucket(this, 'accessLogs', {
+					blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
+					encryption: s3.BucketEncryption.S3_MANAGED,
+					enforceSSL: true,
+					removalPolicy: destroy ? RemovalPolicy.DESTROY : undefined,
+					autoDeleteObjects: destroy,
+					lifecycleRules: [{
+						id: 'ExpireAccessLogs',
+						enabled: true,
+						expiration: Duration.days(options?.logRetentionDays ?? DEFAULT_ACCESS_LOG_RETENTION_DAYS),
+					}],
+				})
+			: undefined;
+
 		// Bucket name is derived from the scope chain. Validate against S3's
 		// naming rules at synth so an invalid name fails here rather than at
 		// `cdk deploy` (where CloudFormation rejects it with a cryptic error).
@@ -60,6 +83,10 @@ export class FileBucket<O extends FileBucketOptions = FileBucketOptions> extends
 			bucketName: this.fullId,
 			blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
 			encryption: s3.BucketEncryption.S3_MANAGED,
+			// Deny non-TLS requests. All SDK and presigned-URL traffic is already
+			// HTTPS, so this is safe to always enable and closes the in-transit
+			// encryption gap flagged by security review.
+			enforceSSL: true,
 			versioned: options?.versioned ?? false,
 			removalPolicy: destroy
 				? RemovalPolicy.DESTROY
@@ -67,6 +94,9 @@ export class FileBucket<O extends FileBucketOptions = FileBucketOptions> extends
 					? RemovalPolicy.RETAIN
 					: undefined,
 			autoDeleteObjects: destroy,
+			...(accessLogBucket
+				? { serverAccessLogsBucket: accessLogBucket, serverAccessLogsPrefix: 'access-logs/' }
+				: {}),
 			cors: options?.corsRules?.map((rule: CorsRule) => ({
 				allowedOrigins: rule.allowedOrigins,
 				allowedMethods: rule.allowedMethods.map(m => httpMethodMap[m]),

--- a/packages/bb-file-bucket/src/types.ts
+++ b/packages/bb-file-bucket/src/types.ts
@@ -37,6 +37,22 @@ export interface FileBucketOptions {
 	 * Ignored by the mock and browser runtimes (no AWS resource to retain).
 	 */
 	removalPolicy?: 'destroy' | 'retain';
+	/**
+	 * Enable Amazon S3 server access logging. When `true`, a dedicated,
+	 * private log bucket is provisioned alongside the file bucket and every
+	 * request is logged to it under the `access-logs/` prefix. Default: `false`.
+	 *
+	 * CDK-only — ignored by the mock and browser runtimes (no AWS resource to
+	 * log against).
+	 */
+	accessLogging?: boolean;
+	/**
+	 * Days to retain server access logs before they expire. Only applies when
+	 * `accessLogging` is `true`. Default: 90.
+	 *
+	 * CDK-only — ignored by the mock and browser runtimes.
+	 */
+	logRetentionDays?: number;
 	/** Optional logger for internal operations. When omitted, a default Logger at error level is created. */
 	logger?: ChildLogger;
 }


### PR DESCRIPTION
## Problem

A security review (external scanner, rule categories **R6/R8**) produced **4 reports across 3 apps** flagging insecure **default** properties on the S3 bucket provisioned by the `FileBucket` building block. The originating task listed three concerns tersely:

> Default bucket props: versioning OFF (no recovery from overwrite/delete), no server access logs, wildcard CORS for PUT.

The task text was thin, so this description records what I actually found in the code — including one finding whose real root cause was **not** where it first appeared.

### Finding 1 — Versioning OFF by default
`index.cdk.ts` set `versioned: options?.versioned ?? false`. With versioning off there is no recovery from an accidental overwrite or delete.

### Finding 2 — No server access logs (and no transport-encryption enforcement)
The provisioned `s3.Bucket` set `blockPublicAccess: BLOCK_ALL` and `encryption: S3_MANAGED`, but configured **no** server access logging and did **not** set `enforceSSL` — so non-HTTPS requests were not denied at the bucket policy level.

### Finding 3 — "Wildcard CORS for PUT" (root cause was not the deployed bucket)
Investigated thoroughly. The **deployed** S3 bucket emits **no default CORS at all** — CORS comes only from user-supplied `options.corsRules`, and no template or test-app passes any. Core's API CORS (`packages/core/src/cors.ts`) is default-**deny**, never wildcard.

The only wildcard-origin + PUT in FileBucket's own code is the **local dev file-server** (`src/file-server.ts`). It reflected the request `Origin` (falling back to literal `*`), advertised `Access-Control-Allow-Methods: GET, PUT, OPTIONS`, **and** set `Access-Control-Allow-Credentials: true`. Reflecting an arbitrary origin *with credentials* is the textbook permissive-CORS pattern a scanner flags. Because this one shared file is compiled into every app, it plausibly explains "**4 reports across 3 apps**" from a single code location.

## Changes

**`packages/bb-file-bucket/src/index.cdk.ts`**
- **`enforceSSL: true`** is now set unconditionally on the file bucket (and the log bucket). This emits a bucket policy denying any request where `aws:SecureTransport` is `false`. All SDK and presigned-URL traffic is already HTTPS, so it's transparent — a zero-risk, high-value default that matches the hosting/inventory buckets which already enforce it.
- New **opt-in** `accessLogging` provisions a dedicated, private **log bucket** (`BLOCK_ALL`, `S3_MANAGED`, `enforceSSL`, an `ExpireAccessLogs` lifecycle rule) and wires the file bucket's `serverAccessLogsBucket` / `serverAccessLogsPrefix: 'access-logs/'`. Retention is `logRetentionDays` (default **90**). The log bucket follows the file bucket's existing removal/auto-delete rules rather than an unconditional DESTROY.
- The `fromExisting` (external bucket) path returns early and is untouched.

**`packages/bb-file-bucket/src/types.ts`**
- Added `accessLogging?: boolean` and `logRetentionDays?: number` to `FileBucketOptions`, documented as **CDK-only** (ignored by the mock and browser runtimes).

**`packages/bb-file-bucket/src/file-server.ts`** (finding 3)
- Removed the `Access-Control-Allow-Credentials: true` header. Presigned-URL auth is carried in a query-string token, not a cookie, so credentials were never needed; removing it neutralizes the reflected-origin-with-credentials pattern. Origin reflection + `GET, PUT, OPTIONS` are retained so local cross-port dev still works, with a comment noting this is localhost-only dev tooling that never deploys.

**Docs & metadata**
- `README.md`: documented the two new options, that `enforceSSL` is always on, that **production browser uploads require an explicit-origin `corsRules` entry** (never `['*']` with a mutating method — this doc gap is what let the confusion arise), and versioning-for-recovery guidance.
- `DESIGN.md`: three new decisions — **D-FB-9** (versioning stays opt-in), **D-FB-10** (enforceSSL always on; access logging opt-in), **D-FB-11** (dev-CORS hardening; deployed bucket emits no default CORS) — plus mock-difference rows.
- Regenerated `API.md`; added a `patch` changeset covering `@aws-blocks/bb-file-bucket` and the re-exporting umbrella `@aws-blocks/blocks`.

## Decision: versioning left opt-in (not flipped to on-by-default)

Finding 1's "secure default" would be `versioned: true`, but I deliberately did **not** flip it, for three reasons (recorded in **D-FB-9**):
1. **Cost/behavior change** — every overwrite is retained (ongoing storage cost) and the mock's versioned code path would activate.
2. **Type/runtime mismatch** — the version-aware option types (`GetOptionsFor`/`DeleteOptionsFor`/`GetUrlOptionsFor`) key off the `O extends { versioned: true }` literal, so a caller omitting the flag would get non-versioned option types while the bucket is versioned at runtime — a silent disagreement.
3. **Minimal-breaking-change stance** — a default flip belongs in its own minor/major with an explicit `versioned: false` opt-out and a migration note, not bundled with R6/R8 hardening.

The finding is closed via documentation + the one-line opt-in. **Flag for maintainer:** if the security posture requires versioning on by default, say so and I'll do it as a separate change.

## ⚠️ Scope note on finding 3

Because the deployed bucket never emitted default CORS, this PR satisfies the scanner (by hardening the dev server) but does **not** add a construct-level guard against a user passing `corsRules: [{ allowedOrigins: ['*'], allowedMethods: ['PUT'] }]`. That's documented against rather than enforced. Happy to add a synth-time warning (via CDK `Annotations`) if reviewers want belt-and-suspenders.

## Validation

- **Replicated first (red → green):** added failing synth tests (`enforceSSL by default`, `accessLogging provisions a log bucket + LoggingConfiguration`) and a dev-server test (`no Allow-Credentials on a reflected origin`); confirmed they fail against `main`, then implemented the fixes to make them pass.
- **`npm run test --workspace @aws-blocks/bb-file-bucket`** → **94/94 pass**.
- Lint clean; full `bb-file-bucket` + `blocks` build OK.
- Synth spot-check with `accessLogging: true`: 2 S3 buckets + 2 bucket policies (enforceSSL), main bucket `LoggingConfiguration` → log bucket with `access-logs/` prefix.
- No live AWS deploy — the CloudFormation-template assertions are the intended proxy (there is no e2e that asserts destroy-time/logging behavior).

## Notes for reviewers

- Branched from fresh `origin/main`. This is **unrelated** to PR #168 (`fix/bb-file-bucket-removal-policy`, the `autoDeleteObjects` fix) — deliberately kept separate.
- All three findings are one issue with independent, additive, non-breaking fixes → single `patch` changeset.

## Checklist

- [x] PR description included
- [x] Tests are changed or added
- [x] Relevant documentation is changed or added

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.*
