### PR TITLE
fix(dart): make blocks_runtime_flutter WASM-compatible

### DIFF
--- a/native/dart/packages/blocks_runtime_flutter/lib/src/flutter_secure_store.dart
+++ b/native/dart/packages/blocks_runtime_flutter/lib/src/flutter_secure_store.dart
@@ -1,20 +1,10 @@
-import 'package:flutter_secure_storage/flutter_secure_storage.dart';
-import 'package:blocks_runtime/blocks_runtime.dart';
+/// Exports the platform-appropriate [FlutterSecureStore] implementation.
+///
+/// Native platforms use `flutter_secure_storage` (iOS Keychain / Android
+/// Keystore). That package transitively imports `dart:io`, which is not
+/// WASM-compatible, so the web/WASM build selects a stub instead — keeping this
+/// package importable and WASM-compatible on the web.
+library;
 
-/// Persistent [TokenStore] backed by iOS Keychain / Android Keystore.
-class FlutterSecureStore implements TokenStore {
-  final FlutterSecureStorage _storage;
-
-  FlutterSecureStore({FlutterSecureStorage? storage})
-    : _storage = storage ?? const FlutterSecureStorage();
-
-  @override
-  Future<String?> get(String key) => _storage.read(key: key);
-
-  @override
-  Future<void> set(String key, String value) =>
-      _storage.write(key: key, value: value);
-
-  @override
-  Future<void> delete(String key) => _storage.delete(key: key);
-}
+export 'flutter_secure_store_io.dart'
+    if (dart.library.js_interop) 'flutter_secure_store_web.dart';

--- a/native/dart/packages/blocks_runtime_flutter/lib/src/flutter_secure_store_io.dart
+++ b/native/dart/packages/blocks_runtime_flutter/lib/src/flutter_secure_store_io.dart
@@ -1,0 +1,20 @@
+import 'package:blocks_runtime/blocks_runtime.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+
+/// Persistent [TokenStore] backed by iOS Keychain / Android Keystore.
+class FlutterSecureStore implements TokenStore {
+  final FlutterSecureStorage _storage;
+
+  FlutterSecureStore({FlutterSecureStorage? storage})
+    : _storage = storage ?? const FlutterSecureStorage();
+
+  @override
+  Future<String?> get(String key) => _storage.read(key: key);
+
+  @override
+  Future<void> set(String key, String value) =>
+      _storage.write(key: key, value: value);
+
+  @override
+  Future<void> delete(String key) => _storage.delete(key: key);
+}

--- a/native/dart/packages/blocks_runtime_flutter/lib/src/flutter_secure_store_web.dart
+++ b/native/dart/packages/blocks_runtime_flutter/lib/src/flutter_secure_store_web.dart
@@ -1,0 +1,31 @@
+import 'package:blocks_runtime/blocks_runtime.dart';
+
+/// Web/WASM stub for [TokenStore].
+///
+/// `flutter_secure_storage` (iOS Keychain / Android Keystore) is not available
+/// on the web, and its platform interface transitively imports `dart:io`, which
+/// is not WASM-compatible. To keep `blocks_runtime_flutter` importable — and
+/// WASM-compatible — on the web, this stub is selected instead of the native
+/// implementation. Its methods throw [UnsupportedError]; web apps should supply
+/// their own [TokenStore] (e.g. one backed by browser storage) when
+/// constructing `BlocksClient`.
+class FlutterSecureStore implements TokenStore {
+  FlutterSecureStore() {
+    throw UnsupportedError(
+      'FlutterSecureStore is not supported on the web. Provide a '
+      'web-specific TokenStore implementation when constructing BlocksClient.',
+    );
+  }
+
+  @override
+  Future<String?> get(String key) =>
+      throw UnsupportedError('FlutterSecureStore is not supported on the web.');
+
+  @override
+  Future<void> set(String key, String value) =>
+      throw UnsupportedError('FlutterSecureStore is not supported on the web.');
+
+  @override
+  Future<void> delete(String key) =>
+      throw UnsupportedError('FlutterSecureStore is not supported on the web.');
+}


### PR DESCRIPTION
## Problem

`blocks_runtime_flutter` gets a partial [pub.dev score](https://pub.dev/packages/blocks_runtime_flutter/score) because it is **not WASM-compatible**. The analyzer traces:

```
blocks_runtime_flutter.dart
  → src/flutter_secure_store.dart
    → package:flutter_secure_storage/flutter_secure_storage.dart
      → flutter_secure_storage_platform_interface.dart
        → dart:io   ← not WASM-compatible
```

`flutter_secure_storage`'s platform interface imports `dart:io` **unconditionally**, so any import of it pulls `dart:io` into the web/WASM compile graph. There is no newer `flutter_secure_storage` release that fixes this (latest is still `11.0.0`), so this must be solved at the import level.

## Fix

Split `FlutterSecureStore` behind a **conditional export**:

- `src/flutter_secure_store_io.dart` — native platforms; keeps the `flutter_secure_storage`-backed implementation (iOS Keychain / Android Keystore). Unchanged behavior.
- `src/flutter_secure_store_web.dart` — web/WASM; a stub that does **not** import `flutter_secure_storage`, so `dart:io` stays out of the web/WASM graph. Its methods throw `UnsupportedError`.
- `src/flutter_secure_store.dart` — now a shim: `export '..._io.dart' if (dart.library.js_interop) '..._web.dart';`

The public barrel export (`blocks_runtime_flutter.dart`) and the native API are unchanged.

## Behavior change

Because `dart.library.io` / `dart.library.js_interop` cannot distinguish web-JS from web-WASM, the web branch cannot import `flutter_secure_storage` at all. Previously the web build used `flutter_secure_storage`'s (experimental) WebCrypto backend; now `FlutterSecureStore` throws `UnsupportedError` on the web. This package is mobile-oriented (Keychain/Keystore + `app_links` deep-link OIDC), so this seems acceptable — but flagging it for maintainer review. Web apps should supply their own `TokenStore` when constructing `BlocksClient`.