### PR TITLE
fix(dart): Remove unnecessary library names in dart packages

### DIFF
--- a/native/dart/packages/blocks_codegen/lib/blocks_codegen.dart
+++ b/native/dart/packages/blocks_codegen/lib/blocks_codegen.dart
@@ -1,5 +1,5 @@
 /// Blocks Codegen — reads OpenRPC specs and generates typed Dart clients.
-library blocks_codegen;
+library;
 
 export 'src/parser.dart';
 export 'src/builder.dart';

--- a/native/dart/packages/blocks_runtime/lib/blocks_runtime.dart
+++ b/native/dart/packages/blocks_runtime/lib/blocks_runtime.dart
@@ -1,5 +1,5 @@
 /// Blocks Runtime — JSON-RPC 2.0 client, WebSocket realtime, and file transferables.
-library blocks_runtime;
+library;
 
 export 'src/auth_provider.dart';
 export 'src/browser_launcher.dart';

--- a/native/dart/packages/blocks_runtime_flutter/lib/blocks_runtime_flutter.dart
+++ b/native/dart/packages/blocks_runtime_flutter/lib/blocks_runtime_flutter.dart
@@ -1,5 +1,5 @@
 /// Flutter-specific implementations for blocks_runtime.
-library blocks_runtime_flutter;
+library;
 
 export 'src/flutter_browser_launcher.dart';
 export 'src/flutter_secure_store.dart';


### PR DESCRIPTION
Lint: `unnecessary_library_name` flagged `library <name>;` in all 3 dart packages (blocks_runtime, blocks_codegen, blocks_runtime_flutter).
Fix: one line each - made the directive anonymous (`library;`), keeping the dartdoc attached to it.
blocks_runtime and blocks_runtime_flutter now have zero lints, so each recovers 10 points on the pub.dev static analysis check.
blocks_codegen has 10 other pre-existing lints, so its 10 points stay withheld until those are fixed separately.
Scores: https://pub.dev/packages/blocks_runtime/score , https://pub.dev/packages/blocks_codegen/score , https://pub.dev/packages/blocks_runtime_flutter/score
