### PR TITLE
fix(swift): disable wrapIfStatementBodies to unbreak SwiftFormat

### DIFF
--- a/native/swift/.swiftformat
+++ b/native/swift/.swiftformat
@@ -129,6 +129,7 @@
 --disable sortImports
 --disable wrapPropertyBodies
 --disable wrapFunctionBodies
+--disable wrapIfStatementBodies
 --disable simplifyGenericConstraints
 --disable redundantThrows
 --disable noForceUnwrapInTests


### PR DESCRIPTION
## Summary

This change adds one line to `native/swift/.swiftformat`. It reformats no Swift source.

It re-lands #296. That PR proposed the same one-line change. Its author closed it one day later. No review and no objection were recorded. The check has stayed red since then.

## Cause

SwiftFormat 0.62.0, released 2026-07-06, split the `wrapConditionalBodies` rule into three rules:

- `wrapIfStatementBodies`
- `wrapIfExpressionBodies`
- `wrapGuardStatementBodies`

`native/swift/.swiftformat` does not name `wrapIfStatementBodies`. The new rule therefore took the tool default, and it started to flag existing code.

The workflow installs the formatter without a version:

```yaml
- name: Install SwiftFormat
  run: brew install swiftformat
```

The rule set changed inside CI. No commit to this repository caused the change. This is why the check failed on branches that change no Swift file.

## Rationale

The configuration already disables the other wrap-body rules:

```
--disable wrapPropertyBodies
--disable wrapFunctionBodies
--disable wrapMultilineStatementBraces
--disable wrapArguments
--wrapconditions preserve
```

`wrapIfStatementBodies` did not exist when the author wrote this configuration. Disabling it restores the original intent. It lowers no standard.

The other option is to reformat 9 files. That option changes source code to satisfy one rule while the project disables the three sibling rules.

## Results

One rule causes every violation:

```
$ swiftformat --lint . | grep -oE "\((\w+)\)" | sort | uniq -c
  92 (wrapIfStatementBodies)
```

92 violations, 9 files, 1 rule.

| Command | Before | After |
|---|---|---|
| `swiftformat --lint .` | 9/63 files require formatting | 0/63 |

## Verification

- `swiftformat --lint .` reports `0/63 files require formatting, 5 files skipped`.
- `swift build` succeeds.
- `swift test` runs 149 tests. 0 failures.
- `git status` lists only `.swiftformat`.

This change needs no changeset. The Swift changeset gate watches `native/swift/Sources/**` and `native/swift/Package.swift`. `.swiftformat` is outside both paths, and the published package does not change.

## Next

`brew install swiftformat` installs the newest version. The break was therefore silent, and the next release that changes a default can break CI again. Pin the formatter version in the workflow. Homebrew does not pin versions cleanly, so this needs a choice between a versioned action, Mint, and an SPM dependency. That choice belongs in a separate PR.
