### PR TITLE
feat(core): throttle the Blocks API Gateway stage by default

### DIFF
--- a/.changeset/apigw-default-throttle.md
+++ b/.changeset/apigw-default-throttle.md
@@ -1,0 +1,5 @@
+---
+"@aws-blocks/core": patch
+---
+
+Apply a default request throttle (200 rps / 400 burst) to the Blocks API Gateway stage instead of inheriting the AWS account default of 10,000 rps. Override it with the new optional `throttling` prop on `BlocksBackendProps` for high-traffic deployments.

--- a/.changeset/apigw-default-throttle.md
+++ b/.changeset/apigw-default-throttle.md
@@ -2,4 +2,4 @@
 "@aws-blocks/core": patch
 ---
 
-Apply a default request throttle (200 rps / 400 burst) to the Blocks API Gateway stage instead of inheriting the AWS account default of 10,000 rps. Override it with the new optional `throttling` prop on `BlocksBackendProps` for high-traffic deployments.
+Apply a default request throttle (200 rps / 400 burst) to the Blocks API Gateway stage instead of inheriting the AWS account default of 10,000 rps. Override it with the new optional `throttling` prop, available on both `BlocksStackProps` and `BlocksBackendProps`, for high-traffic deployments. Providing a `rateLimit` or `burstLimit` of zero or less now fails at synth time rather than deploying a stage that throttles all traffic.

--- a/packages/core/src/cdk/blocks-backend.test.ts
+++ b/packages/core/src/cdk/blocks-backend.test.ts
@@ -122,6 +122,37 @@ describe('API Gateway stage throttling', () => {
       ]),
     });
   });
+
+  test('rejects limits that would throttle all traffic', async () => {
+    const invalidCases = [
+      { name: 'zero rate limit', throttling: { rateLimit: 0, burstLimit: 400 } },
+      { name: 'zero burst limit', throttling: { rateLimit: 200, burstLimit: 0 } },
+      { name: 'negative rate limit', throttling: { rateLimit: -1, burstLimit: 400 } },
+      { name: 'both zero', throttling: { rateLimit: 0, burstLimit: 0 } },
+    ];
+
+    for (const [i, { name, throttling }] of invalidCases.entries()) {
+      const app = new cdk.App();
+      const stack = new cdk.Stack(app, `ThrottleInvalidStack${i}`);
+
+      await assert.rejects(
+        BlocksBackend.create(stack, 'Blocks', {
+          backendHandlerPath: handlerPath,
+          backendCDKPath: sideEffectBackendPath,
+          throttling,
+        }),
+        (err: Error) => {
+          assert.match(
+            err.message,
+            /must both be greater than 0/,
+            `Expected throttling validation error for ${name}, got: ${err.message}`,
+          );
+          return true;
+        },
+        `Expected ${name} to be rejected at synth time`,
+      );
+    }
+  });
 });
 
 describe('factory function support', () => {

--- a/packages/core/src/cdk/blocks-backend.test.ts
+++ b/packages/core/src/cdk/blocks-backend.test.ts
@@ -6,7 +6,7 @@ import assert from 'node:assert';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import * as cdk from 'aws-cdk-lib';
-import { Template } from 'aws-cdk-lib/assertions';
+import { Match, Template } from 'aws-cdk-lib/assertions';
 import { BlocksBackend } from './blocks-backend.js';
 
 // Simulate the CDK condition being active (tests import CDK files directly)
@@ -86,6 +86,41 @@ describe('synth shape (drop into existing stack)', () => {
 
     const template = Template.fromStack(parent);
     template.resourceCountIs('AWS::ApiGateway::RestApi', 2);
+  });
+});
+
+describe('API Gateway stage throttling', () => {
+  test('defaults to 200 rps / 400 burst instead of inheriting the account limit', async () => {
+    const app = new cdk.App();
+    const stack = new cdk.Stack(app, 'ThrottleDefaultStack');
+
+    await BlocksBackend.create(stack, 'Blocks', {
+      backendHandlerPath: handlerPath,
+      backendCDKPath: sideEffectBackendPath,
+    });
+
+    Template.fromStack(stack).hasResourceProperties('AWS::ApiGateway::Stage', {
+      MethodSettings: Match.arrayWith([
+        Match.objectLike({ ThrottlingRateLimit: 200, ThrottlingBurstLimit: 400 }),
+      ]),
+    });
+  });
+
+  test('explicit throttling prop overrides the default', async () => {
+    const app = new cdk.App();
+    const stack = new cdk.Stack(app, 'ThrottleOverrideStack');
+
+    await BlocksBackend.create(stack, 'Blocks', {
+      backendHandlerPath: handlerPath,
+      backendCDKPath: sideEffectBackendPath,
+      throttling: { rateLimit: 2500, burstLimit: 5000 },
+    });
+
+    Template.fromStack(stack).hasResourceProperties('AWS::ApiGateway::Stage', {
+      MethodSettings: Match.arrayWith([
+        Match.objectLike({ ThrottlingRateLimit: 2500, ThrottlingBurstLimit: 5000 }),
+      ]),
+    });
   });
 });
 

