### PR TITLE
fix(ci): skip blocks-integrity check on release PR

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -80,6 +80,12 @@ jobs:
         run: |
           set -euo pipefail
 
+          # Release PRs consume changesets — the files are already gone. Skip.
+          if [[ "$GITHUB_HEAD_REF" == "changeset-release/main" ]]; then
+            echo "✅ Skipping — release PR (changesets already consumed into version bumps)"
+            exit 0
+          fi
+
           # sync-block-docs.mjs regenerates packages/blocks/docs/ from sibling READMEs
           # (docs/ is gitignored, built at publish time). We compare the packed
           # @aws-blocks/blocks tarball at THIS PR's head against the PR base branch —


### PR DESCRIPTION
The Blocks Package Integrity check greps for changeset files that bump @aws-blocks/blocks. On the release PR (changeset-release/main), those files have already been consumed by the changesets action and converted into version bumps + CHANGELOGs. The grep finds nothing and the check incorrectly fails. Fix: skip the check entirely on the release branch.