### PR TITLE
[bb-kv-store + 10 more] Attach IAM grants to the shared execution role

### DIFF
--- a/.changeset/data-blocks-execution-role.md
+++ b/.changeset/data-blocks-execution-role.md
@@ -1,0 +1,26 @@
+---
+"@aws-blocks/bb-kv-store": patch
+"@aws-blocks/bb-distributed-table": patch
+"@aws-blocks/bb-file-bucket": patch
+"@aws-blocks/bb-data": patch
+"@aws-blocks/bb-app-setting": patch
+"@aws-blocks/bb-knowledge-base": patch
+"@aws-blocks/bb-email-client": patch
+"@aws-blocks/bb-auth-cognito": patch
+"@aws-blocks/bb-auth-oidc": patch
+"@aws-blocks/bb-distributed-data": patch
+"@aws-blocks/bb-agent": patch
+---
+
+refactor(bb): attach IAM grants to the shared execution role
+
+Data and auth blocks now grant permissions to the shared Blocks execution role
+(`this.executionRole`) instead of the handler function directly. Grants land on
+the same role the handler assumes, so the effective runtime permissions are
+identical — this decouples IAM wiring from the concrete Lambda function ahead of
+the multi-compute model.
+
+For `bb-distributed-data`, the DSQL endpoint and region now flow through the
+config registry (loaded into `process.env` at cold start, like every other
+block) rather than being set as direct handler environment variables, and the
+migration Lambda maps the shared execution role's ARN.

