### PR TITLE
fix(hosting): encrypt alarm SNS topic with a CloudWatch-usable KMS key

### DIFF
--- a/.changeset/hosting-alarm-topic-kms-encryption.md
+++ b/.changeset/hosting-alarm-topic-kms-encryption.md
@@ -1,0 +1,40 @@
+---
+"@aws-blocks/hosting": patch
+---
+
+fix(hosting): encrypt the alarm SNS topic by default, with a key policy CloudWatch can actually use
+
+The monitoring construct's auto-created alarm topic was unencrypted. It now gets
+a dedicated customer-managed KMS key (`MonitoringAlarmTopicKey`) whose policy
+grants `cloudwatch.amazonaws.com` `kms:Decrypt` + `kms:GenerateDataKey*` in
+addition to the usual account-root administration statement.
+
+Both halves matter. Encrypting the topic makes hosting secure-by-default, and
+the CloudWatch grant is what keeps alarms working once it is encrypted: when an
+SNS topic used as a CloudWatch alarm action is KMS-encrypted, the key policy
+must grant the `cloudwatch.amazonaws.com` service principal, because CloudWatch
+calls KMS **directly** (not via SNS) and an account-root `kms:*` statement does
+not cover AWS service principals. Without the grant, CloudWatch's publish fails
+with `KMSAccessDenied` and notifications are dropped silently — the alarm still
+transitions to ALARM in the console, so the only symptom is the notification
+that never arrives.
+
+An AWS-managed key (`alias/aws/sns`) cannot be used instead: its key policy is
+not editable and does not grant CloudWatch, so a customer-managed key is the
+only option that can carry the grant.
+
+The grant is scoped to just those two actions for that one service principal on
+a single-purpose key, plus a `StringEqualsIfExists` guard on `aws:SourceAccount`
+against cross-account confused-deputy use. `IfExists` is deliberate:
+`aws:SourceAccount` is only populated on direct service-principal calls, and a
+hard `StringEquals` would reintroduce the very silent deny this grant exists to
+prevent.
+
+No configuration changes: encryption is unconditional, with no opt-out knob to
+weaken it. The only API addition is a read-only `encryptionKey` accessor on
+`MonitoringConstruct`, alongside the existing `topic` and `alarms`, so callers
+can grant additional publishers on the key. Callers who need different key
+management continue to pass their own `snsTopic` / `snsTopicArn` and own that
+topic's encryption. Note the KMS key adds roughly $1/month per stack, and
+monitoring is on by default; `monitoring: { enabled: false }` or a BYO topic
+avoids it.

