### PR TITLE
fix(create-blocks-app): add missing vendorize script to auth-cognito template

### DIFF
--- a/.changeset/auth-cognito-vendorize-script.md
+++ b/.changeset/auth-cognito-vendorize-script.md
@@ -1,0 +1,5 @@
+---
+"@aws-blocks/create-blocks-app": patch
+---
+
+Add the missing `vendorize` script to the `auth-cognito` template. Every other deployable template shipped `"vendorize": "blocks-vendorize"`, but auth-cognito omitted it, so `npm run vendorize` (used to inline a Building Block's source for customization) didn't work in scaffolded auth-cognito apps. Also adds a regression test asserting every deployable template carries the standard `vendorize` script.

--- a/packages/create-blocks-app/src/cli.test.ts
+++ b/packages/create-blocks-app/src/cli.test.ts
@@ -3,7 +3,7 @@ import { execFileSync } from 'node:child_process';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { tmpdir } from 'node:os';
-import { existsSync, mkdirSync, mkdtempSync, writeFileSync, readFileSync, rmSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, writeFileSync, readFileSync, readdirSync, rmSync } from 'node:fs';
 import assert from 'node:assert';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -332,6 +332,30 @@ describe('create-blocks-app auto-detection', () => {
     } finally {
       rmSync(tmpDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
     }
+  });
+
+  it('every deployable template ships the standard `vendorize` script', () => {
+    // Regression guard: the auth-cognito template was missing `vendorize`
+    // (all other deployable templates had it), so `npm run vendorize` didn't
+    // work in scaffolded auth-cognito apps. A template that can `sandbox`/`deploy`
+    // (i.e. has those lifecycle scripts) must also expose `vendorize` so users
+    // can inline a Block's source for customization.
+    const templatesDir = join(__dirname, '..', 'templates');
+    const templates = readdirSync(templatesDir, { withFileTypes: true })
+      .filter((e) => e.isDirectory())
+      .map((e) => e.name);
+    const missing: string[] = [];
+    for (const name of templates) {
+      const pkgPath = join(templatesDir, name, 'package.json');
+      if (!existsSync(pkgPath)) continue;
+      const scripts = JSON.parse(readFileSync(pkgPath, 'utf-8')).scripts ?? {};
+      // Only deployable templates (those with a sandbox lifecycle) are expected
+      // to carry vendorize; e.g. the amplify template has no sandbox/deploy.
+      if (scripts.sandbox && scripts.vendorize !== 'blocks-vendorize') {
+        missing.push(name);
+      }
+    }
+    assert.deepStrictEqual(missing, [], `Deployable templates missing "vendorize": ${missing.join(', ')}`);
   });
 
   it('skips npm install when creating a fresh project with --skip-install', () => {

--- a/packages/create-blocks-app/templates/auth-cognito/package.json
+++ b/packages/create-blocks-app/templates/auth-cognito/package.json
@@ -23,7 +23,8 @@
     "preview": "vite preview",
     "deploy": "tsx aws-blocks/scripts/deploy.ts",
     "destroy": "tsx aws-blocks/scripts/destroy.ts",
-    "test:e2e": "tsx -C browser test/e2e.test.ts"
+    "test:e2e": "tsx -C browser test/e2e.test.ts",
+    "vendorize": "blocks-vendorize"
   },
   "dependencies": {
     "@aws-blocks/blocks": "*",


### PR DESCRIPTION
## What

Add the missing `vendorize` script to the **auth-cognito** create-blocks-app template.

```diff
   "test:e2e": "tsx -C browser test/e2e.test.ts",
+  "vendorize": "blocks-vendorize"
```

## Why

Board bug-bash card (P3 / DX): **scaffold: auth-cognito template missing vendorize script** — https://github.com/orgs/aws-amplify/projects/141/views/15?pane=issue&itemId=195534942

Every other deployable template (`default`, `bare`, `react`, `backend`, `nextjs`, `demo`) ships `"vendorize": "blocks-vendorize"`, but `auth-cognito`'s `scripts` block — otherwise line-for-line identical to `default`'s — omitted it. So `npm run vendorize` (which inlines a Building Block's source into the app for customization) silently didn't exist in scaffolded auth-cognito apps. `@aws-blocks/blocks` (which provides the `blocks-vendorize` bin) is already a dependency of the template, so the script resolves once added.

(The `amplify` template also lacks it, but that's expected — it has no sandbox/deploy lifecycle and is structurally different; the card is scoped to auth-cognito.)

## Testing

- **Regression test added** to `cli.test.ts`: asserts every *deployable* template (one with a `sandbox` lifecycle script) also carries `"vendorize": "blocks-vendorize"`. This guards against the same drift recurring in any template. **Verified red** without the fix (flags auth-cognito), green with it.
- `create-blocks-app` suite: **51/51** pass. `npm run build` green, `biome lint --changed` clean. Changeset included (`@aws-blocks/create-blocks-app` patch).
