### PR TITLE
chore: update release instructions

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -5,9 +5,8 @@ name: Release
 # and no changesets remain, publishes to npm. Merging the PR is the release gate.
 # Canary publishes live in publish-canary.yml.
 #
-# NOTE: The Version Packages PR is created by GITHUB_TOKEN, so it does NOT
-# auto-trigger PR check workflows (GitHub platform limitation). To run checks
-# before merging, close and reopen the PR — this fires a real event and CI runs.
+# NOTE: The Version Packages PR does not start its PR checks automatically.
+# Approve the workflow runs at the bottom of the PR. Then merge the PR.
 
 on:
   push:
@@ -66,10 +65,13 @@ jobs:
           INSTRUCTIONS="## Release Instructions
 
           > **To complete this release:**
-          > 1. Review the version bumps and changelogs below
-          > 2. **Close and reopen this PR** to trigger CI checks (required due to GitHub token limitations)
-          > 3. Once all checks pass, merge the PR
-          > 4. The merge triggers npm publish automatically
+          > 1. Read the version bumps and changelogs below.
+          > 2. Go to the bottom of this PR.
+          > 3. **Approve the workflow runs.**
+          > 4. Wait until all checks pass.
+          > 5. Merge the PR.
+          >
+          > The merge starts the npm publish.
 
           ---
 


### PR DESCRIPTION
## Problem

<!--
Describe the issue this PR is solving. For trivial changes, a short one-liner is fine.
-->
The generated "Release Instructions" block on the Version Packages PR tells the operator to close and reopen the PR to get CI to run. That is no longer the action needed.

**Issue #, if available:**

## Changes

<!--
Summarize the changes introduced in this PR. Call out critical or potentially problematic parts of the change.
-->

Text-only edits to `.github/workflows/publish-packages.yml`. No triggers, steps, jobs, or logic changed.

1. The header comment (lines 9-11) no longer describes the close/reopen workaround.
2. Step 2 of the `INSTRUCTIONS` string now points at the approval prompt.


## Validation

<!--
Describe how changes have been validated — added/updated unit, integration, or E2E tests, manual verification, etc.
If no automated tests were added, explain why.
-->

## Checklist

- [ ] PR description included
- [ ] Tests are changed or added
- [ ] Relevant documentation is changed or added (and PR referenced)

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