--- a/packages/bb-agent/src/index.cdk.ts
+++ b/packages/bb-agent/src/index.cdk.ts
@@ -30,7 +30,7 @@ export class Agent extends Scope {
 	constructor(scope: ScopeParent, id: string, config?: any) {
 		super(id, { parent: scope });
 
-		this.handler.addToRolePolicy(new PolicyStatement({
+		this.executionRole.addToPrincipalPolicy(new PolicyStatement({
 			actions: ['bedrock:InvokeModel', 'bedrock:InvokeModelWithResponseStream', 'bedrock:GetFoundationModel', 'bedrock:ListFoundationModels', 'bedrock:GetInferenceProfile'],
 			resources: [
 				'arn:aws:bedrock:*::foundation-model/*',

--- a/packages/bb-app-setting/src/index.cdk.test.ts
+++ b/packages/bb-app-setting/src/index.cdk.test.ts
@@ -17,15 +17,20 @@ import { AppSetting } from './index.cdk.js';
 
 class StubBlocksStack extends cdk.Stack {
 	public readonly handler: cdk.aws_lambda.Function;
+	public readonly executionRole: cdk.aws_iam.IRole;
 	public readonly id: string;
 	constructor(scope: Construct, id: string) {
 		super(scope, id);
 		this.id = id;
 		(globalThis as any).CURRENT_BLOCKS_STACK = this;
+		this.executionRole = new cdk.aws_iam.Role(this, 'BlocksRole', {
+			assumedBy: new cdk.aws_iam.ServicePrincipal('lambda.amazonaws.com'),
+		});
 		this.handler = new cdk.aws_lambda.Function(this, 'StubHandler', {
 			runtime: DEFAULT_NODE_RUNTIME,
 			handler: 'index.handler',
 			code: cdk.aws_lambda.Code.fromInline('exports.handler = async () => {};'),
+			role: this.executionRole,
 		});
 	}
 }

--- a/packages/bb-app-setting/src/index.cdk.ts
+++ b/packages/bb-app-setting/src/index.cdk.ts
@@ -136,7 +136,7 @@ export class AppSetting<T = string> extends Scope {
 			// Grant handler KMS access for the default aws/ssm key. External secrets
 			// are read-only (Decrypt only); stack-managed secrets also need Encrypt
 			// so the app can write the value via put().
-			this.handler.addToRolePolicy(new iam.PolicyStatement({
+			this.executionRole.addToPrincipalPolicy(new iam.PolicyStatement({
 				actions: external ? ['kms:Decrypt'] : ['kms:Decrypt', 'kms:Encrypt'],
 				resources: ['*'],
 				conditions: {
@@ -159,7 +159,7 @@ export class AppSetting<T = string> extends Scope {
 
 		// Grant handler SSM access on this parameter. External parameters are owned
 		// elsewhere, so the app only reads them (no ssm:PutParameter).
-		this.handler.addToRolePolicy(new iam.PolicyStatement({
+		this.executionRole.addToPrincipalPolicy(new iam.PolicyStatement({
 			actions: external ? ['ssm:GetParameter'] : ['ssm:GetParameter', 'ssm:PutParameter'],
 			resources: [parameterArn],
 		}));

--- a/packages/bb-auth-cognito/src/index.cdk.test.ts
+++ b/packages/bb-auth-cognito/src/index.cdk.test.ts
@@ -26,12 +26,17 @@ function synth(build: (stack: cdk.Stack) => void) {
 	// BlocksStack has a private ctor; build a plain Stack + placeholder Handler
 	// Lambda so AuthCognito can register config via the config registry.
 	const stack = new cdk.Stack(app, 'TestStack');
+	const executionRole = new cdk.aws_iam.Role(stack, 'BlocksRole', {
+		assumedBy: new cdk.aws_iam.ServicePrincipal('lambda.amazonaws.com'),
+	});
 	const handler = new lambda.Function(stack, 'Handler', {
 		runtime: DEFAULT_NODE_RUNTIME,
 		handler: 'index.handler',
 		code: lambda.Code.fromInline('exports.handler = async () => {};'),
+		role: executionRole,
 	});
 	(stack as any).handler = handler;
+	(stack as any).executionRole = executionRole;
 	(globalThis as any).CURRENT_BLOCKS_STACK = stack;
 	try {
 		build(stack);
@@ -70,12 +75,17 @@ import { AuthCognito } from '@aws-blocks/bb-auth-cognito';
 
 const app = new cdk.App();
 const stack = new cdk.Stack(app, 'TestStack');
+const executionRole = new cdk.aws_iam.Role(stack, 'BlocksRole', {
+	assumedBy: new cdk.aws_iam.ServicePrincipal('lambda.amazonaws.com'),
+});
 const handler = new lambda.Function(stack, 'Handler', {
 	runtime: DEFAULT_NODE_RUNTIME,
 	handler: 'index.handler',
 	code: lambda.Code.fromInline('exports.handler = async () => {};'),
+	role: executionRole,
 });
 stack.handler = handler;
+stack.executionRole = executionRole;
 globalThis.CURRENT_BLOCKS_STACK = stack;
 new AuthCognito(stack, 'auth');
 finalizeConfigRegistry(stack, handler);

--- a/packages/bb-auth-cognito/src/index.cdk.ts
+++ b/packages/bb-auth-cognito/src/index.cdk.ts
@@ -21,7 +21,7 @@
 import * as cdk from 'aws-cdk-lib';
 import * as cognito from 'aws-cdk-lib/aws-cognito';
 import * as iam from 'aws-cdk-lib/aws-iam';
-import type * as lambda from 'aws-cdk-lib/aws-lambda';
+
 import { Scope } from '@aws-blocks/core/cdk';
 import { registerConfig } from '@aws-blocks/core/cdk';
 import type { ScopeParent } from '@aws-blocks/core';
@@ -290,11 +290,10 @@ export class AuthCognito<const O extends AuthCognitoOptions = AuthCognitoOptions
 		this.sessions = new KVStore(this, 'sessions', { removalPolicy: opts.removalPolicy, ttl: true });
 
 		// 6. Env vars + IAM
-		const fn = this.handler as lambda.Function;
 		registerConfig(this, env.USER_POOL_ID, this.userPool.userPoolId);
 		registerConfig(this, env.CLIENT_ID, this.userPoolClient.userPoolClientId);
 		registerConfig(this, env.REGION, cdk.Stack.of(this).region);
-		this.grantCognitoPermissions(fn);
+		this.grantCognitoPermissions(this.executionRole);
 	}
 
 	/**
@@ -320,10 +319,10 @@ export class AuthCognito<const O extends AuthCognitoOptions = AuthCognitoOptions
 
 	// ─── IAM helpers ──────────────────────────────────────────────────────
 
-	private grantCognitoPermissions(fn: lambda.Function): void {
+	private grantCognitoPermissions(role: iam.IRole): void {
 		const poolArn = this.userPool.userPoolArn;
 		// Client-facing actions — work on the signed-in user via their access token.
-		fn.addToRolePolicy(new iam.PolicyStatement({
+		role.addToPrincipalPolicy(new iam.PolicyStatement({
 			actions: [
 				'cognito-idp:SignUp',
 				'cognito-idp:ConfirmSignUp',
@@ -367,7 +366,7 @@ export class AuthCognito<const O extends AuthCognitoOptions = AuthCognitoOptions
 		if (admin) {
 			const adminActions = adminIamActions(admin.actions);
 			if (adminActions.length > 0) {
-				fn.addToRolePolicy(new iam.PolicyStatement({
+				role.addToPrincipalPolicy(new iam.PolicyStatement({
 					actions: adminActions,
 					resources: [poolArn],
 				}));

--- a/packages/bb-auth-oidc/src/index.cdk.ts
+++ b/packages/bb-auth-oidc/src/index.cdk.ts
@@ -28,13 +28,13 @@
  *   the provider helpers.
  */
 
-import { type ScopeParent } from '@aws-blocks/core';
+import type { ScopeParent } from '@aws-blocks/core';
 import { Scope, registerConfig } from '@aws-blocks/core/cdk';
 import { AppSetting } from '@aws-blocks/bb-app-setting';
 import { KVStore } from '@aws-blocks/bb-kv-store';
 import * as cdk from 'aws-cdk-lib';
 import * as cognito from 'aws-cdk-lib/aws-cognito';
-import type * as lambda from 'aws-cdk-lib/aws-lambda';
+
 import type { IDependable } from 'constructs';
 import type { AuthOIDCOptions, CognitoFederatedProvider, ProviderConfig } from './types.js';
 import {
@@ -175,7 +175,6 @@ export class AuthOIDC<
 			client.node.addDependency(dep);
 		}
 
-		const fn = this.handler as lambda.Function;
 		const envPrefix = `BLOCKS_AUTH_OIDC_COGNITO_${this.fullId.toUpperCase().replace(/[^A-Z0-9]/g, '_')}`;
 		registerConfig(this, `${envPrefix}_POOL_ID`, pool.userPoolId);
 		registerConfig(this, `${envPrefix}_CLIENT_ID`, client.userPoolClientId);

--- a/packages/bb-data/src/index.cdk.ts
+++ b/packages/bb-data/src/index.cdk.ts
@@ -43,7 +43,7 @@ export class Database extends Scope {
         registerConfig(this, `${ENV_VAR_PREFIX}_${envName}_CLUSTER_ARN`, conn.host);
         registerConfig(this, `${ENV_VAR_PREFIX}_${envName}_SECRET_ARN`, conn.secretArn);
         registerConfig(this, `${ENV_VAR_PREFIX}_${envName}_DATABASE`, conn.database);
-        grantExternalDataApi(this, this.fullId, conn, this.handler);
+        grantExternalDataApi(this, this.fullId, conn, this.executionRole);
       }
       // connectionString variant: AppSetting handles parameter creation, IAM grants, and env var injection.
 
@@ -88,8 +88,8 @@ export class Database extends Scope {
       registerConfig(this, key, value);
     });
 
-    // Grant Data API permissions to the Lambda handler
-    infra.grantDataApi(this.handler);
+    // Grant Data API permissions to the shared execution role
+    infra.grantDataApi(this.executionRole);
   }
 
   /**

--- a/packages/bb-distributed-data/src/index.cdk.test.ts
+++ b/packages/bb-distributed-data/src/index.cdk.test.ts
@@ -22,12 +22,17 @@ const MIGRATIONS_DIR = '.bb-data/__test_cdk_migrations__';
 function synth(build: (stack: cdk.Stack) => void): Template {
   const app = new cdk.App();
   const stack = new cdk.Stack(app, 'TestStack');
+  const executionRole = new cdk.aws_iam.Role(stack, 'BlocksRole', {
+    assumedBy: new cdk.aws_iam.ServicePrincipal('lambda.amazonaws.com'),
+  });
   const handler = new lambda.Function(stack, 'Handler', {
     runtime: DEFAULT_NODE_RUNTIME,
     handler: 'index.handler',
     code: lambda.Code.fromInline('exports.handler = async () => {};'),
+    role: executionRole,
   });
   (stack as any).handler = handler;
+  (stack as any).executionRole = executionRole;
   (globalThis as any).CURRENT_BLOCKS_STACK = stack;
   try {
     build(stack);
@@ -67,13 +72,18 @@ test('CDK: per-block removalPolicy is independent of deletion protection', () =>
   // RETAINed on stack delete but not deletion-protected.
   const app = new cdk.App();
   const stack = new cdk.Stack(app, 'IndepStack');
+  const executionRole = new cdk.aws_iam.Role(stack, 'BlocksRole', {
+    assumedBy: new cdk.aws_iam.ServicePrincipal('lambda.amazonaws.com'),
+  });
   const handler = new lambda.Function(stack, 'Handler', {
     runtime: DEFAULT_NODE_RUNTIME,
     handler: 'index.handler',
     code: lambda.Code.fromInline('exports.handler = async () => {};'),
+    role: executionRole,
   });
   (stack as any).handler = handler;
   (stack as any).defaults = BlocksPresets.sandbox;
+  (stack as any).executionRole = executionRole;
   (globalThis as any).CURRENT_BLOCKS_STACK = stack;
   try {
     new DistributedDatabase(scope(stack), 'mydsql', { removalPolicy: 'retain' });
@@ -90,15 +100,20 @@ test('CDK: per-block removalPolicy is independent of deletion protection', () =>
 test('CDK: sandbox defaults disable deletion protection', () => {
   const app = new cdk.App();
   const stack = new cdk.Stack(app, 'SandboxStack');
+  const executionRole = new cdk.aws_iam.Role(stack, 'BlocksRole', {
+    assumedBy: new cdk.aws_iam.ServicePrincipal('lambda.amazonaws.com'),
+  });
   const handler = new lambda.Function(stack, 'Handler', {
     runtime: DEFAULT_NODE_RUNTIME,
     handler: 'index.handler',
     code: lambda.Code.fromInline('exports.handler = async () => {};'),
+    role: executionRole,
   });
   (stack as any).handler = handler;
   // The cluster's removal/protection follows the stack-wide defaults (resolved
   // via the globalThis fallback here), not the sandboxMode context.
   (stack as any).defaults = BlocksPresets.sandbox;
+  (stack as any).executionRole = executionRole;
   (globalThis as any).CURRENT_BLOCKS_STACK = stack;
   try {
     new DistributedDatabase(scope(stack), 'mydsql');
@@ -130,19 +145,39 @@ test('CDK: handler gets dsql:DbConnect policy (least privilege)', () => {
   });
 });
 
-// --- Environment variables ---
+// --- Runtime config (endpoint + region) ---
 
-test('CDK: handler gets ENDPOINT and REGION env vars', () => {
-  const template = synth((stack) => {
-    new DistributedDatabase(scope(stack), 'mydsql');
+test('CDK: registers ENDPOINT and REGION via the config registry (not handler env vars)', () => {
+  const app = new cdk.App();
+  const stack = new cdk.Stack(app, 'TestStack');
+  const executionRole = new cdk.aws_iam.Role(stack, 'BlocksRole', {
+    assumedBy: new cdk.aws_iam.ServicePrincipal('lambda.amazonaws.com'),
   });
-  const fns = template.findResources('AWS::Lambda::Function');
-  const handlerFn = Object.entries(fns).find(([id]) => id.startsWith('Handler'));
-  assert.ok(handlerFn, 'Handler Lambda should exist');
-  const env = (handlerFn![1] as any).Properties?.Environment?.Variables ?? {};
-  const envKeys = Object.keys(env);
-  assert.ok(envKeys.some(k => k.includes('ENDPOINT')), `Expected ENDPOINT env var, got: ${envKeys}`);
-  assert.ok(envKeys.some(k => k.includes('REGION')), `Expected REGION env var, got: ${envKeys}`);
+  const handler = new lambda.Function(stack, 'Handler', {
+    runtime: DEFAULT_NODE_RUNTIME,
+    handler: 'index.handler',
+    code: lambda.Code.fromInline('exports.handler = async () => {};'),
+    role: executionRole,
+  });
+  (stack as any).handler = handler;
+  (stack as any).executionRole = executionRole;
+  (globalThis as any).CURRENT_BLOCKS_STACK = stack;
+  try {
+    new DistributedDatabase(scope(stack), 'mydsql');
+
+    // Endpoint + region now flow through the config registry (loaded into
+    // process.env at cold start) like every other block — not a direct env var
+    // on the handler.
+    const registry = (stack as any)[Symbol.for('BLOCKS_CONFIG_REGISTRY')] as
+      | { entries: Map<string, unknown> }
+      | undefined;
+    assert.ok(registry, 'config registry exists on the stack');
+    const keys = [...registry.entries.keys()];
+    assert.ok(keys.some(k => k.includes('ENDPOINT')), `Expected an ENDPOINT config key, got: ${keys}`);
+    assert.ok(keys.some(k => k.includes('REGION')), `Expected a REGION config key, got: ${keys}`);
+  } finally {
+    delete (globalThis as any).CURRENT_BLOCKS_STACK;
+  }
 });
 
 // --- CfnOutput ---

--- a/packages/bb-distributed-data/src/index.cdk.ts
+++ b/packages/bb-distributed-data/src/index.cdk.ts
@@ -7,7 +7,7 @@
  * Optionally runs migrations via a CustomResource Lambda.
  */
 
-import { Scope, DEFAULT_NODE_RUNTIME, synthGuard, blocksNodejsBundling } from '@aws-blocks/core/cdk';
+import { Scope, DEFAULT_NODE_RUNTIME, synthGuard, blocksNodejsBundling, registerConfig } from '@aws-blocks/core/cdk';
 import type { ScopeParent } from '@aws-blocks/core';
 import * as cdk from 'aws-cdk-lib';
 import * as iam from 'aws-cdk-lib/aws-iam';
@@ -51,20 +51,22 @@ export class DistributedDatabase extends Scope {
 
     const endpoint = cluster.getAtt('Endpoint').toString();
 
-    // Env vars for runtime
-    this.handler.addEnvironment(`BLOCKS_${envName}_ENDPOINT`, endpoint);
-    this.handler.addEnvironment(`BLOCKS_${envName}_REGION`, region);
+    // Config for runtime — flows through S3 config (loaded into process.env at
+    // cold start) like every other block, instead of a direct env var.
+    registerConfig(this, `BLOCKS_${envName}_ENDPOINT`, endpoint);
+    registerConfig(this, `BLOCKS_${envName}_REGION`, region);
 
-    // IAM grant — app Lambda gets DML-only access via custom DB role (least privilege)
-    this.handler.addToRolePolicy(new iam.PolicyStatement({
+    // IAM grant — the shared execution role gets DML-only access via custom DB
+    // role (least privilege).
+    this.executionRole.addToPrincipalPolicy(new iam.PolicyStatement({
       actions: ['dsql:DbConnect'],
       resources: [`arn:aws:dsql:${region}:${stack.account}:cluster/${cluster.ref}`],
     }));
 
     new cdk.CfnOutput(stack, `${this.fullId}DsqlEndpoint`, { value: endpoint });
 
-    // The app Lambda's IAM role ARN is needed to map the custom DB role.
-    const appRoleArn = this.handler.role!.roleArn;
+    // The shared execution role ARN is mapped to the custom DB role.
+    const appRoleArn = this.executionRole.roleArn;
 
     // Resolve migrations path if provided
     const resolvedMigrationsPath = options?.migrationsPath ? resolve(options.migrationsPath) : undefined;

--- a/packages/bb-distributed-table/src/index.cdk.test.ts
+++ b/packages/bb-distributed-table/src/index.cdk.test.ts
@@ -27,16 +27,21 @@ const userSchema = z.object({
 
 class StubBlocksStack extends cdk.Stack {
 	public readonly handler: cdk.aws_lambda.Function;
+	public readonly executionRole: cdk.aws_iam.IRole;
 	public readonly id: string;
 	public defaults: BlocksDefaults = BlocksPresets.production;
 	constructor(scope: Construct, id: string) {
 		super(scope, id);
 		this.id = id;
 		(globalThis as any).CURRENT_BLOCKS_STACK = this;
+		this.executionRole = new cdk.aws_iam.Role(this, 'BlocksRole', {
+			assumedBy: new cdk.aws_iam.ServicePrincipal('lambda.amazonaws.com'),
+		});
 		this.handler = new cdk.aws_lambda.Function(this, 'StubHandler', {
 			runtime: DEFAULT_NODE_RUNTIME,
 			handler: 'index.handler',
 			code: cdk.aws_lambda.Code.fromInline('exports.handler = async () => {};'),
+			role: this.executionRole,
 		});
 	}
 }

--- a/packages/bb-distributed-table/src/index.cdk.ts
+++ b/packages/bb-distributed-table/src/index.cdk.ts
@@ -42,8 +42,8 @@ export class DistributedTable<T = any> extends Scope {
 			// We deliberately skip the GSI custom resource — the customer owns the
 			// table's index lifecycle when they bring their own.
 			this.table = Table.fromTableName(this, 'table', config.table.tableName);
-			this.table.grantReadWriteData(this.handler);
-			this.handler.addToRolePolicy(new PolicyStatement({
+			this.table.grantReadWriteData(this.executionRole);
+			this.executionRole.addToPrincipalPolicy(new PolicyStatement({
 				actions: ['dynamodb:Query'],
 				resources: [`${this.table.tableArn}/index/*`],
 			}));
@@ -90,10 +90,10 @@ export class DistributedTable<T = any> extends Scope {
 			deletionProtection: this.defaults.deletionProtection,
 		});
 
-		this.table.grantReadWriteData(this.handler);
+		this.table.grantReadWriteData(this.executionRole);
 
 		// Explicit index query permissions
-		this.handler.addToRolePolicy(new PolicyStatement({
+		this.executionRole.addToPrincipalPolicy(new PolicyStatement({
 			actions: ['dynamodb:Query'],
 			resources: [`${this.table.tableArn}/index/*`],
 		}));

--- a/packages/bb-email-client/src/index.cdk.ts
+++ b/packages/bb-email-client/src/index.cdk.ts
@@ -31,7 +31,7 @@ export class EmailClient extends Scope {
 
 		// Grant the Lambda handler permission to send emails
 		// Scoped to this account's SES identities rather than '*'
-		this.handler.addToRolePolicy(new PolicyStatement({
+		this.executionRole.addToPrincipalPolicy(new PolicyStatement({
 			effect: Effect.ALLOW,
 			actions: [
 				'ses:SendEmail',

--- a/packages/bb-file-bucket/src/index.cdk.test.ts
+++ b/packages/bb-file-bucket/src/index.cdk.test.ts
@@ -18,15 +18,20 @@ import { FileBucket } from './index.cdk.js';
 
 class StubBlocksStack extends cdk.Stack {
   public readonly handler: cdk.aws_lambda.Function;
+  public readonly executionRole: cdk.aws_iam.IRole;
   public readonly id: string;
   constructor(scope: Construct, id: string) {
     super(scope, id);
     this.id = id;
     (globalThis as any).CURRENT_BLOCKS_STACK = this;
+    this.executionRole = new cdk.aws_iam.Role(this, 'BlocksRole', {
+      assumedBy: new cdk.aws_iam.ServicePrincipal('lambda.amazonaws.com'),
+    });
     this.handler = new cdk.aws_lambda.Function(this, 'StubHandler', {
       runtime: DEFAULT_NODE_RUNTIME,
       handler: 'index.handler',
       code: cdk.aws_lambda.Code.fromInline('exports.handler = async () => {};'),
+      role: this.executionRole,
     });
   }
 }

--- a/packages/bb-file-bucket/src/index.cdk.ts
+++ b/packages/bb-file-bucket/src/index.cdk.ts
@@ -39,7 +39,7 @@ export class FileBucket<O extends FileBucketOptions = FileBucketOptions> extends
 			// `fromExisting`: don't provision; bind to the pre-existing bucket and
 			// grant read/write to the Blocks runtime Lambda.
 			this.bucket = s3.Bucket.fromBucketName(this, 'bucket', options.bucket.bucketName);
-			this.bucket.grantReadWrite(this.handler);
+			this.bucket.grantReadWrite(this.executionRole);
 			return;
 		}
 
@@ -84,6 +84,6 @@ export class FileBucket<O extends FileBucketOptions = FileBucketOptions> extends
 			})),
 		});
 
-		this.bucket.grantReadWrite(this.handler);
+		this.bucket.grantReadWrite(this.executionRole);
 	}
 }

--- a/packages/bb-knowledge-base/src/index.cdk.test.ts
+++ b/packages/bb-knowledge-base/src/index.cdk.test.ts
@@ -44,16 +44,21 @@ const VECTOR_INDEX_TYPE = s3vectors.CfnIndex.CFN_RESOURCE_TYPE_NAME;
 // resolve through CURRENT_BLOCKS_STACK (mirrors the production BlocksStack).
 class StubBlocksStack extends cdk.Stack {
   public readonly handler: cdk.aws_lambda.Function;
+  public readonly executionRole: cdk.aws_iam.IRole;
   public readonly id: string;
   public defaults: BlocksDefaults = BlocksPresets.production;
   constructor(scope: Construct, id: string) {
     super(scope, id);
     this.id = id;
     (globalThis as any).CURRENT_BLOCKS_STACK = this;
+    this.executionRole = new cdk.aws_iam.Role(this, 'BlocksRole', {
+      assumedBy: new cdk.aws_iam.ServicePrincipal('lambda.amazonaws.com'),
+    });
     this.handler = new cdk.aws_lambda.Function(this, 'StubHandler', {
       runtime: DEFAULT_NODE_RUNTIME,
       handler: 'index.handler',
       code: cdk.aws_lambda.Code.fromInline('exports.handler = async () => {};'),
+      role: this.executionRole,
     });
   }
 }

--- a/packages/bb-knowledge-base/src/index.cdk.ts
+++ b/packages/bb-knowledge-base/src/index.cdk.ts
@@ -471,7 +471,7 @@ export class KnowledgeBase extends Scope {
 			arnFormat: cdk.ArnFormat.SLASH_RESOURCE_NAME,
 		});
 
-		this.handler.addToRolePolicy(new iam.PolicyStatement({
+		this.executionRole.addToPrincipalPolicy(new iam.PolicyStatement({
 			actions: ['bedrock:Retrieve'],
 			resources: [knowledgeBaseArn],
 		}));
@@ -479,7 +479,7 @@ export class KnowledgeBase extends Scope {
 		// Ingestion-job status for isSynced()/waitUntilSynced(). These actions are
 		// authorized at the knowledge-base resource level (the data source and
 		// ingestion jobs are sub-resources of the KB ARN).
-		this.handler.addToRolePolicy(new iam.PolicyStatement({
+		this.executionRole.addToPrincipalPolicy(new iam.PolicyStatement({
 			actions: ['bedrock:GetIngestionJob', 'bedrock:ListIngestionJobs'],
 			resources: [knowledgeBaseArn],
 		}));

--- a/packages/bb-kv-store/src/index.cdk.test.ts
+++ b/packages/bb-kv-store/src/index.cdk.test.ts
@@ -17,24 +17,29 @@ import { Scope, DEFAULT_NODE_RUNTIME, BlocksPresets, type BlocksDefaults } from 
 import { KVStore } from './index.cdk.js';
 
 // Minimal BlocksStack-shaped parent. The production code path uses BlocksStack,
-// which exposes `handler` on a Lambda that lives inside a `cdk.Stack`. We
-// reproduce that here so KVStore can call grantReadWriteData(this.handler)
-// and still synth into a real stack. It also carries `defaults` — Building
-// Blocks resolve `scope.defaults` by walking up to the owning
-// BlocksStack/BlocksBackend, falling back to `globalThis.CURRENT_BLOCKS_STACK`,
-// which is this stub in these tests.
+// which exposes the shared `executionRole` (blocks grant to it) plus `handler`,
+// both living inside a `cdk.Stack`. We reproduce them here so KVStore can call
+// grantReadWriteData(this.executionRole) and still synth into a real stack. It
+// also carries `defaults` — Building Blocks resolve `scope.defaults` by walking
+// up to the owning BlocksStack/BlocksBackend, falling back to
+// `globalThis.CURRENT_BLOCKS_STACK`, which is this stub in these tests.
 class StubBlocksStack extends cdk.Stack {
   public readonly handler: cdk.aws_lambda.Function;
+  public readonly executionRole: cdk.aws_iam.IRole;
   public readonly id: string;
   public defaults: BlocksDefaults = BlocksPresets.production;
   constructor(scope: Construct, id: string) {
     super(scope, id);
     this.id = id;
     (globalThis as any).CURRENT_BLOCKS_STACK = this;
+    this.executionRole = new cdk.aws_iam.Role(this, 'BlocksRole', {
+      assumedBy: new cdk.aws_iam.ServicePrincipal('lambda.amazonaws.com'),
+    });
     this.handler = new cdk.aws_lambda.Function(this, 'StubHandler', {
       runtime: DEFAULT_NODE_RUNTIME,
       handler: 'index.handler',
       code: cdk.aws_lambda.Code.fromInline('exports.handler = async () => {};'),
+      role: this.executionRole,
     });
   }
 }

--- a/packages/bb-kv-store/src/index.cdk.ts
+++ b/packages/bb-kv-store/src/index.cdk.ts
@@ -56,7 +56,7 @@ export class KVStore extends Scope {
 			});
 		}
 
-		this.table.grantReadWriteData(this.handler);
+		this.table.grantReadWriteData(this.executionRole);
 	}
 
 	// ── Runtime methods are not available during CDK synth ────────────────

--- a/packages/core/src/cdk/blocks-backend.ts
+++ b/packages/core/src/cdk/blocks-backend.ts
@@ -76,6 +76,13 @@ export function setupBlocksInfra(scope: Construct, props: BlocksBackendProps, id
   // via `scope.executionRole`). Block grants sit on the role's default (inline)
   // policy. AWSLambdaBasicExecutionRole is attached so the handler retains
   // CloudWatch Logs permissions.
+  //
+  // INVARIANT: this must be a mutable, framework-owned `iam.Role` — never an
+  // imported role (`Role.fromRoleArn`/`fromRoleName`), which is immutable by
+  // default. On an immutable role, every Building Block's `grant*()` /
+  // `addToPrincipalPolicy()` silently becomes a no-op (returns false, no error),
+  // so permissions would quietly vanish. If a bring-your-own-role option is ever
+  // added, it must resolve to a mutable role (`{ mutable: true }`).
   const executionRole = new iam.Role(scope, 'BlocksRole', {
     // CompositePrincipal (rather than a bare ServicePrincipal) so additional
     // compute types can assume this same shared role as they are introduced


### PR DESCRIPTION
## Problem

Building Blocks granted IAM permissions directly on the handler `NodejsFunction` (`this.handler.grant*()` / `this.handler.addToRolePolicy(...)`). That couples every block's IAM wiring to the one concrete Lambda function, which blocks the multi-compute model where a block's permissions must land on a shared role that any compute type can assume.

This PR is Issue **B3** of Multi-Compute Phase 1. It depends only on **A1** (the shared `BlocksRole` / `Scope.executionRole`, already merged into `main`) and is intentionally **standalone** — it does not stack on A2/A3.

## Changes

Migrate every data, auth, and agent block's CDK layer from granting on the handler function to granting on the shared Blocks execution role (`this.executionRole`):

- `grant*(this.handler)` → `grant*(this.executionRole)`
- `this.handler.addToRolePolicy(...)` → `this.executionRole.addToPrincipalPolicy(...)`

Blocks migrated: `bb-kv-store`, `bb-distributed-table`, `bb-file-bucket`, `bb-data`, `bb-app-setting`, `bb-knowledge-base`, `bb-email-client`, `bb-auth-cognito`, `bb-auth-oidc`, `bb-distributed-data`, `bb-agent`.

Because the shared role is the same role the handler assumes, effective runtime permissions are **identical** — this is a behavior-preserving refactor.

Additional notes:
- **`bb-distributed-data`**: the DSQL endpoint and region now flow through the config registry (`registerConfig`, loaded into `process.env` at cold start like every other block) instead of direct handler environment variables; the migration Lambda now maps the shared execution role's ARN.
- Removed dead `this.handler as lambda.Function` casts and now-unused `lambda` imports in the auth/data blocks.
- Test stubs updated to expose `executionRole` (a `BlocksRole` the stub handler assumes).

**Not in scope (deliberately):** `handler` is **not** removed here — event/observability blocks (`bb-async-job`, `bb-cron-job`, `bb-realtime`, `bb-logger`, `bb-tracer`, `bb-dashboard`) still use it. `bb-tracer` also does a compute-specific `tracingConfig` poke, so it moves in Track C (C6), not here. `Scope.handler` is removed last, in C9, once all consumers migrate.

## Validation

- `npm run build` ✓
- Unit tests for all affected packages pass (kv-store 95, distributed-table 117, file-bucket 92, data 366, app-setting 59, knowledge-base 129, email-client 20, auth-cognito 241, auth-oidc 112, distributed-data 157, agent 78) ✓
- `npm run lint` — zero blocking errors ✓
- `npm run lint:deps`, `npm run check:api` ✓
- `npm run test:e2e:local` — 8/8 ✓
- Confirmed no data/auth/agent block references `this.handler` for IAM after the change.

## Checklist

- [x] PR description included
- [x] Tests are changed or added
- [x] Relevant documentation is changed or added (and PR referenced)