--- a/packages/hosting/src/constructs/hosting_construct.test.ts
+++ b/packages/hosting/src/constructs/hosting_construct.test.ts
@@ -1914,12 +1914,17 @@ void describe('HostingConstruct — KMS Key Policy', () => {
     if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
+  // These cases are about the *storage bucket* key, so they turn
+  // monitoring off — the default alarm topic brings its own KMS key
+  // and a stack-wide key count would conflate the two.
+
   void it('creates KMS key when storage.encryption is KMS', () => {
     const staticDir = createStaticDir();
     const stack = createStack();
     new HostingConstruct(stack, 'Hosting', {
       manifest: spaManifest(staticDir),
       storage: { encryption: 'KMS' },
+      monitoring: { enabled: false },
     });
 
     const template = Template.fromStack(stack);
@@ -1932,6 +1937,7 @@ void describe('HostingConstruct — KMS Key Policy', () => {
     new HostingConstruct(stack, 'Hosting', {
       manifest: spaManifest(staticDir),
       storage: { encryption: 'KMS' },
+      monitoring: { enabled: false },
     });
 
     const template = Template.fromStack(stack);
@@ -1974,6 +1980,7 @@ void describe('HostingConstruct — KMS Key Policy', () => {
     const stack = createStack();
     new HostingConstruct(stack, 'Hosting', {
       manifest: spaManifest(staticDir),
+      monitoring: { enabled: false },
     });
 
     const template = Template.fromStack(stack);
@@ -1991,6 +1998,7 @@ void describe('HostingConstruct — KMS Key Policy', () => {
     new HostingConstruct(stack, 'Hosting', {
       manifest: spaManifest(staticDir),
       storage: { encryption: 'S3_MANAGED' },
+      monitoring: { enabled: false },
     });
 
     const template = Template.fromStack(stack);
@@ -2000,6 +2008,48 @@ void describe('HostingConstruct — KMS Key Policy', () => {
       0,
       'Should NOT create a KMS key with explicit S3_MANAGED encryption',
     );
+  });
+
+  // ---- Alarm topic encryption through the L3 ----
+
+  void it('encrypts the default alarm topic and grants CloudWatch on its key', () => {
+    const staticDir = createStaticDir();
+    const stack = createStack();
+    new HostingConstruct(stack, 'Hosting', {
+      manifest: spaManifest(staticDir),
+    });
+
+    const template = Template.fromStack(stack);
+    template.hasResourceProperties('AWS::SNS::Topic', {
+      KmsMasterKeyId: Match.anyValue(),
+    });
+    template.hasResourceProperties('AWS::KMS::Key', {
+      KeyPolicy: {
+        Statement: Match.arrayWith([
+          Match.objectLike({
+            Effect: 'Allow',
+            Principal: { Service: 'cloudwatch.amazonaws.com' },
+            Action: ['kms:Decrypt', 'kms:GenerateDataKey*'],
+          }),
+        ]),
+      },
+    });
+  });
+
+  void it('creates no alarm topic key when a BYO topic ARN is supplied', () => {
+    const staticDir = createStaticDir();
+    const stack = createStack();
+    new HostingConstruct(stack, 'Hosting', {
+      manifest: spaManifest(staticDir),
+      monitoring: {
+        snsTopicArn: 'arn:aws:sns:us-west-2:123456789012:existing-alarms',
+      },
+    });
+
+    const template = Template.fromStack(stack);
+    // The caller owns the imported topic's encryption.
+    template.resourceCountIs('AWS::KMS::Key', 0);
+    template.resourceCountIs('AWS::SNS::Topic', 0);
   });
 
   // ---- cdn.ssrDefaultTtl ----

--- a/packages/hosting/src/constructs/monitoring_construct.test.ts
+++ b/packages/hosting/src/constructs/monitoring_construct.test.ts
@@ -13,6 +13,9 @@
  *   - Thresholds and metric dimensions are correct (CloudFront metrics
  *     in `us-east-1`, the right namespaces, threshold values).
  *   - BYO SNS topic skips topic creation and reuses the supplied one.
+ *   - The auto-created topic is KMS-encrypted and its key policy
+ *     grants CloudWatch `kms:Decrypt` + `kms:GenerateDataKey*` —
+ *     without that grant alarm notifications are dropped silently.
  *
  * Driven by review feedback on PR #3220 — a 177-line construct with
  * zero tests.
@@ -291,6 +294,140 @@ void describe('MonitoringConstruct', () => {
           'each alarm should reference exactly one SNS action (the alarm topic)',
         );
       }
+    });
+  });
+
+  // ---- Alarm topic encryption (KMS) ----
+
+  // A CloudWatch alarm publishing to a KMS-encrypted SNS topic calls
+  // KMS *directly*; if the key policy has no `cloudwatch.amazonaws.com`
+  // statement the action fails with KMSAccessDenied and the
+  // notification is dropped silently (the alarm still shows ALARM).
+  // These tests are the regression guard for that grant.
+  void describe('alarm topic encryption', () => {
+    void it('encrypts the auto-created topic with a customer-managed key by default', () => {
+      const stack = createStack();
+      new MonitoringConstruct(stack, 'Monitoring', { enabled: true });
+      const template = Template.fromStack(stack);
+
+      template.resourceCountIs('AWS::KMS::Key', 1);
+      template.hasResourceProperties('AWS::SNS::Topic', {
+        KmsMasterKeyId: Match.anyValue(),
+      });
+    });
+
+    void it('grants cloudwatch.amazonaws.com kms:Decrypt and kms:GenerateDataKey* on the key', () => {
+      const stack = createStack();
+      new MonitoringConstruct(stack, 'Monitoring', { enabled: true });
+      const template = Template.fromStack(stack);
+
+      template.hasResourceProperties('AWS::KMS::Key', {
+        KeyPolicy: {
+          Statement: Match.arrayWith([
+            Match.objectLike({
+              Effect: 'Allow',
+              Principal: { Service: 'cloudwatch.amazonaws.com' },
+              Action: ['kms:Decrypt', 'kms:GenerateDataKey*'],
+              Resource: '*',
+            }),
+          ]),
+        },
+      });
+    });
+
+    void it('scopes the CloudWatch grant to this account without hard-failing when aws:SourceAccount is absent', () => {
+      const stack = createStack();
+      new MonitoringConstruct(stack, 'Monitoring', { enabled: true });
+      const template = Template.fromStack(stack);
+
+      // `IfExists` matters: aws:SourceAccount is only populated on
+      // direct service-principal calls, and a hard StringEquals would
+      // reintroduce the silent deny this grant exists to prevent.
+      template.hasResourceProperties('AWS::KMS::Key', {
+        KeyPolicy: {
+          Statement: Match.arrayWith([
+            Match.objectLike({
+              Principal: { Service: 'cloudwatch.amazonaws.com' },
+              Condition: {
+                StringEqualsIfExists: { 'aws:SourceAccount': '123456789012' },
+              },
+            }),
+          ]),
+        },
+      });
+    });
+
+    void it('keeps the account-root admin statement on the key', () => {
+      const stack = createStack();
+      new MonitoringConstruct(stack, 'Monitoring', { enabled: true });
+      const template = Template.fromStack(stack);
+
+      // The CloudWatch grant is additive — key administration must
+      // still be delegable to IAM in the owning account.
+      template.hasResourceProperties('AWS::KMS::Key', {
+        KeyPolicy: {
+          Statement: Match.arrayWith([
+            Match.objectLike({
+              Effect: 'Allow',
+              Action: 'kms:*',
+              Principal: { AWS: Match.anyValue() },
+            }),
+          ]),
+        },
+      });
+    });
+
+    void it('wires the alarm actions to the encrypted topic', () => {
+      const stack = createStack();
+      const m = new MonitoringConstruct(stack, 'Monitoring', {
+        enabled: true,
+        distribution: newDistribution(stack),
+      });
+      const template = Template.fromStack(stack);
+
+      assert.ok(m.encryptionKey, 'construct should expose the topic key');
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const json = template.toJSON() as any;
+      const topicIds = Object.keys(json.Resources).filter(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (id) => (json.Resources[id] as any)['Type'] === 'AWS::SNS::Topic',
+      );
+      assert.strictEqual(topicIds.length, 1);
+      const encryptedTopicId = topicIds[0] as string;
+      assert.ok(
+        json.Resources[encryptedTopicId]['Properties']['KmsMasterKeyId'],
+        'the topic alarms publish to must be the encrypted one',
+      );
+
+      const alarm = Object.values(json.Resources).find(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (r: any) => r['Type'] === 'AWS::CloudWatch::Alarm',
+      );
+      assert.deepStrictEqual(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (alarm as any)['Properties']['AlarmActions'],
+        [{ Ref: encryptedTopicId }],
+      );
+    });
+
+    void it('creates no key for a BYO topic — the caller owns its encryption', () => {
+      const stack = createStack();
+      const m = new MonitoringConstruct(stack, 'Monitoring', {
+        enabled: true,
+        snsTopic: new Topic(stack, 'UserTopic'),
+      });
+      const template = Template.fromStack(stack);
+
+      template.resourceCountIs('AWS::KMS::Key', 0);
+      assert.strictEqual(m.encryptionKey, undefined);
+    });
+
+    void it('creates no key when monitoring is disabled', () => {
+      const stack = createStack();
+      new MonitoringConstruct(stack, 'Monitoring', { enabled: false });
+      const template = Template.fromStack(stack);
+
+      template.resourceCountIs('AWS::KMS::Key', 0);
     });
   });
 

--- a/packages/hosting/src/constructs/monitoring_construct.ts
+++ b/packages/hosting/src/constructs/monitoring_construct.ts
@@ -1,5 +1,5 @@
 import { Construct } from 'constructs';
-import { Duration } from 'aws-cdk-lib';
+import { Duration, RemovalPolicy, Stack } from 'aws-cdk-lib';
 import {
   Alarm,
   ComparisonOperator,
@@ -9,6 +9,8 @@ import {
 } from 'aws-cdk-lib/aws-cloudwatch';
 import { SnsAction } from 'aws-cdk-lib/aws-cloudwatch-actions';
 import { Distribution } from 'aws-cdk-lib/aws-cloudfront';
+import * as iam from 'aws-cdk-lib/aws-iam';
+import { type IKey, Key } from 'aws-cdk-lib/aws-kms';
 import { Function as LambdaFunction } from 'aws-cdk-lib/aws-lambda';
 import { Queue } from 'aws-cdk-lib/aws-sqs';
 import { ITopic, Topic } from 'aws-cdk-lib/aws-sns';
@@ -34,7 +36,16 @@ import { ITopic, Topic } from 'aws-cdk-lib/aws-sns';
  * cheap-by-default. When the user opts in we either create an SNS
  * topic and surface its ARN (so the user can subscribe), or attach
  * the user-supplied topic. Cost: pennies/month at idle, scales with
- * alarm-state changes (not requests).
+ * alarm-state changes (not requests), plus ~$1/month for the alarm
+ * topic's KMS key.
+ *
+ * The auto-created topic is always encrypted with a dedicated
+ * customer-managed KMS key. An AWS-managed key (`alias/aws/sns`)
+ * cannot be used: its policy is not editable and does not grant
+ * CloudWatch, so every alarm action fails with `KMSAccessDenied` and
+ * notifications are dropped silently. See `createAlarmTopicKey`.
+ * Callers who need different key management supply their own
+ * `snsTopic` (and own its encryption).
  */
 export type MonitoringConstructProps = {
   enabled: boolean;
@@ -63,12 +74,67 @@ export type MonitoringConstructProps = {
 };
 
 /**
+ * Create the customer-managed key that encrypts the alarm topic.
+ *
+ * CloudWatch calls KMS **directly** (not via SNS) when it publishes an
+ * alarm notification to an encrypted topic, so the key policy needs an
+ * explicit grant for the `cloudwatch.amazonaws.com` service principal.
+ * Without it the alarm action fails with `KMSAccessDenied` and the
+ * notification is dropped — the alarm still flips to ALARM in the
+ * console, so the failure is invisible until someone notices the page
+ * that never arrived. Account-root/IAM delegation (the only statement
+ * on the default `Key` policy, and the only one some policy injectors
+ * add) does NOT cover service principals.
+ *
+ * `resources: ['*']` is scoped to *this* key — a resource policy can
+ * only speak for the resource it is attached to, and this key is
+ * single-purpose (the alarm topic is its only user). The
+ * `aws:SourceAccount` guard blocks the cross-account confused-deputy
+ * case; it is `IfExists` because that key is only populated on direct
+ * service-principal calls, and a hard `StringEquals` would
+ * reintroduce the exact silent-deny this grant exists to prevent.
+ */
+const createAlarmTopicKey = (scope: Construct): Key => {
+  const key = new Key(scope, 'AlarmTopicKey', {
+    description:
+      'Encrypts CloudWatch alarm notifications published to the hosting alarm topic.',
+    enableKeyRotation: true,
+    // The key protects in-flight notifications only — nothing durable
+    // is lost with the stack, so don't leave a billable orphan behind.
+    removalPolicy: RemovalPolicy.DESTROY,
+  });
+
+  key.addToResourcePolicy(
+    new iam.PolicyStatement({
+      sid: 'AllowCloudWatchAlarmsToPublishToEncryptedTopic',
+      effect: iam.Effect.ALLOW,
+      principals: [new iam.ServicePrincipal('cloudwatch.amazonaws.com')],
+      actions: ['kms:Decrypt', 'kms:GenerateDataKey*'],
+      resources: ['*'],
+      conditions: {
+        StringEqualsIfExists: {
+          'aws:SourceAccount': Stack.of(scope).account,
+        },
+      },
+    }),
+  );
+
+  return key;
+};
+
+/**
  * CloudWatch alarm wiring construct. See module-level doc-comment for
  * the rationale and the alarm set.
  */
 export class MonitoringConstruct extends Construct {
   /** SNS topic alarm actions are sent to. Undefined when monitoring is disabled. */
   readonly topic?: ITopic;
+  /**
+   * KMS key encrypting the auto-created alarm topic. Undefined when
+   * monitoring is disabled or when a BYO `snsTopic` is supplied.
+   * Exposed so callers can grant additional publishers on the key.
+   */
+  readonly encryptionKey?: IKey;
   /** All CloudWatch alarms created by this construct. */
   readonly alarms: Alarm[] = [];
 
@@ -83,7 +149,14 @@ export class MonitoringConstruct extends Construct {
       return;
     }
 
-    this.topic = props.snsTopic ?? new Topic(this, 'AlarmTopic');
+    if (props.snsTopic) {
+      this.topic = props.snsTopic;
+    } else {
+      this.encryptionKey = createAlarmTopicKey(this);
+      this.topic = new Topic(this, 'AlarmTopic', {
+        masterKey: this.encryptionKey,
+      });
+    }
     const action = new SnsAction(this.topic);
 
     if (props.distribution) {


### PR DESCRIPTION
## Problem

`MonitoringConstruct` created the SNS topic backing its CloudWatch alarm actions unencrypted — not secure-by-default — and simply turning on encryption is a trap that silently breaks every alarm notification.

```ts
// packages/hosting/src/constructs/monitoring_construct.ts:86 (before)
this.topic = props.snsTopic ?? new Topic(this, 'AlarmTopic');
```

When an SNS topic used as a CloudWatch alarm action is KMS-encrypted, the key policy **must** grant the `cloudwatch.amazonaws.com` service principal `kms:Decrypt` and `kms:GenerateDataKey*`. CloudWatch calls KMS **directly** (not via SNS) when publishing an alarm notification, and an account-root `kms:*` statement does **not** cover AWS service principals. Without that explicit grant, CloudWatch's publish fails with `KMSAccessDenied` and notifications are **silently dropped**.

Silently is the important part: the alarm still transitions to `ALARM` in the console and the metric graph looks completely normal. The failure appears only as an easily-missed line in alarm history, so the sole practical symptom is the notification that never arrives. That failure mode applies to every alarm this construct creates (CloudFront 5xx rate, SSR Lambda errors/throttles, image-opt errors, revalidation DLQ depth) — the whole point of the construct is to tell operators when something is wrong.

Also worth noting: an AWS-managed key cannot solve this, so the topic could not simply be pointed at `alias/aws/sns`. See Changes.

**Issue #, if available:**

## Changes

The auto-created alarm topic is now encrypted with a dedicated customer-managed `kms.Key` whose policy grants CloudWatch exactly what it needs to publish, making the topic secure-by-default **and** keeping alarm notifications working.

```ts
new iam.PolicyStatement({
  sid: 'AllowCloudWatchAlarmsToPublishToEncryptedTopic',
  effect: iam.Effect.ALLOW,
  principals: [new iam.ServicePrincipal('cloudwatch.amazonaws.com')],
  actions: ['kms:Decrypt', 'kms:GenerateDataKey*'],
  resources: ['*'],
  conditions: {
    StringEqualsIfExists: { 'aws:SourceAccount': Stack.of(scope).account },
  },
})
```

Synthesized key policy — the account-root administration statement is preserved and the grant is additive:

```json
{ "Action": "kms:*", "Effect": "Allow",
  "Principal": { "AWS": "arn:<partition>:iam::123456789012:root" }, "Resource": "*" },
{ "Sid": "AllowCloudWatchAlarmsToPublishToEncryptedTopic",
  "Action": ["kms:Decrypt", "kms:GenerateDataKey*"], "Effect": "Allow",
  "Principal": { "Service": "cloudwatch.amazonaws.com" }, "Resource": "*",
  "Condition": { "StringEqualsIfExists": { "aws:SourceAccount": "123456789012" } } }
```

**Why a customer-managed key is required.** This is forced, not a stylistic choice. An AWS-managed key (`alias/aws/sns`) has a key policy that cannot be edited and does not grant CloudWatch, so it can never carry the statement above. Per [AWS's guidance for this exact scenario](https://repost.aws/knowledge-center/cloudwatch-configure-alarm-sns): *"You must use an AWS KMS customer managed key… If you use the default alias/aws/sns AWS managed key for encryption, then the CloudWatch alarm fails to initiate the alarm action."* So the real choice is a CMK or an unencrypted topic — hence a CMK.

### Least-privilege, and two deliberate decisions

The grant is narrow where it counts: exactly two actions, one service principal, on a **single-purpose key** whose only user is this alarm topic. `resources: ['*']` inside a resource policy only ever speaks for the resource it is attached to — this key.

- **No topic-ARN / encryption-context condition.** Scoping to `kms:EncryptionContext:aws:sns:topicArn` looks tighter but the topic references the key, so referencing the topic back from the key policy is a CloudFormation circular dependency. Pinning alarm ARNs instead would require explicit physical names.
- **`StringEqualsIfExists`, not `StringEquals`.** `aws:SourceAccount` guards the cross-account confused-deputy case, but it is [only populated when the call is made directly by an AWS service principal](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_condition-keys.html). A hard `StringEquals` that silently evaluated false would reintroduce the exact invisible `KMSAccessDenied` this PR exists to fix; `IfExists` is AWS's documented pattern for conditionally-present keys. For reference, AWS's own remediation for this scenario uses no condition at all.

### No configuration API change

Encryption is **unconditional** — there is no opt-out flag. A knob whose only purpose is to make the topic less secure would work against secure-by-default, and the fix needs no new configuration. `HostingConstruct` and the `Hosting` L3 (`@aws-blocks/core`) are untouched and byte-identical to `main`.

The only API addition is a **read-only** `encryptionKey` accessor on `MonitoringConstruct`, sitting alongside the existing `topic` and `alarms` resource accessors, so callers can grant additional publishers on the key.

Callers who need different key management — their own CMK, their own rotation/retention policy, or an existing topic — use the escape hatch that already existed before this PR: supply `snsTopic` / `monitoring.snsTopicArn` and own that topic's encryption. That path is unchanged, and no key is created for it.

**Cost.** The KMS key adds roughly $1/month per stack, and monitoring is enabled by default — worth flagging against the construct's "pennies/month" idle-cost claim. It is called out in the construct doc-comment and the changeset, and is avoidable with a BYO topic or `monitoring: { enabled: false }`. The key uses `RemovalPolicy.DESTROY` (it protects in-flight notifications only, nothing durable) so `cdk destroy` does not leave a billable orphan behind.

## Validation

Built with Node 22 in dependency order (`hosting`; then `pipeline` → `core`) and tested against `dist/`:

```
packages/hosting   # tests 838   # pass 838   # fail 0
packages/core      # tests 654   # pass 654   # fail 0
```

**9 tests added** — 7 in `monitoring_construct.test.ts`, 2 covering the L3 path in `hosting_construct.test.ts`:

- the auto-created topic is KMS-encrypted (`KmsMasterKeyId` set) and exactly one key is created
- the key policy grants the `cloudwatch.amazonaws.com` principal both `kms:Decrypt` and `kms:GenerateDataKey*` — the direct regression guard for the silent-drop failure
- the `StringEqualsIfExists` / `aws:SourceAccount` condition is present as intended
- the account-root administration statement survives (the grant is additive, not a replacement)
- alarm actions point at the *encrypted* topic, not some other topic in the stack
- a BYO `snsTopic`, and monitoring disabled, each create no key

The synthesized key policy and topic were also inspected directly from a real `Template.fromStack` synth to confirm the rendered CloudFormation matches the intent (root statement intact, grant appended, `KmsMasterKeyId` → key ARN).

**3 pre-existing tests adjusted.** The `HostingConstruct — KMS Key Policy` cases asserted **stack-wide** `AWS::KMS::Key` counts while actually testing the *storage bucket* key, so the new alarm key broke them. They now pass `monitoring: { enabled: false }` to keep their assertions scoped to the bucket key. This also removes a latent fragility: one of them selected its key via `Object.values(keys)[0]` and was relying on resource ordering.

`npm run update:api` produces **no** API report diff. Biome reports no new findings on the changed files — the `useImportType` hits there are pre-existing baseline (a byte-identical `origin/main` copy of `hosting_construct.ts` reports the same 9), and the one import this PR adds is written `import { type IKey, Key }` to comply.

A **PATCH** changeset is included for `@aws-blocks/hosting`, per the repo's 0.x convention (minor = breaking).

Not validated by a live deploy: the assertions above are synth-level. The behaviour being fixed is an IAM/KMS authorization outcome that only fully manifests against deployed infrastructure.

## Checklist

- [x] PR description included
- [x] Tests are changed or added
- [ ] Relevant documentation is changed or added (and PR referenced)

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
