### PR TITLE
[core + bb-lambda-compute] Add Compute abstraction and a Lambda compute package

### DIFF
--- a/.changeset/core-compute-block-classes.md
+++ b/.changeset/core-compute-block-classes.md
@@ -1,0 +1,12 @@
+---
+"@aws-blocks/core": patch
+---
+
+feat(core): add the internal `Compute` abstraction
+
+Introduce the abstract `Compute` base behind a new internal entry point
+(`@aws-blocks/core/cdk/internal`). A compute resolves its owning
+`BlocksStack`/`BlocksBackend` on construction to derive its runtime identity
+(backend entry + stack name). It is framework/test-only — not part of the public
+API, and customers cannot instantiate a compute yet. Concrete computes live in
+their own packages (e.g. `@aws-blocks/bb-lambda-compute`).

--- a/.changeset/lambda-compute-package.md
+++ b/.changeset/lambda-compute-package.md
@@ -1,0 +1,15 @@
+---
+"@aws-blocks/bb-lambda-compute": minor
+"@aws-blocks/core": patch
+"@aws-blocks/blocks": patch
+---
+
+feat: extract `LambdaCompute` into `@aws-blocks/bb-lambda-compute`
+
+The abstract `Compute` base stays in core as a framework primitive; the concrete
+`LambdaCompute` (a `NodejsFunction` fronted by its own API Gateway, assuming the
+shared execution role) moves into a new package, `@aws-blocks/bb-lambda-compute`.
+
+The package is CDK-only and its sole export is internal — customers cannot
+instantiate a compute yet. Nothing in the default path constructs it, so this is
+additive and non-breaking.

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "packages/bb-email-client",
         "packages/bb-tracer",
         "packages/bb-metrics",
+        "packages/bb-lambda-compute",
         "packages/blocks",
         "packages/create-blocks-app",
         "test-apps/comprehensive",
@@ -20710,6 +20711,10 @@
     },
     "node_modules/@aws-blocks/bb-kv-store": {
       "resolved": "packages/bb-kv-store",
+      "link": true
+    },
+    "node_modules/@aws-blocks/bb-lambda-compute": {
+      "resolved": "packages/bb-lambda-compute",
       "link": true
     },
     "node_modules/@aws-blocks/bb-logger": {
@@ -55884,6 +55889,22 @@
         "constructs": "^10.6.0"
       }
     },
