### PR TITLE
fix(core): SandboxDisableDeletionProtection never matched DynamoDB tables

### DIFF
--- a/.changeset/sandbox-disable-deletion-protection-cfntable.md
+++ b/.changeset/sandbox-disable-deletion-protection-cfntable.md
@@ -1,0 +1,20 @@
+---
+"@aws-blocks/core": patch
+---
+
+fix(core): make `SandboxDisableDeletionProtection` actually disable DynamoDB deletion protection
+
+The mixin duck-typed only on the `deletionProtection` property name, but the
+DynamoDB L1 `CfnTable` behind an L2 `Table` spells it
+`deletionProtectionEnabled` — and the L2 `Table` never re-exposes the prop. As a
+result the mixin silently never matched DynamoDB tables: sandbox stacks synthed
+`DeletionProtectionEnabled: true` and `sandbox:destroy` failed on every
+protected table, because DynamoDB refuses `DeleteTable` while protection is on
+regardless of the CloudFormation `DeletionPolicy`.
+
+The mixin now matches both the `deletionProtection` and
+`deletionProtectionEnabled` spellings, so DynamoDB tables are cleared through
+their L1 and consumers no longer need a local `CfnTable` workaround loop.
+Behavior for other resource types is unchanged: only explicitly-enabled
+protection is flipped, so unprotected resources still omit the property (Aurora
+DB instances continue to synth without `DeletionProtection`).

--- a/packages/core/src/cdk/mixins.test.ts
+++ b/packages/core/src/cdk/mixins.test.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { test, describe } from 'node:test';
-import assert from 'node:assert';
 import * as cdk from 'aws-cdk-lib';
 import { Template, Match } from 'aws-cdk-lib/assertions';
 import { Table, AttributeType, BillingMode } from 'aws-cdk-lib/aws-dynamodb';
@@ -107,6 +106,62 @@ describe('sandbox removal policy', () => {
     // (RDS rejects it for cluster members)
     template.hasResourceProperties('AWS::RDS::DBInstance', {
       DeletionProtection: Match.absent(),
+    });
+  });
+
+  test('SandboxDisableDeletionProtection mixin: deletionProtection disabled on DynamoDB table', () => {
+    const app = new cdk.App({ context: { sandboxMode: 'true' } });
+    const stack = new cdk.Stack(app, 'TestStack');
+
+    new Table(stack, 'MyTable', {
+      partitionKey: { name: 'pk', type: AttributeType.STRING },
+      billingMode: BillingMode.PAY_PER_REQUEST,
+      deletionProtection: true,
+    });
+
+    RemovalPolicies.of(stack).destroy();
+    Mixins.of(stack).apply(new SandboxDisableDeletionProtection());
+
+    const template = Template.fromStack(stack);
+    // DynamoDB refuses DeleteTable while protection is on, regardless of DeletionPolicy
+    template.hasResourceProperties('AWS::DynamoDB::Table', {
+      DeletionProtectionEnabled: false,
+    });
+    template.hasResource('AWS::DynamoDB::Table', {
+      DeletionPolicy: 'Delete',
+    });
+  });
+
+  test('production mode: deletionProtection stays enabled on DynamoDB table when mixin is not applied', () => {
+    const app = new cdk.App();
+    const stack = new cdk.Stack(app, 'TestStack');
+
+    new Table(stack, 'MyTable', {
+      partitionKey: { name: 'pk', type: AttributeType.STRING },
+      billingMode: BillingMode.PAY_PER_REQUEST,
+      deletionProtection: true,
+    });
+
+    const template = Template.fromStack(stack);
+    template.hasResourceProperties('AWS::DynamoDB::Table', {
+      DeletionProtectionEnabled: true,
+    });
+  });
+
+  test('SandboxDisableDeletionProtection mixin: does not set DeletionProtectionEnabled on unprotected tables', () => {
+    const app = new cdk.App({ context: { sandboxMode: 'true' } });
+    const stack = new cdk.Stack(app, 'TestStack');
+
+    new Table(stack, 'MyTable', {
+      partitionKey: { name: 'pk', type: AttributeType.STRING },
+      billingMode: BillingMode.PAY_PER_REQUEST,
+    });
+
+    Mixins.of(stack).apply(new SandboxDisableDeletionProtection());
+
+    const template = Template.fromStack(stack);
+    template.hasResourceProperties('AWS::DynamoDB::Table', {
+      DeletionProtectionEnabled: Match.absent(),
     });
   });
 