--- a/packages/core/src/cdk/blocks-backend.ts
+++ b/packages/core/src/cdk/blocks-backend.ts
@@ -12,6 +12,7 @@ import { addBlocksStackMetadata } from './stack-metadata.js';
 import { finalizeConfigRegistry, registerConfig } from './config-registry.js';
 import { BLOCKS_NAMESPACE, BLOCKS_RPC_PREFIX } from '../constants.js';
 import { registerBuiltinRoutes } from '../builtin-routes.js';
+import type { BlocksThrottlingProps } from '../common/index.js';
 
 /**
  * Validate that the Node.js process was started with `--conditions=cdk`.
@@ -41,19 +42,36 @@ export function assertCdkConditionActive(): void {
   }
 }
 
-export interface BlocksBackendProps {
+export interface BlocksBackendProps extends BlocksThrottlingProps {
   backendHandlerPath: string;
   backendCDKPath: string;
-  /**
-   * Request throttle applied to the API Gateway stage.
-   *
-   * Defaults to 200 requests/second with a 400 request burst — ample for
-   * typical application traffic while capping cost amplification from abuse.
-   * Without it the stage inherits the AWS account default of 10,000 rps /
-   * 5,000 burst, so a single hot endpoint can drive unbounded Lambda,
-   * DynamoDB and Bedrock spend. Raise it for high-traffic deployments.
-   */
-  throttling?: { rateLimit: number; burstLimit: number };
+}
+
+export const DEFAULT_THROTTLING = { rateLimit: 200, burstLimit: 400 } as const;
+
+/**
+ * Resolve the stage throttle, rejecting limits that would throttle all traffic.
+ *
+ * API Gateway treats a zero or negative limit as "deny everything", which only
+ * surfaces as 429s after deploy — so fail at synth time instead.
+ */
+function resolveThrottling(throttling: BlocksThrottlingProps['throttling']) {
+  if (!throttling) return DEFAULT_THROTTLING;
+
+  const { rateLimit, burstLimit } = throttling;
+  const invalid = Object.entries({ rateLimit, burstLimit })
+    .filter(([, value]) => !Number.isFinite(value) || value <= 0)
+    .map(([key, value]) => `${key}=${value}`);
+
+  if (invalid.length > 0) {
+    throw new Error(
+      `Invalid throttling prop (${invalid.join(', ')}): rateLimit and burstLimit must both be greater than 0.\n\n` +
+      'API Gateway throttles every request when a limit is 0 or negative, so the API would return 429 for all traffic.\n' +
+      `Omit the \`throttling\` prop to use the default (${DEFAULT_THROTTLING.rateLimit} rps / ${DEFAULT_THROTTLING.burstLimit} burst), or pass positive values.`,
+    );
+  }
+
+  return throttling;
 }
 
 /** Shared infra setup — creates Lambda + API Gateway on the given scope. */
@@ -92,7 +110,7 @@ export function setupBlocksInfra(scope: Construct, props: BlocksBackendProps, id
     handler.addEnvironment('CORS_ALLOWED_ORIGINS', '^https?://(localhost|127\\.0\\.0\\.1)(:\\d+)?$');
   }
 
