### PR TITLE
fix(create-blocks-app): prevent 'aws' prefix in generated resource names

### DIFF
--- a/.changeset/fix-aws-prefix-resource-names.md
+++ b/.changeset/fix-aws-prefix-resource-names.md
@@ -1,0 +1,9 @@
+---
+"@aws-blocks/create-blocks-app": patch
+---
+
+Prevent generated stackId from starting with "aws"
+
+AWS reserves the "aws" prefix for resource names in many services (Resource Groups, IAM, etc.), so a project scaffolded with a name like `aws-my-app` would produce a stackId starting with "aws-", causing CloudFormation deployments to fail.
+
+The `generateStackId()` function now strips a leading "aws-" prefix (case-insensitive) when it appears as a distinct word boundary, while preserving names like "awesome-app" where "aws" is part of a longer word.

--- a/packages/create-blocks-app/src/cli.test.ts
+++ b/packages/create-blocks-app/src/cli.test.ts
@@ -305,6 +305,51 @@ describe('create-blocks-app auto-detection', () => {
     }
   });
 
+  it('stackId does not start with "aws" when project name has aws prefix (fresh scaffold)', () => {
+    const tmpDir = join(__dirname, '../.test-aws-prefix-fresh/aws-my-project');
+    try {
+      const result = run([tmpDir, '--template', 'bare', '--skip-install']);
+      assert.strictEqual(result.exitCode, 0);
+      const config = JSON.parse(readFileSync(join(tmpDir, '.blocks', 'config.json'), 'utf-8'));
+      assert.ok(config.stackId, '.blocks/config.json should have a stackId');
+      assert.doesNotMatch(config.stackId, /^aws/i, 'stackId must not start with "aws" — AWS reserves that prefix');
+      assert.ok(config.stackId.startsWith('my-project-'), 'stackId should strip the aws- prefix and keep the rest');
+    } finally {
+      rmSync(join(__dirname, '../.test-aws-prefix-fresh'), { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+    }
+  });
+
+  it('stackId does not start with "aws" when existing project name has aws prefix', () => {
+    const tmpDir = join(__dirname, '../.test-aws-prefix-existing');
+    mkdirSync(tmpDir, { recursive: true });
+    writeFileSync(join(tmpDir, 'package.json'), JSON.stringify({ name: 'aws-my-project', version: '1.0.0' }));
+    try {
+      const result = run(['-y', '--skip-install'], tmpDir);
+      assert.strictEqual(result.exitCode, 0);
+      const config = JSON.parse(readFileSync(join(tmpDir, '.blocks', 'config.json'), 'utf-8'));
+      assert.ok(config.stackId, '.blocks/config.json should have a stackId');
+      assert.doesNotMatch(config.stackId, /^aws/i, 'stackId must not start with "aws" — AWS reserves that prefix');
+      assert.ok(config.stackId.startsWith('my-project-'), 'stackId should strip the aws- prefix and keep the rest');
+    } finally {
+      rmSync(tmpDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+    }
+  });
+
+  it('stackId preserves names starting with "aws" as part of a word (e.g., awesome)', () => {
+    const tmpDir = join(__dirname, '../.test-aws-prefix-awesome');
+    mkdirSync(tmpDir, { recursive: true });
+    writeFileSync(join(tmpDir, 'package.json'), JSON.stringify({ name: 'awesome-app', version: '1.0.0' }));
+    try {
+      const result = run(['-y', '--skip-install'], tmpDir);
+      assert.strictEqual(result.exitCode, 0);
+      const config = JSON.parse(readFileSync(join(tmpDir, '.blocks', 'config.json'), 'utf-8'));
+      assert.ok(config.stackId, '.blocks/config.json should have a stackId');
+      assert.ok(config.stackId.startsWith('awesome-app-'), 'stackId should preserve "awesome" (aws is part of the word)');
+    } finally {
+      rmSync(tmpDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+    }
+  });
+
   it('honors --template when adding to an existing project (nextjs uses next dev)', () => {
     const tmpDir = join(__dirname, '../.test-existing-nextjs-template');
     mkdirSync(tmpDir, { recursive: true });

--- a/packages/create-blocks-app/src/index.ts
+++ b/packages/create-blocks-app/src/index.ts
@@ -13,13 +13,20 @@ import { trackCommand } from './telemetry.js';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
 function generateStackId(name: string): string {
-  const sanitized = name
+  let sanitized = name
     .replace(/[^A-Za-z0-9-]/g, '-')
     .replace(/^[^A-Za-z]+/, 'app-')
     .replace(/-+/g, '-')
     .replace(/-$/, '')
     .slice(0, 16)
     .replace(/-$/, '') || 'blocks-app';
+  // AWS reserves the "aws" prefix for resource names (Resource Groups, IAM, etc.)
+  // — strip it so CloudFormation deployments don't fail.
+  // Only strip when "aws" is a distinct prefix (followed by hyphen or end), not
+  // when it's part of a longer word like "awesome".
+  if (/^aws(-|$)/i.test(sanitized)) {
+    sanitized = sanitized.replace(/^aws-?/i, '') || 'blocks-app';
+  }
   return `${sanitized}-${randomBytes(4).toString('hex').slice(0, 6)}`;
 }
 


### PR DESCRIPTION
## Problem

A user reported that AWS Resource Groups reject names starting with "AWS" as reserved. When scaffolding a project with a name like `aws-my-app`, the generated `stackId` starts with `aws-`, which flows into CloudFormation stack names and resource names, causing deployment failures.

## Fix

`generateStackId()` now strips a leading `aws-` prefix (case-insensitive) when it appears as a distinct prefix (followed by hyphen or end of string). Names like `awesome-app` where "aws" is part of a longer word are preserved.

**Before:** `aws-my-project` → stackId `aws-my-project-a1b2c3` (❌ deployment fails)
**After:** `aws-my-project` → stackId `my-project-a1b2c3` (✅ deploys fine)

## Testing

- Added 3 tests verifying:
  - Fresh scaffold with `aws-` prefixed name produces a stackId without `aws` prefix
  - Existing project integration with `aws-` prefixed package name produces a stackId without `aws` prefix
  - Names where "aws" is part of a word (e.g., `awesome-app`) are not affected
- All 54 existing tests continue to pass

## Changeset

Patch on `@aws-blocks/create-blocks-app`