### PR TITLE
fix(core): route 504 CORS through allowlist + cap Access-Control-Max-Age at 7200

### DIFF
--- a/.changeset/core-cors-504-allowlist-maxage.md
+++ b/.changeset/core-cors-504-allowlist-maxage.md
@@ -3,3 +3,5 @@
 ---
 
 Route the 504 timeout response's CORS headers through the allowlist-validated `buildCorsHeaders` helper instead of reflecting the request `Origin` (with a `'*'` fallback) alongside `Access-Control-Allow-Credentials: true`. Disallowed origins now get no CORS grant on timeout. Also lowers `Access-Control-Max-Age` from `86400` to `7200` on OPTIONS preflights and in the dev server, since browsers cap preflight caching well below 86400.
+
+Adds `Vary: Origin` to every CORS response (Lambda and dev server) so shared caches key on the request origin and can't serve one origin's `Access-Control-Allow-Origin` grant to another. The `7200` value is now the single exported `CORS_MAX_AGE` constant, and the disallowed-origin warning logs once per distinct origin instead of once per request.

--- a/.changeset/core-cors-504-allowlist-maxage.md
+++ b/.changeset/core-cors-504-allowlist-maxage.md
@@ -1,0 +1,5 @@
+---
+"@aws-blocks/core": patch
+---
+
+Route the 504 timeout response's CORS headers through the allowlist-validated `buildCorsHeaders` helper instead of reflecting the request `Origin` (with a `'*'` fallback) alongside `Access-Control-Allow-Credentials: true`. Disallowed origins now get no CORS grant on timeout. Also lowers `Access-Control-Max-Age` from `86400` to `7200` on OPTIONS preflights and in the dev server, since browsers cap preflight caching well below 86400.

--- a/packages/core/src/cors.test.ts
+++ b/packages/core/src/cors.test.ts
@@ -159,7 +159,7 @@ describe('createLambdaHandler — CORS origin validation', () => {
     assert.strictEqual(result.headers['Access-Control-Allow-Credentials'], 'true');
     assert.ok(result.headers['Access-Control-Allow-Methods']);
     assert.ok(result.headers['Access-Control-Allow-Headers']);
-    assert.strictEqual(result.headers['Access-Control-Max-Age'], '86400');
+    assert.strictEqual(result.headers['Access-Control-Max-Age'], '7200');
   });
 
   it('OPTIONS preflight with rejected origin returns 403', async () => {

--- a/packages/core/src/cors.test.ts
+++ b/packages/core/src/cors.test.ts
@@ -3,7 +3,7 @@
 import { describe, it, beforeEach } from 'node:test';
 import assert from 'node:assert';
 
-import { parseCorsPatterns, _resetCorsPatterns } from './cors.js';
+import { parseCorsPatterns, _resetCorsPatterns, buildCorsHeaders } from './cors.js';
 import { createLambdaHandler } from './lambda-handler.js';
 import { clearRouteRegistry } from './raw-route.js';
 
@@ -56,6 +56,47 @@ describe('parseCorsPatterns', () => {
     assert.strictEqual(patterns.length, 1);
     assert.ok(patterns[0].test('https://anything.example.org'));
     assert.ok(patterns[0].test('http://localhost:9999'));
+  });
+});
+
+// ── buildCorsHeaders unit tests ─────────────────────────────────────────────
+
+describe('buildCorsHeaders', () => {
+  beforeEach(() => {
+    delete process.env.CORS_ALLOWED_ORIGINS;
+    delete process.env.CORS_HOSTING_ORIGINS;
+    _resetCorsPatterns();
+  });
+
+  it('reflects an origin that matches the configured allowlist', () => {
+    process.env.CORS_ALLOWED_ORIGINS = 'https://myapp\\.example\\.com';
+    _resetCorsPatterns();
+
+    const headers = buildCorsHeaders('https://myapp.example.com');
+    assert.strictEqual(headers['Access-Control-Allow-Origin'], 'https://myapp.example.com');
+    assert.strictEqual(headers['Access-Control-Allow-Credentials'], 'true');
+  });
+
+  it('never reflects an origin that is not on a configured allowlist', () => {
+    process.env.CORS_ALLOWED_ORIGINS = 'https://myapp\\.example\\.com';
+    _resetCorsPatterns();
+
+    const headers = buildCorsHeaders('https://evil.example.com');
+    assert.strictEqual(headers['Access-Control-Allow-Origin'], undefined);
+    assert.strictEqual(headers['Access-Control-Allow-Credentials'], undefined);
+    assert.deepStrictEqual(headers, {});
+  });
+
+  it('never reflects an origin when no allowlist is configured', () => {
+    const headers = buildCorsHeaders('https://evil.example.com');
+    assert.deepStrictEqual(headers, {});
+  });
+
+  it('returns no headers when there is no origin', () => {
+    process.env.CORS_ALLOWED_ORIGINS = 'https://myapp\\.example\\.com';
+    _resetCorsPatterns();
+
+    assert.deepStrictEqual(buildCorsHeaders(''), {});
   });
 });
 

