### PR TITLE
fix(dart): Make blocks_runtime_flutter WASM-compatible

### DIFF
--- a/native/dart/.gitignore
+++ b/native/dart/.gitignore
@@ -1,5 +1,6 @@
 .dart_tool/
 pubspec.lock
+.flutter-plugins-dependencies
 *.iml
 .metadata
 .packages

--- a/native/dart/packages/blocks_runtime_flutter/pubspec.yaml
+++ b/native/dart/packages/blocks_runtime_flutter/pubspec.yaml
@@ -7,13 +7,14 @@ issue_tracker: https://github.com/aws-devtools-labs/aws-blocks/issues
 
 environment:
   sdk: ^3.3.0
-  flutter: '>=3.0.0'
+  flutter: '>=3.19.0'
 
 dependencies:
   flutter:
     sdk: flutter
   blocks_runtime: ^0.1.1
-  flutter_secure_storage: ^9.0.0
+  # 10.x dropped the `dart:io` import that made this package Web/WASM-incompatible.
+  flutter_secure_storage: ^10.0.0
   url_launcher: ^6.2.0
   app_links: ^6.0.0
 

--- a/native/dart/packages/blocks_runtime_flutter/test/flutter_secure_store_test.mocks.dart
+++ b/native/dart/packages/blocks_runtime_flutter/test/flutter_secure_store_test.mocks.dart
@@ -76,8 +76,8 @@ class _FakeWebOptions_4 extends _i1.SmartFake implements _i2.WebOptions {
         );
 }
 
-class _FakeMacOsOptions_5 extends _i1.SmartFake implements _i2.MacOsOptions {
-  _FakeMacOsOptions_5(
+class _FakeAppleOptions_5 extends _i1.SmartFake implements _i2.AppleOptions {
+  _FakeAppleOptions_5(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -141,13 +141,20 @@ class MockFlutterSecureStorage extends _i1.Mock
       ) as _i2.WebOptions);
 
   @override
-  _i2.MacOsOptions get mOptions => (super.noSuchMethod(
+  _i2.AppleOptions get mOptions => (super.noSuchMethod(
         Invocation.getter(#mOptions),
-        returnValue: _FakeMacOsOptions_5(
+        returnValue: _FakeAppleOptions_5(
           this,
           Invocation.getter(#mOptions),
         ),
-      ) as _i2.MacOsOptions);
+      ) as _i2.AppleOptions);
+
+  @override
+  Map<String, List<_i3.ValueChanged<String?>>> get getListeners =>
+      (super.noSuchMethod(
+        Invocation.getter(#getListeners),
+        returnValue: <String, List<_i3.ValueChanged<String?>>>{},
+      ) as Map<String, List<_i3.ValueChanged<String?>>>);
 
   @override
   void registerListener({
@@ -207,11 +214,11 @@ class MockFlutterSecureStorage extends _i1.Mock
   _i4.Future<void> write({
     required String? key,
     required String? value,
-    _i2.IOSOptions? iOptions,
+    _i2.AppleOptions? iOptions,
     _i2.AndroidOptions? aOptions,
     _i2.LinuxOptions? lOptions,
     _i2.WebOptions? webOptions,
-    _i2.MacOsOptions? mOptions,
+    _i2.AppleOptions? mOptions,
     _i2.WindowsOptions? wOptions,
   }) =>
       (super.noSuchMethod(
@@ -236,11 +243,11 @@ class MockFlutterSecureStorage extends _i1.Mock
   @override
   _i4.Future<String?> read({
     required String? key,
-    _i2.IOSOptions? iOptions,
+    _i2.AppleOptions? iOptions,
     _i2.AndroidOptions? aOptions,
     _i2.LinuxOptions? lOptions,
     _i2.WebOptions? webOptions,
-    _i2.MacOsOptions? mOptions,
+    _i2.AppleOptions? mOptions,
     _i2.WindowsOptions? wOptions,
   }) =>
       (super.noSuchMethod(
@@ -263,11 +270,11 @@ class MockFlutterSecureStorage extends _i1.Mock
   @override
   _i4.Future<bool> containsKey({
     required String? key,
-    _i2.IOSOptions? iOptions,
+    _i2.AppleOptions? iOptions,
     _i2.AndroidOptions? aOptions,
     _i2.LinuxOptions? lOptions,
     _i2.WebOptions? webOptions,
-    _i2.MacOsOptions? mOptions,
+    _i2.AppleOptions? mOptions,
     _i2.WindowsOptions? wOptions,
   }) =>
       (super.noSuchMethod(
@@ -290,11 +297,11 @@ class MockFlutterSecureStorage extends _i1.Mock
   @override
   _i4.Future<void> delete({
     required String? key,
-    _i2.IOSOptions? iOptions,
+    _i2.AppleOptions? iOptions,
     _i2.AndroidOptions? aOptions,
     _i2.LinuxOptions? lOptions,
     _i2.WebOptions? webOptions,
-    _i2.MacOsOptions? mOptions,
+    _i2.AppleOptions? mOptions,
     _i2.WindowsOptions? wOptions,
   }) =>
       (super.noSuchMethod(
@@ -317,11 +324,11 @@ class MockFlutterSecureStorage extends _i1.Mock
 
   @override
   _i4.Future<Map<String, String>> readAll({
-    _i2.IOSOptions? iOptions,
+    _i2.AppleOptions? iOptions,
     _i2.AndroidOptions? aOptions,
     _i2.LinuxOptions? lOptions,
     _i2.WebOptions? webOptions,
-    _i2.MacOsOptions? mOptions,
+    _i2.AppleOptions? mOptions,
     _i2.WindowsOptions? wOptions,
   }) =>
       (super.noSuchMethod(
@@ -342,11 +349,11 @@ class MockFlutterSecureStorage extends _i1.Mock
 
   @override
   _i4.Future<void> deleteAll({
-    _i2.IOSOptions? iOptions,
+    _i2.AppleOptions? iOptions,
     _i2.AndroidOptions? aOptions,
     _i2.LinuxOptions? lOptions,
     _i2.WebOptions? webOptions,
-    _i2.MacOsOptions? mOptions,
+    _i2.AppleOptions? mOptions,
     _i2.WindowsOptions? wOptions,
   }) =>
       (super.noSuchMethod(


### PR DESCRIPTION
`flutter_secure_storage` 9.x imports `dart:io`, which cost `blocks_runtime_flutter` the WASM and full Web platform points on its pub.dev score. 10.x dropped that import, so bumping the constraint clears it.

- `flutter_secure_storage: ^9.0.0` -> `^10.0.0`
- `flutter: '>=3.0.0'` -> `'>=3.19.0'` (required by 10.x)
- Regenerated the mockito mocks (`IOSOptions`/`MacOsOptions` are now `AppleOptions`)

Local pana, before -> after:

```
Platform support   10/20  ->  20/20
  not WASM-compatible  ->  WASM-ready
Total             130/160 -> 140/160
```

Staying on 10.x rather than 11.x keeps the SDK floor at `^3.3.0` and routes existing Android users through the automatic 9.x -> 10.x data migration, which upstream requires before 11.

The only public API touched is `FlutterSecureStore({FlutterSecureStorage? storage})`, so callers passing their own instance move to 10.x with us.

Tests and format pass; the remaining analyzer infos are pre-existing.