### PR TITLE
test(docs): cover catalog parsing helpers

### DIFF
--- a/.github/workflows/block-catalog-check.yml
+++ b/.github/workflows/block-catalog-check.yml
@@ -21,5 +21,7 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version-file: '.nvmrc'
+      - name: Test Building Block catalog helpers
+        run: node --test scripts/sync-catalog.test.mjs
       - name: Verify Building Block catalog is in sync
         run: node scripts/sync-catalog.mjs --check

--- a/scripts/sync-catalog.mjs
+++ b/scripts/sync-catalog.mjs
@@ -33,7 +33,7 @@
  */
 
 import { readFileSync, writeFileSync, readdirSync, existsSync } from 'node:fs';
-import { join, dirname } from 'node:path';
+import { join, dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -47,21 +47,26 @@ const END_MARKER = '<!-- END:block-catalog -->';
 
 const SYNC_HINT = 'Run `npm run sync-docs` and commit the result.';
 
-const mode = process.argv.includes('--check') ? 'check' : 'write';
-
-const packages = getPackages();
-const catalog = buildCatalog(packages);
-const table = renderCatalogTable(catalog);
-
-if (mode === 'check') {
-  runCheck();
-} else {
-  runWrite();
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main();
 }
 
 // ─── Modes ───────────────────────────────────────────────────────────────────
 
-function runCheck() {
+function main() {
+  const mode = process.argv.includes('--check') ? 'check' : 'write';
+  const packages = getPackages();
+  const catalog = buildCatalog(packages);
+  const table = renderCatalogTable(catalog);
+
+  if (mode === 'check') {
+    runCheck(table);
+  } else {
+    runWrite(catalog, table);
+  }
+}
+
+function runCheck(table) {
   const readme = readFileSync(readmePath, 'utf-8');
   const current = extractBetweenMarkers(readme);
 
@@ -83,7 +88,7 @@ function runCheck() {
   process.exit(0);
 }
 
-function runWrite() {
+function runWrite(catalog, table) {
   const readme = readFileSync(readmePath, 'utf-8');
   const updated = injectCatalog(readme, table);
   if (updated !== readme) writeFileSync(readmePath, updated);
@@ -120,7 +125,7 @@ function escapeCell(value) {
 
 // ─── Marker helpers ──────────────────────────────────────────────────────────
 
-function injectCatalog(readme, catalogTable) {
+export function injectCatalog(readme, catalogTable) {
   const begin = readme.indexOf(BEGIN_MARKER);
   const end = readme.indexOf(END_MARKER);
   if (begin === -1 || end === -1 || end < begin) {
@@ -134,7 +139,7 @@ function injectCatalog(readme, catalogTable) {
   return `${before}\n${catalogTable}\n${after}`;
 }
 
-function extractBetweenMarkers(readme) {
+export function extractBetweenMarkers(readme) {
   const begin = readme.indexOf(BEGIN_MARKER);
   const end = readme.indexOf(END_MARKER);
   if (begin === -1 || end === -1 || end < begin) return null;
@@ -143,7 +148,7 @@ function extractBetweenMarkers(readme) {
 
 // ─── README parsing ──────────────────────────────────────────────────────────
 
-function extractBlurb(content) {
+export function extractBlurb(content) {
   const lines = content.split('\n');
   const h1 = lines.findIndex((l) => l.startsWith('# '));
   if (h1 === -1) return '';

--- a/scripts/sync-catalog.test.mjs
+++ b/scripts/sync-catalog.test.mjs
@@ -1,0 +1,83 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Run: node --test scripts/sync-catalog.test.mjs
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { extractBetweenMarkers, extractBlurb, injectCatalog } from './sync-catalog.mjs';
+
+const BEGIN_MARKER = '<!-- BEGIN:block-catalog -->';
+const END_MARKER = '<!-- END:block-catalog -->';
+
+describe('extractBlurb', () => {
+  const cases = [
+    {
+      name: 'returns the first sentence after the h1',
+      content: '# Block\n\nProvides the first capability. Additional details follow.',
+      expected: 'Provides the first capability.',
+    },
+    {
+      name: 'returns the whole line when it has no sentence-ending period',
+      content: '# Block\nProvides a capability without punctuation',
+      expected: 'Provides a capability without punctuation',
+    },
+    {
+      name: 'skips blank lines after the h1',
+      content: '# Block\n\n  \nProvides a capability.',
+      expected: 'Provides a capability.',
+    },
+    {
+      name: 'returns empty when the document has no h1',
+      content: '## Block\nProvides a capability.',
+      expected: '',
+    },
+    {
+      name: 'stops at a heading before descriptive text',
+      content: '# Block\n\n## Usage\nProvides a capability.',
+      expected: '',
+    },
+    {
+      name: 'stops at an HTML comment before descriptive text',
+      content: '# Block\n\n<!-- generated -->\nProvides a capability.',
+      expected: '',
+    },
+  ];
+
+  for (const { name, content, expected } of cases) {
+    it(name, () => {
+      assert.equal(extractBlurb(content), expected);
+    });
+  }
+});
+
+describe('catalog markers', () => {
+  const readme = `Before\n${BEGIN_MARKER}\nOld table\n${END_MARKER}\nAfter`;
+
+  it('extracts the content between valid markers', () => {
+    assert.equal(extractBetweenMarkers(readme), '\nOld table\n');
+  });
+
+  it('injects a catalog without changing content outside the markers', () => {
+    assert.equal(
+      injectCatalog(readme, 'New table'),
+      `Before\n${BEGIN_MARKER}\nNew table\n${END_MARKER}\nAfter`,
+    );
+  });
+
+  const invalidCases = [
+    { name: 'missing begin marker', readme: `Before\n${END_MARKER}\nAfter` },
+    { name: 'missing end marker', readme: `Before\n${BEGIN_MARKER}\nAfter` },
+    { name: 'end marker before begin marker', readme: `${END_MARKER}\n${BEGIN_MARKER}` },
+  ];
+
+  for (const { name, readme: invalidReadme } of invalidCases) {
+    it(`returns null for ${name}`, () => {
+      assert.equal(extractBetweenMarkers(invalidReadme), null);
+    });
+
+    it(`throws on write for ${name}`, () => {
+      assert.throws(() => injectCatalog(invalidReadme, 'New table'), /catalog markers .* not found/);
+    });
+  }
+});


### PR DESCRIPTION
## Problem

**Issue #, if available:** #323

The catalog sync gate exercises `scripts/sync-catalog.mjs` only as a CLI command. Its parsing helpers have no direct tests, so a regression in blurb extraction or marker handling could silently corrupt the committed catalog or weaken the CI check.

## Changes

- Make the pure catalog helpers importable without running the CLI.
- Add table-driven coverage for `extractBlurb`, `extractBetweenMarkers`, and `injectCatalog`, including malformed marker order and missing-marker behavior.
- Run the new tests in the existing Block Catalog Check workflow before the catalog freshness check.

No published package behavior changes, so no changeset is needed.

This intentionally follows the narrow scope proposed in #323. If the maintainers would prefer a different test location, helper extraction, or scope, I am happy to adjust this PR or close it.

## Validation

- `node --test scripts/*.test.mjs` (45 passing)
- `node scripts/sync-catalog.mjs --check`
- `node scripts/sync-catalog.mjs --write` (no README changes)
- `git diff --check`

`npm run build` could not run in this dedicated worktree because its workspace dependencies are not installed (`tsc` is unavailable). The changed script and its CI workflow use Node built-ins only; the targeted checks above exercise the complete changed behavior.

## Checklist

- [x] PR description included
- [x] Tests are changed or added
- [x] Relevant documentation is unchanged; this is a test and CI-only change

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