-  const throttling = props.throttling ?? { rateLimit: 200, burstLimit: 400 };
+  const throttling = resolveThrottling(props.throttling);
 
   const api = new apigateway.RestApi(scope, 'API', {
     restApiName: 'Blocks API',

--- a/packages/core/src/cdk/blocks-backend.ts
+++ b/packages/core/src/cdk/blocks-backend.ts
@@ -44,6 +44,16 @@ export function assertCdkConditionActive(): void {
 export interface BlocksBackendProps {
   backendHandlerPath: string;
   backendCDKPath: string;
+  /**
+   * Request throttle applied to the API Gateway stage.
+   *
+   * Defaults to 200 requests/second with a 400 request burst — ample for
+   * typical application traffic while capping cost amplification from abuse.
+   * Without it the stage inherits the AWS account default of 10,000 rps /
+   * 5,000 burst, so a single hot endpoint can drive unbounded Lambda,
+   * DynamoDB and Bedrock spend. Raise it for high-traffic deployments.
+   */
+  throttling?: { rateLimit: number; burstLimit: number };
 }
 
 /** Shared infra setup — creates Lambda + API Gateway on the given scope. */
@@ -82,9 +92,15 @@ export function setupBlocksInfra(scope: Construct, props: BlocksBackendProps, id
     handler.addEnvironment('CORS_ALLOWED_ORIGINS', '^https?://(localhost|127\\.0\\.0\\.1)(:\\d+)?$');
   }
 
+  const throttling = props.throttling ?? { rateLimit: 200, burstLimit: 400 };
+
   const api = new apigateway.RestApi(scope, 'API', {
     restApiName: 'Blocks API',
-    deployOptions: { cachingEnabled: false },
+    deployOptions: {
+      cachingEnabled: false,
+      throttlingRateLimit: throttling.rateLimit,
+      throttlingBurstLimit: throttling.burstLimit,
+    },
   });
 
   const integration = new apigateway.LambdaIntegration(handler);

--- a/packages/core/src/cdk/blocks-stack.test.ts
+++ b/packages/core/src/cdk/blocks-stack.test.ts
@@ -6,6 +6,7 @@ import assert from 'node:assert';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import * as cdk from 'aws-cdk-lib';
+import { Match, Template } from 'aws-cdk-lib/assertions';
 import { BlocksBackend } from './blocks-backend.js';
 import { BlocksStack } from './index.js';
 
@@ -74,6 +75,55 @@ describe('legacy side-effect mode (no default export)', () => {
     assert.ok(
       marker,
       'Side-effect-only module should register construct via globalThis.CURRENT_BLOCKS_STACK',
+    );
+  });
+});
+
+describe('API Gateway stage throttling', () => {
+  test('BlocksStack.create() defaults to 200 rps / 400 burst', async () => {
+    const app = new cdk.App();
+
+    const stack = await BlocksStack.create(app, 'StackThrottleDefault', {
+      backendHandlerPath: handlerPath,
+      backendCDKPath: sideEffectBackendPath,
+    });
+
+    Template.fromStack(stack).hasResourceProperties('AWS::ApiGateway::Stage', {
+      MethodSettings: Match.arrayWith([
+        Match.objectLike({ ThrottlingRateLimit: 200, ThrottlingBurstLimit: 400 }),
+      ]),
+    });
+  });
+
+  test('BlocksStack.create() forwards an explicit throttling override', async () => {
+    const app = new cdk.App();
+
+    const stack = await BlocksStack.create(app, 'StackThrottleOverride', {
+      backendHandlerPath: handlerPath,
+      backendCDKPath: sideEffectBackendPath,
+      throttling: { rateLimit: 2500, burstLimit: 5000 },
+    });
+
+    Template.fromStack(stack).hasResourceProperties('AWS::ApiGateway::Stage', {
+      MethodSettings: Match.arrayWith([
+        Match.objectLike({ ThrottlingRateLimit: 2500, ThrottlingBurstLimit: 5000 }),
+      ]),
+    });
+  });
+
+  test('BlocksStack.create() rejects a throttle that would block all traffic', async () => {
+    const app = new cdk.App();
+
+    await assert.rejects(
+      BlocksStack.create(app, 'StackThrottleInvalid', {
+        backendHandlerPath: handlerPath,
+        backendCDKPath: sideEffectBackendPath,
+        throttling: { rateLimit: 0, burstLimit: 0 },
+      }),
+      (err: Error) => {
+        assert.match(err.message, /must both be greater than 0/, `Unexpected error: ${err.message}`);
+        return true;
+      },
     );
   });
 });

--- a/packages/core/src/common/index.ts
+++ b/packages/core/src/common/index.ts
@@ -322,7 +322,27 @@ export function computeScopeFullId(scope: { id: string; parent?: any }) {
   return scope.id;
 }
 
-export interface BlocksStackProps extends StackProps {
+/**
+ * Shared throttle configuration, mixed into both `BlocksStackProps` and
+ * `BlocksBackendProps` so the override is reachable from either entry point.
+ */
+export interface BlocksThrottlingProps {
+  /**
+   * Request throttle applied to the API Gateway stage.
+   *
+   * Defaults to 200 requests/second with a 400 request burst — ample for
+   * typical application traffic while capping cost amplification from abuse.
+   * Without it the stage inherits the AWS account default of 10,000 rps /
+   * 5,000 burst, so a single hot endpoint can drive unbounded Lambda,
+   * DynamoDB and Bedrock spend. Raise it for high-traffic deployments.
+   *
+   * Both values must be greater than zero; synth fails otherwise, since a
+   * zero or negative limit throttles every request to the API.
+   */
+  throttling?: { rateLimit: number; burstLimit: number };
+}
+
+export interface BlocksStackProps extends StackProps, BlocksThrottlingProps {
   backendHandlerPath: string;
   backendCDKPath: string;
 }

--- a/packages/core/src/index.cdk.ts
+++ b/packages/core/src/index.cdk.ts
@@ -5,7 +5,7 @@ export { ApiNamespace, type BlocksContext, type ApiHandler } from './api.js';
 export { BLOCKS_RPC_PREFIX, BLOCKS_AUTH_PREFIX } from './constants.js';
 export { ApiError, isBlocksError, hasAuthError, DEFAULT_API_ERROR_NAME } from './errors.js';
 export { EventSourceMapping } from './lambda-handler.js';
-export { BlocksStackProps } from './common/index.js';
+export { BlocksStackProps, type BlocksThrottlingProps } from './common/index.js';
 export { registerSdkIdentifiers, getSdkIdentifiers, getAllSdkIdentifiers, _resetSdkRegistry } from './common/sdk-registry.js';
 export { getConfig, getConfigSync, preloadConfig, loadConfigToProcessEnv, _resetConfigCache } from './common/config.js';
 export { BlocksStack, Scope, SandboxDisableDeletionProtection, BlocksBackend, registerConfig, finalizeConfigRegistry, synthGuard, DEFAULT_NODE_RUNTIME, type BlocksBackendProps } from './cdk/index.js';


### PR DESCRIPTION
## Finding (bug bash)

The repo sets **no API Gateway throttle anywhere**, so every Blocks deployment silently inherits the AWS **account-level default of 10,000 rps / 5,000 burst**.

The core Blocks REST API (`packages/core/src/cdk/blocks-backend.ts`) is internet-facing — authentication runs *in-Lambda*, not at the gateway — so an abused or hot endpoint can amplify Lambda, DynamoDB and Bedrock cost with no ceiling.

## Change

- `RestApi` `deployOptions` now sets `throttlingRateLimit` / `throttlingBurstLimit`, defaulting to **200 rps / 400 burst**. That is ample headroom for typical application traffic while capping cost amplification from abuse.
- New optional `throttling?: { rateLimit: number; burstLimit: number }` prop on `BlocksBackendProps` lets high-traffic deployments raise (or lower) the limit.
- `cachingEnabled: false` is unchanged.

Adding an optional prop is non-breaking → **patch** changeset for `@aws-blocks/core`.

## Scope

Intentionally limited to the shipped core Blocks REST API. `packages/hosting` (`cdn_construct.ts`) and `bb-realtime` are deliberately **not** touched here.

## Testing

Two CDK-assertion tests added to `packages/core/src/cdk/blocks-backend.test.ts`:

1. default synth carries `ThrottlingRateLimit: 200` / `ThrottlingBurstLimit: 400` on `AWS::ApiGateway::Stage`
2. an explicit `throttling` prop overrides it (2500 / 5000)

Full `@aws-blocks/core` suite green:

```
# tests 651
# suites 171
# pass 651
# fail 0
```