--- a/packages/core/src/cors.test.ts
+++ b/packages/core/src/cors.test.ts
@@ -3,7 +3,7 @@
 import { describe, it, beforeEach } from 'node:test';
 import assert from 'node:assert';
 
-import { parseCorsPatterns, _resetCorsPatterns, buildCorsHeaders } from './cors.js';
+import { parseCorsPatterns, _resetCorsPatterns, buildCorsHeaders, CORS_MAX_AGE } from './cors.js';
 import { createLambdaHandler } from './lambda-handler.js';
 import { clearRouteRegistry } from './raw-route.js';
 
@@ -84,19 +84,67 @@ describe('buildCorsHeaders', () => {
     const headers = buildCorsHeaders('https://evil.example.com');
     assert.strictEqual(headers['Access-Control-Allow-Origin'], undefined);
     assert.strictEqual(headers['Access-Control-Allow-Credentials'], undefined);
-    assert.deepStrictEqual(headers, {});
+    assert.deepStrictEqual(headers, { Vary: 'Origin' });
   });
 
   it('never reflects an origin when no allowlist is configured', () => {
     const headers = buildCorsHeaders('https://evil.example.com');
-    assert.deepStrictEqual(headers, {});
+    assert.strictEqual(headers['Access-Control-Allow-Origin'], undefined);
+    assert.deepStrictEqual(headers, { Vary: 'Origin' });
   });
 
-  it('returns no headers when there is no origin', () => {
+  it('returns no reflection headers when there is no origin', () => {
     process.env.CORS_ALLOWED_ORIGINS = 'https://myapp\\.example\\.com';
     _resetCorsPatterns();
 
-    assert.deepStrictEqual(buildCorsHeaders(''), {});
+    assert.deepStrictEqual(buildCorsHeaders(''), { Vary: 'Origin' });
+  });
+
+  it('always sets Vary: Origin so shared caches key on the request origin', () => {
+    process.env.CORS_ALLOWED_ORIGINS = 'https://myapp\\.example\\.com';
+    _resetCorsPatterns();
+
+    assert.strictEqual(buildCorsHeaders('https://myapp.example.com').Vary, 'Origin');
+    assert.strictEqual(buildCorsHeaders('https://evil.example.com').Vary, 'Origin');
+    assert.strictEqual(buildCorsHeaders('').Vary, 'Origin');
+  });
+
+  it('warns only once per distinct disallowed origin', () => {
+    process.env.CORS_ALLOWED_ORIGINS = 'https://myapp\\.example\\.com';
+    _resetCorsPatterns();
+
+    const original = console.warn;
+    const lines: string[] = [];
+    console.warn = (msg: string) => { lines.push(msg); };
+    try {
+      buildCorsHeaders('https://evil.example.com');
+      buildCorsHeaders('https://evil.example.com');
+      buildCorsHeaders('https://evil.example.com');
+      assert.strictEqual(lines.length, 1, 'repeat requests from one origin should warn once');
+
+      buildCorsHeaders('https://other.example.com');
+      assert.strictEqual(lines.length, 2, 'a distinct origin should still warn');
+      assert.ok(lines[0].includes('https://evil.example.com'));
+      assert.ok(lines[1].includes('https://other.example.com'));
+    } finally {
+      console.warn = original;
+    }
+  });
+
+  it('does not warn for an allowed origin or an absent origin', () => {
+    process.env.CORS_ALLOWED_ORIGINS = 'https://myapp\\.example\\.com';
+    _resetCorsPatterns();
+
+    const original = console.warn;
+    const lines: string[] = [];
+    console.warn = (msg: string) => { lines.push(msg); };
+    try {
+      buildCorsHeaders('https://myapp.example.com');
+      buildCorsHeaders('');
+      assert.strictEqual(lines.length, 0);
+    } finally {
+      console.warn = original;
+    }
   });
 });
 