+    "packages/bb-lambda-compute": {
+      "name": "@aws-blocks/bb-lambda-compute",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-blocks/core": "*"
+      },
+      "devDependencies": {
+        "@types/node": "^20.0.0",
+        "typescript": "^5.3.0"
+      },
+      "peerDependencies": {
+        "aws-cdk-lib": "^2.257.0",
+        "constructs": "^10.6.0"
+      }
+    },
     "packages/bb-logger": {
       "name": "@aws-blocks/bb-logger",
       "version": "0.1.3",
@@ -55994,6 +56015,7 @@
         "@aws-blocks/bb-file-bucket": "^0.1.3",
         "@aws-blocks/bb-knowledge-base": "^0.2.0",
         "@aws-blocks/bb-kv-store": "^0.1.5",
+        "@aws-blocks/bb-lambda-compute": "*",
         "@aws-blocks/bb-logger": "^0.1.3",
         "@aws-blocks/bb-metrics": "^0.1.3",
         "@aws-blocks/bb-realtime": "^0.1.3",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "packages/bb-email-client",
     "packages/bb-tracer",
     "packages/bb-metrics",
+    "packages/bb-lambda-compute",
     "packages/blocks",
     "packages/create-blocks-app",
     "test-apps/comprehensive",

--- a/packages/bb-lambda-compute/DESIGN.md
+++ b/packages/bb-lambda-compute/DESIGN.md
@@ -1,0 +1,119 @@
+# LambdaCompute — Design
+
+Design document for `@aws-blocks/bb-lambda-compute`. For usage, see [README.md](./README.md).
+
+**Package:** `@aws-blocks/bb-lambda-compute`
+**Type:** Compute (framework infrastructure, not a customer-facing data block)
+**AWS Services:** Lambda (`NodejsFunction`) + API Gateway (REST)
+
+## Why a compute is a Building Block
+
+A Blocks app runs its handler code on a *compute*. Modeling compute as a
+first-class type — rather than inlining a Lambda and API Gateway in core — lets
+one app run on multiple compute targets (Lambda, containers, customer-owned) and
+target namespaces and handlers at specific ones.
+
+`Compute` (the abstract base) lives in `@aws-blocks/core` because it is a
+framework primitive: `Scope`, the base every block extends, resolves the compute
+a handler runs on, so the type it resolves to must be visible to core. The
+concrete `LambdaCompute` lives in its own package so core never depends on a
+concrete compute implementation — the same package-boundary split the framework
+uses for client middleware, where core defines the seam and a block package
+supplies the implementation.
+
+## Infrastructure (CDK)
+
+`LambdaCompute extends Compute` and, in its constructor, provisions and owns:
+
+- **A `NodejsFunction`** — 2048 MB memory, 15-minute timeout, `NODE_ENV=production`,
+  bundled with `--conditions=aws-runtime` so blocks resolve their runtime (not
+  CDK/mock) entry points. It assumes the **shared Blocks execution role**
+  (`this.executionRole`) rather than an auto-generated per-function role, so
+  Building Block grants — which target that shared role — reach it.
+- **An API Gateway REST API** fronting the function:
+  - the `/aws-blocks` resource gets a proxy so `RawRoute` sub-paths reach the
+    function;
+  - `/aws-blocks/api` gets explicit `POST` + `OPTIONS` methods (the JSON-RPC
+    endpoint);
+  - the root gets a catch-all proxy so all other paths reach the function.
+
+Public surface (CDK layer):
+
+| Member | Type | Description |
+|--------|------|-------------|
+| `fn` | `NodejsFunction` | The function backing this compute. |
+| `apiGateway` | `RestApi` | The REST API fronting `fn`. |
+| `setEnv(key, value)` | `void` | Inject a runtime env var onto the function — the `Compute` contract the framework calls instead of `handler.addEnvironment` directly. |
+
+`fn` and `apiGateway` exist only on the CDK layer (they are `aws-cdk-lib`
+constructs); `setEnv` is part of the `Compute` contract present in every layer
+(a no-op in the non-CDK layers — see below).
+
+## Owner-derived identity
+
+`LambdaCompute` does not take the backend entry path or stack name as a
+constructor argument. Both are resolved from the owning `BlocksStack` /
+`BlocksBackend` through the `Compute` (→ `Scope`) accessors:
+
+- `backendHandlerPath` → the function's `entry`;
+- `backendStackName` → the function's `BLOCKS_STACK_NAME` env var.
+
+`BLOCKS_STACK_NAME` is the token-free identity the runtime rebuilds `fullId`
+from, so the physical resource names a block computes at synth match the names
+the runtime looks up. Deriving both values from the single owner — never from
+the caller — guarantees every compute in an app runs the same backend and
+resolves the same resource-name namespace. If they could be passed per compute,
+two computes in one app could disagree on either, so owner-derivation removes
+that failure mode by construction.
+
+## Conditional-export layers
+
+A Blocks app's backend module is imported in **two phases**: at CDK synth, and
+again at request time inside the deployed runtime (the framework ships one
+bundle and selects behavior by config, not by shipping different code). A
+`new LambdaCompute(...)` line in that module therefore executes in both phases,
+so the package resolves a different implementation per phase through conditional
+exports:
+
+| Condition | Entry | Role |
+|-----------|-------|------|
+| `cdk` | `index.cdk.ts` | Provisions the `NodejsFunction` + API Gateway (above). The only layer that touches `aws-cdk-lib`. |
+| `aws-runtime` | `index.aws.ts` | An **inert handle**. At runtime the infrastructure already exists and the handler already runs on it, so the compute provisions nothing; it constructs (so the import succeeds and `{ compute }` references resolve) and `setEnv` is a no-op — config is injected at synth. |
+| `default` / `types` | `index.mock.ts` | Local dev runs the backend in-process with no Lambda, so it reuses the same inert handle. Also backs the public `types`, so the customer-facing type is the CDK-free `Compute` handle. |
+| `browser` | `index.browser.ts` | A stub. The backend module is type-imported by frontends; this keeps `aws-cdk-lib` out of the browser bundle. |
+
+The runtime, mock, and browser layers extend the runtime `Scope` (not the CDK
+one), so **only the `cdk` layer ever pulls in `aws-cdk-lib`** — the deployed
+function and the browser bundle stay free of CDK. This is the same layering data
+blocks use; a compute differs only in that its non-CDK layers carry no
+request-time behavior (nothing to persist or serve), so they are inert rather
+than SDK-backed.
+
+It is excluded from the customer-facing Building Block catalog
+(`scripts/sync-catalog.mjs` + `scripts/gen-block-docs.mjs`) and the vendorize map
+(`packages/blocks`): an app author does not select a compute the way they select
+`KVStore` or `Database`. It is framework machinery.
+
+## Fit within the multi-compute model
+
+`LambdaCompute` is the Lambda implementation of the compute abstraction and the
+framework's default compute. It slots into the broader model as follows:
+
+- **Default compute.** Core builds a stack/backend's default compute through a
+  registered factory — a hook mirroring client-middleware registration. This
+  package supplies `LambdaCompute` as that factory via a side-effect `register`
+  module that `@aws-blocks/blocks` imports, so every app gets a Lambda-backed
+  default with no explicit wiring while core never imports the concrete class.
+- **Compute resolution.** `Scope.compute` resolves the compute a handler runs
+  on: an explicit assignment on the block or an ancestor scope, else the app's
+  default compute.
+- **Resource ownership.** The default compute owns the Lambda function and API
+  Gateway that back a stack's `handler` / `gateway` / `apiUrl`; those stack
+  accessors delegate to it.
+- **Other compute types.** Sibling packages provide container and
+  customer-owned `Compute` implementations; event blocks that need
+  compute-specific delivery narrow on the concrete type.
+
+The broader multi-compute model also covers request routing across computes,
+per-compute event delivery, the IAM and trust model, and VPC networking — none
+of which live in this package.

--- a/packages/bb-lambda-compute/LICENSE
+++ b/packages/bb-lambda-compute/LICENSE
@@ -1,0 +1,174 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.

--- a/packages/bb-lambda-compute/README.md
+++ b/packages/bb-lambda-compute/README.md
@@ -1,0 +1,35 @@
+# @aws-blocks/bb-lambda-compute
+
+The Lambda-backed **compute** for AWS Blocks: a `NodejsFunction` fronted by its
+own API Gateway REST API, backing the handler code an app's Building Blocks run
+on.
+
+> **Internal / not yet customer-facing.** `LambdaCompute` is not re-exported
+> from the public `@aws-blocks/blocks` surface, and nothing in the default app
+> path constructs it. This package ships the compute type and its infrastructure
+> so later work can build on it. Do not depend on it directly.
+
+> Design and rationale: [DESIGN.md](./DESIGN.md)
+
+## What it provides
+
+`LambdaCompute` — a `Compute` (the abstract base from `@aws-blocks/core`) that
+provisions and owns a `NodejsFunction` (2048 MB, 15-minute timeout) fronted by
+its own API Gateway REST API. The function assumes the shared Blocks execution
+role, so Building Block grants reach it; its handler entry and `BLOCKS_STACK_NAME`
+are derived from the owning `BlocksStack` / `BlocksBackend`, never
+caller-supplied.
+
+| Member | Type | Description |
+|--------|------|-------------|
+| `fn` | `NodejsFunction` | The Lambda function backing this compute (CDK layer). |
+| `apiGateway` | `RestApi` | The API Gateway REST API fronting `fn` (CDK layer). |
+| `setEnv(key, value)` | `void` | Inject a runtime environment variable into the function. |
+
+## Local Development
+
+Only the `cdk` layer provisions infrastructure (the `NodejsFunction` + API
+Gateway); the runtime, local-dev, and browser layers are inert handles that
+construct without pulling in CDK, because a compute has no request-time
+behavior. See the CDK tests (`src/index.cdk.test.ts`) for how `LambdaCompute`
+synthesizes within a stack.

--- a/packages/bb-lambda-compute/package.json
+++ b/packages/bb-lambda-compute/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@aws-blocks/bb-lambda-compute",
+  "version": "0.1.0",
+  "author": "Amazon Web Services",
+  "license": "Apache-2.0",
+  "type": "module",
+  "files": [
+    "dist",
+    "README.md",
+    "DESIGN.md",
+    "src",
+    "LICENSE"
+  ],
+  "exports": {
+    ".": {
+      "browser": "./dist/index.browser.js",
+      "cdk": {
+        "types": "./dist/index.cdk.d.ts",
+        "default": "./dist/index.cdk.js"
+      },
+      "aws-runtime": "./dist/index.aws.js",
+      "types": "./dist/index.mock.d.ts",
+      "default": "./dist/index.mock.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc --build",
+    "test": "node --test dist/index.cdk.test.js"
+  },
+  "dependencies": {
+    "@aws-blocks/core": "*"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "typescript": "^5.3.0"
+  },
+  "peerDependencies": {
+    "aws-cdk-lib": "^2.257.0",
+    "constructs": "^10.6.0"
+  }
+}

--- a/packages/bb-lambda-compute/src/index.aws.ts
+++ b/packages/bb-lambda-compute/src/index.aws.ts
@@ -1,0 +1,28 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { ScopeParent } from '@aws-blocks/core';
+/**
+ * AWS-runtime entry point for `LambdaCompute`.
+ *
+ * The same backend module that declares `new LambdaCompute(...)` is imported in
+ * two phases: at CDK synth (where the `cdk` entry provisions the function + API
+ * Gateway) and again at request time inside the deployed runtime. At runtime
+ * there is nothing for a compute to do — it *is* the environment the handler
+ * already runs in, and its infrastructure was created at synth. So the runtime
+ * `LambdaCompute` is an inert handle: it constructs (so the import succeeds and
+ * any `{ compute }` reference resolves) but provisions nothing and pulls in no
+ * CDK. `setEnv` is a no-op — configuration is injected at synth, not at runtime.
+ */
+import { Scope } from '@aws-blocks/core';
+import type { LambdaComputeProps } from './types.js';
+
+export type { LambdaComputeProps } from './types.js';
+
+export class LambdaCompute extends Scope {
+	constructor(scope: ScopeParent, id: string, _options?: LambdaComputeProps) {
+		super(id, { parent: scope });
+	}
+
+	setEnv(_key: string, _value: string): void {}
+}

--- a/packages/bb-lambda-compute/src/index.browser.ts
+++ b/packages/bb-lambda-compute/src/index.browser.ts
@@ -1,0 +1,10 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Browser stub — a compute is server-side infrastructure and never runs in the
+// browser. The backend module that constructs it is type-imported by frontends,
+// so this stub keeps CDK out of the browser bundle while the reference resolves.
+export class LambdaCompute {
+	setEnv(_key: string, _value: string): void {}
+}
+export type { LambdaComputeProps } from './types.js';

--- a/packages/bb-lambda-compute/src/index.cdk.test.ts
+++ b/packages/bb-lambda-compute/src/index.cdk.test.ts
@@ -1,0 +1,161 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Unit tests for LambdaCompute.
+ *
+ * LambdaCompute is not yet instantiated by the default app and is not reachable
+ * by customers. These tests exercise it directly to pin its shape: function +
+ * gateway, shared role, distinct construct paths, and owner-derived identity.
+ */
+
+import assert from 'node:assert';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { after, before, describe, test } from 'node:test';
+import { fileURLToPath } from 'node:url';
+import { Scope } from '@aws-blocks/core/cdk';
+import { Compute } from '@aws-blocks/core/cdk/internal';
+import * as cdk from 'aws-cdk-lib';
+import { Template } from 'aws-cdk-lib/assertions';
+import type { Construct } from 'constructs';
+import { LambdaCompute } from './index.cdk.js';
+
+// A trivial handler entry for the NodejsFunction to bundle. Written to a temp
+// dir under the package (rather than a checked-in fixture) so the package
+// carries no test scaffolding on disk. It must live under the project root —
+// CDK's NodejsFunction rejects an entry outside it.
+const __dirname = dirname(fileURLToPath(import.meta.url));
+let handlerPath: string;
+let tmpDir: string;
+
+before(() => {
+	process.env.NODE_OPTIONS = `${process.env.NODE_OPTIONS ?? ''} --conditions=cdk`;
+	tmpDir = mkdtempSync(join(__dirname, 'tmp-handler-'));
+	handlerPath = join(tmpDir, 'handler.mjs');
+	writeFileSync(handlerPath, "export const handler = async () => ({ statusCode: 200, body: '{}' });\n");
+});
+
+after(() => {
+	rmSync(tmpDir, { recursive: true, force: true });
+});
+
+// Minimal BlocksStack-shaped owner. LambdaCompute (via Compute → Scope) reads
+// `backendHandlerPath`, `executionRole`, and the owner's `id` (for
+// BLOCKS_STACK_NAME) from the nearest BlocksStack/BlocksBackend — or, absent
+// one in the tree, from the ambient `globalThis.CURRENT_BLOCKS_STACK`. We
+// reproduce that surface here so the compute synthesizes into a real stack
+// without spinning up a full BlocksBackend.
+class StubBlocksStack extends cdk.Stack {
+	public readonly id: string;
+	public readonly executionRole: cdk.aws_iam.IRole;
+	public readonly backendHandlerPath: string;
+	constructor(scope: Construct, id: string) {
+		super(scope, id);
+		this.id = id;
+		this.backendHandlerPath = handlerPath;
+		(globalThis as any).CURRENT_BLOCKS_STACK = this;
+		this.executionRole = new cdk.aws_iam.Role(this, 'BlocksRole', {
+			assumedBy: new cdk.aws_iam.ServicePrincipal('lambda.amazonaws.com'),
+		});
+	}
+}
+
+function setup(stackId: string): { stack: StubBlocksStack; parent: Scope } {
+	const app = new cdk.App();
+	const stack = new StubBlocksStack(app, stackId);
+	const parent = new Scope('app');
+	return { stack, parent };
+}
+
+describe('LambdaCompute', () => {
+	test('provisions a Lambda function and its own API Gateway', () => {
+		const { stack, parent } = setup('LambdaComputeShape');
+
+		const compute = new LambdaCompute(parent, 'extra');
+
+		assert.ok(compute.fn, 'LambdaCompute should expose .fn');
+		assert.ok(compute.apiGateway, 'LambdaCompute should expose .apiGateway');
+		assert.ok(compute instanceof Compute, 'LambdaCompute should be a Compute');
+
+		const template = Template.fromStack(stack);
+		template.resourceCountIs('AWS::ApiGateway::RestApi', 1);
+
+		const roles = template.findResources('AWS::IAM::Role');
+		const blocksRoleId = Object.keys(roles).find((k) => k.includes('BlocksRole'));
+		const fns = template.findResources('AWS::Lambda::Function');
+		const blocksFns = Object.values(fns).filter(
+			(fn: any) => fn.Properties?.Role?.['Fn::GetAtt']?.[0] === blocksRoleId,
+		);
+		assert.strictEqual(blocksFns.length, 1, 'the compute function runs on the shared role');
+	});
+
+	test('the function assumes the shared execution role', () => {
+		const { stack, parent } = setup('LambdaComputeRole');
+
+		const compute = new LambdaCompute(parent, 'extra');
+
+		// The compute resolves the same shared role the owner exposes.
+		assert.strictEqual(compute.executionRole, stack.executionRole);
+
+		const template = Template.fromStack(stack);
+		const roles = template.findResources('AWS::IAM::Role');
+		const blocksRoleId = Object.keys(roles).find((k) => k.includes('BlocksRole'));
+		assert.ok(blocksRoleId, 'expected the shared BlocksRole');
+		const fns = template.findResources('AWS::Lambda::Function');
+		const onSharedRole = Object.values(fns).filter(
+			(fn: any) => fn.Properties?.Role?.['Fn::GetAtt']?.[0] === blocksRoleId,
+		);
+		assert.strictEqual(onSharedRole.length, 1, 'the compute function should assume the shared BlocksRole');
+	});
+
+	test('multiple computes under one owner get distinct construct paths', () => {
+		const { stack, parent } = setup('LambdaComputeMultiple');
+
+		const a = new LambdaCompute(parent, 'a');
+		const b = new LambdaCompute(parent, 'b');
+
+		assert.notStrictEqual(a.node.path, b.node.path, 'distinct ids → distinct construct paths');
+		// Both synthesize without a logical-id collision.
+		assert.doesNotThrow(() => Template.fromStack(stack));
+	});
+
+	test('setEnv adds an environment variable to the function', () => {
+		const { stack, parent } = setup('LambdaComputeSetEnv');
+
+		const compute = new LambdaCompute(parent, 'extra');
+		compute.setEnv('BLOCKS_THING', 'value-123');
+
+		const template = Template.fromStack(stack);
+		template.hasResourceProperties('AWS::Lambda::Function', {
+			Environment: { Variables: { BLOCKS_THING: 'value-123' } },
+		});
+	});
+
+	test('derives BLOCKS_STACK_NAME from the owner', () => {
+		const { stack, parent } = setup('LambdaComputeStackName');
+
+		new LambdaCompute(parent, 'extra');
+
+		// The compute's function must agree with the owner's token-free identity
+		// — otherwise the runtime derives physical resource names that were never
+		// created.
+		const template = Template.fromStack(stack);
+		const fns = template.findResources('AWS::Lambda::Function');
+		const computeFnId = Object.keys(fns).find((k) => k.includes('extra'));
+		assert.ok(computeFnId, 'expected the compute function in the template');
+		assert.strictEqual(fns[computeFnId].Properties.Environment.Variables.BLOCKS_STACK_NAME, stack.id);
+	});
+
+	test('throws when created outside a BlocksStack/BlocksBackend', () => {
+		// With no real BlocksStack/BlocksBackend in the tree or as the ambient
+		// owner (a plain cdk.Stack exposes none of backendHandlerPath / a Blocks
+		// identity), the compute cannot derive its entry or BLOCKS_STACK_NAME and
+		// fails at construction.
+		const app = new cdk.App();
+		const bareStack = new cdk.Stack(app, 'BareStack');
+		(globalThis as any).CURRENT_BLOCKS_STACK = bareStack;
+
+		assert.throws(() => new LambdaCompute(new Scope('app'), 'orphan'));
+	});
+});

--- a/packages/bb-lambda-compute/src/index.cdk.ts
+++ b/packages/bb-lambda-compute/src/index.cdk.ts
@@ -1,0 +1,79 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { ScopeParent } from '@aws-blocks/core';
+import { DEFAULT_NODE_RUNTIME } from '@aws-blocks/core/cdk';
+import { BLOCKS_NAMESPACE, Compute } from '@aws-blocks/core/cdk/internal';
+import * as cdk from 'aws-cdk-lib';
+import * as apigateway from 'aws-cdk-lib/aws-apigateway';
+import * as lambda from 'aws-cdk-lib/aws-lambda-nodejs';
+import type { LambdaComputeProps } from './types.js';
+
+export type { LambdaComputeProps } from './types.js';
+
+/**
+ * A Lambda-backed {@link Compute}: a `NodejsFunction` fronted by its own API
+ * Gateway REST API. The compute *owns* these resources.
+ *
+ * The function assumes the shared execution role (`this.executionRole`), so
+ * Building Block grants reach it via that role. The handler entry and
+ * `BLOCKS_STACK_NAME` are **derived from the owning BlocksStack/BlocksBackend** —
+ * never caller-supplied — so every compute in an app runs the same backend and
+ * agrees on the runtime resource-name namespace.
+ *
+ * @internal Not exported from the package's public entry point. Customers
+ * cannot instantiate a compute until the customer-facing surface exists.
+ */
+export class LambdaCompute extends Compute {
+	/** The Lambda function backing this compute. */
+	readonly fn: lambda.NodejsFunction;
+	/** The API Gateway REST API fronting {@link fn}. */
+	readonly apiGateway: apigateway.RestApi;
+
+	constructor(scope: ScopeParent, id: string, _options?: LambdaComputeProps) {
+		super(id, { parent: scope });
+
+		// Entry + BLOCKS_STACK_NAME are derived from the owning stack/backend
+		// (resolved by Compute) — never caller-supplied — so every compute in an
+		// app runs the same backend and agrees on the resource-name namespace the
+		// runtime rebuilds from BLOCKS_STACK_NAME.
+		this.fn = new lambda.NodejsFunction(this, 'Handler', {
+			entry: this.backendHandlerPath,
+			runtime: DEFAULT_NODE_RUNTIME,
+			handler: 'handler',
+			role: this.executionRole,
+			memorySize: 2048,
+			timeout: cdk.Duration.seconds(60 * 15),
+			environment: {
+				NODE_ENV: 'production',
+				BLOCKS_STACK_NAME: this.backendStackName,
+			},
+			bundling: {
+				minify: true,
+				esbuildArgs: { '--conditions': 'aws-runtime' },
+			},
+		});
+
+		this.apiGateway = new apigateway.RestApi(this, 'API', {
+			restApiName: 'Blocks API',
+			deployOptions: { cachingEnabled: false },
+		});
+
+		const integration = new apigateway.LambdaIntegration(this.fn);
+
+		// Nested resource tree for /aws-blocks/api. The intermediate resource
+		// gets a proxy so sub-paths (RawRoutes) still reach the function.
+		const awsBlocksResource = this.apiGateway.root.addResource(BLOCKS_NAMESPACE.slice(1));
+		awsBlocksResource.addProxy({ defaultIntegration: integration, anyMethod: true });
+
+		const apiResource = awsBlocksResource.addResource('api');
+		apiResource.addMethod('POST', integration);
+		apiResource.addMethod('OPTIONS', integration);
+
+		this.apiGateway.root.addProxy({ defaultIntegration: integration, anyMethod: true });
+	}
+
+	setEnv(key: string, value: string): void {
+		this.fn.addEnvironment(key, value);
+	}
+}

--- a/packages/bb-lambda-compute/src/index.mock.ts
+++ b/packages/bb-lambda-compute/src/index.mock.ts
@@ -1,0 +1,14 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Local-dev (mock) and types entry point for `LambdaCompute`.
+ *
+ * Local dev runs the backend in-process with no Lambda, so — as at runtime —
+ * there is nothing for a compute to provision or execute. The mock reuses the
+ * inert runtime handle: it constructs and its `setEnv` is a no-op. This entry
+ * also backs the package's public `types`, so the customer-facing type is the
+ * CDK-free `Compute` handle.
+ */
+export { LambdaCompute } from './index.aws.js';
+export type { LambdaComputeProps } from './types.js';

--- a/packages/bb-lambda-compute/src/types.ts
+++ b/packages/bb-lambda-compute/src/types.ts
@@ -1,0 +1,10 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Options for constructing a `LambdaCompute`. Empty for now — a placeholder for
+ * future options (e.g. memory, timeout), matching how other Building Blocks
+ * carry an options bag.
+ */
+// biome-ignore lint/complexity/noBannedTypes: intentional placeholder options bag
+export type LambdaComputeProps = {};

--- a/packages/bb-lambda-compute/tsconfig.json
+++ b/packages/bb-lambda-compute/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -84,7 +84,8 @@
     "@aws-blocks/bb-logger": "^0.1.3",
     "@aws-blocks/bb-email-client": "^0.1.3",
     "@aws-blocks/bb-metrics": "^0.1.3",
-    "@aws-blocks/bb-dashboard": "^0.1.2"
+    "@aws-blocks/bb-dashboard": "^0.1.2",
+    "@aws-blocks/bb-lambda-compute": "*"
   },
   "aws-blocks": {
     "vendorize": {

--- a/packages/blocks/src/vendorize-map.test.ts
+++ b/packages/blocks/src/vendorize-map.test.ts
@@ -46,8 +46,10 @@ describe('aws-blocks.vendorize map', () => {
     const missing: string[] = [];
 
     for (const dep of deps) {
-      // Skip infrastructure packages (not user-facing BBs)
-      if (dep.endsWith('/core') || dep.endsWith('/auth-common')) continue;
+      // Skip infrastructure packages (not user-facing BBs). bb-lambda-compute
+      // is the internal default compute — CDK-only and not customer-instantiable
+      // — so it has no public symbol to vendorize.
+      if (dep.endsWith('/core') || dep.endsWith('/auth-common') || dep.endsWith('/bb-lambda-compute')) continue;
 
       // Find the package directory by resolving its main entry and walking up
       let pkgDir: string | null = null;

--- a/packages/blocks/tsconfig.json
+++ b/packages/blocks/tsconfig.json
@@ -26,6 +26,7 @@
     { "path": "../bb-metrics" },
     { "path": "../bb-logger" },
     { "path": "../bb-tracer" },
-    { "path": "../bb-dashboard" }
+    { "path": "../bb-dashboard" },
+    { "path": "../bb-lambda-compute" }
   ]
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -32,6 +32,10 @@
       "types": "./dist/index.cdk.js",
       "default": "./dist/index.cdk.js"
     },
+    "./cdk/internal": {
+      "types": "./dist/cdk/internal.d.ts",
+      "default": "./dist/cdk/internal.js"
+    },
     "./client": "./dist/client/index.js",
     "./lambda-handler": "./dist/lambda-handler.js",
     "./bb-utils": {

--- a/packages/core/src/cdk/blocks-backend.ts
+++ b/packages/core/src/cdk/blocks-backend.ts
@@ -74,10 +74,8 @@ export function setupBlocksInfra(scope: Construct, props: BlocksBackendProps, id
   // A single IAM role that every Building Block grants to. Provisioned here so
   // it exists before the backend module is imported (Building Blocks reach it
   // via `scope.executionRole`). Block grants sit on the role's default (inline)
-  // policy, exactly as they did on the auto-generated NodejsFunction role.
-  //
-  // AWSLambdaBasicExecutionRole is attached explicitly because the auto-role
-  // included it by default — omitting it would silently break CloudWatch Logs.
+  // policy. AWSLambdaBasicExecutionRole is attached so the handler retains
+  // CloudWatch Logs permissions.
   const executionRole = new iam.Role(scope, 'BlocksRole', {
     // CompositePrincipal (rather than a bare ServicePrincipal) so additional
     // compute types can assume this same shared role as they are introduced

--- a/packages/core/src/cdk/compute/compute.ts
+++ b/packages/core/src/cdk/compute/compute.ts
@@ -1,0 +1,37 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Scope } from '../index.js';
+
+/**
+ * Base class for a Blocks *compute* — a runtime that executes handler code
+ * (Lambda today; containers later). A compute owns the physical function/service
+ * plus its ingress, and receives config via {@link setEnv}.
+ *
+ * The backend entry and stack name a compute needs are inherited from
+ * {@link Scope} (`backendHandlerPath` / `backendStackName`), which resolve them
+ * from the owning BlocksStack/BlocksBackend — never caller-supplied, so every
+ * compute in an app runs the same backend and agrees on the resource-name
+ * namespace.
+ *
+ * The abstract base lives in core (a framework primitive); concrete computes
+ * live in their own packages (e.g. `LambdaCompute` in `@aws-blocks/bb-lambda-compute`).
+ *
+ * @internal Not exported from the package's public entry points. Customers
+ * cannot instantiate a compute until the customer-facing surface exists.
+ */
+export abstract class Compute extends Scope {
+	/**
+	 * API namespaces assigned to run on this compute — recorded so request
+	 * routing can map a namespace to the compute that hosts it. Currently
+	 * unpopulated (no compute assignment surface yet).
+	 */
+	readonly namespaces: string[] = [];
+
+	/**
+	 * Inject a runtime configuration value (an environment variable) into this
+	 * compute. The framework calls this instead of `handler.addEnvironment()`
+	 * directly so config targets the right compute.
+	 */
+	abstract setEnv(key: string, value: string): void;
+}

--- a/packages/core/src/cdk/index.ts
+++ b/packages/core/src/cdk/index.ts
@@ -95,46 +95,77 @@ export class Scope extends Construct {
   readonly bbName?: string;
   readonly bbVersion?: string;
 
+  /**
+   * The owning stack/backend (the root of the Blocks construct tree), resolved
+   * once at construction: the nearest BlocksStack/BlocksBackend up the construct
+   * tree, or the ambient `globalThis.CURRENT_BLOCKS_STACK` fallback. All
+   * root-derived accessors below read from this instead of each repeating the
+   * tree walk.
+   */
+  private readonly root: BlocksStack | BlocksBackend;
+
   constructor(id: string, options?: ScopeOptions) {
     const parent = options?.parent || (globalThis as any).CURRENT_BLOCKS_STACK;
     super(parent, id);
     this.id = id;
     this.parent = parent;
+    this.root = this.resolveRoot();
   }
 
-  get handler() {
-    // Walk up the construct tree to find the owning BlocksStack/BlocksBackend
+  /**
+   * Walk up the construct tree to the nearest owning BlocksStack/BlocksBackend;
+   * fall back to the ambient `globalThis.CURRENT_BLOCKS_STACK`. Called once from
+   * the constructor; the result is cached in {@link root}.
+   */
+  private resolveRoot(): BlocksStack | BlocksBackend {
     let current: Construct = this;
     while (current.node.scope) {
         current = current.node.scope as Construct;
         if (current instanceof BlocksStack || current instanceof BlocksBackend) {
-            return current.handler;
+            return current;
         }
     }
-    // Fallback to globalThis for backward compatibility
-    return ((globalThis as any).CURRENT_BLOCKS_STACK as { handler: cdk.aws_lambda_nodejs.NodejsFunction }).handler;
+    // Fallback to the ambient stack. In production this is always a real
+    // BlocksStack/BlocksBackend; the cast also admits the test doubles that set
+    // globalThis.CURRENT_BLOCKS_STACK to a stub exposing the same surface.
+    return (globalThis as any).CURRENT_BLOCKS_STACK as BlocksStack | BlocksBackend;
+  }
+
+  get handler() {
+    return this.root.handler;
   }
 
   /**
    * The shared IAM role assumed by all Blocks compute. Building Blocks grant
-   * their permissions to this role instead of to an individual function's
-   * auto-role. CDK's `grant*()` / `addToPrincipalPolicy()` route those grants
-   * to the role's default (inline) policy — exactly where they landed on the
-   * auto-generated role before.
-   *
-   * Resolves the same way as {@link handler}: walk up to the owning
-   * BlocksStack/BlocksBackend, falling back to the ambient stack.
+   * their permissions to this role; CDK's `grant*()` / `addToPrincipalPolicy()`
+   * route those grants to the role's default (inline) policy.
    */
   get executionRole(): cdk.aws_iam.IRole {
-    let current: Construct = this;
-    while (current.node.scope) {
-        current = current.node.scope as Construct;
-        if (current instanceof BlocksStack || current instanceof BlocksBackend) {
-            return current.executionRole;
-        }
+    return this.root.executionRole;
+  }
+
+  /**
+   * The backend entry file the owning BlocksStack/BlocksBackend runs — the
+   * single handler entry shared across the whole app.
+   */
+  get backendHandlerPath(): string {
+    return this.root.backendHandlerPath;
+  }
+
+  /**
+   * The owning stack/backend's token-free root identity. This is the value the
+   * runtime receives as `BLOCKS_STACK_NAME` and rebuilds `fullId` from, so
+   * physical resource names (DynamoDB tables, env-var keys, IAM ARNs) derived
+   * from `fullId` match byte-for-byte between synth and runtime — otherwise the
+   * runtime looks up names that were never created. `BlocksBackend` exposes this
+   * as `fullId` ({@link BlocksBackend.fullId}); `BlocksStack` as `id`.
+   */
+  get backendStackName(): string {
+    const name = this.root instanceof BlocksBackend ? this.root.fullId : this.root.id;
+    if (!name) {
+      throw new Error('Owning Blocks stack/backend has no id to derive BLOCKS_STACK_NAME');
     }
-    // Fallback to globalThis for backward compatibility
-    return ((globalThis as any).CURRENT_BLOCKS_STACK as { executionRole: cdk.aws_iam.IRole }).executionRole;
+    return name;
   }
 
   get fullId(): string {

--- a/packages/core/src/cdk/internal.ts
+++ b/packages/core/src/cdk/internal.ts
@@ -1,0 +1,29 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Internal CDK entry point — framework- and test-only surface that is
+ * intentionally NOT part of the public API (`@aws-blocks/core` /
+ * `@aws-blocks/core/cdk`).
+ *
+ * The compute abstraction lives behind this path while it has no public,
+ * customer-facing surface. Importing from here is a signal that you are inside
+ * the framework or a test, not a customer.
+ *
+ * Planned removal: once a customer can assign a compute and have it actually
+ * take effect — i.e. `this.compute` resolution and request routing to the
+ * chosen compute both exist, plus a synth-time guard that rejects an assignment
+ * with no route — these exports move to the public CDK entry point
+ * (`@aws-blocks/core/cdk`, re-exported from `index.cdk.ts`) and this file is
+ * deleted. It must NOT be made public before then: a compute a customer can
+ * declare but that is silently ignored is a worse experience than not having
+ * the feature. Until that flip, treat everything here as unstable — no
+ * backward-compatibility guarantee.
+ *
+ * @internal
+ */
+
+export { Compute } from './compute/compute.js';
+// Reserved `/aws-blocks` path segment, needed by concrete computes (e.g.
+// LambdaCompute in @aws-blocks/bb-lambda-compute) to build their API route tree.
+export { BLOCKS_NAMESPACE } from '../constants.js';

--- a/scripts/gen-block-docs.mjs
+++ b/scripts/gen-block-docs.mjs
@@ -48,7 +48,7 @@ const packagesDir = join(__dirname, '..', 'packages');
 const blocksDir = join(packagesDir, 'blocks');
 const outDir = join(blocksDir, 'docs');
 
-const EXCLUDED = new Set(['blocks', 'data-common', 'foundations', 'create-blocks-app']);
+const EXCLUDED = new Set(['blocks', 'data-common', 'foundations', 'create-blocks-app', 'bb-lambda-compute']);
 
 const packages = getPackages();
 

--- a/scripts/sync-catalog.mjs
+++ b/scripts/sync-catalog.mjs
@@ -40,7 +40,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const packagesDir = join(__dirname, '..', 'packages');
 const readmePath = join(packagesDir, 'blocks', 'README.md');
 
-const EXCLUDED = new Set(['blocks', 'data-common', 'foundations', 'create-blocks-app']);
+const EXCLUDED = new Set(['blocks', 'data-common', 'foundations', 'create-blocks-app', 'bb-lambda-compute']);
 
 const BEGIN_MARKER = '<!-- BEGIN:block-catalog -->';
 const END_MARKER = '<!-- END:block-catalog -->';


### PR DESCRIPTION
## Problem

Multi-compute needs a first-class *compute* abstraction — a type that owns a runtime (a Lambda function + its API Gateway today, other runtimes later) — that the framework can build against. This is the foundational, non-breaking step: introduce the abstraction and add a Building Block for the Lambda compute, without changing the default app's behavior or exposing anything to customers.

## Changes

- **New abstract `Compute` in core (internal-only).** Added behind a new entry point `@aws-blocks/core/cdk/internal` (added to `package.json` `exports`) so these types are reachable by framework/test code but stay off the public `@aws-blocks/core` / `@aws-blocks/core/cdk` surface (api-extractor confirms they're absent from `API.md`). `Compute` is an abstract `Scope` subclass: it declares `namespaces` (routing seam, currently unpopulated) and `setEnv()`, and resolves its owning `BlocksStack`/`BlocksBackend` on construction to derive its runtime identity (backend entry + `BLOCKS_STACK_NAME`).
- **New `@aws-blocks/bb-lambda-compute` package** holding the concrete `LambdaCompute` (a `NodejsFunction` fronted by its own API Gateway, assuming the shared `executionRole`). Its `entry` and `BLOCKS_STACK_NAME` are **derived from the owning stack/backend**, never caller-supplied, so every compute runs the same backend and agrees on the resource-name namespace.
- **Conditional-export layers.** The backend module that will declare `new LambdaCompute(...)` is imported both at CDK synth and at runtime, so the package ships the standard layers: the `cdk` layer provisions the infrastructure (the only layer that touches `aws-cdk-lib`); the `aws-runtime`, local-dev (`default`/`types`), and `browser` layers are **inert handles** — they construct so the import succeeds and `{ compute }` references resolve, but provision nothing and `setEnv` is a no-op (config is injected at synth). This keeps `aws-cdk-lib` out of the runtime and browser bundles. `LambdaCompute` is **not re-exported from `@aws-blocks/blocks`**, so customers cannot reach it yet.
- **Consolidated the owner tree-walk on `Scope`.** A single `root` field (resolved once in the constructor) now backs `handler`, `executionRole`, and the `backendHandlerPath` / `backendStackName` accessors, replacing repeated copies of the walk.
- **Excluded `bb-lambda-compute` from customer-facing surfaces** consistent with it being internal infrastructure: the Building Block catalog (`scripts/sync-catalog.mjs` + `scripts/gen-block-docs.mjs` `EXCLUDED` sets) and the vendorize map check.

**Non-breaking:** pure additive dead code — nothing in the default path constructs a `LambdaCompute`, and customers cannot reach the compute types. App behavior is unchanged.

> **Note:** `@aws-blocks/bb-lambda-compute` is a new package but is not published until a release cuts it (changeset-driven).

## Validation

- `npm run build:force` (full monorepo) green.
- `@aws-blocks/core`: 654/654 pass, including internal `LambdaCompute` tests (function + gateway shape, shared-role assumption, owner-derived `BLOCKS_STACK_NAME`, distinct construct paths, and construction failure with no Blocks owner).
- `@aws-blocks/bb-lambda-compute`: 6/6 pass (uses an inline `StubBlocksStack` — no on-disk fixtures).
- `@aws-blocks/blocks`: 42/42 pass, including conditional-export parity (now auto-discovers bb-lambda-compute via its `aws-runtime` condition) and the vendorize-map check (bb-lambda-compute excluded as internal infrastructure).
- `npm run lint`, `npm run lint:deps`, `npm run check:api`, `npm run sync-docs:check` all clean.

## Checklist

- [x] PR description included
- [x] Tests are changed or added
- [x] Relevant documentation is changed or added (and PR referenced)

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