--- a/packages/core/src/cdk/mixins.ts
+++ b/packages/core/src/cdk/mixins.ts
@@ -6,13 +6,30 @@ import type { IConstruct } from 'constructs';
 import type { IMixin } from 'constructs';
 
 /**
- * Disables deletion protection on any construct that has a `deletionProtection`
- * property (e.g. RDS clusters, RDS instances). Uses duck-typing so it
- * automatically covers current and future resource types.
+ * Property names used across CloudFormation resources to express deletion
+ * protection. L2 constructs and most L1s use `deletionProtection` (e.g. RDS
+ * clusters and instances, ELBv2 load balancers), while others spell it
+ * `deletionProtectionEnabled` (e.g. the DynamoDB `CfnTable` behind an L2
+ * `Table`, Aurora DSQL clusters).
+ */
+const DELETION_PROTECTION_PROPERTIES = ['deletionProtection', 'deletionProtectionEnabled'] as const;
+
+/**
+ * Disables deletion protection on any construct that exposes a deletion
+ * protection property (e.g. RDS clusters, RDS instances, DynamoDB tables).
+ * Uses duck-typing so it automatically covers current and future resource
+ * types, matching both the `deletionProtection` and
+ * `deletionProtectionEnabled` spellings.
+ *
+ * Note that a DynamoDB L2 `Table` only accepts `deletionProtection` as a prop
+ * and does not re-expose it, so tables are matched through their underlying
+ * L1 `CfnTable.deletionProtectionEnabled`.
  *
  * Intended for sandbox teardown — use in the CDK layer alongside
  * `RemovalPolicies.of(stack).destroy()` to ensure `sandbox:destroy` can
- * delete the entire stack without manual cleanup.
+ * delete the entire stack without manual cleanup. DynamoDB refuses
+ * `DeleteTable` while deletion protection is enabled, regardless of the
+ * CloudFormation `DeletionPolicy`.
  *
  * @example
  * ```ts
@@ -27,15 +44,17 @@ import type { IMixin } from 'constructs';
  */
 export class SandboxDisableDeletionProtection extends Mixin implements IMixin {
   supports(construct: any): boolean {
-    return 'deletionProtection' in construct;
+    return DELETION_PROTECTION_PROPERTIES.some((property) => property in construct);
   }
   applyTo(node: IConstruct): void {
     // Only flip explicitly-enabled protection. When undefined (the default),
     // deletion protection is already off — setting it to false would emit the
     // property in the CloudFormation template, which breaks Aurora DB instances
     // (RDS rejects DeletionProtection on cluster members).
-    if ((node as any).deletionProtection === true) {
-      (node as any).deletionProtection = false;
+    for (const property of DELETION_PROTECTION_PROPERTIES) {
+      if ((node as any)[property] === true) {
+        (node as any)[property] = false;
+      }
     }
   }
 }


### PR DESCRIPTION
## Problem

**Issue #, if available:** n/a

`SandboxDisableDeletionProtection` is meant to turn off deletion protection in sandbox mode so ephemeral sandbox stacks can be torn down. For DynamoDB it never worked.

The mixin duck-typed on a single property name:

```ts
supports(construct: any): boolean {
  return 'deletionProtection' in construct;
}
```

But the DynamoDB L1 `CfnTable` spells the property **`deletionProtectionEnabled`**, and the L2 `Table` only accepts `deletionProtection` as a *prop* — it never re-exposes it as a member (`TableProps.deletionProtection` exists, `Table.deletionProtection` does not). So `supports()` returned `false` for every DynamoDB construct in the tree and the mixin silently did nothing.

The consequence is that any table created with deletion protection enabled blocks sandbox stack teardown. Sandbox stacks synth `DeletionProtectionEnabled: true`, and DynamoDB refuses `DeleteTable` while protection is on **regardless of the CloudFormation `DeletionPolicy`** — so `sandbox:destroy` / stack teardown hard-fails on every such table. Consumers have had to work around this with a local `CfnTable` loop.

## Changes

`packages/core/src/cdk/mixins.ts` — match both spellings used across CloudFormation resources, so DynamoDB tables are cleared through their underlying L1:

```ts
const DELETION_PROTECTION_PROPERTIES = ['deletionProtection', 'deletionProtectionEnabled'] as const;

supports(construct: any): boolean {
  return DELETION_PROTECTION_PROPERTIES.some((property) => property in construct);
}
applyTo(node: IConstruct): void {
  for (const property of DELETION_PROTECTION_PROPERTIES) {
    if ((node as any)[property] === true) {
      (node as any)[property] = false;
    }
  }
}
```

This stays inside the mixin's existing duck-typing design — no new imports, and no `instanceof` that could break across duplicate `aws-cdk-lib` copies. It also picks up other L1s using the same spelling (e.g. Aurora DSQL `CfnCluster`). Consumers can drop their local `CfnTable` workaround loops. The class doc comment is updated to record why DynamoDB has to be reached through its L1.

Also updated the `SandboxDisableDeletionProtection` doc block and removed a pre-existing unused `node:assert` import in the test file so biome lint is clean on the touched files.

### Potentially problematic parts, and why they are safe

- **Existing behavior is preserved.** Only explicitly-enabled protection is flipped — when the value is `undefined` nothing is written, so unprotected resources still omit the property. Aurora DB instances continue to synth without `DeletionProtection` (RDS rejects it on cluster members). There is a regression test for this.
- **Blast radius of the newly-matched property.** Every call site applies the mixin only inside a `sandboxMode` branch, so this cannot weaken protection on a production path. Verified across `packages/create-blocks-app/templates/*/aws-blocks/index.cdk.ts` and `test-apps/*`.
- **`AWS::DSQL::Cluster` in `bb-distributed-data` is unaffected.** It is an untyped `cdk.CfnResource`, so the property lives inside the nested `properties` object rather than as an instance member and is not matched by duck-typing. It already handles sandbox teardown via its own `removalPolicy` logic.
- **Not a breaking API change.** The exported class signature is unchanged and `DELETION_PROTECTION_PROPERTIES` is module-private; `npm run check:api` reports the API reports are still up to date, so no `npm run update:api` was needed. Changeset is `patch` per the repo convention that minor signals breaking on 0.x.

## Validation

Three unit tests added to `packages/core/src/cdk/mixins.test.ts`:

1. **sandbox mode** — table with `deletionProtection: true` + mixin applied → synths `DeletionProtectionEnabled: false` and `DeletionPolicy: Delete`.
2. **non-sandbox** — table with `deletionProtection: true` and no mixin → stays `DeletionProtectionEnabled: true`, so protection is not weakened outside sandbox.
3. **regression guard** — unprotected table + mixin applied → `DeletionProtectionEnabled` stays `Match.absent()`, proving we never emit the property where it wasn't set.

Test (1) was verified to **fail without the fix**, reproducing the bug exactly:

```
not ok 5 - SandboxDisableDeletionProtection mixin: deletionProtection disabled on DynamoDB table
  Template has 1 resources with type AWS::DynamoDB::Table, but none match as expected.
```

Results on Node 22:

- `npm run build` (full monorepo, dependency order) — pass
- `packages/core` — **657/657 tests pass, 0 fail**
- `npm run test:unit` (all workspaces, what CI runs) — **27 test files, all `# fail 0`, exit 0**
- `npm run check:api` — "All API reports are up-to-date"
- biome lint on the touched files — clean

Manual end-to-end synth against the built `dist/`, asserting the real synthesized template:

```
SANDBOX      : {"DeletionPolicy":"Delete","DeletionProtectionEnabled":false}
NON-SANDBOX  : {"DeletionPolicy":"Retain","DeletionProtectionEnabled":true}
```

## Checklist

- [x] PR description included
- [x] Tests are changed or added
- [x] Relevant documentation is changed or added (and PR referenced) — the mixin's own doc comment is updated; no separate docs page covers this mixin

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