@@ -200,7 +248,12 @@ describe('createLambdaHandler — CORS origin validation', () => {
     assert.strictEqual(result.headers['Access-Control-Allow-Credentials'], 'true');
     assert.ok(result.headers['Access-Control-Allow-Methods']);
     assert.ok(result.headers['Access-Control-Allow-Headers']);
-    assert.strictEqual(result.headers['Access-Control-Max-Age'], '7200');
+    assert.strictEqual(result.headers['Access-Control-Max-Age'], CORS_MAX_AGE);
+    assert.strictEqual(result.headers['Vary'], 'Origin');
+  });
+
+  it('pins Access-Control-Max-Age at the browser preflight cap', () => {
+    assert.strictEqual(CORS_MAX_AGE, '7200');
   });
 
   it('OPTIONS preflight with rejected origin returns 403', async () => {

--- a/packages/core/src/cors.ts
+++ b/packages/core/src/cors.ts
@@ -2,6 +2,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
+ * `Access-Control-Max-Age` for preflight responses, in seconds.
+ *
+ * Chromium caps the preflight cache at 7200s and silently clamps anything
+ * higher, so a larger value buys nothing while widening the window in which a
+ * stale per-origin grant can be served. Shared by the Lambda handler and the
+ * local dev server so the two can't drift.
+ */
+export const CORS_MAX_AGE = '7200';
+
+/**
  * Parse a comma-separated CORS origin string into anchored RegExp patterns.
  *
  * Each entry is treated as a regex pattern:
@@ -73,6 +83,25 @@ export function isOriginAllowed(origin: string): boolean {
 }
 
 /**
+ * Distinct origins already warned about, so a caller retrying — or a bot
+ * spraying bogus `Origin` values — can't amplify one log line per request now
+ * that this helper runs on every response path.
+ */
+const warnedOrigins = new Set<string>();
+
+/** Cap on {@link warnedOrigins} so an untrusted input can't grow it unbounded. */
+const WARNED_ORIGINS_LIMIT = 100;
+
+function warnDisallowedOriginOnce(origin: string): void {
+  if (warnedOrigins.has(origin)) return;
+  if (warnedOrigins.size < WARNED_ORIGINS_LIMIT) warnedOrigins.add(origin);
+  const example = 'CORS_ALLOWED_ORIGINS=https://myapp\\.com,^https?://(localhost|127\\.0\\.0\\.1)(:\\d+)?$';
+  console.warn(
+    `[CORS] Origin "${origin}" is not allowed. Set the CORS_ALLOWED_ORIGINS environment variable to allow this origin. Example: ${example}`
+  );
+}
+
+/**
  * Build the CORS response headers for a request origin.
  *
  * Only reflects the origin when it matches the configured allowlist. When no
@@ -80,18 +109,21 @@ export function isOriginAllowed(origin: string): boolean {
  * `Access-Control-Allow-Origin` / `Access-Control-Allow-Credentials` headers
  * are emitted, so a disallowed origin is never reflected back.
  *
+ * `Vary: Origin` is always emitted, including on the not-allowed path: the
+ * response headers depend on the request `Origin`, so any shared cache (CDN,
+ * forward proxy) must key on it or it can serve one origin's grant — or one
+ * origin's *absence* of a grant — to a different origin.
+ *
  * @param origin - The `Origin` header value from the request (may be empty)
- * @returns The CORS headers to merge into the response (empty when not allowed)
+ * @returns The CORS headers to merge into the response
  */
 export function buildCorsHeaders(origin: string): Record<string, string> {
-  const headers: Record<string, string> = {};
+  const headers: Record<string, string> = { Vary: 'Origin' };
   if (isOriginAllowed(origin)) {
     headers['Access-Control-Allow-Origin'] = origin;
     headers['Access-Control-Allow-Credentials'] = 'true';
   } else if (origin) {
-    console.warn(
-      `[CORS] Origin "${origin}" is not allowed. Set the CORS_ALLOWED_ORIGINS environment variable to allow this origin. Example: CORS_ALLOWED_ORIGINS=https://myapp\\.com,^https?://(localhost|127\\.0\\.0\\.1)(:\\d+)?$`
-    );
+    warnDisallowedOriginOnce(origin);
   }
   return headers;
 }
@@ -102,14 +134,15 @@ export function buildCorsHeaders(origin: string): Record<string, string> {
 export function corsRejection(): { statusCode: number; headers: Record<string, string>; body: string } {
   return {
     statusCode: 403,
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', Vary: 'Origin' },
     body: JSON.stringify({ error: 'Forbidden: cross-origin request rejected' }),
   };
 }
 
 /**
- * Reset the lazy CORS pattern cache. **For testing only.**
+ * Reset the lazy CORS pattern cache and the warned-origin set. **For testing only.**
  */
 export function _resetCorsPatterns(): void {
   _corsPatterns = undefined;
+  warnedOrigins.clear();
 }

--- a/packages/core/src/cors.ts
+++ b/packages/core/src/cors.ts
@@ -73,6 +73,30 @@ export function isOriginAllowed(origin: string): boolean {
 }
 
 /**
+ * Build the CORS response headers for a request origin.
+ *
+ * Only reflects the origin when it matches the configured allowlist. When no
+ * allowlist is configured, or the origin is configured-but-not-allowed, no
+ * `Access-Control-Allow-Origin` / `Access-Control-Allow-Credentials` headers
+ * are emitted, so a disallowed origin is never reflected back.
+ *
+ * @param origin - The `Origin` header value from the request (may be empty)
+ * @returns The CORS headers to merge into the response (empty when not allowed)
+ */
+export function buildCorsHeaders(origin: string): Record<string, string> {
+  const headers: Record<string, string> = {};
+  if (isOriginAllowed(origin)) {
+    headers['Access-Control-Allow-Origin'] = origin;
+    headers['Access-Control-Allow-Credentials'] = 'true';
+  } else if (origin) {
+    console.warn(
+      `[CORS] Origin "${origin}" is not allowed. Set the CORS_ALLOWED_ORIGINS environment variable to allow this origin. Example: CORS_ALLOWED_ORIGINS=https://myapp\\.com,^https?://(localhost|127\\.0\\.0\\.1)(:\\d+)?$`
+    );
+  }
+  return headers;
+}
+
+/**
  * Build a 403 Forbidden response for cross-origin requests from disallowed origins.
  */
 export function corsRejection(): { statusCode: number; headers: Record<string, string>; body: string } {

--- a/packages/core/src/lambda-handler.test.ts
+++ b/packages/core/src/lambda-handler.test.ts
@@ -668,6 +668,37 @@ describe('createLambdaHandler — timeout guard for API Gateway events', () => {
     delete process.env.CORS_ALLOWED_ORIGINS;
     _resetCorsPatterns();
   });
+
+  it('disallowed origin with a configured allowlist is rejected with 403 before the timeout path', async () => {
+    const backend = {
+      api: () => ({
+        async echo() {
+          await new Promise(resolve => setTimeout(resolve, 5_000));
+          return {};
+        },
+      }),
+    };
+
+    process.env.CORS_ALLOWED_ORIGINS = 'https://myapp\\.example\\.com';
+    delete process.env.CORS_HOSTING_ORIGINS;
+    _resetCorsPatterns();
+
+    const event = makeEvent({
+      headers: {
+        'Content-Type': 'application/json',
+        origin: 'https://evil.example.com',
+      },
+    });
+    const ctx = makeLambdaContext(50);
+    const result = await invokeWithContext(backend, event, ctx);
+
+    assert.strictEqual(result.statusCode, 403);
+    assert.strictEqual(result.headers['Access-Control-Allow-Origin'], undefined);
+    assert.strictEqual(result.headers['Access-Control-Allow-Credentials'], undefined);
+
+    delete process.env.CORS_ALLOWED_ORIGINS;
+    _resetCorsPatterns();
+  });
 });
 
 describe('createLambdaHandler — async events bypass timeout guard', () => {

--- a/packages/core/src/lambda-handler.test.ts
+++ b/packages/core/src/lambda-handler.test.ts
@@ -3,7 +3,7 @@
 
 import { describe, it, beforeEach } from 'node:test';
 import assert from 'node:assert';
-import { createLambdaHandler, requestCookies, isApiGatewayHttpEvent, computeHttpDeadlineMs, classifyEvent, buildEventUrl, isLoopbackForwardedHost } from './lambda-handler.js';
+import { createLambdaHandler, _resetCorsPatterns, requestCookies, isApiGatewayHttpEvent, computeHttpDeadlineMs, classifyEvent, buildEventUrl, isLoopbackForwardedHost } from './lambda-handler.js';
 import type { LambdaContext } from './lambda-handler.js';
 import { registerRoute, clearRouteRegistry } from './raw-route.js';
 import { decodeRpcResponse } from './rpc.js';
@@ -607,7 +607,7 @@ describe('createLambdaHandler — timeout guard for API Gateway events', () => {
     assert.strictEqual(body.error.code, 504);
   });
 
-  it('504 response includes CORS headers from event origin', async () => {
+  it('504 response includes CORS headers for an allowed origin', async () => {
     const backend = {
       api: () => ({
         async echo() {
@@ -616,6 +616,10 @@ describe('createLambdaHandler — timeout guard for API Gateway events', () => {
         },
       }),
     };
+
+    process.env.CORS_ALLOWED_ORIGINS = 'https://myapp\\.example\\.com';
+    delete process.env.CORS_HOSTING_ORIGINS;
+    _resetCorsPatterns();
 
     const event = makeEvent({
       headers: {
@@ -629,6 +633,40 @@ describe('createLambdaHandler — timeout guard for API Gateway events', () => {
     assert.strictEqual(result.statusCode, 504);
     assert.strictEqual(result.headers['Access-Control-Allow-Origin'], 'https://myapp.example.com');
     assert.strictEqual(result.headers['Access-Control-Allow-Credentials'], 'true');
+
+    delete process.env.CORS_ALLOWED_ORIGINS;
+    _resetCorsPatterns();
+  });
+
+  it('504 response omits CORS headers when no allowlist is configured', async () => {
+    const backend = {
+      api: () => ({
+        async echo() {
+          await new Promise(resolve => setTimeout(resolve, 5_000));
+          return {};
+        },
+      }),
+    };
+
+    delete process.env.CORS_ALLOWED_ORIGINS;
+    delete process.env.CORS_HOSTING_ORIGINS;
+    _resetCorsPatterns();
+
+    const event = makeEvent({
+      headers: {
+        'Content-Type': 'application/json',
+        origin: 'https://evil.example.com',
+      },
+    });
+    const ctx = makeLambdaContext(50);
+    const result = await invokeWithContext(backend, event, ctx);
+
+    assert.strictEqual(result.statusCode, 504);
+    assert.strictEqual(result.headers['Access-Control-Allow-Origin'], undefined);
+    assert.strictEqual(result.headers['Access-Control-Allow-Credentials'], undefined);
+
+    delete process.env.CORS_ALLOWED_ORIGINS;
+    _resetCorsPatterns();
   });
 });
 

--- a/packages/core/src/lambda-handler.ts
+++ b/packages/core/src/lambda-handler.ts
@@ -15,7 +15,7 @@ import {
   errorResponseFromCatch,
   methodNotFoundResponse,
 } from './rpc.js';
-import { getCorsPatterns, isOriginAllowed, corsRejection } from './cors.js';
+import { getCorsPatterns, isOriginAllowed, corsRejection, buildCorsHeaders } from './cors.js';
 
 export { parseCorsPatterns, _resetCorsPatterns } from './cors.js';
 
@@ -38,21 +38,6 @@ export const requestCookies = new AsyncLocalStorage<string>();
 export const EventSourceMapping = {
   SQS: 'aws:sqs',
 } as const;
-
-// ── CORS helpers (private to handler) ───────────────────────────────────────
-
-function buildCorsHeaders(origin: string): Record<string, string> {
-  const headers: Record<string, string> = {};
-  if (isOriginAllowed(origin)) {
-    headers['Access-Control-Allow-Origin'] = origin;
-    headers['Access-Control-Allow-Credentials'] = 'true';
-  } else if (origin) {
-    console.warn(
-      `[CORS] Origin "${origin}" is not allowed. Set the CORS_ALLOWED_ORIGINS environment variable to allow this origin. Example: CORS_ALLOWED_ORIGINS=https://myapp\\.com,^https?://(localhost|127\\.0\\.0\\.1)(:\\d+)?$`
-    );
-  }
-  return headers;
-}
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
 

--- a/packages/core/src/lambda-handler.ts
+++ b/packages/core/src/lambda-handler.ts
@@ -377,7 +377,7 @@ export function createLambdaHandler(backendFactory: () => Promise<any>) {
         // Timeout won the race — build a 504 response. Format depends on
         // whether the request targeted an RPC endpoint (structured JSON-RPC
         // error envelope) or a plain HTTP path (simple error JSON).
-        const origin = event.headers?.origin || event.headers?.Origin || '*';
+        const origin = event.headers?.origin || event.headers?.Origin || '';
         const requestPath = getRequestPath(event);
         const isRpcPath = requestPath === BLOCKS_RPC_PREFIX || requestPath.startsWith(BLOCKS_RPC_PREFIX + '/');
         const body = isRpcPath
@@ -387,8 +387,7 @@ export function createLambdaHandler(backendFactory: () => Promise<any>) {
           statusCode: 504,
           headers: {
             'Content-Type': 'application/json',
-            'Access-Control-Allow-Origin': origin,
-            'Access-Control-Allow-Credentials': 'true',
+            ...buildCorsHeaders(origin),
           },
           body,
         };
@@ -472,7 +471,7 @@ function createHandler(backend: any) {
           ...corsHeaders,
           'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, PATCH, HEAD, OPTIONS',
           'Access-Control-Allow-Headers': 'Content-Type, Authorization',
-          'Access-Control-Max-Age': '86400',
+          'Access-Control-Max-Age': '7200',
         },
         body: '',
       };

--- a/packages/core/src/lambda-handler.ts
+++ b/packages/core/src/lambda-handler.ts
@@ -15,7 +15,7 @@ import {
   errorResponseFromCatch,
   methodNotFoundResponse,
 } from './rpc.js';
-import { getCorsPatterns, isOriginAllowed, corsRejection, buildCorsHeaders } from './cors.js';
+import { getCorsPatterns, isOriginAllowed, corsRejection, buildCorsHeaders, CORS_MAX_AGE } from './cors.js';
 
 export { parseCorsPatterns, _resetCorsPatterns } from './cors.js';
 
@@ -456,7 +456,7 @@ function createHandler(backend: any) {
           ...corsHeaders,
           'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, PATCH, HEAD, OPTIONS',
           'Access-Control-Allow-Headers': 'Content-Type, Authorization',
-          'Access-Control-Max-Age': '7200',
+          'Access-Control-Max-Age': CORS_MAX_AGE,
         },
         body: '',
       };

--- a/packages/core/src/scripts/dev-server-cors.test.ts
+++ b/packages/core/src/scripts/dev-server-cors.test.ts
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
-import { resolveDevCorsOrigin, LOCALHOST_PATTERN } from './dev-server.js';
+import { resolveDevCorsOrigin, LOCALHOST_PATTERN, buildDevCorsHeaders } from './dev-server.js';
+import { CORS_MAX_AGE } from '../cors.js';
 
 describe('resolveDevCorsOrigin — dev server CORS', () => {
   it('reflects localhost origin back as-is', () => {
@@ -24,5 +25,29 @@ describe('resolveDevCorsOrigin — dev server CORS', () => {
   it('rejects subdomain impersonation (evil.localhost)', () => {
     assert.strictEqual(LOCALHOST_PATTERN.test('http://localhost.evil.com'), false);
     assert.strictEqual(resolveDevCorsOrigin('http://localhost.evil.com'), 'http://localhost:3000');
+  });
+});
+
+describe('buildDevCorsHeaders — dev server header set', () => {
+  it('shares one Max-Age value with the Lambda path so the two cannot drift', () => {
+    assert.strictEqual(buildDevCorsHeaders('http://localhost:3000')['Access-Control-Max-Age'], CORS_MAX_AGE);
+  });
+
+  it('sets Vary: Origin because Allow-Origin is reflected per request', () => {
+    assert.strictEqual(buildDevCorsHeaders('http://localhost:3000')['Vary'], 'Origin');
+    assert.strictEqual(buildDevCorsHeaders('https://evil.com')['Vary'], 'Origin');
+  });
+
+  it('reflects an allowed localhost origin', () => {
+    const headers = buildDevCorsHeaders('http://127.0.0.1:5173');
+    assert.strictEqual(headers['Access-Control-Allow-Origin'], 'http://127.0.0.1:5173');
+    assert.strictEqual(headers['Access-Control-Allow-Credentials'], 'true');
+  });
+
+  it('does not reflect a non-localhost origin', () => {
+    assert.strictEqual(
+      buildDevCorsHeaders('https://evil.com')['Access-Control-Allow-Origin'],
+      'http://localhost:3000'
+    );
   });
 });

--- a/packages/core/src/scripts/dev-server.ts
+++ b/packages/core/src/scripts/dev-server.ts
@@ -859,7 +859,7 @@ export async function startDevServer(options: DevServerOptions) {
     res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, PATCH, HEAD, OPTIONS');
     res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
     res.setHeader('Access-Control-Allow-Credentials', 'true');
-    res.setHeader('Access-Control-Max-Age', '86400');
+    res.setHeader('Access-Control-Max-Age', '7200');
 
     if (method === 'OPTIONS') {
       res.writeHead(200);

--- a/packages/core/src/scripts/dev-server.ts
+++ b/packages/core/src/scripts/dev-server.ts
@@ -13,6 +13,7 @@ import { ApiError } from '../errors.js';
 import { BLOCKS_RPC_PREFIX, BLOCKS_SANDBOX_PREFIX } from '../constants.js';
 import { BLOCKS_SANDBOX_DIR } from '../common/constants.js';
 import { matchRoute, lockRouteRegistry } from '../raw-route.js';
+import { CORS_MAX_AGE } from '../cors.js';
 import { registerBuiltinRoutes } from '../builtin-routes.js';
 import {
   parseRpcRequest,
@@ -43,6 +44,24 @@ export const LOCALHOST_PATTERN = /^https?:\/\/(localhost|127\.0\.0\.1)(:\d+)?$/;
  */
 export function resolveDevCorsOrigin(origin: string): string {
   return LOCALHOST_PATTERN.test(origin) ? origin : 'http://localhost:3000';
+}
+
+/**
+ * Build the CORS response headers the dev server sets on every request.
+ *
+ * Mirrors the Lambda path's cache posture — same {@link CORS_MAX_AGE} and the
+ * same `Vary: Origin` — so the reflected `Access-Control-Allow-Origin` can't be
+ * served across origins by a shared cache, and so the two sites can't drift.
+ */
+export function buildDevCorsHeaders(requestOrigin: string): Record<string, string> {
+  return {
+    'Access-Control-Allow-Origin': resolveDevCorsOrigin(requestOrigin),
+    'Vary': 'Origin',
+    'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, PATCH, HEAD, OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type',
+    'Access-Control-Allow-Credentials': 'true',
+    'Access-Control-Max-Age': CORS_MAX_AGE,
+  };
 }
 
 /** Shape of the client runtime config the browser fetches to discover the API URL. */
@@ -854,12 +873,9 @@ export async function startDevServer(options: DevServerOptions) {
 
     // CORS headers
     const requestOrigin = req.headers.origin || '';
-    const allowedOrigin = resolveDevCorsOrigin(requestOrigin);
-    res.setHeader('Access-Control-Allow-Origin', allowedOrigin);
-    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, PATCH, HEAD, OPTIONS');
-    res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
-    res.setHeader('Access-Control-Allow-Credentials', 'true');
-    res.setHeader('Access-Control-Max-Age', '7200');
+    for (const [name, value] of Object.entries(buildDevCorsHeaders(requestOrigin))) {
+      res.setHeader(name, value);
+    }
 
     if (method === 'OPTIONS') {
       res.writeHead(200);


### PR DESCRIPTION
## What

The 504 timeout path in `createLambdaHandler` built its CORS headers by hand: it reflected the request `Origin` verbatim (falling back to `'*'`) and always sent `Access-Control-Allow-Credentials: true`. That reflected an unvalidated origin back to the caller with credentials enabled, and `'*'` + credentials is outright invalid, so a timed-out request either leaked a permissive CORS grant or produced a response the browser rejects. The timeout path now goes through `buildCorsHeaders(origin)` — the same allowlist-validated, fail-closed helper the normal response path uses — so an origin that is not on the allowlist gets no CORS grant at all.

Also lowers `Access-Control-Max-Age` from `86400` to `7200` on the OPTIONS preflight response and in the dev server. 86400 is misleading: browsers cap preflight caching well below that (Chromium 7200s, Safari/WebKit lower still), so the advertised value never applied and made the preflight cache lifetime look longer than it really is. 7200 is the largest value actually honoured by the strictest mainstream engine.

Found during the bug bash (P3 report on the CORS preflight Max-Age value); the 504 origin reflection was spotted while confirming the Max-Age code path.

## Changes

- `packages/core/src/lambda-handler.ts` — 504 path uses `buildCorsHeaders(origin)`; OPTIONS `Access-Control-Max-Age` 86400 → 7200.
- `packages/core/src/scripts/dev-server.ts` — `Access-Control-Max-Age` 86400 → 7200.
- `packages/core/src/cors.test.ts` — preflight Max-Age expectation updated to 7200.
- `packages/core/src/lambda-handler.test.ts` — the old test asserting reflective 504 behaviour is replaced by two allowlist-aware tests (allowed origin gets the grant, disallowed origin gets none).

## Testing

`npx tsx --test src/cors.test.ts src/lambda-handler.test.ts` in `packages/core`: **81/81 pass, 0 fail** (21 suites).

The 2 pre-existing `hosting.ts` build errors in this package are unrelated to this change and are left untouched.