### PR TITLE
fix(dart): Clear lints in `blocks_codegen`

### DIFF
--- a/native/dart/packages/blocks_codegen/lib/builder.dart
+++ b/native/dart/packages/blocks_codegen/lib/builder.dart
@@ -36,7 +36,7 @@ class _BlocksCodegenBuilder extends Builder {
     // .spec.json → .blocks.dart (strip both extensions)
     final path = inputId.path;
     final outputPath =
-        path.substring(0, path.length - '.spec.json'.length) + '.blocks.dart';
+        '${path.substring(0, path.length - '.spec.json'.length)}.blocks.dart';
     final outputId = AssetId(inputId.package, outputPath);
     await buildStep.writeAsString(outputId, output);
   }

--- a/native/dart/packages/blocks_codegen/lib/src/builder.dart
+++ b/native/dart/packages/blocks_codegen/lib/src/builder.dart
@@ -313,7 +313,7 @@ class CodegenModelBuilder {
       [String? path]) {
     if (ref is InlineObjectRef) {
       // Resolve fields first, then check for structural match
-      final tempName = hint != null ? '${hint}Message' : '_Anon${_anonCounter}';
+      final tempName = hint != null ? '${hint}Message' : '_Anon$_anonCounter';
       final childPath = path == null ? null : '$path>message';
       final fields = ref.properties.entries.map((e) {
         return RecordField(
@@ -523,7 +523,7 @@ class CodegenModelBuilder {
       SealedClassType? embeddedUnion;
       if (group.length == 1 && group.first.embeddedUnion != null) {
         final nestedName =
-            '${className}${_capitalize(group.first.embeddedUnion!.discriminant)}';
+            '$className${_capitalize(group.first.embeddedUnion!.discriminant)}';
         final resolved = _resolveDiscriminatedUnion(
             group.first.embeddedUnion!, nestedName, variantPath);
         embeddedUnion = resolved is SealedClassType ? resolved : null;

--- a/native/dart/packages/blocks_codegen/lib/src/generator.dart
+++ b/native/dart/packages/blocks_codegen/lib/src/generator.dart
@@ -69,8 +69,10 @@ class DartCodeGenerator {
     buf.writeln();
     for (final entry in model.types.entries) {
       if (emittedTypes.contains(entry.key)) continue;
-      if (!schemaTypes.contains(entry.key) && typeUsage.containsKey(entry.key))
+      if (!schemaTypes.contains(entry.key) &&
+          typeUsage.containsKey(entry.key)) {
         continue;
+      }
       final code = _emitType(entry.value, model.types, emittedTypes);
       if (code.isNotEmpty) {
         buf.writeln(code);
@@ -276,8 +278,9 @@ class DartCodeGenerator {
             .map((p) => p.isEmpty ? '' : p[0].toUpperCase() + p.substring(1))
             .join();
     // Ensure it starts with a letter
-    if (result.isEmpty || !RegExp(r'^[a-zA-Z_]').hasMatch(result))
+    if (result.isEmpty || !RegExp(r'^[a-zA-Z_]').hasMatch(result)) {
       return '_$result';
+    }
     return result;
   }
 
@@ -874,7 +877,7 @@ class DartCodeGenerator {
         '$accessor == null ? null : $name.fromJson($accessor as Map<String, dynamic>)',
       SealedClassType(name: final name) =>
         '$accessor == null ? null : $name.fromJson($accessor as Map<String, dynamic>)',
-      _ => '$accessor',
+      _ => accessor,
     };
   }
 
@@ -945,8 +948,9 @@ class DartCodeGenerator {
     final cast = '$accessor as Map<String, dynamic>';
     return switch (blocksType) {
       'realtime/channel' => () {
-          if (typeArgs.isEmpty)
+          if (typeArgs.isEmpty) {
             return 'RealtimeChannel.fromJson($cast, (json) => json)';
+          }
           final argType = _dartTypeStr(typeArgs[0], allTypes);
           return 'RealtimeChannel.fromJson($cast, (json) => $argType.fromJson(json))';
         }(),

--- a/native/dart/packages/blocks_codegen/lib/src/model.dart
+++ b/native/dart/packages/blocks_codegen/lib/src/model.dart
@@ -1,5 +1,6 @@
 /// Intermediate representation produced by the parser.
 /// TypeRef is a sealed class representing unresolved type references from the spec.
+library;
 
 class Constraints {
   final String? format;

--- a/native/dart/packages/blocks_codegen/lib/src/parser.dart
+++ b/native/dart/packages/blocks_codegen/lib/src/parser.dart
@@ -139,9 +139,10 @@ class OpenRpcParser {
       }
       // Regular array (or array-form items as tuple)
       final items = schema['items'];
-      if (items == null)
+      if (items == null) {
         return ArrayRef(PrimitiveRef('dynamic'),
             constraints: _parseConstraints(schema));
+      }
       if (items is List<dynamic>) {
         final tupleItems = items
             .map((item) => _parseTypeRef(item as Map<String, dynamic>))
@@ -150,9 +151,10 @@ class OpenRpcParser {
         return TupleRef(tupleItems);
       }
       final itemsMap = items as Map<String, dynamic>;
-      if (itemsMap.isEmpty)
+      if (itemsMap.isEmpty) {
         return ArrayRef(PrimitiveRef('dynamic'),
             constraints: _parseConstraints(schema));
+      }
       return ArrayRef(_parseTypeRef(itemsMap),
           constraints: _parseConstraints(schema));
     }


### PR DESCRIPTION
Lint: blocks_codegen lib/ had 10 lints under the pub.dev ruleset (package:lints/recommended), incl. prefer_interpolation_to_compose_strings at builder.dart:39.
Fixed: 5x curly_braces_in_flow_control_structures, 2x unnecessary_brace_in_string_interps, 1x unnecessary_string_interpolations, 1x prefer_interpolation_to_compose_strings, 1x dangling_library_doc_comments.
Verified: `dart analyze lib` against package:lints/recommended goes from 10 issues to "No issues found"; in-repo strict ruleset 133 -> 123, zero new issues.
This recovers the last 10 points on the pub.dev static analysis check (blocks_runtime and blocks_runtime_flutter were done in #343).
Score: https://pub.dev/packages/blocks_codegen/score - format clean (0 changed), all 61 tests pass incl. byte-identical golden files.
