### PR TITLE
feat(bb-kv-store): add opt-in TTL support and use it to expire AuthCognito sessions

### DIFF
--- a/.changeset/kv-store-ttl-and-session-expiry.md
+++ b/.changeset/kv-store-ttl-and-session-expiry.md
@@ -1,0 +1,11 @@
+---
+"@aws-blocks/bb-kv-store": minor
+"@aws-blocks/bb-auth-cognito": minor
+"@aws-blocks/blocks": patch
+---
+
+Add opt-in TTL support to `KVStore` and use it to expire `AuthCognito` session records.
+
+`KVStore` gains a `ttl` construct option that enables DynamoDB Time-to-Live on the table, plus per-write expiry via `put(key, value, { ttlSeconds })` or `{ expiresAt }`. Both default to off, so existing tables and every existing `put()` call are unaffected. Because DynamoDB deletes expired items asynchronously, `get` and `scan` also filter expired items on read in every runtime, and the local mock emulates the same expiry semantics.
+
+`AuthCognito` now enables TTL on its sessions table and stamps each session write with `now + sessionTtlSeconds`. Session records store live Cognito refresh tokens, so without an expiry the table grew without bound and retained those credentials at rest indefinitely; abandoned sessions are now reaped automatically. Authorization is unchanged — validity is still decided by token revalidation on every request.

--- a/.changeset/kv-store-ttl-and-session-expiry.md
+++ b/.changeset/kv-store-ttl-and-session-expiry.md
@@ -6,6 +6,11 @@
 
 Add opt-in TTL support to `KVStore` and use it to expire `AuthCognito` session records.
 
-`KVStore` gains a `ttl` construct option that enables DynamoDB Time-to-Live on the table, plus per-write expiry via `put(key, value, { ttlSeconds })` or `{ expiresAt }`. Both default to off, so existing tables and every existing `put()` call are unaffected. Because DynamoDB deletes expired items asynchronously, `get` and `scan` also filter expired items on read in every runtime, and the local mock emulates the same expiry semantics.
+`KVStore` gains a `ttl` construct option that enables DynamoDB Time-to-Live on the table, plus per-write expiry via `put(key, value, { ttlSeconds })` or `{ expiresAt }`. Both default to off, so existing tables and every existing `put()` call are unaffected. Because DynamoDB deletes expired items asynchronously, `get` and `scan` also filter expired items on read in every runtime, and the local mock emulates the same expiry semantics. Maintenance sweeps that need to act on rows the reaper has not collected yet can opt out with `scan({ includeExpired: true })`.
 
 `AuthCognito` now enables TTL on its sessions table and stamps each session write with `now + sessionTtlSeconds`. Session records store live Cognito refresh tokens, so without an expiry the table grew without bound and retained those credentials at rest indefinitely; abandoned sessions are now reaped automatically. Authorization is unchanged — validity is still decided by token revalidation on every request.
+
+Two things to know before upgrading:
+
+- **Your next `cdk deploy` enables TTL on the existing sessions table.** Even though this is a patch, `AuthCognito` now passes `{ ttl: true }`, so the deploy issues a one-time `UpdateTimeToLive` against the live table. That is an online, non-disruptive DynamoDB operation — no downtime, no data loss — but it is a mutation of a live resource, so it shouldn't surprise anyone diffing a patch upgrade.
+- **Only sessions written after the upgrade expire.** A missing `ttl` attribute means "never expires" (matching DynamoDB), and existing rows are not backfilled, so sessions created before the upgrade keep their refresh tokens at rest indefinitely. Backfilling would need a one-time migration writing `ttl` onto every existing row. To close the retention gap immediately, revoke the pre-existing sessions instead — the revoke sweep deletes rows regardless of expiry state.

--- a/.changeset/kv-store-ttl-and-session-expiry.md
+++ b/.changeset/kv-store-ttl-and-session-expiry.md
@@ -1,6 +1,6 @@
 ---
-"@aws-blocks/bb-kv-store": minor
-"@aws-blocks/bb-auth-cognito": minor
+"@aws-blocks/bb-kv-store": patch
+"@aws-blocks/bb-auth-cognito": patch
 "@aws-blocks/blocks": patch
 ---
 

