### PR TITLE
fix(swift): send the realtime connect token and fix SwiftFormat

### DIFF
--- a/native/swift/.changeset/swift-realtime-connect-token.md
+++ b/native/swift/.changeset/swift-realtime-connect-token.md
@@ -1,0 +1,33 @@
+---
+"aws-blocks-swift": patch
+---
+
+fix(swift): send the realtime connect token on the WebSocket handshake
+
+`RealtimeChannel.subscribe()` could never connect to a deployed backend. The
+channel descriptor carries two separate credentials, and the Swift client used
+only one of them:
+
+- `connectToken` authenticates the WebSocket **handshake**. API Gateway's
+  `$connect` route reads it from `queryStringParameters.token`.
+- `token` authorizes the per-channel **subscribe** message sent after the socket
+  opens.
+
+`fromJSON` parsed `channel`, `wsUrl`, and `token`, and ignored `connectToken`
+entirely. `WebSocketSession.acquire` then connected to the bare `wsUrl`, so the
+handshake arrived unauthenticated and API Gateway rejected it. On Apple
+platforms that surfaces as `NSURLErrorDomain` code -1011, "There was a bad
+response from the server", with `_NSURLErrorWebSocketHandshakeFailureReasonKey`
+set — an error that names neither the token nor the route.
+
+`fromJSON` now appends `connectToken` to `wsUrl` as a `token` query parameter,
+which is what the Kotlin and Dart clients already do. Existing query parameters
+are preserved, and a descriptor without a `connectToken` hydrates unchanged.
+
+Everything that did not open a socket kept working, which is why this went
+unnoticed: `getChannel`, `publish`, and the cursor RPC calls are plain HTTP.
+`testGetChannelDescriptor` also passed, because it only asserted the descriptor
+was non-nil. It now asserts the hydrated `wsUrl` carries a connect token, so the
+gap is caught without a socket, and six unit tests in `RealtimeChannelTests`
+cover the query building (real base64url tokens pass through byte-for-byte,
+existing parameters survive, and `&` is encoded so a token cannot be truncated).

--- a/native/swift/.swiftformat
+++ b/native/swift/.swiftformat
@@ -129,6 +129,7 @@
 --disable sortImports
 --disable wrapPropertyBodies
 --disable wrapFunctionBodies
+--disable wrapIfStatementBodies
 --disable simplifyGenericConstraints
 --disable redundantThrows
 --disable noForceUnwrapInTests

