### PR TITLE
fix(bb-app-setting): browser stub throws actionable server-only error

### DIFF
--- a/.changeset/app-setting-browser-stub.md
+++ b/.changeset/app-setting-browser-stub.md
@@ -1,0 +1,5 @@
+---
+"@aws-blocks/bb-app-setting": patch
+---
+
+Make the AppSetting browser build fail loudly instead of silently. AppSetting is server-side only, but its browser stub previously omitted the `get`/`put` methods entirely, so client-side calls hit a cryptic `is not a function`. The stub now carries the full public shape and its data methods throw a named, catchable `AppSettingErrors.BrowserNotSupported` error with guidance to read the value on the server and return it to the client. The constructor stays a no-op so a shared backend module that instantiates AppSetting still imports in the browser. Also removes the `any` casts from the stub.

--- a/packages/bb-app-setting/API.md
+++ b/packages/bb-app-setting/API.md
@@ -28,6 +28,7 @@ export class AppSetting<T = string> extends Scope {
 export const AppSettingErrors: {
     readonly ParameterNotFound: "ParameterNotFoundException";
     readonly ValidationFailed: "ValidationFailedException";
+    readonly BrowserNotSupported: "BrowserNotSupportedException";
 };
 
 // @public

--- a/packages/bb-app-setting/README.md
+++ b/packages/bb-app-setting/README.md
@@ -62,6 +62,8 @@ try {
 
 `get()` can throw `AppSettingErrors.ParameterNotFound` when the parameter does not exist or a secret parameter has an empty value (in both the AWS and mock runtimes).
 
+AppSetting is **server-side only**. Calling `get()`/`put()` from browser code throws `AppSettingErrors.BrowserNotSupported` — the browser build has no store or credentials. Read the value on the server (e.g. inside an `ApiNamespace` method) and return it to the client.
+
 ## Examples
 
 ### Plain String Setting

--- a/packages/bb-app-setting/src/errors.ts
+++ b/packages/bb-app-setting/src/errors.ts
@@ -24,4 +24,10 @@ export const AppSettingErrors = {
 	ParameterNotFound: 'ParameterNotFoundException',
 	/** Thrown when schema validation fails, value exceeds 4 KB, or options are invalid. */
 	ValidationFailed: 'ValidationFailedException',
+	/**
+	 * Thrown when an AppSetting data method (`get`/`put`) is called in the
+	 * browser. AppSetting is server-only; the browser build has no store or
+	 * credentials. Expose the value through your own API method instead.
+	 */
+	BrowserNotSupported: 'BrowserNotSupportedException',
 } as const;

--- a/packages/bb-app-setting/src/index.browser.test.ts
+++ b/packages/bb-app-setting/src/index.browser.test.ts
@@ -1,0 +1,47 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * The browser build of AppSetting is a stub — AppSetting runs server-side only.
+ * Its data methods must fail loudly with an actionable, catchable error rather
+ * than being absent (cryptic `is not a function`) or silently no-op'ing.
+ */
+import { test, describe } from 'node:test';
+import assert from 'node:assert';
+import { AppSetting, AppSettingErrors } from './index.browser.js';
+
+describe('AppSetting browser stub', () => {
+	test('constructor is a no-op so a shared backend module still imports in the browser', () => {
+		assert.doesNotThrow(() => new AppSetting());
+	});
+
+	test('get() throws a named, actionable server-only error', async () => {
+		const setting = new AppSetting<string>();
+		await assert.rejects(
+			() => setting.get(),
+			(err: Error) => {
+				assert.strictEqual(err.name, AppSettingErrors.BrowserNotSupported);
+				assert.match(err.message, /server-only/);
+				assert.match(err.message, /browser/);
+				return true;
+			},
+		);
+	});
+
+	test('put() throws a named, actionable server-only error', async () => {
+		const setting = new AppSetting<string>();
+		await assert.rejects(
+			() => setting.put('value'),
+			(err: Error) => {
+				assert.strictEqual(err.name, AppSettingErrors.BrowserNotSupported);
+				assert.match(err.message, /server-only/);
+				return true;
+			},
+		);
+	});
+
+	test('fromExisting() returns an instance whose methods also throw', async () => {
+		const setting = AppSetting.fromExisting(undefined as never, 'cfg', { name: 'my-setting' });
+		await assert.rejects(() => setting.get(), (e: Error) => e.name === AppSettingErrors.BrowserNotSupported);
+	});
+});

--- a/packages/bb-app-setting/src/index.browser.ts
+++ b/packages/bb-app-setting/src/index.browser.ts
@@ -1,10 +1,48 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-// Browser stub - AppSetting runs server-side only
-export class AppSetting {
-	static fromExisting(...args: any[]): any {
-		return new AppSetting();
+import type { ScopeParent } from '@aws-blocks/core';
+import { AppSettingErrors } from './errors.js';
+import type { AppSettingOptions } from './types.js';
+
+export { AppSettingErrors } from './errors.js';
+export type { AppSettingOptions } from './types.js';
+
+/** Construct a named, catchable browser-not-supported error. */
+function browserNotSupported(method: 'get' | 'put'): Error {
+	const err = new Error(
+		`AppSetting.${method}() is server-only and cannot run in the browser. ` +
+			`AppSetting has no store or credentials in the browser build — read the value ` +
+			`on the server (e.g. inside an ApiNamespace method) and return it to the client.`,
+	);
+	err.name = AppSettingErrors.BrowserNotSupported;
+	return err;
+}
+
+/**
+ * Browser stub for AppSetting. AppSetting runs server-side only, so the browser
+ * build carries the same public shape but its data methods throw an actionable
+ * error instead of silently doing nothing (or failing with a cryptic
+ * `is not a function`). The constructor is a no-op so a shared backend module
+ * that instantiates AppSetting can still be imported in the browser; calling
+ * `get`/`put` from the browser is the actual mistake and is what throws.
+ */
+export class AppSetting<T = string> {
+	static fromExisting<T = string>(
+		_scope: ScopeParent,
+		_id: string,
+		_options: { name: string; secret?: boolean },
+	): AppSetting<T> {
+		return new AppSetting<T>();
 	}
-	constructor(...args: any[]) {}
+
+	constructor(..._args: [ScopeParent, string, AppSettingOptions<T>] | []) {}
+
+	async get(): Promise<T> {
+		throw browserNotSupported('get');
+	}
+
+	async put(_value: T): Promise<void> {
+		throw browserNotSupported('put');
+	}
 }


### PR DESCRIPTION
## What

Make the **AppSetting browser build fail loudly** instead of silently. `AppSetting` runs server-side only, but its browser stub (`packages/bb-app-setting/src/index.browser.ts`) omitted the `get`/`put` methods entirely — so client-side code calling `appSetting.get()` hit a cryptic `TypeError: appSetting.get is not a function` with no guidance.

The stub now carries the full public shape and its data methods throw a **named, catchable** error:

```ts
// browser
await appSetting.get();
// → Error(name: AppSettingErrors.BrowserNotSupported):
//   "AppSetting.get() is server-only and cannot run in the browser. …
//    read the value on the server (e.g. inside an ApiNamespace method) and return it to the client."
```

The constructor stays a no-op so a shared backend module that instantiates `AppSetting` can still be imported in the browser — calling `get`/`put` from the browser is the actual mistake, and that's what throws.

## Why

Board bug-bash card (P2 / DX): **bb-app-setting: browser stub is silent 7-line no-op** — https://github.com/orgs/aws-amplify/projects/141/views/15?pane=issue&itemId=195533286

(Draft card, so it can't be `Closes #`-linked — referenced here for tracking.)

## Choices

- **Mirrors the established browser-stub-throws convention** already used by `bb-agent` and `bb-auth-cognito` (and codified in AGENTS.md: *"methods are server-side (throw)"*) — not a new pattern.
- Adds a typed `AppSettingErrors.BrowserNotSupported` constant so client code can `isBlocksError(e, …)` on it.
- **Removes the `: any` casts** from the stub (AGENTS.md rule 8); the stub is now type-accurate against the real generic surface.

## Testing

- **Browser-stub tests added** (`index.browser.test.ts`): constructor is a no-op; `get()`/`put()`/`fromExisting().get()` throw the named `BrowserNotSupported` error. **Verified red on the prior no-op stub.**
- Full `bb-app-setting` suite **63/63**; umbrella `conditional-exports` parity test **20/20** (browser exports remain a superset of the mock).
- `npm run build` green, `biome lint --changed` clean, `check:api` regenerated (`API.md` gains the new constant), README updated. Changeset included (`@aws-blocks/bb-app-setting` patch).