--- a/packages/bb-auth-cognito/API.md
+++ b/packages/bb-auth-cognito/API.md
@@ -469,7 +469,7 @@ export interface SessionRecord {
 //
 // @internal
 export class SessionStore {
-    constructor(scope: ScopeParent, id?: string);
+    constructor(scope: ScopeParent, id?: string, ttlSeconds?: number);
     createSession(record: SessionRecord): Promise<string>;
     deleteByUsername(username: string): Promise<number>;
     deleteSession(sessionId: string): Promise<void>;

--- a/packages/bb-auth-cognito/src/index.aws.ts
+++ b/packages/bb-auth-cognito/src/index.aws.ts
@@ -170,6 +170,11 @@ export { SessionStore, type SessionRecord } from './sessions.js';
  * Overridable via `AuthCognitoOptions.sessionTtlSeconds` for apps that want
  * shorter cookies (regulated apps where stepping away from a workstation
  * should force re-auth even if tokens are still valid).
+ *
+ * The same value bounds retention of the server-side record: each write
+ * stamps the session item with a DynamoDB TTL of `now + sessionTtlSeconds`,
+ * so a session abandoned mid-flight (cookie dropped, browser wiped) is
+ * reaped instead of storing its Cognito refresh token indefinitely.
  */
 const DEFAULT_SESSION_TTL_SECONDS = 400 * 86400;
 
@@ -651,7 +656,7 @@ export class AuthCognito<const O extends AuthCognitoOptions = AuthCognitoOptions
 		// Defer CognitoJwtVerifier.create until we actually verify a token —
 		// the factory validates userPoolId at construction time and blows up
 		// if it's empty (as happens during client code generation).
-		this.sessions = new SessionStore(this, 'sessions');
+		this.sessions = new SessionStore(this, 'sessions', this.sessionTtlSeconds);
 		// Nested scope `session-secret` — matches the CDK layer's AppSetting
 		// so both sides derive the same SSM parameter path.
 		this.sessionSecretSetting = new AppSetting(this, 'session-secret', { secret: true });
@@ -1539,8 +1544,9 @@ export class AuthCognito<const O extends AuthCognitoOptions = AuthCognitoOptions
 		const record = await this.sessions.lookupSession(id);
 		if (!record) {
 			// Cookie points at a session the server has forgotten (manual
-			// deletion, TTL cleanup, signOut from elsewhere). Clear the
-			// cookie so the browser stops replaying a dead session ID.
+			// deletion, expired past `sessionTtlSeconds`, signOut from
+			// elsewhere). Clear the cookie so the browser stops replaying a
+			// dead session ID.
 			clearSessionCookie(context, this.fullId, this.crossDomain);
 			return null;
 		}

--- a/packages/bb-auth-cognito/src/index.cdk.test.ts
+++ b/packages/bb-auth-cognito/src/index.cdk.test.ts
@@ -3,6 +3,10 @@
 
 import { test, describe, beforeEach } from 'node:test';
 import assert from 'node:assert';
+import { spawnSync } from 'node:child_process';
+import { rmSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import * as cdk from 'aws-cdk-lib';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 import { Template } from 'aws-cdk-lib/assertions';
@@ -41,6 +45,60 @@ function synth(build: (stack: cdk.Stack) => void) {
 /** The CDK `Stack` has a `.id` property exactly like a BlocksStack, so `ScopeParent` accepts it once cast. */
 function scope(stack: cdk.Stack): ScopeParent {
 	return stack as unknown as ScopeParent;
+}
+
+/**
+ * Synth `AuthCognito` in a child process started with `--conditions=cdk` and
+ * return every DynamoDB table in the resulting template.
+ *
+ * Needed because this test file imports `./index.cdk.js` directly, which leaves
+ * nested blocks (`KVStore`, `AppSetting`) resolving to their mock entry points —
+ * those emit no CloudFormation. Only the real condition-based resolution shows
+ * the nested infrastructure a customer actually deploys.
+ *
+ * Runs against the built `dist/`, which the package's own test script requires
+ * anyway (`node --test dist/**\/*.test.js`).
+ */
+function synthUnderCdkConditions(): { id: string; timeToLive: unknown }[] {
+	const probe = join(dirname(fileURLToPath(import.meta.url)), `.cdk-ttl-probe.${process.pid}.mjs`);
+	writeFileSync(probe, `
+import * as cdk from 'aws-cdk-lib';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import { Template } from 'aws-cdk-lib/assertions';
+import { finalizeConfigRegistry, DEFAULT_NODE_RUNTIME } from '@aws-blocks/core/cdk';
+import { AuthCognito } from '@aws-blocks/bb-auth-cognito';
+
+const app = new cdk.App();
+const stack = new cdk.Stack(app, 'TestStack');
+const handler = new lambda.Function(stack, 'Handler', {
+	runtime: DEFAULT_NODE_RUNTIME,
+	handler: 'index.handler',
+	code: lambda.Code.fromInline('exports.handler = async () => {};'),
+});
+stack.handler = handler;
+globalThis.CURRENT_BLOCKS_STACK = stack;
+new AuthCognito(stack, 'auth');
+finalizeConfigRegistry(stack, handler);
+
+const resources = Template.fromStack(stack).toJSON().Resources;
+const tables = Object.entries(resources)
+	.filter(([, r]) => r.Type === 'AWS::DynamoDB::Table')
+	.map(([id, r]) => ({ id, timeToLive: r.Properties.TimeToLiveSpecification }));
+console.log('__TABLES__' + JSON.stringify(tables));
+`);
+	try {
+		const result = spawnSync(process.execPath, ['--conditions=cdk', probe], { encoding: 'utf8' });
+		assert.strictEqual(
+			result.status,
+			0,
+			`real-CDK probe failed (build dist first: npm run build -w packages/bb-auth-cognito)\n${result.stderr}`,
+		);
+		const marker = result.stdout.split('__TABLES__')[1];
+		assert.ok(marker, `probe produced no table report\n${result.stdout}\n${result.stderr}`);
+		return JSON.parse(marker.trim());
+	} finally {
+		rmSync(probe, { force: true });
+	}
 }
 
 // ─── User Pool ──────────────────────────────────────────────────────────────
@@ -212,6 +270,20 @@ describe('AuthCognito (CDK) — session store', () => {
 		const customResources = template.findResources('Custom::CDKBucketDeployment');
 		const crKeys = Object.keys(customResources);
 		assert.ok(crKeys.length >= 1, 'Should have a BucketDeployment for config');
+	});
+
+	// Session records hold live Cognito refresh tokens, so the table must carry a
+	// TTL. That assertion needs the real CDK resolution, which this file cannot
+	// use (see the note above) — so synth it in a child process started with
+	// `--conditions=cdk`, exactly how a customer's `cdk synth` resolves it.
+	test('sessions table is provisioned with DynamoDB TTL enabled (real CDK resolution)', () => {
+		const tables = synthUnderCdkConditions();
+		assert.strictEqual(tables.length, 1, `expected exactly one DynamoDB table, got ${JSON.stringify(tables)}`);
+		assert.deepStrictEqual(
+			tables[0].timeToLive,
+			{ AttributeName: 'ttl', Enabled: true },
+			'the sessions table must expire session records instead of retaining refresh tokens forever',
+		);
 	});
 });
 

--- a/packages/bb-auth-cognito/src/index.cdk.ts
+++ b/packages/bb-auth-cognito/src/index.cdk.ts
@@ -283,8 +283,11 @@ export class AuthCognito<const O extends AuthCognitoOptions = AuthCognitoOptions
 		new AppSetting(this, 'session-secret', { secret: true });
 
 		// 5. Session store (KVStore). Propagate `removalPolicy` so retain-mode
-		// customers don't lose live sessions on stack delete.
-		this.sessions = new KVStore(this, 'sessions', { removalPolicy: opts.removalPolicy });
+		// customers don't lose live sessions on stack delete. TTL is enabled so
+		// session records — which hold live Cognito refresh tokens — expire with
+		// the session instead of accumulating forever; the runtime stamps each
+		// write with `now + sessionTtlSeconds`.
+		this.sessions = new KVStore(this, 'sessions', { removalPolicy: opts.removalPolicy, ttl: true });
 
 		// 6. Env vars + IAM
 		const fn = this.handler as lambda.Function;

--- a/packages/bb-auth-cognito/src/index.ts
+++ b/packages/bb-auth-cognito/src/index.ts
@@ -248,7 +248,7 @@ export class AuthCognito<const O extends AuthCognitoMockOptions = AuthCognitoMoc
 		}
 		this.sessionDuration = this.options.sessionTtlSeconds ?? DEFAULT_SESSION_TTL_SECONDS;
 		this.crossDomain = this.options.crossDomain ?? false;
-		this.sessions = new SessionStore(this, 'sessions');
+		this.sessions = new SessionStore(this, 'sessions', this.sessionDuration);
 		this.stateFile = join(getMockDataDir(this), 'state.json');
 		this.state = this.loadFromDisk();
 		this.challenges = new Map(Object.entries(this.state.challenges));

--- a/packages/bb-auth-cognito/src/sessions.test.ts
+++ b/packages/bb-auth-cognito/src/sessions.test.ts
@@ -1,9 +1,10 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { test, describe, beforeEach, afterEach } from 'node:test';
+import { test, describe, beforeEach, afterEach, after } from 'node:test';
 import assert from 'node:assert';
-import { readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { readFileSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { SessionStore, safeStringArrayClaim, safeStringClaim } from './sessions.js';
 import type { SessionRecord } from './sessions.js';
@@ -121,11 +122,27 @@ function nowSeconds(): number {
 	return Math.floor(Date.now() / 1000);
 }
 
+/**
+ * These tests assert on the mock store's persisted `ttl` attribute, so they
+ * wipe its data root between cases. The mock resolves that root from
+ * `process.cwd()`, and the test runner executes files concurrently by default —
+ * so wiping the shared `.bb-data` would delete directories a sibling test file
+ * is actively reading. Run against a private root instead.
+ */
+const originalCwd = process.cwd();
+const dataRoot = mkdtempSync(join(tmpdir(), 'bb-auth-cognito-sessions-'));
+process.chdir(dataRoot);
+
+after(() => {
+	process.chdir(originalCwd);
+	rmSync(dataRoot, { recursive: true, force: true });
+});
+
 beforeEach(() => {
-	try { rmSync('.bb-data', { recursive: true, force: true }); } catch { /* ignore */ }
+	rmSync('.bb-data', { recursive: true, force: true });
 });
 afterEach(() => {
-	try { rmSync('.bb-data', { recursive: true, force: true }); } catch { /* ignore */ }
+	rmSync('.bb-data', { recursive: true, force: true });
 });
 
 describe('SessionStore TTL', () => {
@@ -221,5 +238,23 @@ describe('SessionStore TTL', () => {
 		assert.strictEqual(await store.deleteByUsername('alice'), 1);
 		assert.strictEqual(await store.lookupSession(aliceTwo), null);
 		assert.ok(await store.lookupSession(bob), "bob's session must survive");
+	});
+
+	test('deleteByUsername physically deletes a session past its ttl that the reaper has not collected', async () => {
+		const store = new SessionStore(ROOT, 'delete-expired', 3600);
+		const stale = await store.createSession(recordFor('alice'));
+		const live = await store.createSession(recordFor('alice'));
+		const bob = await store.createSession(recordFor('bob'));
+
+		rewriteTtl('delete-expired', stale, nowSeconds() - 60);
+		assert.ok(stale in storedItems('delete-expired'), 'row is still on disk — this is the case under test');
+
+		const reopened = new SessionStore(ROOT, 'delete-expired', 3600);
+		assert.strictEqual(await reopened.deleteByUsername('alice'), 2, 'revoke must count the expired row too');
+
+		const remaining = storedItems('delete-expired');
+		assert.ok(!(stale in remaining), 'expired row must be physically deleted, not left holding a refresh token');
+		assert.ok(!(live in remaining));
+		assert.ok(bob in remaining, "bob's session must survive");
 	});
 });

--- a/packages/bb-auth-cognito/src/sessions.test.ts
+++ b/packages/bb-auth-cognito/src/sessions.test.ts
@@ -1,9 +1,12 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { test, describe } from 'node:test';
+import { test, describe, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert';
-import { safeStringArrayClaim, safeStringClaim } from './sessions.js';
+import { readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { SessionStore, safeStringArrayClaim, safeStringClaim } from './sessions.js';
+import type { SessionRecord } from './sessions.js';
 
 describe('safeStringClaim', () => {
 	test('returns the string value when the claim is a string', () => {
@@ -73,5 +76,150 @@ describe('safeStringArrayClaim', () => {
 			safeStringArrayClaim({ groups: [1, 2, null] }, 'groups'),
 			[],
 		);
+	});
+});
+
+// ── Session record retention (DynamoDB TTL) ─────────────────────────────────
+
+// Session records hold live Cognito refresh tokens. Without a TTL the sessions
+// table grows without bound and keeps those credentials at rest indefinitely,
+// so every write must stamp an expiry bounded by the session lifetime.
+
+const ROOT = { id: 'sessions-ttl-root' } as any;
+
+function jwtWith(claims: Record<string, unknown>): string {
+	const segment = (obj: Record<string, unknown>) =>
+		Buffer.from(JSON.stringify(obj)).toString('base64url');
+	return `${segment({ alg: 'none', typ: 'JWT' })}.${segment(claims)}.signature`;
+}
+
+function recordFor(username: string): SessionRecord {
+	return {
+		idToken: jwtWith({ sub: `sub-${username}`, 'cognito:username': username, token_use: 'id' }),
+		accessToken: jwtWith({ sub: `sub-${username}`, username, token_use: 'access' }),
+		refreshToken: `refresh-token-${username}`,
+	};
+}
+
+/** Raw mock-store contents, so tests assert the persisted attribute directly. */
+function storedItems(storeId: string): Record<string, any> {
+	return JSON.parse(readFileSync(storePath(storeId), 'utf8'));
+}
+
+function storePath(storeId: string): string {
+	return join('.bb-data', `${ROOT.id}-${storeId}`, 'store.json');
+}
+
+/** Overwrite a stored item's `ttl` to simulate the passage of time. */
+function rewriteTtl(storeId: string, sessionId: string, ttl: number): void {
+	const items = storedItems(storeId);
+	items[sessionId] = { ...items[sessionId], ttl };
+	writeFileSync(storePath(storeId), JSON.stringify(items));
+}
+
+function nowSeconds(): number {
+	return Math.floor(Date.now() / 1000);
+}
+
+beforeEach(() => {
+	try { rmSync('.bb-data', { recursive: true, force: true }); } catch { /* ignore */ }
+});
+afterEach(() => {
+	try { rmSync('.bb-data', { recursive: true, force: true }); } catch { /* ignore */ }
+});
+
+describe('SessionStore TTL', () => {
+	test('createSession stamps a ttl within the configured session lifetime', async () => {
+		const ttlSeconds = 3600;
+		const store = new SessionStore(ROOT, 'create-ttl', ttlSeconds);
+
+		const before = nowSeconds();
+		const id = await store.createSession(recordFor('alice'));
+
+		const item = storedItems('create-ttl')[id];
+		assert.strictEqual(typeof item, 'object', 'expected a TTL-bearing entry, not a bare value');
+		assert.strictEqual(typeof item.ttl, 'number');
+		assert.ok(Number.isInteger(item.ttl), 'DynamoDB TTL must be an integer');
+		assert.ok(
+			item.ttl >= before + ttlSeconds && item.ttl <= nowSeconds() + ttlSeconds + 1,
+			`ttl ${item.ttl} outside [now+${ttlSeconds}] window`,
+		);
+	});
+
+	test('the stored session is still readable while its ttl is in the future', async () => {
+		const store = new SessionStore(ROOT, 'readable', 3600);
+		const record = recordFor('alice');
+		const id = await store.createSession(record);
+		assert.deepStrictEqual(await store.lookupSession(id), record);
+	});
+
+	test('refresh (updateSession) slides the ttl forward', async () => {
+		const store = new SessionStore(ROOT, 'refresh-ttl', 3600);
+		const id = await store.createSession(recordFor('alice'));
+		const initial = storedItems('refresh-ttl')[id].ttl;
+
+		// Rewind the persisted expiry to prove the next write recomputes it
+		// rather than leaving the original stamp in place.
+		rewriteTtl('refresh-ttl', id, initial - 1200);
+
+		const reopened = new SessionStore(ROOT, 'refresh-ttl', 3600);
+		await reopened.updateSession(id, { accessToken: jwtWith({ token_use: 'access', rotated: true }) });
+
+		const updated = storedItems('refresh-ttl')[id].ttl;
+		assert.ok(updated > initial - 1200, `expected the ttl to move forward, got ${updated}`);
+		assert.ok(updated >= nowSeconds() + 3600 - 1, `expected ~now+3600, got ${updated}`);
+	});
+
+	test('a session whose ttl has passed is no longer returned', async () => {
+		const store = new SessionStore(ROOT, 'expired', 3600);
+		const id = await store.createSession(recordFor('alice'));
+
+		rewriteTtl('expired', id, nowSeconds() - 1);
+
+		const reopened = new SessionStore(ROOT, 'expired', 3600);
+		assert.strictEqual(await reopened.lookupSession(id), null);
+	});
+
+	test('the 400-day default keeps records well inside the DynamoDB TTL horizon', async () => {
+		const defaultTtl = 400 * 86400;
+		const store = new SessionStore(ROOT, 'default-ttl', defaultTtl);
+		const id = await store.createSession(recordFor('alice'));
+
+		const ttl = storedItems('default-ttl')[id].ttl;
+		assert.ok(ttl > nowSeconds(), 'ttl must be in the future');
+		assert.ok(ttl <= nowSeconds() + defaultTtl + 1, 'ttl must not exceed the session lifetime');
+	});
+
+	test('omitting ttlSeconds writes no expiry (unchanged legacy behavior)', async () => {
+		const store = new SessionStore(ROOT, 'no-ttl');
+		const id = await store.createSession(recordFor('alice'));
+
+		const item = storedItems('no-ttl')[id];
+		assert.strictEqual(typeof item, 'string', 'expected the bare serialized value, with no ttl attribute');
+		assert.ok(await store.lookupSession(id));
+	});
+
+	test('a non-positive ttlSeconds is treated as no expiry rather than instant deletion', async () => {
+		for (const [storeId, ttlSeconds] of [['zero-ttl', 0], ['negative-ttl', -1]] as const) {
+			const store = new SessionStore(ROOT, storeId, ttlSeconds);
+			const id = await store.createSession(recordFor('alice'));
+
+			assert.strictEqual(typeof storedItems(storeId)[id], 'string', `${storeId}: expected no ttl attribute`);
+			assert.ok(await store.lookupSession(id), `${storeId}: session must remain readable`);
+		}
+	});
+
+	test('deleteSession and deleteByUsername still work on TTL-stamped records', async () => {
+		const store = new SessionStore(ROOT, 'delete-ttl', 3600);
+		const aliceOne = await store.createSession(recordFor('alice'));
+		const aliceTwo = await store.createSession(recordFor('alice'));
+		const bob = await store.createSession(recordFor('bob'));
+
+		await store.deleteSession(aliceOne);
+		assert.strictEqual(await store.lookupSession(aliceOne), null);
+
+		assert.strictEqual(await store.deleteByUsername('alice'), 1);
+		assert.strictEqual(await store.lookupSession(aliceTwo), null);
+		assert.ok(await store.lookupSession(bob), "bob's session must survive");
 	});
 });

--- a/packages/bb-auth-cognito/src/sessions.ts
+++ b/packages/bb-auth-cognito/src/sessions.ts
@@ -217,15 +217,34 @@ export interface SessionRecord {
  */
 export class SessionStore {
 	private kv: KVStore<SessionRecord>;
+	private ttlSeconds?: number;
 
-	constructor(scope: ScopeParent, id = 'sessions') {
+	/**
+	 * @param ttlSeconds - When set, every write stamps the record with a DynamoDB
+	 * TTL of `now + ttlSeconds` so abandoned sessions are reaped instead of
+	 * retaining Cognito refresh tokens at rest forever. Callers pass the session
+	 * lifetime, keeping the record's ceiling aligned with the session cookie's
+	 * `Max-Age`. Authorization itself is still decided by token revalidation on
+	 * every request — this only bounds retention.
+	 */
+	constructor(scope: ScopeParent, id = 'sessions', ttlSeconds?: number) {
 		this.kv = new KVStore<SessionRecord>(scope, id);
+		this.ttlSeconds = ttlSeconds !== undefined && ttlSeconds > 0 ? ttlSeconds : undefined;
+	}
+
+	/**
+	 * Expiry options for a write, or `undefined` when no TTL is configured.
+	 * Recomputed per write so refreshing a session slides its expiry forward,
+	 * matching how the session cookie's `Max-Age` is re-issued on refresh.
+	 */
+	private writeOptions(): { ttlSeconds: number } | undefined {
+		return this.ttlSeconds === undefined ? undefined : { ttlSeconds: this.ttlSeconds };
 	}
 
 	/** Insert a new session record; returns the generated session ID. */
 	async createSession(record: SessionRecord): Promise<string> {
 		const sessionId = crypto.randomBytes(24).toString('base64url');
-		await this.kv.put(sessionId, record);
+		await this.kv.put(sessionId, record, this.writeOptions());
 		return sessionId;
 	}
 
@@ -242,7 +261,7 @@ export class SessionStore {
 	async updateSession(sessionId: string, update: Partial<SessionRecord>): Promise<void> {
 		const existing = await this.kv.get(sessionId);
 		if (!existing) return;
-		await this.kv.put(sessionId, { ...existing, ...update });
+		await this.kv.put(sessionId, { ...existing, ...update }, this.writeOptions());
 	}
 
 	/**

--- a/packages/bb-auth-cognito/src/sessions.ts
+++ b/packages/bb-auth-cognito/src/sessions.ts
@@ -272,10 +272,15 @@ export class SessionStore {
 	 * `SessionRecord` is deliberately minimal (tokens only — see its docs), so
 	 * the owning username is recovered by decoding each session's ID token
 	 * rather than read from a denormalized field.
+	 *
+	 * The sweep scans with `includeExpired` because DynamoDB's reaper runs up to
+	 * ~48 h after expiry. A row past its TTL but still on disk holds a live
+	 * refresh token, and a deliberate revoke is the one moment retention matters
+	 * most — so it is deleted rather than skipped as already-invisible.
 	 */
 	async deleteByUsername(username: string): Promise<number> {
 		const toDelete: string[] = [];
-		for await (const { key, value } of this.kv.scan()) {
+		for await (const { key, value } of this.kv.scan({ includeExpired: true })) {
 			if (decodeIdToken(value.idToken).username === username) toDelete.push(key);
 		}
 		for (const id of toDelete) await this.kv.delete(id);

--- a/packages/bb-kv-store/API.md
+++ b/packages/bb-kv-store/API.md
@@ -39,7 +39,7 @@ export class KVStore<T = string> extends Scope {
     get(key: string): Promise<T | null>;
     // @internal
     protected log: ChildLogger;
-    put(key: string, value: T, conditions?: ConditionalWriteOptions<T>): Promise<void>;
+    put(key: string, value: T, options?: PutOptions<T>): Promise<void>;
     scan(): AsyncIterable<{
         key: string;
         value: T;
@@ -59,6 +59,13 @@ export interface KVStoreOptions<T = string> {
     removalPolicy?: 'destroy' | 'retain';
     schema?: StandardSchemaV1<T>;
     table?: ExternalTableRef;
+    ttl?: boolean;
+}
+
+// @public
+export interface PutOptions<T = unknown> extends ConditionalWriteOptions<T> {
+    expiresAt?: Date | number;
+    ttlSeconds?: number;
 }
 
 // (No @packageDocumentation comment for this package)

--- a/packages/bb-kv-store/API.md
+++ b/packages/bb-kv-store/API.md
@@ -40,7 +40,7 @@ export class KVStore<T = string> extends Scope {
     // @internal
     protected log: ChildLogger;
     put(key: string, value: T, options?: PutOptions<T>): Promise<void>;
-    scan(): AsyncIterable<{
+    scan(options?: ScanOptions): AsyncIterable<{
         key: string;
         value: T;
     }>;
@@ -66,6 +66,11 @@ export interface KVStoreOptions<T = string> {
 export interface PutOptions<T = unknown> extends ConditionalWriteOptions<T> {
     expiresAt?: Date | number;
     ttlSeconds?: number;
+}
+
+// @public
+export interface ScanOptions {
+    includeExpired?: boolean;
 }
 
 // (No @packageDocumentation comment for this package)

--- a/packages/bb-kv-store/DESIGN.md
+++ b/packages/bb-kv-store/DESIGN.md
@@ -25,9 +25,13 @@ TTL is opt-in at the construct (`{ ttl: true }`) and per write (`put(k, v, { ttl
 
 The attribute name is fixed to `ttl` rather than configurable like `DistributedTable`'s `ttl?: keyof T`. A `DistributedTable` item's attributes are the customer's schema fields, so TTL points at one of them; a `KVStore` item is always `{ pk, value }` with the customer payload opaque inside `value`, so there is no customer attribute to name. Fixing it also matches the `timeToLiveAttribute: 'ttl'` convention already used elsewhere in the repo.
 
-`ttlSeconds` (relative) and `expiresAt` (absolute `Date` or epoch seconds) resolve through one shared helper (`src/ttl.ts`) used by both runtimes, so the mock and AWS layers cannot drift on the value written or on when an item counts as expired. It rejects mutually-exclusive options, non-positive durations, and numbers large enough to be epoch milliseconds — a milliseconds value would be accepted by DynamoDB as a year-5138 expiry, silently defeating the feature.
+`ttlSeconds` (relative) and `expiresAt` (absolute `Date` or epoch seconds) resolve through one shared helper (`src/ttl.ts`) used by both runtimes, so the mock and AWS layers cannot drift on the value written or on when an item counts as expired. It rejects mutually-exclusive options, non-positive `ttlSeconds` durations, and numbers large enough to be epoch milliseconds — a milliseconds value would be accepted by DynamoDB as a year-5138 expiry, silently defeating the feature. `expiresAt` is an instant rather than a duration, so it has no positive lower bound: any past timestamp, epoch `0` included, reads as "expire immediately".
 
 Because DynamoDB deletes expired items asynchronously (typically within 48 hours), an expired item can still be physically present. Both runtimes therefore filter on read: `get` returns `null` and `scan` skips the item as soon as its expiry passes. Conditional expressions still see the stored item until it is actually deleted, matching DynamoDB.
+
+Maintenance sweeps that must act on every row still physically present — deleting the remains of expired items rather than waiting on the reaper — opt out of that filter with `scan({ includeExpired: true })`. It is deliberately not the default: a read answering "is this still valid?" must never see an expired item. `AuthCognito`'s session revoke uses it so a deliberate revoke physically deletes rows whose refresh tokens are still at rest.
+
+This read-side filtering is a `KVStore` guarantee only. `DistributedTable` also supports TTL (`ttl?: keyof T`) but sets `timeToLiveAttribute` without filtering reads, so an expired item there keeps reading as live until the reaper collects it — up to 48 hours. Do not assume the two blocks behave the same; a `DistributedTable` consumer relying on TTL for expiry semantics needs its own read-side check.
 
 ## Serialization & Validation
 

--- a/packages/bb-kv-store/DESIGN.md
+++ b/packages/bb-kv-store/DESIGN.md
@@ -14,9 +14,20 @@ Creates a single DynamoDB table:
 - **Billing mode:** PAY_PER_REQUEST
 - **Table name:** Derived from `scope.fullId` (includes stack name for uniqueness)
 - **Removal policy:** DESTROY (sandbox), configurable for production
+- **Time-to-Live:** Disabled by default; `{ ttl: true }` sets `timeToLiveAttribute: 'ttl'`
 - **Permissions:** `grantReadWriteData` to the parent scope's handler automatically
 
 No sort key, no GSIs. This is intentional — `KVStore` is the simple case. Customers needing sort keys or secondary indexes should use `DistributedTable`.
+
+## Expiry (TTL)
+
+TTL is opt-in at the construct (`{ ttl: true }`) and per write (`put(k, v, { ttlSeconds })` or `{ expiresAt }`), because switching TTL on for a table that already exists is a CloudFormation update to the live table.
+
+The attribute name is fixed to `ttl` rather than configurable like `DistributedTable`'s `ttl?: keyof T`. A `DistributedTable` item's attributes are the customer's schema fields, so TTL points at one of them; a `KVStore` item is always `{ pk, value }` with the customer payload opaque inside `value`, so there is no customer attribute to name. Fixing it also matches the `timeToLiveAttribute: 'ttl'` convention already used elsewhere in the repo.
+
+`ttlSeconds` (relative) and `expiresAt` (absolute `Date` or epoch seconds) resolve through one shared helper (`src/ttl.ts`) used by both runtimes, so the mock and AWS layers cannot drift on the value written or on when an item counts as expired. It rejects mutually-exclusive options, non-positive durations, and numbers large enough to be epoch milliseconds — a milliseconds value would be accepted by DynamoDB as a year-5138 expiry, silently defeating the feature.
+
+Because DynamoDB deletes expired items asynchronously (typically within 48 hours), an expired item can still be physically present. Both runtimes therefore filter on read: `get` returns `null` and `scan` skips the item as soon as its expiry passes. Conditional expressions still see the stored item until it is actually deleted, matching DynamoDB.
 
 ## Serialization & Validation
 
@@ -31,6 +42,7 @@ When `options.schema` is provided (any `StandardSchemaV1` implementation — Zod
 - Conditional write/delete failures throw with `error.name = 'ConditionalCheckFailedException'`.
 - Schema validation on `put()` when configured, throws `ValidationFailedException`.
 - Validates the 400 KB item size limit; throws `ItemTooLargeException` (`KVStoreErrors.ItemTooLarge`) on oversized items. On AWS, DynamoDB raises a generic `ValidationException`; the runtime narrows on the size-specific message and re-maps only that case to `ItemTooLarge`, so both layers surface the same `error.name`.
+- Emulates TTL: items with an expiry are persisted as `{ "value": "...", "ttl": 1234567890 }` and pruned lazily on `get` (single key) and `scan` (full sweep), standing in for DynamoDB's background reaper. Items without an expiry stay bare serialized strings, so stores written by earlier versions load unchanged and non-expiring writes produce no format churn.
 
 ### Mock vs AWS Behavior Differences
 
@@ -41,3 +53,4 @@ When `options.schema` is provided (any `StandardSchemaV1` implementation — Zod
 | Immediate consistency (vs eventual) | Reads always reflect the latest write locally | No mitigation — eventual consistency is inherently non-deterministic |
 | No IAM enforcement | Permission errors only surface in AWS | No mitigation at mock level — IAM is handled by CDK grants automatically |
 | Disk I/O vs DynamoDB latency | Local ops are faster and never timeout | No mitigation needed — latency differences don't affect correctness |
+| TTL deletion is immediate on read (vs up to 48 h in DynamoDB) | An expired item's storage is reclaimed sooner locally | Both layers hide expired items from `get`/`scan`, so observable behavior matches; only physical deletion timing differs |

--- a/packages/bb-kv-store/README.md
+++ b/packages/bb-kv-store/README.md
@@ -16,10 +16,10 @@ const store = new KVStore(scope, id, options?)
 
 | Method | Returns | Description |
 |--------|---------|-------------|
-| `get(key)` | `Promise<T \| null>` | Retrieve a value. Returns `null` if absent. |
-| `put(key, value, conditions?)` | `Promise<void>` | Store a value. Overwrites unless conditions are set. |
+| `get(key)` | `Promise<T \| null>` | Retrieve a value. Returns `null` if absent or expired. |
+| `put(key, value, options?)` | `Promise<void>` | Store a value. Overwrites unless conditions are set; accepts an optional expiry. |
 | `delete(key, conditions?)` | `Promise<void>` | Remove a value. |
-| `scan()` | `AsyncIterable<{ key, value }>` | Enumerate all entries. Expensive on large datasets. |
+| `scan()` | `AsyncIterable<{ key, value }>` | Enumerate all entries. Skips expired items. Expensive on large datasets. |
 | `KVStore.fromExisting(tableName)` | `ExternalTableRef` | Wrap a pre-existing DynamoDB table. |
 
 **Runtime only.** Data methods (`get`, `put`, `delete`, `scan`) run at request time — call them inside an `ApiNamespace` method, `RawRoute` handler, job handler, or a runtime script, **not** at the top level of your `aws-blocks/index.ts`. Top-level code runs during CDK synth, where the block resolves to its infrastructure construct (no data methods), so a top-level call throws `store.<method> is not a function` (throws `TypeError` at runtime if called during CDK synth). To seed data, do it from inside a handler or a separate runtime script. Constructing the block at module scope is fine; only method calls must move into handlers.
@@ -32,10 +32,37 @@ const store = new KVStore(scope, id, options?)
 | `table` | `ExternalTableRef` | Wrap an existing DynamoDB table instead of creating one. |
 | `logger` | `ChildLogger` | Optional logger for internal operations. When omitted, a default Logger at error level is created. |
 | `removalPolicy` | `'destroy' \| 'retain'` | CDK removal behavior for the underlying DynamoDB table. When omitted, CDK's default (RETAIN — data preserved on `cdk destroy`) applies; pass `'destroy'` for sandbox / ephemeral stacks. Ignored by the mock and browser runtimes. |
+| `ttl` | `boolean` | Enable DynamoDB Time-to-Live so items written with an expiry are deleted automatically. Defaults to `false`. See [Expiring Items](#expiring-items-ttl). |
+
+### Expiring Items (TTL)
+
+TTL is opt-in in two steps — turn it on for the table, then set an expiry per write:
+
+```typescript
+const cache = new KVStore(scope, 'cache', { ttl: true });
+
+// Relative expiry — delete 5 minutes from now
+await cache.put('otp:alice', code, { ttlSeconds: 300 });
+
+// Absolute expiry — a Date, or Unix epoch time in SECONDS
+await cache.put('session:1', record, { expiresAt: new Date('2027-01-01') });
+
+// No expiry — stored indefinitely (the default)
+await cache.put('config:theme', 'dark');
+```
+
+- **`ttl` defaults to `false`.** Enabling it on a table that already exists is a CloudFormation update to the live table, so it never happens implicitly.
+- **The attribute is named `ttl`.** It is written only when `ttlSeconds` or `expiresAt` is supplied, and it holds Unix epoch **seconds**.
+- **`ttlSeconds` and `expiresAt` are mutually exclusive.** Passing both — or a value that looks like epoch milliseconds — throws `ValidationFailedException` rather than silently storing a year-5138 expiry.
+- **Reads never return expired items.** DynamoDB's reaper is asynchronous (typically within 48 hours), so `get` returns `null` and `scan` skips an item as soon as its expiry passes, in every runtime.
+- **Expiry is per write.** Re-putting a key without expiry options clears any previous expiry; re-putting with them slides it forward.
+- TTL composes with conditional writes: `put(key, value, { ifNotExists: true, ttlSeconds: 60 })`.
+
+TTL is a retention control, not an authorization one. Anything security-sensitive (session validity, token revocation) must still be checked on read.
 
 ### Conditional Operations
 
-Both `put` and `delete` accept an optional conditions object:
+Both `put` and `delete` accept an optional options object:
 
 ```typescript
 // Only write if key doesn't exist (idempotent create)

--- a/packages/bb-kv-store/README.md
+++ b/packages/bb-kv-store/README.md
@@ -19,7 +19,7 @@ const store = new KVStore(scope, id, options?)
 | `get(key)` | `Promise<T \| null>` | Retrieve a value. Returns `null` if absent or expired. |
 | `put(key, value, options?)` | `Promise<void>` | Store a value. Overwrites unless conditions are set; accepts an optional expiry. |
 | `delete(key, conditions?)` | `Promise<void>` | Remove a value. |
-| `scan()` | `AsyncIterable<{ key, value }>` | Enumerate all entries. Skips expired items. Expensive on large datasets. |
+| `scan(options?)` | `AsyncIterable<{ key, value }>` | Enumerate all entries. Skips expired items unless `{ includeExpired: true }`. Expensive on large datasets. |
 | `KVStore.fromExisting(tableName)` | `ExternalTableRef` | Wrap a pre-existing DynamoDB table. |
 
 **Runtime only.** Data methods (`get`, `put`, `delete`, `scan`) run at request time — call them inside an `ApiNamespace` method, `RawRoute` handler, job handler, or a runtime script, **not** at the top level of your `aws-blocks/index.ts`. Top-level code runs during CDK synth, where the block resolves to its infrastructure construct (no data methods), so a top-level call throws `store.<method> is not a function` (throws `TypeError` at runtime if called during CDK synth). To seed data, do it from inside a handler or a separate runtime script. Constructing the block at module scope is fine; only method calls must move into handlers.

--- a/packages/bb-kv-store/src/index.aws.ts
+++ b/packages/bb-kv-store/src/index.aws.ts
@@ -13,7 +13,8 @@ import { TTL_ATTRIBUTE, isExpired, resolveTtlEpochSeconds } from './ttl.js';
 
 // Re-export public types and errors
 export { KVStoreErrors } from './errors.js';
-export type { ConditionalWriteOptions, ConditionalDeleteOptions, PutOptions, KVStoreOptions, ExternalTableRef } from './types.js';
+export type { ConditionalWriteOptions, ConditionalDeleteOptions, PutOptions, KVStoreOptions, ExternalTableRef, ScanOptions } from './types.js';
+import type { ScanOptions } from './types.js';
 
 /**
  * Simple key-value storage backed by DynamoDB.
@@ -152,11 +153,13 @@ export class KVStore<T = string> extends Scope {
 	/**
 	 * Enumerate all key-value pairs. Reads every item in the table —
 	 * use sparingly on large datasets. Uses DynamoDB's native Scan operation.
-	 * Expired items are skipped even if DynamoDB has not reaped them yet.
+	 * Expired items are skipped even if DynamoDB has not reaped them yet,
+	 * unless `includeExpired` is set.
 	 *
 	 * @returns An async iterable of key-value entries.
 	 */
-	async *scan(): AsyncIterable<{ key: string; value: T }> {
+	async *scan(options?: ScanOptions): AsyncIterable<{ key: string; value: T }> {
+		const includeExpired = options?.includeExpired === true;
 		let lastKey: Record<string, any> | undefined;
 		do {
 			const result = await this.docClient.send(new ScanCommand({
@@ -164,7 +167,7 @@ export class KVStore<T = string> extends Scope {
 				ExclusiveStartKey: lastKey,
 			}));
 			for (const item of result.Items ?? []) {
-				if (isExpired(item[TTL_ATTRIBUTE])) continue;
+				if (!includeExpired && isExpired(item[TTL_ATTRIBUTE])) continue;
 				yield { key: item.pk as string, value: JSON.parse(item.value as string) as T };
 			}
 			lastKey = result.LastEvaluatedKey;

--- a/packages/bb-kv-store/src/index.aws.ts
+++ b/packages/bb-kv-store/src/index.aws.ts
@@ -9,10 +9,11 @@ import { Logger } from '@aws-blocks/bb-logger';
 import type { ChildLogger } from '@aws-blocks/bb-logger';
 import { BB_NAME, BB_VERSION } from './version.js';
 import { KVStoreErrors } from './errors.js';
+import { TTL_ATTRIBUTE, isExpired, resolveTtlEpochSeconds } from './ttl.js';
 
 // Re-export public types and errors
 export { KVStoreErrors } from './errors.js';
-export type { ConditionalWriteOptions, ConditionalDeleteOptions, KVStoreOptions, ExternalTableRef } from './types.js';
+export type { ConditionalWriteOptions, ConditionalDeleteOptions, PutOptions, KVStoreOptions, ExternalTableRef } from './types.js';
 
 /**
  * Simple key-value storage backed by DynamoDB.
@@ -53,8 +54,11 @@ export class KVStore<T = string> extends Scope {
 	/**
 	 * Retrieve a value by key.
 	 *
+	 * Items whose TTL has passed are treated as absent even if DynamoDB has not
+	 * reaped them yet (deletion is asynchronous, typically within 48 hours).
+	 *
 	 * @param key - The key to retrieve.
-	 * @returns The value, or `null` if the key does not exist.
+	 * @returns The value, or `null` if the key does not exist or has expired.
 	 */
 	async get(key: string): Promise<T | null> {
 		const result = await this.docClient.send(new GetCommand({
@@ -62,6 +66,7 @@ export class KVStore<T = string> extends Scope {
 			Key: { pk: key },
 		}));
 		if (!result.Item) return null;
+		if (isExpired(result.Item[TTL_ATTRIBUTE])) return null;
 		return JSON.parse(result.Item.value) as T;
 	}
 
@@ -71,12 +76,13 @@ export class KVStore<T = string> extends Scope {
 	 *
 	 * @param key - The key to store.
 	 * @param value - The value to store.
-	 * @param conditions - Optional write conditions.
+	 * @param options - Optional write conditions and expiry (`ttlSeconds` / `expiresAt`).
 	 * @throws {KVStoreErrors.ItemTooLarge} If the serialized value exceeds the 400 KB DynamoDB per-item size limit.
 	 * @throws {KVStoreErrors.ConditionalCheckFailed} If `ifNotExists` is true and the key already exists.
 	 * @throws {KVStoreErrors.ConditionalCheckFailed} If `ifValueEquals` is set and the current value does not match.
+	 * @throws {KVStoreErrors.ValidationFailed} If both `ttlSeconds` and `expiresAt` are set, or either is not a usable time.
 	 */
-	async put(key: string, value: T, conditions?: import('./index.mock.js').ConditionalWriteOptions<T>): Promise<void> {
+	async put(key: string, value: T, options?: import('./index.mock.js').PutOptions<T>): Promise<void> {
 		if (this.schema) {
 			const result = this.schema['~standard'].validate(value);
 			const resolved = result instanceof Promise ? await result : result;
@@ -87,18 +93,22 @@ export class KVStore<T = string> extends Scope {
 			}
 		}
 
+		const expiresAtEpochSeconds = resolveTtlEpochSeconds(options);
+		const item: Record<string, unknown> = { pk: key, value: JSON.stringify(value) };
+		if (expiresAtEpochSeconds !== undefined) item[TTL_ATTRIBUTE] = expiresAtEpochSeconds;
+
 		const command: any = {
 			TableName: getSdkIdentifiers(this).tableName,
-			Item: { pk: key, value: JSON.stringify(value) },
+			Item: item,
 		};
 
-		if (conditions?.ifNotExists) {
+		if (options?.ifNotExists) {
 			command.ConditionExpression = 'attribute_not_exists(#pk)';
 			command.ExpressionAttributeNames = { '#pk': 'pk' };
-		} else if (conditions && 'ifValueEquals' in conditions) {
+		} else if (options && 'ifValueEquals' in options) {
 			command.ConditionExpression = '#value = :expected';
 			command.ExpressionAttributeNames = { '#value': 'value' };
-			command.ExpressionAttributeValues = { ':expected': JSON.stringify(conditions.ifValueEquals) };
+			command.ExpressionAttributeValues = { ':expected': JSON.stringify(options.ifValueEquals) };
 		}
 
 		try {
@@ -142,6 +152,7 @@ export class KVStore<T = string> extends Scope {
 	/**
 	 * Enumerate all key-value pairs. Reads every item in the table —
 	 * use sparingly on large datasets. Uses DynamoDB's native Scan operation.
+	 * Expired items are skipped even if DynamoDB has not reaped them yet.
 	 *
 	 * @returns An async iterable of key-value entries.
 	 */
@@ -153,6 +164,7 @@ export class KVStore<T = string> extends Scope {
 				ExclusiveStartKey: lastKey,
 			}));
 			for (const item of result.Items ?? []) {
+				if (isExpired(item[TTL_ATTRIBUTE])) continue;
 				yield { key: item.pk as string, value: JSON.parse(item.value as string) as T };
 			}
 			lastKey = result.LastEvaluatedKey;

--- a/packages/bb-kv-store/src/index.cdk.test.ts
+++ b/packages/bb-kv-store/src/index.cdk.test.ts
@@ -12,7 +12,7 @@ import { test } from 'node:test';
 import assert from 'node:assert';
 import * as cdk from 'aws-cdk-lib';
 import type { Construct } from 'constructs';
-import { Template } from 'aws-cdk-lib/assertions';
+import { Template, Match } from 'aws-cdk-lib/assertions';
 import { Scope, DEFAULT_NODE_RUNTIME } from '@aws-blocks/core/cdk';
 import { KVStore } from './index.cdk.js';
 
@@ -74,4 +74,47 @@ test('CDK: calling a runtime data method throws an actionable error (not a crypt
       `${method}() should throw the actionable synth-time error`,
     );
   }
+});
+
+// TTL is opt-in: switching it on for a table that already exists is an update
+// to the live table, so the default must never emit a TimeToLiveSpecification.
+
+test('CDK: TTL is off by default', () => {
+  const { stack, parent } = setup();
+  new KVStore(parent, 'sessions');
+  Template.fromStack(stack).hasResourceProperties('AWS::DynamoDB::Table', {
+    TimeToLiveSpecification: Match.absent(),
+  });
+});
+
+test('CDK: { ttl: false } does not enable TTL', () => {
+  const { stack, parent } = setup();
+  new KVStore(parent, 'sessions', { ttl: false });
+  Template.fromStack(stack).hasResourceProperties('AWS::DynamoDB::Table', {
+    TimeToLiveSpecification: Match.absent(),
+  });
+});
+
+test('CDK: { ttl: true } enables TTL on the ttl attribute', () => {
+  const { stack, parent } = setup();
+  new KVStore(parent, 'sessions', { ttl: true });
+  Template.fromStack(stack).hasResourceProperties('AWS::DynamoDB::Table', {
+    TimeToLiveSpecification: { AttributeName: 'ttl', Enabled: true },
+  });
+});
+
+test('CDK: TTL composes with removalPolicy', () => {
+  const { stack, parent } = setup();
+  new KVStore(parent, 'sessions', { ttl: true, removalPolicy: 'destroy' });
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::DynamoDB::Table', {
+    TimeToLiveSpecification: { AttributeName: 'ttl', Enabled: true },
+  });
+  template.hasResource('AWS::DynamoDB::Table', { DeletionPolicy: 'Delete' });
+});
+
+test('CDK: fromExisting + ttl still provisions nothing (no table to configure)', () => {
+  const { stack, parent } = setup();
+  new KVStore(parent, 'sessions', { ttl: true, table: KVStore.fromExisting('preexisting-table-123') });
+  Template.fromStack(stack).resourceCountIs('AWS::DynamoDB::Table', 0);
 });

--- a/packages/bb-kv-store/src/index.cdk.ts
+++ b/packages/bb-kv-store/src/index.cdk.ts
@@ -6,10 +6,11 @@ import { RemovalPolicy } from 'aws-cdk-lib';
 import { Scope, synthGuard } from '@aws-blocks/core/cdk';
 import type { ScopeParent } from '@aws-blocks/core';
 import type { KVStoreOptions, ExternalTableRef } from './types.js';
+import { TTL_ATTRIBUTE } from './ttl.js';
 
 // Re-export public types and errors (no runtime dependencies)
 export { KVStoreErrors } from './errors.js';
-export type { ConditionalWriteOptions, ConditionalDeleteOptions, KVStoreOptions, ExternalTableRef } from './types.js';
+export type { ConditionalWriteOptions, ConditionalDeleteOptions, PutOptions, KVStoreOptions, ExternalTableRef } from './types.js';
 
 export class KVStore extends Scope {
 	private table: ITable;
@@ -44,6 +45,9 @@ export class KVStore extends Scope {
 					: options?.removalPolicy === 'retain'
 						? RemovalPolicy.RETAIN
 						: undefined,
+				// Opt-in: enabling TTL on an already-deployed table is a live table
+				// update, so it must never happen implicitly.
+				timeToLiveAttribute: options?.ttl ? TTL_ATTRIBUTE : undefined,
 			});
 		}
 

--- a/packages/bb-kv-store/src/index.mock.ts
+++ b/packages/bb-kv-store/src/index.mock.ts
@@ -19,12 +19,14 @@ export {
 export type {
 	ConditionalWriteOptions,
 	ConditionalDeleteOptions,
+	PutOptions,
 	KVStoreOptions,
 	ExternalTableRef,
 } from './types.js';
 
-import type { ConditionalWriteOptions, ConditionalDeleteOptions, KVStoreOptions, ExternalTableRef } from './types.js';
+import type { ConditionalDeleteOptions, PutOptions, KVStoreOptions, ExternalTableRef } from './types.js';
 import { KVStoreErrors } from './errors.js';
+import { isExpired, nowEpochSeconds, resolveTtlEpochSeconds } from './ttl.js';
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -43,6 +45,30 @@ async function validateSchema<T>(schema: StandardSchemaV1<T> | undefined, value:
 	if (resolved.issues) {
 		throw blocksError('ValidationFailedException', resolved.issues[0].message);
 	}
+}
+
+/**
+ * One stored item. `ttl` mirrors the DynamoDB TTL attribute (Unix epoch
+ * seconds) and is absent for items written without an expiry.
+ */
+interface MockEntry {
+	value: string;
+	ttl?: number;
+}
+
+/**
+ * On-disk shape. Items without a TTL stay bare serialized strings so stores
+ * written by earlier versions load unchanged and non-expiring writes produce
+ * no format churn.
+ */
+type StoredEntry = string | MockEntry;
+
+function toMockEntry(stored: unknown): MockEntry | null {
+	if (typeof stored === 'string') return { value: stored };
+	if (!stored || typeof stored !== 'object') return null;
+	const { value, ttl } = stored as Partial<MockEntry>;
+	if (typeof value !== 'string') return null;
+	return typeof ttl === 'number' ? { value, ttl } : { value };
 }
 
 // ── KVStore (mock) ──────────────────────────────────────────────────────────
@@ -66,7 +92,7 @@ async function validateSchema<T>(schema: StandardSchemaV1<T> | undefined, value:
  */
 export class KVStore<T = string> extends Scope {
 	private filePath: string;
-	private data: Map<string, string>;
+	private data: Map<string, MockEntry>;
 	private schema?: StandardSchemaV1<T>;
 	/** @internal Logger for internal operations. Defaults to error-level when not provided. */
 	protected log: ChildLogger;
@@ -83,13 +109,21 @@ export class KVStore<T = string> extends Scope {
 	/**
 	 * Retrieve a value by key.
 	 *
+	 * Items whose TTL has passed are treated as absent, mirroring DynamoDB TTL
+	 * (whose reaper is asynchronous, so reads must filter regardless).
+	 *
 	 * @param key - The key to retrieve.
-	 * @returns The value, or `null` if the key does not exist.
+	 * @returns The value, or `null` if the key does not exist or has expired.
 	 */
 	async get(key: string): Promise<T | null> {
-		const raw = this.data.get(key);
-		if (raw === undefined) return null;
-		return JSON.parse(raw) as T;
+		const entry = this.data.get(key);
+		if (entry === undefined) return null;
+		if (isExpired(entry.ttl)) {
+			this.data.delete(key);
+			this.flushToDisk();
+			return null;
+		}
+		return JSON.parse(entry.value) as T;
 	}
 
 	/**
@@ -98,12 +132,13 @@ export class KVStore<T = string> extends Scope {
 	 *
 	 * @param key - The key to store.
 	 * @param value - The value to store.
-	 * @param conditions - Optional write conditions.
+	 * @param options - Optional write conditions and expiry (`ttlSeconds` / `expiresAt`).
 	 * @throws {KVStoreErrors.ItemTooLarge} If the serialized value exceeds the 400 KB DynamoDB per-item size limit.
 	 * @throws {KVStoreErrors.ConditionalCheckFailed} If `ifNotExists` is true and the key already exists.
 	 * @throws {KVStoreErrors.ConditionalCheckFailed} If `ifValueEquals` is set and the current value does not match.
+	 * @throws {KVStoreErrors.ValidationFailed} If both `ttlSeconds` and `expiresAt` are set, or either is not a usable time.
 	 */
-	async put(key: string, value: T, conditions?: ConditionalWriteOptions<T>): Promise<void> {
+	async put(key: string, value: T, options?: PutOptions<T>): Promise<void> {
 		// Schema validation runs first (matches AWS entry which validates client-side before sending)
 		await validateSchema(this.schema, value);
 
@@ -112,17 +147,21 @@ export class KVStore<T = string> extends Scope {
 			throw blocksError(KVStoreErrors.ItemTooLarge, `Item size has exceeded the maximum allowed size of 400 KB`);
 		}
 
-		if (conditions?.ifNotExists && this.data.has(key)) {
+		const expiresAtEpochSeconds = resolveTtlEpochSeconds(options);
+
+		if (options?.ifNotExists && this.data.has(key)) {
 			throw blocksError(KVStoreErrors.ConditionalCheckFailed, 'The conditional request failed');
 		}
-		if (conditions?.ifValueEquals !== undefined) {
-			const current = this.data.get(key);
-			if (current !== JSON.stringify(conditions.ifValueEquals)) {
+		if (options?.ifValueEquals !== undefined) {
+			const current = this.data.get(key)?.value;
+			if (current !== JSON.stringify(options.ifValueEquals)) {
 				throw blocksError(KVStoreErrors.ConditionalCheckFailed, 'The conditional request failed');
 			}
 		}
 
-		this.data.set(key, serialized);
+		this.data.set(key, expiresAtEpochSeconds === undefined
+			? { value: serialized }
+			: { value: serialized, ttl: expiresAtEpochSeconds });
 		this.flushToDisk();
 	}
 
@@ -139,7 +178,7 @@ export class KVStore<T = string> extends Scope {
 			throw blocksError(KVStoreErrors.ConditionalCheckFailed, 'The conditional request failed');
 		}
 		if (conditions?.ifValueEquals !== undefined) {
-			const current = this.data.get(key);
+			const current = this.data.get(key)?.value;
 			if (current !== JSON.stringify(conditions.ifValueEquals)) {
 				throw blocksError(KVStoreErrors.ConditionalCheckFailed, 'The conditional request failed');
 			}
@@ -150,13 +189,14 @@ export class KVStore<T = string> extends Scope {
 
 	/**
 	 * Enumerate all key-value pairs. Reads every item in the store —
-	 * use sparingly on large datasets.
+	 * use sparingly on large datasets. Expired items are skipped.
 	 *
 	 * @returns An async iterable of key-value entries.
 	 */
 	async *scan(): AsyncIterable<{ key: string; value: T }> {
-		for (const [key, raw] of this.data) {
-			yield { key, value: JSON.parse(raw) as T };
+		this.pruneExpired();
+		for (const [key, entry] of this.data) {
+			yield { key, value: JSON.parse(entry.value) as T };
 		}
 	}
 
@@ -172,17 +212,41 @@ export class KVStore<T = string> extends Scope {
 
 	// ── Disk persistence ──────────────────────────────────────────────────
 
-	private loadFromDisk(): Map<string, string> {
+	/**
+	 * Drop every expired item in one sweep. Stands in for DynamoDB's background
+	 * TTL reaper, which the local store has no equivalent of.
+	 */
+	private pruneExpired(): void {
+		const now = nowEpochSeconds();
+		const expired: string[] = [];
+		for (const [key, entry] of this.data) {
+			if (isExpired(entry.ttl, now)) expired.push(key);
+		}
+		if (expired.length === 0) return;
+		for (const key of expired) this.data.delete(key);
+		this.flushToDisk();
+	}
+
+	private loadFromDisk(): Map<string, MockEntry> {
 		if (!existsSync(this.filePath)) return new Map();
 		try {
-			const obj = JSON.parse(readFileSync(this.filePath, 'utf8'));
-			return new Map(Object.entries(obj));
+			const obj = JSON.parse(readFileSync(this.filePath, 'utf8')) as Record<string, unknown>;
+			const entries = new Map<string, MockEntry>();
+			for (const [key, stored] of Object.entries(obj)) {
+				const entry = toMockEntry(stored);
+				if (entry) entries.set(key, entry);
+			}
+			return entries;
 		} catch {
 			return new Map();
 		}
 	}
 
 	private flushToDisk(): void {
-		writeFileSync(this.filePath, JSON.stringify(Object.fromEntries(this.data), null, 2));
+		const obj: Record<string, StoredEntry> = {};
+		for (const [key, entry] of this.data) {
+			obj[key] = entry.ttl === undefined ? entry.value : { value: entry.value, ttl: entry.ttl };
+		}
+		writeFileSync(this.filePath, JSON.stringify(obj, null, 2));
 	}
 }

--- a/packages/bb-kv-store/src/index.mock.ts
+++ b/packages/bb-kv-store/src/index.mock.ts
@@ -22,9 +22,10 @@ export type {
 	PutOptions,
 	KVStoreOptions,
 	ExternalTableRef,
+	ScanOptions,
 } from './types.js';
 
-import type { ConditionalDeleteOptions, PutOptions, KVStoreOptions, ExternalTableRef } from './types.js';
+import type { ConditionalDeleteOptions, PutOptions, KVStoreOptions, ExternalTableRef, ScanOptions } from './types.js';
 import { KVStoreErrors } from './errors.js';
 import { isExpired, nowEpochSeconds, resolveTtlEpochSeconds } from './ttl.js';
 
@@ -189,11 +190,18 @@ export class KVStore<T = string> extends Scope {
 
 	/**
 	 * Enumerate all key-value pairs. Reads every item in the store —
-	 * use sparingly on large datasets. Expired items are skipped.
+	 * use sparingly on large datasets. Expired items are skipped unless
+	 * `includeExpired` is set.
 	 *
 	 * @returns An async iterable of key-value entries.
 	 */
-	async *scan(): AsyncIterable<{ key: string; value: T }> {
+	async *scan(options?: ScanOptions): AsyncIterable<{ key: string; value: T }> {
+		if (options?.includeExpired) {
+			for (const [key, entry] of this.data) {
+				yield { key, value: JSON.parse(entry.value) as T };
+			}
+			return;
+		}
 		this.pruneExpired();
 		for (const [key, entry] of this.data) {
 			yield { key, value: JSON.parse(entry.value) as T };

--- a/packages/bb-kv-store/src/parity.test.ts
+++ b/packages/bb-kv-store/src/parity.test.ts
@@ -9,6 +9,8 @@ import { test, describe, beforeEach } from 'node:test';
 import assert from 'node:assert/strict';
 import { rmSync } from 'node:fs';
 import { KVStore, KVStoreErrors } from './index.mock.js';
+import { KVStore as AwsKVStore } from './index.aws.js';
+import { TTL_ATTRIBUTE, nowEpochSeconds } from './ttl.js';
 import { z } from 'zod';
 
 beforeEach(() => {
@@ -114,5 +116,113 @@ describe('ifValueEquals: undefined is treated as no-op', () => {
 	test('delete with ifValueEquals: undefined on missing key succeeds silently', async () => {
 		const store = new KVStore({ id: 'root' } as any, 'undef-del-new');
 		await store.delete('nonexistent', { ifValueEquals: undefined } as any);
+	});
+});
+
+// TTL parity. DynamoDB's reaper is asynchronous, so an expired item can still
+// be physically present; both runtimes must therefore hide expired items on
+// read, and neither may write the `ttl` attribute unless asked. Divergence here
+// means code that self-expires sessions locally silently retains them in AWS.
+
+/**
+ * Capture what the AWS runtime would send to DynamoDB and control what it reads
+ * back, without touching the network. Real `KVStore`, real `PutCommand`.
+ */
+function captureAws(id: string, respond: () => any = () => ({})): {
+	store: AwsKVStore<string>;
+	items: () => any[];
+} {
+	const store = new AwsKVStore<string>({ id: 'root' } as any, id);
+	const sent: any[] = [];
+	(store as any).docClient.middlewareStack.add(
+		(_next: any) => async (args: any) => {
+			sent.push(args.input);
+			return { output: respond() };
+		},
+		{ step: 'initialize', name: 'kv-parity-intercept', override: true },
+	);
+	return { store, items: () => sent };
+}
+
+describe('TTL parity between mock and AWS runtimes', () => {
+	test('neither runtime writes a ttl attribute when none is requested', async () => {
+		const mock = new KVStore({ id: 'root' } as any, 'parity-no-ttl');
+		await mock.put('k', 'v');
+		assert.strictEqual(await mock.get('k'), 'v');
+
+		const { store, items } = captureAws('parity-no-ttl-aws');
+		await store.put('k', 'v');
+		assert.ok(!(TTL_ATTRIBUTE in items()[0].Item));
+	});
+
+	test('both runtimes hide an item whose expiry has passed', async () => {
+		const expired = nowEpochSeconds() - 1;
+
+		const mock = new KVStore({ id: 'root' } as any, 'parity-expired');
+		await mock.put('k', 'v', { expiresAt: expired });
+		assert.strictEqual(await mock.get('k'), null);
+
+		const { store } = captureAws('parity-expired-aws', () => ({
+			Item: { pk: 'k', value: JSON.stringify('v'), [TTL_ATTRIBUTE]: expired },
+		}));
+		assert.strictEqual(await store.get('k'), null);
+	});
+
+	test('both runtimes still return an item whose expiry is in the future', async () => {
+		const future = nowEpochSeconds() + 600;
+
+		const mock = new KVStore({ id: 'root' } as any, 'parity-live');
+		await mock.put('k', 'v', { expiresAt: future });
+		assert.strictEqual(await mock.get('k'), 'v');
+
+		const { store } = captureAws('parity-live-aws', () => ({
+			Item: { pk: 'k', value: JSON.stringify('v'), [TTL_ATTRIBUTE]: future },
+		}));
+		assert.strictEqual(await store.get('k'), 'v');
+	});
+
+	test('both runtimes skip expired items during scan', async () => {
+		const expired = nowEpochSeconds() - 1;
+
+		const mock = new KVStore({ id: 'root' } as any, 'parity-scan');
+		await mock.put('live', 'a');
+		await mock.put('dead', 'b', { expiresAt: expired });
+		const mockKeys: string[] = [];
+		for await (const { key } of mock.scan()) mockKeys.push(key);
+		assert.deepStrictEqual(mockKeys, ['live']);
+
+		const { store } = captureAws('parity-scan-aws', () => ({
+			Items: [
+				{ pk: 'live', value: JSON.stringify('a') },
+				{ pk: 'dead', value: JSON.stringify('b'), [TTL_ATTRIBUTE]: expired },
+			],
+		}));
+		const awsKeys: string[] = [];
+		for await (const { key } of store.scan()) awsKeys.push(key);
+		assert.deepStrictEqual(awsKeys, mockKeys);
+	});
+
+	test('both runtimes reject the same invalid TTL options with the same error name', async () => {
+		const bad = [
+			{ ttlSeconds: 60, expiresAt: 123456 },
+			{ ttlSeconds: 0 },
+			{ ttlSeconds: -1 },
+			{ expiresAt: Date.now() },
+		] as const;
+
+		const mock = new KVStore({ id: 'root' } as any, 'parity-invalid');
+		const { store } = captureAws('parity-invalid-aws');
+
+		for (const options of bad) {
+			const label = JSON.stringify(options);
+			await assert.rejects(() => mock.put('k', 'v', options as any), (err: any) => {
+				assert.strictEqual(err.name, KVStoreErrors.ValidationFailed, `mock: ${label}`);
+				return true;
+			});
+			await assert.rejects(() => store.put('k', 'v', options as any), (err: any) => {
+				assert.strictEqual(err.name, KVStoreErrors.ValidationFailed, `aws: ${label}`);
+				return true;
+			});
+		}
 	});
 });

--- a/packages/bb-kv-store/src/parity.test.ts
+++ b/packages/bb-kv-store/src/parity.test.ts
@@ -202,6 +202,27 @@ describe('TTL parity between mock and AWS runtimes', () => {
 		assert.deepStrictEqual(awsKeys, mockKeys);
 	});
 
+	test('both runtimes yield expired items during scan({ includeExpired })', async () => {
+		const expired = nowEpochSeconds() - 1;
+
+		const mock = new KVStore({ id: 'root' } as any, 'parity-scan-include');
+		await mock.put('live', 'a');
+		await mock.put('dead', 'b', { expiresAt: expired });
+		const mockKeys: string[] = [];
+		for await (const { key } of mock.scan({ includeExpired: true })) mockKeys.push(key);
+		assert.deepStrictEqual(mockKeys.sort(), ['dead', 'live']);
+
+		const { store } = captureAws('parity-scan-include-aws', () => ({
+			Items: [
+				{ pk: 'live', value: JSON.stringify('a') },
+				{ pk: 'dead', value: JSON.stringify('b'), [TTL_ATTRIBUTE]: expired },
+			],
+		}));
+		const awsKeys: string[] = [];
+		for await (const { key } of store.scan({ includeExpired: true })) awsKeys.push(key);
+		assert.deepStrictEqual(awsKeys.sort(), mockKeys.sort());
+	});
+
 	test('both runtimes reject the same invalid TTL options with the same error name', async () => {
 		const bad = [
 			{ ttlSeconds: 60, expiresAt: 123456 },

--- a/packages/bb-kv-store/src/ttl.test.ts
+++ b/packages/bb-kv-store/src/ttl.test.ts
@@ -11,16 +11,33 @@
  * the production put/get/scan code paths execute unchanged.
  */
 
-import { test, describe, beforeEach } from 'node:test';
+import { test, describe, beforeEach, after } from 'node:test';
 import assert from 'node:assert/strict';
-import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { KVStore as MockKVStore, KVStoreErrors } from './index.mock.js';
 import { KVStore as AwsKVStore } from './index.aws.js';
 import { TTL_ATTRIBUTE, isExpired, nowEpochSeconds, resolveTtlEpochSeconds } from './ttl.js';
 
+/**
+ * These tests assert on the mock's persisted bytes, so they wipe its data root
+ * between cases. The mock resolves that root from `process.cwd()`, and the test
+ * runner executes files concurrently by default — so wiping the shared
+ * `.bb-data` would delete directories a sibling test file is actively reading.
+ * Run against a private root instead.
+ */
+const originalCwd = process.cwd();
+const dataRoot = mkdtempSync(join(tmpdir(), 'bb-kv-store-ttl-'));
+process.chdir(dataRoot);
+
+after(() => {
+	process.chdir(originalCwd);
+	rmSync(dataRoot, { recursive: true, force: true });
+});
+
 beforeEach(() => {
-	try { rmSync('.bb-data', { recursive: true, force: true }); } catch {}
+	rmSync('.bb-data', { recursive: true, force: true });
 });
 
 function mockStore<T = string>(id: string): MockKVStore<T> {
@@ -99,6 +116,12 @@ describe('resolveTtlEpochSeconds', () => {
 	test('expiresAt in the past is allowed (caller asked for immediate expiry)', () => {
 		const past = nowEpochSeconds() - 60;
 		assert.strictEqual(resolveTtlEpochSeconds({ expiresAt: past }), past);
+	});
+
+	test('expiresAt has no positive lower bound — epoch 0 and negatives are past instants', () => {
+		assert.strictEqual(resolveTtlEpochSeconds({ expiresAt: 0 }), 0);
+		assert.strictEqual(resolveTtlEpochSeconds({ expiresAt: -1 }), -1);
+		assert.strictEqual(resolveTtlEpochSeconds({ expiresAt: new Date(0) }), 0);
 	});
 
 	test('rejects epoch milliseconds passed as expiresAt', () => {
@@ -206,6 +229,25 @@ describe('mock runtime emulates DynamoDB TTL', () => {
 		for await (const _ of store.scan()) { /* drain */ }
 		const onDisk = JSON.parse(readFileSync(storeFile('ttl-scan-prune'), 'utf8'));
 		assert.deepStrictEqual(Object.keys(onDisk), ['live']);
+	});
+
+	test('scan({ includeExpired }) yields expired-but-unreaped items', async () => {
+		const store = mockStore('ttl-scan-include');
+		await store.put('live', 'a');
+		await store.put('dead', 'b', { expiresAt: nowEpochSeconds() - 1 });
+
+		const seen: string[] = [];
+		for await (const { key } of store.scan({ includeExpired: true })) seen.push(key);
+		assert.deepStrictEqual(seen.sort(), ['dead', 'live']);
+	});
+
+	test('scan({ includeExpired }) leaves expired rows on disk for the caller to delete', async () => {
+		const store = mockStore('ttl-scan-include-nodelete');
+		await store.put('dead', 'b', { expiresAt: nowEpochSeconds() - 1 });
+
+		for await (const _ of store.scan({ includeExpired: true })) { /* drain */ }
+		const onDisk = JSON.parse(readFileSync(storeFile('ttl-scan-include-nodelete'), 'utf8'));
+		assert.deepStrictEqual(Object.keys(onDisk), ['dead']);
 	});
 
 	test('expiry survives a restart (persisted, not in-memory only)', async () => {

--- a/packages/bb-kv-store/src/ttl.test.ts
+++ b/packages/bb-kv-store/src/ttl.test.ts
@@ -1,0 +1,404 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * TTL coverage for KVStore: option resolution, mock expiry emulation, and the
+ * DynamoDB wire format produced by the AWS runtime.
+ *
+ * The AWS-runtime tests drive the REAL `KVStore` from `index.aws.ts` against a
+ * real `DynamoDBDocumentClient`; only the network boundary is intercepted (an
+ * SDK middleware captures the command input and returns a canned response), so
+ * the production put/get/scan code paths execute unchanged.
+ */
+
+import { test, describe, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { KVStore as MockKVStore, KVStoreErrors } from './index.mock.js';
+import { KVStore as AwsKVStore } from './index.aws.js';
+import { TTL_ATTRIBUTE, isExpired, nowEpochSeconds, resolveTtlEpochSeconds } from './ttl.js';
+
+beforeEach(() => {
+	try { rmSync('.bb-data', { recursive: true, force: true }); } catch {}
+});
+
+function mockStore<T = string>(id: string): MockKVStore<T> {
+	return new MockKVStore<T>({ id: 'root' } as any, id);
+}
+
+/** Path the mock persists to, so tests can assert the on-disk shape. */
+function storeFile(id: string): string {
+	return join('.bb-data', `root-${id}`, 'store.json');
+}
+
+// ── Captured DynamoDB traffic ───────────────────────────────────────────────
+
+interface Captured {
+	commandName: string;
+	input: any;
+}
+
+/**
+ * Short-circuit the SDK before it reaches the network. Middleware added at the
+ * `initialize` step sees the document-shaped input our code built and returns
+ * the document-shaped output our code reads.
+ */
+function interceptDynamo(
+	store: AwsKVStore<any>,
+	respond: (captured: Captured) => any = () => ({}),
+): Captured[] {
+	const calls: Captured[] = [];
+	const docClient = (store as any).docClient;
+	docClient.middlewareStack.add(
+		(_next: any, context: any) => async (args: any) => {
+			const captured: Captured = { commandName: String(context.commandName), input: args.input };
+			calls.push(captured);
+			return { output: respond(captured) };
+		},
+		{ step: 'initialize', name: 'kv-ttl-test-intercept', override: true },
+	);
+	return calls;
+}
+
+function awsStore<T = string>(id: string): AwsKVStore<T> {
+	return new AwsKVStore<T>({ id: 'root' } as any, id);
+}
+
+// ── Option resolution ───────────────────────────────────────────────────────
+
+describe('resolveTtlEpochSeconds', () => {
+	test('returns undefined when no expiry is requested', () => {
+		assert.strictEqual(resolveTtlEpochSeconds(undefined), undefined);
+		assert.strictEqual(resolveTtlEpochSeconds({}), undefined);
+		assert.strictEqual(resolveTtlEpochSeconds({ ifNotExists: true }), undefined);
+	});
+
+	test('ttlSeconds resolves to now + seconds', () => {
+		const before = nowEpochSeconds();
+		const resolved = resolveTtlEpochSeconds({ ttlSeconds: 3600 });
+		assert.ok(resolved !== undefined);
+		assert.ok(resolved >= before + 3600, `expected >= ${before + 3600}, got ${resolved}`);
+		assert.ok(resolved <= nowEpochSeconds() + 3601, `expected <= now+3601, got ${resolved}`);
+	});
+
+	test('fractional ttlSeconds rounds up so a sub-second TTL never lands in the past', () => {
+		const resolved = resolveTtlEpochSeconds({ ttlSeconds: 0.25 });
+		assert.strictEqual(resolved, nowEpochSeconds() + 1);
+	});
+
+	test('expiresAt accepts a Date and converts to epoch seconds', () => {
+		const when = new Date('2030-01-01T00:00:00.000Z');
+		assert.strictEqual(resolveTtlEpochSeconds({ expiresAt: when }), Math.floor(when.getTime() / 1000));
+	});
+
+	test('expiresAt accepts epoch seconds unchanged', () => {
+		assert.strictEqual(resolveTtlEpochSeconds({ expiresAt: 1893456000 }), 1893456000);
+	});
+
+	test('expiresAt in the past is allowed (caller asked for immediate expiry)', () => {
+		const past = nowEpochSeconds() - 60;
+		assert.strictEqual(resolveTtlEpochSeconds({ expiresAt: past }), past);
+	});
+
+	test('rejects epoch milliseconds passed as expiresAt', () => {
+		assert.throws(
+			() => resolveTtlEpochSeconds({ expiresAt: Date.now() }),
+			(err: any) => {
+				assert.strictEqual(err.name, KVStoreErrors.ValidationFailed);
+				assert.match(err.message, /milliseconds/);
+				return true;
+			},
+		);
+	});
+
+	test('rejects ttlSeconds together with expiresAt', () => {
+		assert.throws(
+			() => resolveTtlEpochSeconds({ ttlSeconds: 60, expiresAt: new Date() }),
+			(err: any) => {
+				assert.strictEqual(err.name, KVStoreErrors.ValidationFailed);
+				assert.match(err.message, /not both/);
+				return true;
+			},
+		);
+	});
+
+	for (const bad of [0, -1, Number.NaN, Number.POSITIVE_INFINITY, '60' as any]) {
+		test(`rejects ttlSeconds: ${String(bad)}`, () => {
+			assert.throws(
+				() => resolveTtlEpochSeconds({ ttlSeconds: bad }),
+				(err: any) => {
+					assert.strictEqual(err.name, KVStoreErrors.ValidationFailed);
+					return true;
+				},
+			);
+		});
+	}
+
+	test('rejects an Invalid Date', () => {
+		assert.throws(
+			() => resolveTtlEpochSeconds({ expiresAt: new Date('nope') }),
+			(err: any) => {
+				assert.strictEqual(err.name, KVStoreErrors.ValidationFailed);
+				return true;
+			},
+		);
+	});
+});
+
+describe('isExpired', () => {
+	test('true only once the timestamp has been reached', () => {
+		const now = 1_000_000;
+		assert.strictEqual(isExpired(now - 1, now), true);
+		assert.strictEqual(isExpired(now, now), true);
+		assert.strictEqual(isExpired(now + 1, now), false);
+	});
+
+	test('missing or non-numeric ttl is never expired (DynamoDB ignores those items)', () => {
+		assert.strictEqual(isExpired(undefined), false);
+		assert.strictEqual(isExpired(null), false);
+		assert.strictEqual(isExpired('123'), false);
+		assert.strictEqual(isExpired(Number.NaN), false);
+	});
+});
+
+// ── Mock expiry emulation ───────────────────────────────────────────────────
+
+describe('mock runtime emulates DynamoDB TTL', () => {
+	test('get returns the value while it is still live', async () => {
+		const store = mockStore('ttl-live');
+		await store.put('k', 'v', { ttlSeconds: 600 });
+		assert.strictEqual(await store.get('k'), 'v');
+	});
+
+	test('get returns null once the item has expired', async () => {
+		const store = mockStore('ttl-expired');
+		await store.put('k', 'v', { expiresAt: nowEpochSeconds() - 1 });
+		assert.strictEqual(await store.get('k'), null);
+	});
+
+	test('get prunes the expired item from disk', async () => {
+		const store = mockStore('ttl-prune-get');
+		await store.put('gone', 'v', { expiresAt: nowEpochSeconds() - 1 });
+		await store.put('stays', 'v');
+		await store.get('gone');
+		const onDisk = JSON.parse(readFileSync(storeFile('ttl-prune-get'), 'utf8'));
+		assert.deepStrictEqual(Object.keys(onDisk), ['stays']);
+	});
+
+	test('scan skips expired items and keeps live ones', async () => {
+		const store = mockStore('ttl-scan');
+		await store.put('live', 'a');
+		await store.put('dead', 'b', { expiresAt: nowEpochSeconds() - 1 });
+		await store.put('later', 'c', { ttlSeconds: 600 });
+
+		const seen: string[] = [];
+		for await (const { key } of store.scan()) seen.push(key);
+		assert.deepStrictEqual(seen.sort(), ['later', 'live']);
+	});
+
+	test('scan sweeps expired items off disk', async () => {
+		const store = mockStore('ttl-scan-prune');
+		await store.put('dead1', 'a', { expiresAt: nowEpochSeconds() - 5 });
+		await store.put('dead2', 'b', { expiresAt: nowEpochSeconds() - 5 });
+		await store.put('live', 'c');
+
+		for await (const _ of store.scan()) { /* drain */ }
+		const onDisk = JSON.parse(readFileSync(storeFile('ttl-scan-prune'), 'utf8'));
+		assert.deepStrictEqual(Object.keys(onDisk), ['live']);
+	});
+
+	test('expiry survives a restart (persisted, not in-memory only)', async () => {
+		const first = mockStore('ttl-restart');
+		await first.put('live', 'a', { ttlSeconds: 600 });
+		await first.put('dead', 'b', { expiresAt: nowEpochSeconds() - 1 });
+
+		const second = mockStore('ttl-restart');
+		assert.strictEqual(await second.get('live'), 'a');
+		assert.strictEqual(await second.get('dead'), null);
+	});
+
+	test('re-putting without a TTL clears a previous expiry', async () => {
+		const store = mockStore('ttl-cleared');
+		await store.put('k', 'v', { ttlSeconds: 600 });
+		await store.put('k', 'v2');
+
+		const onDisk = JSON.parse(readFileSync(storeFile('ttl-cleared'), 'utf8'));
+		assert.strictEqual(onDisk.k, JSON.stringify('v2'), 'no-TTL write must persist as a bare string');
+		assert.strictEqual(await store.get('k'), 'v2');
+	});
+
+	test('TTL composes with conditional writes', async () => {
+		const store = mockStore('ttl-conditional');
+		await store.put('k', 'v', { ifNotExists: true, ttlSeconds: 600 });
+		await assert.rejects(
+			() => store.put('k', 'v2', { ifNotExists: true, ttlSeconds: 600 }),
+			(err: any) => {
+				assert.strictEqual(err.name, KVStoreErrors.ConditionalCheckFailed);
+				return true;
+			},
+		);
+		assert.strictEqual(await store.get('k'), 'v');
+	});
+
+	test('invalid TTL options throw before anything is written', async () => {
+		const store = mockStore('ttl-invalid');
+		await assert.rejects(
+			() => store.put('k', 'v', { ttlSeconds: -5 }),
+			(err: any) => {
+				assert.strictEqual(err.name, KVStoreErrors.ValidationFailed);
+				return true;
+			},
+		);
+		assert.strictEqual(await store.get('k'), null);
+	});
+
+	test('items written without a TTL never expire', async () => {
+		const store = mockStore('ttl-absent');
+		await store.put('k', 'v');
+		const onDisk = JSON.parse(readFileSync(storeFile('ttl-absent'), 'utf8'));
+		assert.strictEqual(typeof onDisk.k, 'string', 'expected the legacy bare-string shape');
+		assert.strictEqual(await store.get('k'), 'v');
+	});
+
+	test('stores written by earlier versions (bare strings) still load', async () => {
+		const dir = join('.bb-data', 'root-ttl-legacy');
+		mkdirSync(dir, { recursive: true });
+		writeFileSync(join(dir, 'store.json'), JSON.stringify({ legacy: JSON.stringify('old-value') }));
+
+		const store = mockStore('ttl-legacy');
+		assert.strictEqual(await store.get('legacy'), 'old-value');
+
+		await store.put('fresh', 'new-value', { ttlSeconds: 600 });
+		assert.strictEqual(await store.get('legacy'), 'old-value');
+		assert.strictEqual(await store.get('fresh'), 'new-value');
+	});
+
+	test('typed values round-trip with a TTL', async () => {
+		interface Session { user: string; token: string }
+		const store = mockStore<Session>('ttl-typed');
+		await store.put('s1', { user: 'alice', token: 'abc' }, { ttlSeconds: 600 });
+		assert.deepStrictEqual(await store.get('s1'), { user: 'alice', token: 'abc' });
+	});
+
+	test('a corrupt entry is dropped rather than crashing the load', async () => {
+		const dir = join('.bb-data', 'root-ttl-corrupt');
+		mkdirSync(dir, { recursive: true });
+		writeFileSync(join(dir, 'store.json'), JSON.stringify({
+			good: JSON.stringify('kept'),
+			bad: { ttl: 123 },
+			alsoBad: 42,
+		}));
+
+		const store = mockStore('ttl-corrupt');
+		assert.strictEqual(await store.get('good'), 'kept');
+		assert.strictEqual(await store.get('bad'), null);
+		assert.strictEqual(await store.get('alsoBad'), null);
+	});
+});
+
+// ── AWS runtime wire format ─────────────────────────────────────────────────
+
+describe('AWS runtime writes a DynamoDB TTL attribute', () => {
+	test('put with ttlSeconds writes a numeric epoch-seconds ttl', async () => {
+		const store = awsStore('aws-ttl-put');
+		const calls = interceptDynamo(store);
+
+		const before = nowEpochSeconds();
+		await store.put('k', 'v', { ttlSeconds: 3600 });
+
+		assert.strictEqual(calls.length, 1);
+		assert.strictEqual(calls[0].commandName, 'PutItemCommand');
+		const ttl = calls[0].input.Item[TTL_ATTRIBUTE];
+		assert.strictEqual(typeof ttl, 'number');
+		assert.ok(Number.isInteger(ttl), 'DynamoDB TTL must be an integer');
+		assert.ok(ttl >= before + 3600 && ttl <= nowEpochSeconds() + 3601, `ttl ${ttl} out of expected window`);
+		assert.strictEqual(calls[0].input.Item.pk, 'k');
+		assert.strictEqual(calls[0].input.Item.value, JSON.stringify('v'));
+	});
+
+	test('put with expiresAt writes that exact timestamp', async () => {
+		const store = awsStore('aws-ttl-expires-at');
+		const calls = interceptDynamo(store);
+
+		await store.put('k', 'v', { expiresAt: new Date('2031-06-01T12:00:00.000Z') });
+		assert.strictEqual(calls[0].input.Item[TTL_ATTRIBUTE], Math.floor(Date.parse('2031-06-01T12:00:00.000Z') / 1000));
+	});
+
+	test('put without TTL options omits the attribute entirely', async () => {
+		const store = awsStore('aws-ttl-omitted');
+		const calls = interceptDynamo(store);
+
+		await store.put('k', 'v');
+		await store.put('k2', 'v2', { ifNotExists: true });
+
+		for (const call of calls) {
+			assert.ok(!(TTL_ATTRIBUTE in call.input.Item), `unexpected ttl attribute in ${JSON.stringify(call.input.Item)}`);
+		}
+	});
+
+	test('TTL composes with a conditional write expression', async () => {
+		const store = awsStore('aws-ttl-conditional');
+		const calls = interceptDynamo(store);
+
+		await store.put('k', 'v', { ifNotExists: true, ttlSeconds: 60 });
+		assert.strictEqual(calls[0].input.ConditionExpression, 'attribute_not_exists(#pk)');
+		assert.strictEqual(typeof calls[0].input.Item[TTL_ATTRIBUTE], 'number');
+	});
+
+	test('invalid TTL options throw before any DynamoDB call', async () => {
+		const store = awsStore('aws-ttl-invalid');
+		const calls = interceptDynamo(store);
+
+		await assert.rejects(
+			() => store.put('k', 'v', { ttlSeconds: 60, expiresAt: 123456 }),
+			(err: any) => {
+				assert.strictEqual(err.name, KVStoreErrors.ValidationFailed);
+				return true;
+			},
+		);
+		assert.strictEqual(calls.length, 0, 'nothing should be sent to DynamoDB');
+	});
+
+	test('get filters an expired item DynamoDB has not reaped yet', async () => {
+		const store = awsStore('aws-ttl-get-expired');
+		interceptDynamo(store, () => ({
+			Item: { pk: 'k', value: JSON.stringify('stale'), [TTL_ATTRIBUTE]: nowEpochSeconds() - 1 },
+		}));
+		assert.strictEqual(await store.get('k'), null);
+	});
+
+	test('get returns an item whose ttl is still in the future', async () => {
+		const store = awsStore('aws-ttl-get-live');
+		interceptDynamo(store, () => ({
+			Item: { pk: 'k', value: JSON.stringify('fresh'), [TTL_ATTRIBUTE]: nowEpochSeconds() + 600 },
+		}));
+		assert.strictEqual(await store.get('k'), 'fresh');
+	});
+
+	test('scan filters unreaped expired items', async () => {
+		const store = awsStore('aws-ttl-scan');
+		interceptDynamo(store, () => ({
+			Items: [
+				{ pk: 'live', value: JSON.stringify('a') },
+				{ pk: 'dead', value: JSON.stringify('b'), [TTL_ATTRIBUTE]: nowEpochSeconds() - 1 },
+				{ pk: 'later', value: JSON.stringify('c'), [TTL_ATTRIBUTE]: nowEpochSeconds() + 600 },
+			],
+		}));
+
+		const seen: string[] = [];
+		for await (const { key } of store.scan()) seen.push(key);
+		assert.deepStrictEqual(seen, ['live', 'later']);
+	});
+});
+
+// ── CDK opt-in guard ────────────────────────────────────────────────────────
+
+describe('mock/browser runtimes ignore the ttl construct flag', () => {
+	test('{ ttl: true } is accepted and does not change data behavior', async () => {
+		const store = new MockKVStore({ id: 'root' } as any, 'ttl-flag', { ttl: true });
+		await store.put('k', 'v');
+		assert.strictEqual(await store.get('k'), 'v');
+		assert.ok(existsSync(storeFile('ttl-flag')));
+	});
+});

--- a/packages/bb-kv-store/src/ttl.ts
+++ b/packages/bb-kv-store/src/ttl.ts
@@ -1,0 +1,80 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Shared TTL resolution used by the mock and AWS runtimes so both layers agree
+ * on the exact epoch-seconds value written and on when an item counts as
+ * expired. Zero runtime dependencies beyond the error constants.
+ */
+import { KVStoreErrors } from './errors.js';
+import type { PutOptions } from './types.js';
+
+/**
+ * DynamoDB attribute that holds the expiry timestamp. Fixed rather than
+ * configurable: a KVStore item's shape is owned by the block (`pk` + `value`),
+ * so there is no customer-defined attribute to point TTL at.
+ */
+export const TTL_ATTRIBUTE = 'ttl';
+
+/**
+ * Epoch *seconds* above which a value is almost certainly epoch milliseconds
+ * (1e11 seconds is the year 5138). Writing milliseconds into a DynamoDB TTL
+ * attribute silently means "never expires", which is the exact failure mode
+ * TTL is meant to prevent — so we reject it instead.
+ */
+const MAX_PLAUSIBLE_EPOCH_SECONDS = 1e11;
+
+function invalidTtl(message: string): never {
+	const err = new Error(`${KVStoreErrors.ValidationFailed}: ${message}`);
+	err.name = KVStoreErrors.ValidationFailed;
+	throw err;
+}
+
+/** Current time as Unix epoch seconds — the unit DynamoDB TTL expects. */
+export function nowEpochSeconds(): number {
+	return Math.floor(Date.now() / 1000);
+}
+
+/**
+ * Resolve `ttlSeconds` / `expiresAt` to an absolute Unix epoch-seconds value,
+ * or `undefined` when the caller asked for no expiry.
+ *
+ * @throws {KVStoreErrors.ValidationFailed} If both options are set, or either is not a usable time.
+ */
+export function resolveTtlEpochSeconds(options?: PutOptions<unknown>): number | undefined {
+	const ttlSeconds = options?.ttlSeconds;
+	const expiresAt = options?.expiresAt;
+	if (ttlSeconds === undefined && expiresAt === undefined) return undefined;
+	if (ttlSeconds !== undefined && expiresAt !== undefined) {
+		invalidTtl('put: pass either `ttlSeconds` or `expiresAt`, not both');
+	}
+
+	if (ttlSeconds !== undefined) {
+		if (typeof ttlSeconds !== 'number' || !Number.isFinite(ttlSeconds) || ttlSeconds <= 0) {
+			invalidTtl(`put: \`ttlSeconds\` must be a finite number greater than 0 (received ${String(ttlSeconds)})`);
+		}
+		return nowEpochSeconds() + Math.ceil(ttlSeconds);
+	}
+
+	if (expiresAt instanceof Date) {
+		const ms = expiresAt.getTime();
+		if (!Number.isFinite(ms)) invalidTtl('put: `expiresAt` is an Invalid Date');
+		return Math.floor(ms / 1000);
+	}
+	if (typeof expiresAt !== 'number' || !Number.isFinite(expiresAt) || expiresAt <= 0) {
+		invalidTtl(`put: \`expiresAt\` must be a Date or a positive Unix epoch time in seconds (received ${String(expiresAt)})`);
+	}
+	if (expiresAt >= MAX_PLAUSIBLE_EPOCH_SECONDS) {
+		invalidTtl('put: `expiresAt` looks like epoch milliseconds; DynamoDB TTL expects seconds — pass a Date or divide by 1000');
+	}
+	return Math.floor(expiresAt);
+}
+
+/**
+ * Whether a stored `ttl` attribute has passed. Non-numeric / absent values are
+ * never expired, matching DynamoDB (it ignores items whose TTL attribute is
+ * missing or not a Number).
+ */
+export function isExpired(ttl: unknown, nowSeconds: number = nowEpochSeconds()): boolean {
+	return typeof ttl === 'number' && Number.isFinite(ttl) && ttl <= nowSeconds;
+}

--- a/packages/bb-kv-store/src/ttl.ts
+++ b/packages/bb-kv-store/src/ttl.ts
@@ -39,6 +39,11 @@ export function nowEpochSeconds(): number {
  * Resolve `ttlSeconds` / `expiresAt` to an absolute Unix epoch-seconds value,
  * or `undefined` when the caller asked for no expiry.
  *
+ * `expiresAt` accepts any point in time, including one already past — that
+ * reads as "expire immediately", so there is no lower bound beyond being a
+ * finite time. Only the epoch-milliseconds guard caps the upper end.
+ * `ttlSeconds` is a duration rather than an instant, so it must be positive.
+ *
  * @throws {KVStoreErrors.ValidationFailed} If both options are set, or either is not a usable time.
  */
 export function resolveTtlEpochSeconds(options?: PutOptions<unknown>): number | undefined {
@@ -61,8 +66,8 @@ export function resolveTtlEpochSeconds(options?: PutOptions<unknown>): number | 
 		if (!Number.isFinite(ms)) invalidTtl('put: `expiresAt` is an Invalid Date');
 		return Math.floor(ms / 1000);
 	}
-	if (typeof expiresAt !== 'number' || !Number.isFinite(expiresAt) || expiresAt <= 0) {
-		invalidTtl(`put: \`expiresAt\` must be a Date or a positive Unix epoch time in seconds (received ${String(expiresAt)})`);
+	if (typeof expiresAt !== 'number' || !Number.isFinite(expiresAt)) {
+		invalidTtl(`put: \`expiresAt\` must be a Date or a Unix epoch time in seconds (received ${String(expiresAt)})`);
 	}
 	if (expiresAt >= MAX_PLAUSIBLE_EPOCH_SECONDS) {
 		invalidTtl('put: `expiresAt` looks like epoch milliseconds; DynamoDB TTL expects seconds — pass a Date or divide by 1000');

--- a/packages/bb-kv-store/src/types.ts
+++ b/packages/bb-kv-store/src/types.ts
@@ -49,6 +49,28 @@ export interface PutOptions<T = unknown> extends ConditionalWriteOptions<T> {
 	expiresAt?: Date | number;
 }
 
+/**
+ * Options accepted by `scan`.
+ */
+export interface ScanOptions {
+	/**
+	 * Yield items whose `ttl` has passed but which DynamoDB's reaper has not
+	 * deleted yet. Defaults to `false`, so a scan sees only live items.
+	 *
+	 * Enable this only for maintenance sweeps that must act on every row still
+	 * physically present — deleting the remains of expired items, for example.
+	 * Reads that answer "is this still valid?" must leave it off.
+	 *
+	 * @example
+	 * ```typescript
+	 * for await (const { key } of sessions.scan({ includeExpired: true })) {
+	 *   await sessions.delete(key);
+	 * }
+	 * ```
+	 */
+	includeExpired?: boolean;
+}
+
 export interface ConditionalDeleteOptions<T = unknown> {
 	/** Only delete if the key exists. Throws ConditionalCheckFailedException otherwise. */
 	ifExists?: boolean;

--- a/packages/bb-kv-store/src/types.ts
+++ b/packages/bb-kv-store/src/types.ts
@@ -15,6 +15,40 @@ export interface ConditionalWriteOptions<T = unknown> {
 	ifValueEquals?: T;
 }
 
+/**
+ * Options accepted by `put`. A superset of {@link ConditionalWriteOptions} —
+ * every existing `put(key, value, { ifNotExists })` call remains valid.
+ *
+ * `ttlSeconds` and `expiresAt` are mutually exclusive; passing both throws
+ * `ValidationFailedException`. Both require the store to be constructed with
+ * `{ ttl: true }` for DynamoDB to actually reap the item (reads filter expired
+ * items regardless).
+ */
+export interface PutOptions<T = unknown> extends ConditionalWriteOptions<T> {
+	/**
+	 * Expire this item `ttlSeconds` from now (relative). Must be a finite
+	 * number greater than zero; fractional values round up to the next second.
+	 *
+	 * @example
+	 * ```typescript
+	 * await cache.put('otp:alice', code, { ttlSeconds: 300 }); // 5 minutes
+	 * ```
+	 */
+	ttlSeconds?: number;
+	/**
+	 * Expire this item at an absolute point in time — either a `Date` or a Unix
+	 * epoch timestamp **in seconds** (the DynamoDB TTL unit). Values that look
+	 * like epoch milliseconds are rejected rather than silently stored as a
+	 * year-5138 expiry.
+	 *
+	 * @example
+	 * ```typescript
+	 * await sessions.put(id, record, { expiresAt: new Date(jwt.exp * 1000) });
+	 * ```
+	 */
+	expiresAt?: Date | number;
+}
+
 export interface ConditionalDeleteOptions<T = unknown> {
 	/** Only delete if the key exists. Throws ConditionalCheckFailedException otherwise. */
 	ifExists?: boolean;
@@ -56,6 +90,25 @@ export interface KVStoreOptions<T = string> {
 	 * Ignored by the mock and browser runtimes (no AWS resource to retain).
 	 */
 	removalPolicy?: 'destroy' | 'retain';
+	/**
+	 * Enable DynamoDB Time-to-Live on the underlying table so items written with
+	 * `put(key, value, { ttlSeconds })` (or `{ expiresAt }`) are deleted
+	 * automatically once they expire. The attribute name is fixed to `ttl`.
+	 *
+	 * Defaults to `false`. Opt-in because turning TTL on for a table that
+	 * already exists is a CloudFormation update to the live table.
+	 *
+	 * DynamoDB's reaper is asynchronous (typically within 48 hours of expiry),
+	 * so `get` and `scan` also filter expired items on read in every runtime —
+	 * an expired item is never returned even while it is still on disk.
+	 *
+	 * @example
+	 * ```typescript
+	 * const sessions = new KVStore<Session>(scope, 'sessions', { ttl: true });
+	 * await sessions.put(id, record, { ttlSeconds: 3600 });
+	 * ```
+	 */
+	ttl?: boolean;
 }
 
 export interface ExternalTableRef {

--- a/packages/blocks/API.md
+++ b/packages/blocks/API.md
@@ -111,6 +111,7 @@ import { GroupAdmin } from '@aws-blocks/bb-auth-cognito';
 import { KnowledgeBase } from '@aws-blocks/bb-knowledge-base';
 import { KnowledgeBaseErrors } from '@aws-blocks/bb-knowledge-base';
 import { KnowledgeBaseOptions } from '@aws-blocks/bb-knowledge-base';
+import { PutOptions as KVPutOptions } from '@aws-blocks/bb-kv-store';
 import { KVStore } from '@aws-blocks/bb-kv-store';
 import { KVStoreErrors } from '@aws-blocks/bb-kv-store';
 import { KVStoreOptions } from '@aws-blocks/bb-kv-store';
@@ -485,6 +486,8 @@ export { KnowledgeBase }
 export { KnowledgeBaseErrors }
 
 export { KnowledgeBaseOptions }
+
+export { KVPutOptions }
 
 export { KVStore }
 

--- a/packages/blocks/src/index.cdk.ts
+++ b/packages/blocks/src/index.cdk.ts
@@ -33,7 +33,7 @@ export { AuthOIDC, AuthOIDCErrors, google, github, customOidc, customOauth2, stu
 export type { AuthOIDCErrorName, OIDCUser, MappedClaims, RelayOrigin } from '@aws-blocks/bb-auth-oidc';
 export type { BlocksAuth, AuthUser, AuthState, AuthAction, AuthField } from '@aws-blocks/auth-common';
 export { KVStore, KVStoreErrors } from '@aws-blocks/bb-kv-store';
-export type { ConditionalWriteOptions, ConditionalDeleteOptions, KVStoreOptions, ExternalTableRef } from '@aws-blocks/bb-kv-store';
+export type { ConditionalWriteOptions, ConditionalDeleteOptions, PutOptions as KVPutOptions, KVStoreOptions, ExternalTableRef } from '@aws-blocks/bb-kv-store';
 export { DistributedTable, DistributedTableErrors } from '@aws-blocks/bb-distributed-table';
 export type { DistributedTableOptions, ReadValidationMode, TableKeyConfig, TableKey, PutOptions as DTPutOptions, DeleteOptions as DTDeleteOptions, QueryOptions as DTQueryOptions, ScanOptions as DTScanOptions } from '@aws-blocks/bb-distributed-table';
 export { Realtime } from '@aws-blocks/bb-realtime';

--- a/packages/blocks/src/index.ts
+++ b/packages/blocks/src/index.ts
@@ -141,7 +141,7 @@ export type { BlocksAuth, AuthUser, AuthState, AuthAction, AuthField, AuthAction
  * Full docs: `README.md` in the package directory above.
  */
 export { KVStore, KVStoreErrors } from '@aws-blocks/bb-kv-store';
-export type { ConditionalWriteOptions, ConditionalDeleteOptions, KVStoreOptions, ExternalTableRef } from '@aws-blocks/bb-kv-store';
+export type { ConditionalWriteOptions, ConditionalDeleteOptions, PutOptions as KVPutOptions, KVStoreOptions, ExternalTableRef } from '@aws-blocks/bb-kv-store';
 
 /**
  * **Structured data storage with secondary indexes backed by DynamoDB.**


### PR DESCRIPTION
## Problem

Two related gaps, one of which is a confirmed bug-bash finding.

**1. `sessions-table-no-TTL` (bug bash, medium)** — `AuthCognito`'s sessions DynamoDB table has no TTL, and every `SessionRecord` stores a **live Cognito refresh token**. Nothing removes a record unless the user explicitly signs out, so:

- the table grows without bound, and
- long-lived credentials are retained at rest indefinitely.

A session abandoned mid-flight (cookie dropped, browser wiped, device lost) leaves its refresh token sitting in the table forever. The code even carried a comment in `getCurrentUser` crediting a "TTL cleanup" path that did not exist.

**2. `KVStore` had no TTL surface at all** — so there was nothing for `AuthCognito` to opt into. Anything written to a `KVStore` lived forever; callers wanting bounded retention had to reach for `DistributedTable` (which has had `ttl` since day one) or hand-roll a cleanup job.

**Issue #, if available:** n/a (bug-bash finding: `sessions-table-no-TTL`)

## Changes

### `@aws-blocks/bb-kv-store` (patch) — opt-in TTL, purely additive

Two independent opt-ins, both default off:

| Layer | API | Effect |
|---|---|---|
| Construct | `new KVStore(scope, id, { ttl: true })` | Sets `timeToLiveAttribute: 'ttl'` on the table |
| Write | `put(key, value, { ttlSeconds })` or `{ expiresAt }` | Writes a numeric epoch-seconds `ttl` attribute |

- **Backward compatible.** The `ttl` attribute is written *only* when asked for, so existing `put(k, v)` / `put(k, v, { ifNotExists })` calls produce byte-identical items. The third `put` parameter widens from `ConditionalWriteOptions` to `PutOptions`, which **extends** it — every existing call site still type-checks.
- **`ttl` defaults to `false`** because enabling TTL on a table that already exists is a CloudFormation update to the live table, so it must never happen implicitly. Mirrors `bb-distributed-table`'s `ttl` option; the attribute name is fixed to `ttl` (a `KVStore` item is always `{ pk, value }` with the payload opaque inside `value`, so there is no customer attribute to point at — this also matches the `timeToLiveAttribute: 'ttl'` convention already used in `hosting_construct.ts`).
- **Reads filter expired items in every runtime.** DynamoDB's reaper is asynchronous (up to 48 h), so an expired item can still be physically present. `get` returns `null` and `scan` skips it as soon as the expiry passes — otherwise an expired session would keep authenticating for up to two days.
- **The mock emulates expiry** (persists the expiry, prunes lazily on `get`/`scan`), keeping `src/parity.test.ts` parity real rather than approximate. Items without an expiry stay bare strings on disk, so existing `.bb-data` stores load unchanged.
- **One shared resolver** (`src/ttl.ts`) is used by both runtimes so they cannot drift on the value written or on when an item counts as expired. It rejects mutually-exclusive options, non-positive durations, and values large enough to be epoch **milliseconds** — DynamoDB would happily accept milliseconds as a year-5138 expiry, silently defeating the whole feature.

### `@aws-blocks/bb-auth-cognito` (patch) — consume it

- Sessions `KVStore` is now created with `{ ttl: true }`.
- Every session write (create **and** refresh) stamps `now + sessionTtlSeconds` — the same value that already bounds the session cookie's `Max-Age` (`DEFAULT_SESSION_TTL_SECONDS` = 400 d). Refresh slides the expiry forward, matching how the cookie is re-issued, so an active session is never reaped out from under a user.
- Removed the stale "TTL cleanup" comment.

> **This is a retention control, not an authorization one.** Validity is still decided by the access token's `exp` plus a `REFRESH_TOKEN_AUTH` round-trip on every request. A record surviving to its TTL grants nothing; this just reaps abandoned rows and bounds how long a refresh token sits at rest.

### `@aws-blocks/blocks` (patch)

Re-exports the new type as `KVPutOptions`, matching the existing `DTPutOptions` / `FBPutOptions` convention.

All three bumps are **patch**: these packages are pre-1.0, where a minor bump signals a breaking change. Nothing here is breaking — every addition is optional and defaults to the previous behaviour.

## Validation

**331 unit tests pass, 0 failures** (Node 22.22.3, per `.nvmrc`), from a forced clean rebuild (`dist/` + `tsconfig.tsbuildinfo` deleted first, so nothing was skipped by incremental compilation):

| Package | Result |
|---|---|
| `bb-kv-store` | **91/91 pass** (was 43 — +48 new) |
| `bb-auth-cognito` | **240/240 pass** (was 226 — +14 new) |
| `bb-auth-basic`, `bb-auth-oidc`, `bb-distributed-table` | 13/13, 112/112, 117/117 — other `KVStore` consumers, unaffected |

New coverage:

- **`bb-kv-store/src/ttl.test.ts`** (new) — option resolution (units, rounding, `Date` vs epoch seconds), every rejection path (both options set, non-positive, `NaN`/`Infinity`, non-numeric, invalid `Date`, epoch-milliseconds guard); mock expiry (`get`/`scan` filtering, disk pruning, expiry surviving a restart, re-put clearing an expiry, TTL + conditional writes, invalid options writing nothing); **AWS-runtime wire format** — drives the real `KVStore` from `index.aws.ts` against a real `DynamoDBDocumentClient`, intercepting only the network boundary via SDK middleware, asserting `ttl` is an integer in the right window, is absent when not requested, composes with `ConditionExpression`, and that `get`/`scan` filter unreaped expired items.
- **`bb-kv-store/src/parity.test.ts`** — a mock↔AWS parity block: neither runtime writes `ttl` unless asked, both hide expired items on `get` and `scan`, both still return future-dated items, and both reject the same invalid options with the same `error.name`.
- **`bb-kv-store/src/index.cdk.test.ts`** — `TimeToLiveSpecification` absent by default and with `{ ttl: false }`; present as `{ AttributeName: 'ttl', Enabled: true }` with `{ ttl: true }`; composes with `removalPolicy`; `fromExisting` still provisions nothing.
- **`bb-auth-cognito/src/sessions.test.ts`** — a session write stamps an integer `ttl` inside the configured lifetime; refresh slides it forward (verified by rewinding the persisted value and re-writing); an expired record is no longer returned; omitting `ttlSeconds` writes no expiry; a non-positive `ttlSeconds` means "no expiry" rather than instant deletion; `deleteSession` / `deleteByUsername` still work on TTL-stamped records.
- **`bb-auth-cognito/src/index.cdk.test.ts`** — a **real-CDK probe**. That file resolves `@aws-blocks/bb-kv-store` to its *mock* entry point, so the nested table never appears in its templates. The new test synths in a child process started with `--conditions=cdk` (the resolution a customer's `cdk synth` uses) and asserts the sessions table really carries `{ AttributeName: 'ttl', Enabled: true }` — i.e. it proves the actual security fix end-to-end, not just the wiring.

Also verified: `changeset-guard` `validate-structure` / `verify-coverage` / `block-major` all pass; `npm run lint:deps` clean (311 files); `api-extractor` regenerated and stable, so `check:api` passes; `biome lint` introduces no new findings.

Pre-existing and unrelated (identical with these changes stashed): `packages/hosting` and `packages/bb-knowledge-base` fail to build locally because `@aws-sdk/client-cloudfront-keyvaluestore` and `@aws-sdk/client-bedrock-agent` are declared in `package.json` but missing from this machine's `node_modules`; that also causes the 1 `packages/blocks` conditional-export test failure. `npm ci` in CI installs both.

## Checklist

- [x] PR description included
- [x] Tests are changed or added
- [x] Relevant documentation is changed or added (and PR referenced)

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