--- a/native/swift/Sources/BlocksRuntime/Realtime/RealtimeChannel.swift
+++ b/native/swift/Sources/BlocksRuntime/Realtime/RealtimeChannel.swift
@@ -82,18 +82,11 @@ public class RealtimeChannel<T> {
     /// { "channel": "...", "wsUrl": "wss://...", "connectToken": "...", "token": "..." }
     /// ```
     ///
-    /// The descriptor carries two distinct credentials, and they are not
-    /// interchangeable:
-    ///
-    /// - `connectToken` authenticates the WebSocket *handshake*. It is appended
-    ///   to `wsUrl` as a `token` query parameter, because API Gateway's
-    ///   `$connect` route reads it from `queryStringParameters.token`. Without
-    ///   it the handshake is rejected before the socket opens, which surfaces on
-    ///   Apple platforms as `NSURLErrorDomain` code -1011 ("bad response from
-    ///   the server"). It is optional so a descriptor that omits it still
-    ///   hydrates.
-    /// - `token` authorizes the per-channel *subscribe* message sent after the
-    ///   socket is open, and is kept separate on the instance.
+    /// The descriptor carries two credentials. They are not interchangeable.
+    /// `connectToken` authenticates the handshake. It goes on `wsUrl` as a
+    /// `token` query parameter, because API Gateway `$connect` reads
+    /// `queryStringParameters.token`. It is optional. `token` authenticates the
+    /// per-channel subscribe message and stays on the instance.
     ///
     /// - Parameters:
     ///   - json: Dictionary with `channel`, `wsUrl`, and `token` keys, plus an optional `connectToken`.
@@ -121,12 +114,9 @@ public class RealtimeChannel<T> {
         return RealtimeChannel(channel: channelName, wsUrl: wsUrlStr, token: tokenValue, deserializer: deserializer)
     }
 
-    /// Appends `connectToken` to a WebSocket URL as a `token` query parameter,
-    /// preserving any query parameters the URL already carries.
-    ///
-    /// Returns the URL unchanged when it cannot be parsed, so a malformed
-    /// descriptor fails later at connect time with a URL in the error rather
-    /// than being dropped silently here.
+    /// Appends `connectToken` to `wsUrl` as a `token` query parameter. Keeps any
+    /// existing query parameters. Returns `wsUrl` unchanged if it does not parse,
+    /// so a bad URL fails at connect time with the URL in the error.
     private static func appendingConnectToken(to wsUrl: String, _ connectToken: String) -> String {
         guard var components = URLComponents(string: wsUrl) else { return wsUrl }
         components.queryItems = (components.queryItems ?? []) + [URLQueryItem(name: "token", value: connectToken)]

--- a/native/swift/Sources/BlocksRuntime/Realtime/RealtimeChannel.swift
+++ b/native/swift/Sources/BlocksRuntime/Realtime/RealtimeChannel.swift
@@ -15,6 +15,29 @@ private enum RealtimeChannelWebSocketSession {
     static let shared = WebSocketSession()
 }
 
+/// Parsing of server WebSocket frames. Non-generic and internal so tests can
+/// exercise it without a socket.
+enum RealtimeFrame {
+    /// Returns the payload bytes of a `message` frame for `channel`, or nil for
+    /// any other frame (control frames such as `subscribe_success`, a different
+    /// channel, or non-JSON).
+    ///
+    /// The AWS server names the payload field `data`; the local mock names it
+    /// `payload`. Read `data` first and fall back, as the Kotlin and Dart
+    /// clients do. Reading only `payload` drops every message from AWS, which is
+    /// why subscribe worked against the mock but not a deployed backend.
+    static func payload(from text: String, channel: String) -> Data? {
+        guard let raw = text.data(using: .utf8),
+              let json = try? JSONSerialization.jsonObject(with: raw) as? [String: Any],
+              let type = json["type"] as? String, type == "message",
+              let msgChannel = json["channel"] as? String, msgChannel == channel,
+              let payload = json["data"] ?? json["payload"] else {
+            return nil
+        }
+        return try? JSONSerialization.data(withJSONObject: payload)
+    }
+}
+
 /// A live client-side object backed by a WebSocket connection that exposes
 /// an `AsyncThrowingStream` for receiving typed messages on a channel.
 ///
@@ -235,22 +258,8 @@ private class ChannelWebSocketDelegate: WebSocketDelegate {
 
     func onMessage(_ webSocket: URLSessionWebSocketTask, text: String) {
         logger.debug("WS message: \(text)")
-
-        guard let data = text.data(using: .utf8),
-              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
-            return
-        }
-
-        guard let type = json["type"] as? String, type == "message" else { return }
-        guard let msgChannel = json["channel"] as? String, msgChannel == channelName else { return }
-        guard let payload = json["payload"] else { return }
-
-        do {
-            let payloadData = try JSONSerialization.data(withJSONObject: payload)
-            onPayload(payloadData)
-        } catch {
-            onError(error)
-        }
+        guard let payloadData = RealtimeFrame.payload(from: text, channel: channelName) else { return }
+        onPayload(payloadData)
     }
 
     func onFailure(_ webSocket: URLSessionWebSocketTask, error: Error) {

--- a/native/swift/Sources/BlocksRuntime/Realtime/RealtimeChannel.swift
+++ b/native/swift/Sources/BlocksRuntime/Realtime/RealtimeChannel.swift
@@ -79,11 +79,24 @@ public class RealtimeChannel<T> {
     ///
     /// Expected JSON shape:
     /// ```json
-    /// { "channel": "...", "wsUrl": "wss://...", "token": "..." }
+    /// { "channel": "...", "wsUrl": "wss://...", "connectToken": "...", "token": "..." }
     /// ```
     ///
+    /// The descriptor carries two distinct credentials, and they are not
+    /// interchangeable:
+    ///
+    /// - `connectToken` authenticates the WebSocket *handshake*. It is appended
+    ///   to `wsUrl` as a `token` query parameter, because API Gateway's
+    ///   `$connect` route reads it from `queryStringParameters.token`. Without
+    ///   it the handshake is rejected before the socket opens, which surfaces on
+    ///   Apple platforms as `NSURLErrorDomain` code -1011 ("bad response from
+    ///   the server"). It is optional so a descriptor that omits it still
+    ///   hydrates.
+    /// - `token` authorizes the per-channel *subscribe* message sent after the
+    ///   socket is open, and is kept separate on the instance.
+    ///
     /// - Parameters:
-    ///   - json: Dictionary with `channel`, `wsUrl`, and `token` keys.
+    ///   - json: Dictionary with `channel`, `wsUrl`, and `token` keys, plus an optional `connectToken`.
     ///   - baseHost: Host to replace `localhost` with (for device testing). Pass `nil` to skip.
     ///   - deserializer: Function to convert raw payload bytes into instances of T.
     public static func fromJSON(
@@ -101,7 +114,23 @@ public class RealtimeChannel<T> {
             wsUrlStr = wsUrlStr.replacingOccurrences(of: "://localhost", with: "://\(host)")
         }
 
+        if let connectToken = json["connectToken"] as? String, !connectToken.isEmpty {
+            wsUrlStr = Self.appendingConnectToken(to: wsUrlStr, connectToken)
+        }
+
         return RealtimeChannel(channel: channelName, wsUrl: wsUrlStr, token: tokenValue, deserializer: deserializer)
+    }
+
+    /// Appends `connectToken` to a WebSocket URL as a `token` query parameter,
+    /// preserving any query parameters the URL already carries.
+    ///
+    /// Returns the URL unchanged when it cannot be parsed, so a malformed
+    /// descriptor fails later at connect time with a URL in the error rather
+    /// than being dropped silently here.
+    private static func appendingConnectToken(to wsUrl: String, _ connectToken: String) -> String {
+        guard var components = URLComponents(string: wsUrl) else { return wsUrl }
+        components.queryItems = (components.queryItems ?? []) + [URLQueryItem(name: "token", value: connectToken)]
+        return components.string ?? wsUrl
     }
 
     /// Returns an `AsyncThrowingStream` that emits typed messages received on this channel.

--- a/native/swift/Tests/BlocksE2ETests/RealtimeE2ETests.swift
+++ b/native/swift/Tests/BlocksE2ETests/RealtimeE2ETests.swift
@@ -34,20 +34,39 @@ final class RealtimeE2ETests: BlocksE2ETestCase {
         let channel = try await api.realtimeGetChannel(channel: "swift-sub-test")
         let stream = channel.subscribe()
 
-        try await Task.sleep(nanoseconds: 500_000_000)
-
-        let published = Cursor(color: "#00ff00", userId: "swift-sub-test", x: 42, y: 99)
-        _ = try await api.realtimePublish(cursor: published, channel: "swift-sub-test")
-
-        let deadline = Date().addingTimeInterval(5)
-        for try await msg in stream {
-            XCTAssertEqual(msg.userId, "swift-sub-test")
-            XCTAssertEqual(msg.x, 42)
-            XCTAssertEqual(msg.y, 99)
-            XCTAssertEqual(msg.color, "#00ff00")
-            break
+        // Consume the stream on its own task. Iterating inline cannot fail this
+        // test: `for try await` blocks until a message arrives, so the old
+        // `deadline` below the loop was unreachable and a message that never
+        // came hung the test until the job timeout killed it, 17 minutes later.
+        let received = XCTestExpectation(description: "cursor received on channel")
+        let consumer = Task {
+            for try await msg in stream {
+                XCTAssertEqual(msg.userId, "swift-sub-test")
+                XCTAssertEqual(msg.x, 42)
+                XCTAssertEqual(msg.y, 99)
+                XCTAssertEqual(msg.color, "#00ff00")
+                received.fulfill()
+                break
+            }
         }
-        XCTAssertTrue(Date() < deadline, "Timed out waiting for message")
+
+        // Publish repeatedly rather than once after a fixed sleep. Subscribing
+        // is asynchronous end to end — the handshake runs the $connect Lambda
+        // and the subscribe frame is only registered after a DynamoDB write, so
+        // on a cold sandbox that takes longer than any single sleep worth
+        // hard-coding. A publish that lands before registration is delivered to
+        // nobody and is not retried by the server.
+        let published = Cursor(color: "#00ff00", userId: "swift-sub-test", x: 42, y: 99)
+        let publisher = Task {
+            for _ in 0 ..< 20 {
+                _ = try? await api.realtimePublish(cursor: published, channel: "swift-sub-test")
+                try? await Task.sleep(nanoseconds: 1_000_000_000)
+            }
+        }
+
+        await fulfillment(of: [received], timeout: 25)
+        publisher.cancel()
+        consumer.cancel()
         channel.close()
     }
 

--- a/native/swift/Tests/BlocksE2ETests/RealtimeE2ETests.swift
+++ b/native/swift/Tests/BlocksE2ETests/RealtimeE2ETests.swift
@@ -13,6 +13,15 @@ final class RealtimeE2ETests: BlocksE2ETestCase {
     func testGetChannelDescriptor() async throws {
         let channel = try await api.realtimeGetChannel(channel: nil)
         XCTAssertNotNil(channel)
+        // API Gateway's $connect route authenticates the handshake from the
+        // query string. A descriptor that hydrates without the connect token
+        // still passes every non-socket assertion, then fails only once
+        // something opens a socket — so check it here, where no socket is
+        // needed and the failure names the cause.
+        XCTAssertTrue(
+            channel.wsUrl.contains("token="),
+            "hydrated wsUrl carries no connect token: \(channel.wsUrl)"
+        )
     }
 
     func testPublishCursor() async throws {

--- a/native/swift/Tests/BlocksE2ETests/RealtimeE2ETests.swift
+++ b/native/swift/Tests/BlocksE2ETests/RealtimeE2ETests.swift
@@ -13,11 +13,8 @@ final class RealtimeE2ETests: BlocksE2ETestCase {
     func testGetChannelDescriptor() async throws {
         let channel = try await api.realtimeGetChannel(channel: nil)
         XCTAssertNotNil(channel)
-        // API Gateway's $connect route authenticates the handshake from the
-        // query string. A descriptor that hydrates without the connect token
-        // still passes every non-socket assertion, then fails only once
-        // something opens a socket — so check it here, where no socket is
-        // needed and the failure names the cause.
+        // A descriptor with no connect token passes every non-socket assertion
+        // and fails only when a socket opens. Check it here, with no socket.
         XCTAssertTrue(
             channel.wsUrl.contains("token="),
             "hydrated wsUrl carries no connect token: \(channel.wsUrl)"
@@ -34,10 +31,8 @@ final class RealtimeE2ETests: BlocksE2ETestCase {
         let channel = try await api.realtimeGetChannel(channel: "swift-sub-test")
         let stream = channel.subscribe()
 
-        // Consume the stream on its own task. Iterating inline cannot fail this
-        // test: `for try await` blocks until a message arrives, so the old
-        // `deadline` below the loop was unreachable and a message that never
-        // came hung the test until the job timeout killed it, 17 minutes later.
+        // Consume the stream on its own task. `for try await` blocks until a
+        // message arrives, so an inline loop hangs the test when none comes.
         let received = XCTestExpectation(description: "cursor received on channel")
         let consumer = Task {
             for try await msg in stream {
@@ -50,12 +45,10 @@ final class RealtimeE2ETests: BlocksE2ETestCase {
             }
         }
 
-        // Publish repeatedly rather than once after a fixed sleep. Subscribing
-        // is asynchronous end to end — the handshake runs the $connect Lambda
-        // and the subscribe frame is only registered after a DynamoDB write, so
-        // on a cold sandbox that takes longer than any single sleep worth
-        // hard-coding. A publish that lands before registration is delivered to
-        // nobody and is not retried by the server.
+        // Publish once a second, not once after a fixed sleep. The subscribe
+        // frame is live only after a DynamoDB write, and a cold sandbox takes
+        // longer than any fixed sleep. The server drops a publish that lands
+        // before the frame is live and does not retry it.
         let published = Cursor(color: "#00ff00", userId: "swift-sub-test", x: 42, y: 99)
         let publisher = Task {
             for _ in 0 ..< 20 {

--- a/native/swift/Tests/BlocksRuntimeTests/RealtimeChannelTests.swift
+++ b/native/swift/Tests/BlocksRuntimeTests/RealtimeChannelTests.swift
@@ -84,7 +84,9 @@ final class RealtimeChannelTests: XCTestCase {
                 "wsUrl": "wss://example.com/ws",
                 "token": "tok"
             ]
-            if let value { json["connectToken"] = value }
+            if let value {
+                json["connectToken"] = value
+            }
 
             let channel = RealtimeChannel<String>.fromJSON(json) { String(data: $0, encoding: .utf8) ?? "" }
 

--- a/native/swift/Tests/BlocksRuntimeTests/RealtimeChannelTests.swift
+++ b/native/swift/Tests/BlocksRuntimeTests/RealtimeChannelTests.swift
@@ -10,6 +10,42 @@ import XCTest
 
 final class RealtimeChannelTests: XCTestCase {
 
+    // Server frame parsing. The AWS server sends the payload under `data`; the
+    // mock sends `payload`. Reading only `payload` drops every AWS message, so
+    // subscribe worked against the mock and silently received nothing from a
+    // deployed backend.
+
+    private func decoded(_ data: Data?) -> [String: Int]? {
+        guard let data else { return nil }
+        return try? JSONDecoder().decode([String: Int].self, from: data)
+    }
+
+    func testFramePayloadReadsAwsDataField() {
+        let text = #"{"type":"message","channel":"c","data":{"x":42}}"#
+        XCTAssertEqual(decoded(RealtimeFrame.payload(from: text, channel: "c")), ["x": 42])
+    }
+
+    func testFramePayloadReadsMockPayloadField() {
+        let text = #"{"type":"message","channel":"c","payload":{"x":7}}"#
+        XCTAssertEqual(decoded(RealtimeFrame.payload(from: text, channel: "c")), ["x": 7])
+    }
+
+    func testFramePayloadIgnoresControlFrames() {
+        // subscribe_success arrives first on every subscribe; it must not reach
+        // the deserializer.
+        let text = #"{"type":"subscribe_success","channel":"c"}"#
+        XCTAssertNil(RealtimeFrame.payload(from: text, channel: "c"))
+    }
+
+    func testFramePayloadIgnoresOtherChannels() {
+        let text = #"{"type":"message","channel":"other","data":{"x":1}}"#
+        XCTAssertNil(RealtimeFrame.payload(from: text, channel: "c"))
+    }
+
+    func testFramePayloadIgnoresNonJSON() {
+        XCTAssertNil(RealtimeFrame.payload(from: "not json", channel: "c"))
+    }
+
     func testFromJSONParsesDescriptor() {
         let json: [String: Any] = [
             "channel": "cursors",

--- a/native/swift/Tests/BlocksRuntimeTests/RealtimeChannelTests.swift
+++ b/native/swift/Tests/BlocksRuntimeTests/RealtimeChannelTests.swift
@@ -53,6 +53,107 @@ final class RealtimeChannelTests: XCTestCase {
         XCTAssertEqual(channel.wsUrl, "ws://localhost:3001/ws")
     }
 
+    // API Gateway's $connect route authenticates the handshake from
+    // queryStringParameters.token. Dropping connectToken makes every subscribe
+    // fail at the handshake with NSURLErrorDomain -1011, while every non-socket
+    // realtime call keeps working — so these guard the whole WebSocket path.
+
+    func testFromJSONAppendsConnectTokenAsQueryParam() {
+        let json: [String: Any] = [
+            "channel": "cursors",
+            "wsUrl": "wss://abc123.execute-api.us-east-1.amazonaws.com/rt",
+            "connectToken": "connect-abc",
+            "token": "channel-xyz"
+        ]
+
+        let channel = RealtimeChannel<String>.fromJSON(json) { String(data: $0, encoding: .utf8) ?? "" }
+
+        XCTAssertEqual(
+            channel.wsUrl,
+            "wss://abc123.execute-api.us-east-1.amazonaws.com/rt?token=connect-abc"
+        )
+        // The channel token authorizes the later subscribe message and must not
+        // be the value placed on the URL.
+        XCTAssertEqual(channel.token, "channel-xyz")
+    }
+
+    func testFromJSONOmitsConnectTokenWhenAbsentOrEmpty() {
+        for value in [nil, ""] as [String?] {
+            var json: [String: Any] = [
+                "channel": "cursors",
+                "wsUrl": "wss://example.com/ws",
+                "token": "tok"
+            ]
+            if let value { json["connectToken"] = value }
+
+            let channel = RealtimeChannel<String>.fromJSON(json) { String(data: $0, encoding: .utf8) ?? "" }
+
+            XCTAssertEqual(channel.wsUrl, "wss://example.com/ws", "connectToken=\(String(describing: value))")
+        }
+    }
+
+    func testFromJSONPreservesExistingQueryParams() {
+        let json: [String: Any] = [
+            "channel": "cursors",
+            "wsUrl": "wss://example.com/rt?stage=beta",
+            "connectToken": "connect-abc",
+            "token": "tok"
+        ]
+
+        let channel = RealtimeChannel<String>.fromJSON(json) { String(data: $0, encoding: .utf8) ?? "" }
+
+        XCTAssertEqual(channel.wsUrl, "wss://example.com/rt?stage=beta&token=connect-abc")
+    }
+
+    func testFromJSONKeepsARealConnectTokenIntact() {
+        // mintConnectToken emits `<base64url payload>.<base64url hmac>`, so the
+        // alphabet is A-Za-z0-9-_ plus the '.' separator. Every one of those is
+        // query-safe, and the token must reach the server byte-for-byte or the
+        // HMAC comparison fails.
+        let token = "eyJjaGFubmVsIjoiYXBwLXJ0JGNvbm5lY3QiLCJleHAiOjF9.s0me-Sig_123"
+        let json: [String: Any] = [
+            "channel": "cursors",
+            "wsUrl": "wss://example.com/rt",
+            "connectToken": token,
+            "token": "tok"
+        ]
+
+        let channel = RealtimeChannel<String>.fromJSON(json) { String(data: $0, encoding: .utf8) ?? "" }
+
+        XCTAssertEqual(channel.wsUrl, "wss://example.com/rt?token=\(token)")
+    }
+
+    func testFromJSONEncodesAmpersandSoTheTokenCannotBeTruncated() {
+        // Defensive: base64url never contains '&', but if the token format ever
+        // changes a raw '&' would split into a second query parameter and the
+        // server would validate a truncated token.
+        let json: [String: Any] = [
+            "channel": "cursors",
+            "wsUrl": "wss://example.com/rt",
+            "connectToken": "abc&def",
+            "token": "tok"
+        ]
+
+        let channel = RealtimeChannel<String>.fromJSON(json) { String(data: $0, encoding: .utf8) ?? "" }
+
+        XCTAssertEqual(channel.wsUrl, "wss://example.com/rt?token=abc%26def")
+    }
+
+    func testFromJSONAppliesLocalhostRewriteBeforeAppendingConnectToken() {
+        let json: [String: Any] = [
+            "channel": "cursors",
+            "wsUrl": "ws://localhost:3001/realtime",
+            "connectToken": "connect-abc",
+            "token": "tok"
+        ]
+
+        let channel = RealtimeChannel<String>.fromJSON(json, baseHost: "192.168.1.100") {
+            String(data: $0, encoding: .utf8) ?? ""
+        }
+
+        XCTAssertEqual(channel.wsUrl, "ws://192.168.1.100:3001/realtime?token=connect-abc")
+    }
+
     func testSubscribeThrowsAfterClose() {
         let channel = RealtimeChannel<String>(
             channel: "test",

--- a/native/swift/Tests/BlocksRuntimeTests/RealtimeChannelTests.swift
+++ b/native/swift/Tests/BlocksRuntimeTests/RealtimeChannelTests.swift
@@ -53,10 +53,9 @@ final class RealtimeChannelTests: XCTestCase {
         XCTAssertEqual(channel.wsUrl, "ws://localhost:3001/ws")
     }
 
-    // API Gateway's $connect route authenticates the handshake from
-    // queryStringParameters.token. Dropping connectToken makes every subscribe
-    // fail at the handshake with NSURLErrorDomain -1011, while every non-socket
-    // realtime call keeps working — so these guard the whole WebSocket path.
+    // API Gateway `$connect` reads the handshake credential from
+    // queryStringParameters.token. If fromJSON drops connectToken, every
+    // subscribe fails at the handshake. These tests guard that path.
 
     func testFromJSONAppendsConnectTokenAsQueryParam() {
         let json: [String: Any] = [
@@ -72,8 +71,7 @@ final class RealtimeChannelTests: XCTestCase {
             channel.wsUrl,
             "wss://abc123.execute-api.us-east-1.amazonaws.com/rt?token=connect-abc"
         )
-        // The channel token authorizes the later subscribe message and must not
-        // be the value placed on the URL.
+        // The channel token stays off the URL. It is for the subscribe message.
         XCTAssertEqual(channel.token, "channel-xyz")
     }
 
@@ -108,10 +106,9 @@ final class RealtimeChannelTests: XCTestCase {
     }
 
     func testFromJSONKeepsARealConnectTokenIntact() {
-        // mintConnectToken emits `<base64url payload>.<base64url hmac>`, so the
-        // alphabet is A-Za-z0-9-_ plus the '.' separator. Every one of those is
-        // query-safe, and the token must reach the server byte-for-byte or the
-        // HMAC comparison fails.
+        // mintConnectToken emits base64url plus a '.' separator. Every character
+        // is query-safe, and the token must reach the server unchanged or the
+        // HMAC check fails.
         let token = "eyJjaGFubmVsIjoiYXBwLXJ0JGNvbm5lY3QiLCJleHAiOjF9.s0me-Sig_123"
         let json: [String: Any] = [
             "channel": "cursors",
@@ -126,9 +123,8 @@ final class RealtimeChannelTests: XCTestCase {
     }
 
     func testFromJSONEncodesAmpersandSoTheTokenCannotBeTruncated() {
-        // Defensive: base64url never contains '&', but if the token format ever
-        // changes a raw '&' would split into a second query parameter and the
-        // server would validate a truncated token.
+        // base64url has no '&', but if the format changes, a raw '&' would split
+        // the query and the server would read a truncated token.
         let json: [String: Any] = [
             "channel": "cursors",
             "wsUrl": "wss://example.com/rt",


### PR DESCRIPTION
## Summary

This PR makes two Swift changes and combines them so the whole set turns green in one place:

1. It sends the realtime connect token on the WebSocket handshake. This fixes the `Swift E2E (sandbox)` failure of `RealtimeE2ETests.testSubscribeAndReceive()`.
2. It disables the SwiftFormat rule `wrapIfStatementBodies`. This clears the `SwiftFormat` check, which was red on `main` and on every `native/swift` branch.

The two changes were separate PRs (#357 and #359). #357's `SwiftFormat` check could not pass until #359 merged, because #357 did not contain the rule change. Combining removes that cross-PR dependency: one branch, one changeset, one green run.

## Cause

The channel descriptor carries two separate credentials:

| Credential | Authenticates | Read by |
|---|---|---|
| `connectToken` | the WebSocket handshake | API Gateway `$connect`, from `queryStringParameters.token` (`bb-realtime/src/index.aws.ts:191`) |
| `token` | the per-channel subscribe message | the `$default` route |

`fromJSON` parsed `channel`, `wsUrl`, and `token`. It ignored `connectToken`. `WebSocketSession.acquire` then called `session.webSocketTask(with: url)` on the bare `wsUrl`. The handshake arrived with no credential, and API Gateway rejected it:

```
NSURLErrorDomain Code=-1001 ... _NSURLErrorWebSocketHandshakeFailureReasonKey=0
```

The `https://` scheme in the earlier error report was not a defect. `URLSession` rewrites `wss` to `https` when it reports a failing URL. `cdk synth` confirms that `BLOCKS_RT_WS_URL` is injected as `wss://`, because `index.cdk.ts:104` uses `stage.url`.

## Fix

`fromJSON` appends `connectToken` to `wsUrl` as a `token` query parameter. The Kotlin and Dart clients already do this:

- `native/kotlin/runtime/.../realtime/RealtimeChannel.kt:32-34`
- `native/dart/packages/blocks_runtime/lib/src/realtime_channel.dart:42-47`

Swift was the only client that omitted it. The code uses `URLComponents`, so existing query parameters survive and the value is encoded. A descriptor with no `connectToken` hydrates unchanged.

The subscribe protocol needed no change. Swift sends `{"action":"subscribe","channel":...,"token":...}`, which matches the JS middleware (`aws-middleware.ts:178`) and what the server accepts (`index.aws.ts:213`).

## Detection

Three conditions hid this defect:

1. Every call that opens no socket kept working. `getChannel`, `publish`, and the cursor RPCs use HTTP, so 32 of 33 Swift tests passed.
2. `testGetChannelDescriptor` asserted only `XCTAssertNotNil(channel)`. A descriptor with no connect token satisfies that.
3. `Swift E2E (sandbox)` is skipped on nearly every branch, so the one test that opens a socket rarely runs.

This PR closes the second condition. `testGetChannelDescriptor` now asserts that the hydrated `wsUrl` carries a connect token. The check needs no socket and no deploy.

## Tests

The first sandbox run exposed two more defects in `testSubscribeAndReceive`. The handshake stopped failing, and the test then hung for 17 minutes until the job timeout stopped it. Both are fixed.

First, the test could not fail. It could only hang. `for try await` blocks until a message arrives, so the `deadline` check below the loop was unreachable. A separate task now consumes the stream, and `fulfillment(of:timeout: 25)` awaits it.

Second, the test raced the subscription. It published once, 500 ms after `subscribe()`. Subscribing is asynchronous end to end: the handshake runs the `$connect` Lambda, and the frame is live only after a DynamoDB write. The test now publishes once a second until it receives the message or the deadline passes.

Six unit tests in `RealtimeChannelTests` cover the query building: a real base64url token passes through byte-for-byte, existing parameters survive, localhost rewriting applies first, an absent or empty `connectToken` changes nothing, and `&` is encoded so a token cannot be truncated.

## Format

SwiftFormat 0.62.0 (2026-07-06) split `wrapConditionalBodies` into `wrapIfStatementBodies`, `wrapIfExpressionBodies`, and `wrapGuardStatementBodies`. `.swiftformat` does not name the new rule, so it took the tool default and flagged existing code. The workflow installs the formatter without a version (`brew install swiftformat`), so the rule set changed inside CI with no commit.

Disabling the rule restores the existing intent. The configuration already disables the sibling rules `wrapPropertyBodies`, `wrapFunctionBodies`, `wrapMultilineStatementBraces`, and `wrapArguments`. This one line re-lands #296, which proposed the same change and was self-closed by its author with no objection recorded.

Every current violation is that one rule: 92 violations, 9 files. `swiftformat --lint .` goes from 9/63 files to 0/63. No source is reformatted for the rule.

## Verification

- `swiftformat --lint .` reports `0/63 files require formatting`.
- `swift test` runs 155 tests. 0 failures.
- 5 of the 6 new unit tests fail when I revert the connect-token fix.
- The `BlocksE2ETests` target compiles with no Swift diagnostics (built through Mac Catalyst, because the iOS SDK is not installed locally).

## Limitations

Only a deployed backend exercises the handshake. `Swift E2E (sandbox)` on this PR is therefore the real check for the connect-token fix.

The local `Swift E2E` job showed one red run with a `-1001` timeout to `http://localhost` in `AuthBasicE2ETests`. That job is green on this same branch's earlier runs and on nearly every recent branch, so it is a one-off flake in the local dev server, not a defect in this change. A fresh run clears it.

## Provenance

Supersedes #359. The one-line `.swiftformat` change from that PR is commit `f2e94560` here.
