### PR TITLE
feat(core): expose backendModulePath; self-heal handler init 

### DIFF
--- a/.changeset/core-backend-module-path.md
+++ b/.changeset/core-backend-module-path.md
@@ -1,0 +1,19 @@
+---
+"@aws-blocks/core": minor
+---
+
+feat(core): expose `backendModulePath`; let the shared role be assumed by AgentCore
+
+Two additions that support the Agent BB running its loop on a Bedrock AgentCore Runtime:
+
+- `BlocksStack` / `BlocksBackend` now expose `backendModulePath` (the app's `backendCDKPath`) so
+  Building Blocks that co-bundle the app backend at synth time can discover it via
+  `globalThis.CURRENT_BLOCKS_STACK.backendModulePath`. Used to co-bundle the backend + the agent
+  `serve()` harness into the runtime's code asset.
+- The shared execution role (`BlocksRole`) now also trusts `bedrock-agentcore.amazonaws.com`, so an
+  AgentCore Runtime can run **as** the shared role — the same role the Lambda handler already assumes
+  (`role: executionRole` in `setupBlocksInfra`) — and inherit every Building Block's grants. The
+  AgentCore trust is scoped to this account/region via `aws:SourceAccount` + `aws:SourceArn`
+  conditions (AWS's recommended AgentCore Runtime trust policy), so only AgentCore runtimes in this
+  account can assume it — not an account-wide confused-deputy surface. The `lambda` trust is
+  unchanged (standard, unconditioned).

--- a/.changeset/core-backend-module-path.md
+++ b/.changeset/core-backend-module-path.md
@@ -2,18 +2,14 @@
 "@aws-blocks/core": minor
 ---
 
-feat(core): expose `backendModulePath`; let the shared role be assumed by AgentCore
+feat(core): expose `backendModulePath`
 
-Two additions that support the Agent BB running its loop on a Bedrock AgentCore Runtime:
+`BlocksStack` / `BlocksBackend` now expose `backendModulePath` (the app's `backendCDKPath`) so
+Building Blocks that co-bundle the app backend at synth time can discover it via
+`globalThis.CURRENT_BLOCKS_STACK.backendModulePath`. Used to co-bundle the backend + the agent
+`serve()` harness into the AgentCore Runtime's code asset.
 
-- `BlocksStack` / `BlocksBackend` now expose `backendModulePath` (the app's `backendCDKPath`) so
-  Building Blocks that co-bundle the app backend at synth time can discover it via
-  `globalThis.CURRENT_BLOCKS_STACK.backendModulePath`. Used to co-bundle the backend + the agent
-  `serve()` harness into the runtime's code asset.
-- The shared execution role (`BlocksRole`) now also trusts `bedrock-agentcore.amazonaws.com`, so an
-  AgentCore Runtime can run **as** the shared role — the same role the Lambda handler already assumes
-  (`role: executionRole` in `setupBlocksInfra`) — and inherit every Building Block's grants. The
-  AgentCore trust is scoped to this account/region via `aws:SourceAccount` + `aws:SourceArn`
-  conditions (AWS's recommended AgentCore Runtime trust policy), so only AgentCore runtimes in this
-  account can assume it — not an account-wide confused-deputy surface. The `lambda` trust is
-  unchanged (standard, unconditioned).
+The shared execution role (`BlocksRole`) stays BB-agnostic: it is created with a
+`CompositePrincipal` so a Building Block whose compute runs **as** the shared role can add its own
+trust principal from its own CDK construct (e.g. the Agent BB adds `bedrock-agentcore`), rather than
+core trusting a specific compute by default.

--- a/.changeset/core-config-location.md
+++ b/.changeset/core-config-location.md
@@ -1,0 +1,14 @@
+---
+"@aws-blocks/core": minor
+---
+
+feat(core): expose `getConfigLocation()` so co-located compute can load the app config
+
+`getConfigLocation(scope)` ensures the shared config bucket exists (created once per stack, memoized on
+the config registry) and returns `{ bucketName, key }`. `finalizeConfigRegistry` now uses it for the
+handler's `BLOCKS_CONFIG_BUCKET`/`BLOCKS_CONFIG_KEY` + `s3:GetObject` grant (handler behavior unchanged).
+A Building Block whose compute runs **as** the shared execution role but outside the Lambda handler
+(e.g. the Agent BB's AgentCore Runtime) can now inject the same two vars at construction so its
+`loadConfigToProcessEnv()` loads the identical app config — otherwise it would run with empty config and
+any config-backed BB a tool touches would fail. IAM is unchanged: the config-read grant is on the shared
+role, which such compute inherits.

--- a/.changeset/core-handler-init-retry.md
+++ b/.changeset/core-handler-init-retry.md
@@ -17,3 +17,10 @@ config loader no longer caching a not-found result (a 404 is treated as transien
 poisoning the cache with `{}`), the handler **self-heals** as soon as config becomes readable.
 This is most likely to surface on large/slow deploys (which widen the post-deploy window), but the
 fragility was general.
+
+**Behavior change:** a failed handler init is now **retried per request** instead of cached. A
+transient config blip self-heals (the win), but a *genuinely* broken deploy (bad IAM, wrong bucket,
+malformed config) now re-runs `initialize()` — an S3 GET + backend import — on **every** invocation
+until it recovers or the container cycles, rather than failing fast. Expect added per-request latency
+and repeated S3/CloudWatch activity under a broken deploy; revisit any alarms that assumed a fast,
+sticky init failure.

--- a/.changeset/core-handler-init-retry.md
+++ b/.changeset/core-handler-init-retry.md
@@ -1,0 +1,19 @@
+---
+"@aws-blocks/core": patch
+---
+
+fix(core): retry handler initialization on failure instead of caching the rejection
+
+`createLambdaHandler` memoized its init promise and, if `initialize()` threw — most often
+because `loadConfigToProcessEnv()` couldn't read `blocks-config.json` during the brief
+post-deploy window before it's readable — cached that **rejected** promise for the container's
+entire lifetime. Every subsequent request then re-awaited the same rejection and returned a 500,
+so a *transient* config blip became a *permanent* handler outage for that container (visible as a
+whole stack of API calls returning `undefined`, only "recovering" as Lambda cycled in fresh
+containers).
+
+A failed `initialize()` now resets the promise so the next invocation retries. Combined with the
+config loader no longer caching a not-found result (a 404 is treated as transient rather than
+poisoning the cache with `{}`), the handler **self-heals** as soon as config becomes readable.
+This is most likely to surface on large/slow deploys (which widen the post-deploy window), but the
+fragility was general.

--- a/packages/core/src/cdk/blocks-backend.test.ts
+++ b/packages/core/src/cdk/blocks-backend.test.ts
@@ -170,49 +170,18 @@ describe('shared execution role', () => {
 			'BlocksRole should attach AWSLambdaBasicExecutionRole',
 		);
 
+		// Core is BB-agnostic: with no Building Block that runs AS the shared role, the trust policy
+		// must NOT allow any compute principal beyond Lambda (e.g. bedrock-agentcore is added by the
+		// Agent BB's own construct, not here — see packages/bb-agent).
+		assert.ok(
+			!JSON.stringify(blocksRole.Properties.AssumeRolePolicyDocument).includes('bedrock-agentcore'),
+			'core must not trust bedrock-agentcore by default (no agent → no AgentCore trust)',
+		);
+
 		// The Blocks handler references the shared role, not an auto-generated one.
 		template.hasResourceProperties('AWS::Lambda::Function', {
 			Role: { 'Fn::GetAtt': [blocksRoleId, 'Arn'] },
 		});
-	});
-
-	test('the shared role is assumable by BOTH Lambda and AgentCore (multi-compute trust)', async () => {
-		const app = new cdk.App();
-		const parent = new cdk.Stack(app, 'RoleTrustStack');
-
-		await makeBackend(parent, 'Blocks', sideEffectBackendPath);
-
-		const template = Template.fromStack(parent);
-		const roles = template.findResources('AWS::IAM::Role');
-		const blocksRoleId = Object.keys(roles).find((k) => k.includes('BlocksRole'));
-		assert.ok(blocksRoleId, 'expected a role from the BlocksRole construct');
-
-		// Collect every trusted service principal across all trust statements — robust to whether
-		// CDK renders the CompositePrincipal as one statement (Service: [..]) or one per principal.
-		const statements = roles[blocksRoleId].Properties.AssumeRolePolicyDocument.Statement as Array<{
-			Principal?: { Service?: string | string[] };
-			Condition?: Record<string, Record<string, unknown>>;
-		}>;
-		const servicesOf = (s: (typeof statements)[number]) => {
-			const svc = s.Principal?.Service;
-			return Array.isArray(svc) ? svc : svc ? [svc] : [];
-		};
-		const services = statements.flatMap(servicesOf);
-		// Lambda must remain trusted (the handler runs on it); AgentCore is added so the Agent BB's
-		// AgentCore Runtime can run AS this shared role and inherit every Building Block's grants.
-		assert.ok(services.includes('lambda.amazonaws.com'), 'shared role must stay Lambda-assumable');
-		assert.ok(
-			services.includes('bedrock-agentcore.amazonaws.com'),
-			'shared role must be assumable by the AgentCore Runtime',
-		);
-		// The AgentCore trust must be scoped to this account (aws:SourceAccount) — AWS's recommended
-		// AgentCore trust policy — so it isn't an account-wide confused-deputy surface.
-		const agentCoreStmt = statements.find((s) => servicesOf(s).includes('bedrock-agentcore.amazonaws.com'));
-		assert.ok(agentCoreStmt?.Condition, 'AgentCore trust statement must carry a scoping Condition');
-		assert.ok(
-			JSON.stringify(agentCoreStmt.Condition).includes('aws:SourceAccount'),
-			'AgentCore trust must be scoped by aws:SourceAccount',
-		);
 	});
 
 	test('exposes backendModulePath (props.backendCDKPath) for co-bundling BBs', async () => {

--- a/packages/core/src/cdk/blocks-backend.test.ts
+++ b/packages/core/src/cdk/blocks-backend.test.ts
@@ -176,6 +176,56 @@ describe('shared execution role', () => {
 		});
 	});
 
+	test('the shared role is assumable by BOTH Lambda and AgentCore (multi-compute trust)', async () => {
+		const app = new cdk.App();
+		const parent = new cdk.Stack(app, 'RoleTrustStack');
+
+		await makeBackend(parent, 'Blocks', sideEffectBackendPath);
+
+		const template = Template.fromStack(parent);
+		const roles = template.findResources('AWS::IAM::Role');
+		const blocksRoleId = Object.keys(roles).find((k) => k.includes('BlocksRole'));
+		assert.ok(blocksRoleId, 'expected a role from the BlocksRole construct');
+
+		// Collect every trusted service principal across all trust statements — robust to whether
+		// CDK renders the CompositePrincipal as one statement (Service: [..]) or one per principal.
+		const statements = roles[blocksRoleId].Properties.AssumeRolePolicyDocument.Statement as Array<{
+			Principal?: { Service?: string | string[] };
+			Condition?: Record<string, Record<string, unknown>>;
+		}>;
+		const servicesOf = (s: (typeof statements)[number]) => {
+			const svc = s.Principal?.Service;
+			return Array.isArray(svc) ? svc : svc ? [svc] : [];
+		};
+		const services = statements.flatMap(servicesOf);
+		// Lambda must remain trusted (the handler runs on it); AgentCore is added so the Agent BB's
+		// AgentCore Runtime can run AS this shared role and inherit every Building Block's grants.
+		assert.ok(services.includes('lambda.amazonaws.com'), 'shared role must stay Lambda-assumable');
+		assert.ok(
+			services.includes('bedrock-agentcore.amazonaws.com'),
+			'shared role must be assumable by the AgentCore Runtime',
+		);
+		// The AgentCore trust must be scoped to this account (aws:SourceAccount) — AWS's recommended
+		// AgentCore trust policy — so it isn't an account-wide confused-deputy surface.
+		const agentCoreStmt = statements.find((s) => servicesOf(s).includes('bedrock-agentcore.amazonaws.com'));
+		assert.ok(agentCoreStmt?.Condition, 'AgentCore trust statement must carry a scoping Condition');
+		assert.ok(
+			JSON.stringify(agentCoreStmt.Condition).includes('aws:SourceAccount'),
+			'AgentCore trust must be scoped by aws:SourceAccount',
+		);
+	});
+
+	test('exposes backendModulePath (props.backendCDKPath) for co-bundling BBs', async () => {
+		const app = new cdk.App();
+		const parent = new cdk.Stack(app, 'BackendPathStack');
+
+		const backend = await makeBackend(parent, 'Blocks', sideEffectBackendPath);
+
+		// Building Blocks that co-bundle the app backend at synth time (e.g. the Agent BB's AgentCore
+		// Runtime) discover it via globalThis.CURRENT_BLOCKS_STACK.backendModulePath.
+		assert.strictEqual(backend.backendModulePath, sideEffectBackendPath);
+	});
+
 	test('a nested block resolves executionRole via the construct-tree walk', async () => {
 		const app = new cdk.App();
 		const parent = new cdk.Stack(app, 'RoleResolveStack');

--- a/packages/core/src/cdk/blocks-backend.ts
+++ b/packages/core/src/cdk/blocks-backend.ts
@@ -106,33 +106,15 @@ export function setupBlocksInfra(scope: Construct, props: BlocksBackendProps, id
   // so permissions would quietly vanish. If a bring-your-own-role option is ever
   // added, it must resolve to a mutable role (`{ mutable: true }`).
   const executionRole = new iam.Role(scope, 'BlocksRole', {
-    // CompositePrincipal (rather than a bare ServicePrincipal) so additional
-    // compute types can assume this same shared role as they are introduced
-    // (e.g. ECS tasks via ecs-tasks.amazonaws.com), by adding principals here.
+    // CompositePrincipal (rather than a bare ServicePrincipal) so a Building Block
+    // whose compute runs AS this shared role can add its own trust principal here
+    // (e.g. the Agent BB adds bedrock-agentcore in its CDK construct) — core stays
+    // agnostic and only Lambda is trusted by default.
     assumedBy: new iam.CompositePrincipal(new iam.ServicePrincipal('lambda.amazonaws.com')),
     managedPolicies: [
       iam.ManagedPolicy.fromAwsManagedPolicyName('service-role/AWSLambdaBasicExecutionRole'),
     ],
   });
-
-  // The Agent BB's AgentCore Runtime runs AS this shared role, so its loop inherits every Building
-  // Block's grant (the same way any compute does) rather than needing a bespoke, under-granted role.
-  // Scope that trust to this account/region with aws:SourceAccount + aws:SourceArn — this is AWS's
-  // recommended AgentCore Runtime trust policy (the service sends both keys on AssumeRole), so it
-  // tightens the confused-deputy surface (only AgentCore runtimes in THIS account can assume the
-  // role) without breaking assumption. Added as its own trust statement so the condition applies
-  // only to AgentCore, not to the unconditioned lambda trust.
-  executionRole.assumeRolePolicy?.addStatements(
-    new iam.PolicyStatement({
-      effect: iam.Effect.ALLOW,
-      principals: [new iam.ServicePrincipal('bedrock-agentcore.amazonaws.com')],
-      actions: ['sts:AssumeRole'],
-      conditions: {
-        StringEquals: { 'aws:SourceAccount': cdk.Aws.ACCOUNT_ID },
-        ArnLike: { 'aws:SourceArn': `arn:${cdk.Aws.PARTITION}:bedrock-agentcore:${cdk.Aws.REGION}:${cdk.Aws.ACCOUNT_ID}:*` },
-      },
-    }),
-  );
 
   // ── Resource Groups ───────────────────────────────────────────────────
   let rootStack = cdk.Stack.of(scope);

--- a/packages/core/src/cdk/blocks-backend.ts
+++ b/packages/core/src/cdk/blocks-backend.ts
@@ -115,6 +115,25 @@ export function setupBlocksInfra(scope: Construct, props: BlocksBackendProps, id
     ],
   });
 
+  // The Agent BB's AgentCore Runtime runs AS this shared role, so its loop inherits every Building
+  // Block's grant (the same way any compute does) rather than needing a bespoke, under-granted role.
+  // Scope that trust to this account/region with aws:SourceAccount + aws:SourceArn — this is AWS's
+  // recommended AgentCore Runtime trust policy (the service sends both keys on AssumeRole), so it
+  // tightens the confused-deputy surface (only AgentCore runtimes in THIS account can assume the
+  // role) without breaking assumption. Added as its own trust statement so the condition applies
+  // only to AgentCore, not to the unconditioned lambda trust.
+  executionRole.assumeRolePolicy?.addStatements(
+    new iam.PolicyStatement({
+      effect: iam.Effect.ALLOW,
+      principals: [new iam.ServicePrincipal('bedrock-agentcore.amazonaws.com')],
+      actions: ['sts:AssumeRole'],
+      conditions: {
+        StringEquals: { 'aws:SourceAccount': cdk.Aws.ACCOUNT_ID },
+        ArnLike: { 'aws:SourceArn': `arn:${cdk.Aws.PARTITION}:bedrock-agentcore:${cdk.Aws.REGION}:${cdk.Aws.ACCOUNT_ID}:*` },
+      },
+    }),
+  );
+
   // ── Resource Groups ───────────────────────────────────────────────────
   let rootStack = cdk.Stack.of(scope);
   while (rootStack.nestedStackParent) rootStack = rootStack.nestedStackParent;
@@ -189,6 +208,12 @@ export function setupBlocksInfra(scope: Construct, props: BlocksBackendProps, id
  */
 export class BlocksBackend extends Construct {
   public readonly backendHandlerPath: string;
+  /**
+   * Path to the app's backend module (`props.backendCDKPath`). Exposed so Building Blocks that
+   * co-bundle the backend at synth (e.g. the Agent BB's AgentCore Runtime) can discover it via
+   * `globalThis.CURRENT_BLOCKS_STACK.backendModulePath`.
+   */
+  public readonly backendModulePath: string;
   /** Shared IAM role assumed by all Blocks compute. Building Blocks grant to this role. */
   public readonly executionRole: iam.IRole;
   /** Infrastructure defaults for Building Blocks created under this backend. */
@@ -255,6 +280,7 @@ export class BlocksBackend extends Construct {
     super(scope, id);
 
     this.backendHandlerPath = props.backendHandlerPath;
+    this.backendModulePath = props.backendCDKPath;
 
     // Expose self to Building Blocks at CDK time
     (globalThis as any).CURRENT_BLOCKS_STACK = this;

--- a/packages/core/src/cdk/config-registry.test.ts
+++ b/packages/core/src/cdk/config-registry.test.ts
@@ -1,0 +1,135 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * CDK tests for the config registry — specifically the getConfigLocation ↔ finalizeConfigRegistry
+ * interaction. `getConfigLocation()` creates the config bucket eagerly (so co-located compute can
+ * inject BLOCKS_CONFIG_BUCKET/KEY at construction); finalize must therefore still upload the config
+ * object + wire the computes whenever a bucket exists, even if zero entries were registered —
+ * otherwise that compute's loadConfigToProcessEnv() would 404 forever against a created-but-empty
+ * bucket.
+ */
+import assert from 'node:assert';
+import { afterEach, test } from 'node:test';
+import * as cdk from 'aws-cdk-lib';
+import { Match, Template } from 'aws-cdk-lib/assertions';
+import { Construct } from 'constructs';
+import { Compute } from './compute/compute.js';
+import { finalizeConfigRegistry, getConfigLocation, registerConfig } from './config-registry.js';
+import { DEFAULT_NODE_RUNTIME } from './node-version.js';
+
+// getConfigLocation reads globalThis.CURRENT_BLOCKS_STACK to place the bucket under the owning
+// stack/backend; clear it between tests so one test's owner never leaks into another.
+afterEach(() => {
+	delete (globalThis as any).CURRENT_BLOCKS_STACK;
+});
+
+// A real app's compute comes from @aws-blocks/bb-lambda-compute, which core's own tests can't
+// depend on. This is the same shape: a Compute that owns a real Lambda function and injects config
+// via addEnvironment — enough for finalizeConfigRegistry to stamp BLOCKS_CONFIG_BUCKET/KEY on it.
+class TestCompute extends Compute {
+	readonly fn: cdk.aws_lambda.Function;
+
+	constructor(scope: Construct, id: string) {
+		super(id, { parent: scope as never });
+		this.fn = new cdk.aws_lambda.Function(this, 'Handler', {
+			runtime: DEFAULT_NODE_RUNTIME,
+			handler: 'index.handler',
+			code: cdk.aws_lambda.Code.fromInline('exports.handler = async () => {};'),
+		});
+	}
+
+	setEnv(key: string, value: string): void {
+		this.fn.addEnvironment(key, value);
+	}
+}
+
+function stackWithCompute(id: string): {
+	stack: cdk.Stack;
+	role: cdk.aws_iam.Role;
+	computes: readonly Compute[];
+} {
+	const app = new cdk.App();
+	const stack = new cdk.Stack(app, id);
+	const role = new cdk.aws_iam.Role(stack, 'BlocksRole', {
+		assumedBy: new cdk.aws_iam.ServicePrincipal('lambda.amazonaws.com'),
+	});
+	const compute = new TestCompute(stack, 'Compute');
+	return { stack, role, computes: [compute] };
+}
+
+test('finalize uploads + wires the computes even with zero entries when a bucket was created', () => {
+	const { stack, role, computes } = stackWithCompute('EmptyWithBucket');
+	// Simulate a co-located BB that creates the bucket but registers no config of its own.
+	getConfigLocation(stack);
+	finalizeConfigRegistry(stack, role, computes);
+
+	const t = Template.fromStack(stack);
+	assert.strictEqual(Object.keys(t.findResources('AWS::S3::Bucket')).length, 1, 'one config bucket');
+	t.resourceCountIs('Custom::CDKBucketDeployment', 1); // the (empty) blocks-config.json is uploaded
+	t.hasResourceProperties('AWS::Lambda::Function', {
+		Environment: { Variables: Match.objectLike({ BLOCKS_CONFIG_KEY: 'blocks-config.json' }) },
+	});
+	// Read is granted once to the shared role (not per-function), so every compute that assumes it
+	// — including co-located compute that never went through finalize — can read the object.
+	t.hasResourceProperties('AWS::IAM::Policy', {
+		PolicyDocument: {
+			Statement: Match.arrayWith([
+				Match.objectLike({ Action: Match.arrayWith([Match.stringLikeRegexp('^s3:GetObject')]) }),
+			]),
+		},
+		Roles: Match.arrayWith([Match.objectLike({ Ref: Match.stringLikeRegexp('BlocksRole') })]),
+	});
+});
+
+test('finalize is a no-op with zero entries and no bucket', () => {
+	const { stack, role, computes } = stackWithCompute('EmptyNoBucket');
+	finalizeConfigRegistry(stack, role, computes);
+
+	const t = Template.fromStack(stack);
+	assert.strictEqual(Object.keys(t.findResources('AWS::S3::Bucket')).length, 0, 'no config bucket created');
+	t.resourceCountIs('Custom::CDKBucketDeployment', 0);
+});
+
+test('finalize uploads + wires the computes when config was registered (bucket auto-created)', () => {
+	const { stack, role, computes } = stackWithCompute('WithEntries');
+	registerConfig(stack, 'BLOCKS_SOMETHING', 'value');
+	finalizeConfigRegistry(stack, role, computes);
+
+	const t = Template.fromStack(stack);
+	assert.strictEqual(Object.keys(t.findResources('AWS::S3::Bucket')).length, 1, 'one config bucket');
+	t.resourceCountIs('Custom::CDKBucketDeployment', 1);
+	t.hasResourceProperties('AWS::Lambda::Function', {
+		Environment: { Variables: Match.objectLike({ BLOCKS_CONFIG_KEY: 'blocks-config.json' }) },
+	});
+});
+
+test('the config bucket is created under the owning stack/backend, not the (deep) caller scope', () => {
+	// Mimic a BlocksBackend embedded in a customer stack: the owner is a nested construct, and the
+	// first caller of getConfigLocation is a *deep* construct (like the AgentCore Runtime).
+	const app = new cdk.App();
+	const stack = new cdk.Stack(app, 'CustomerStack');
+	const owner = new Construct(stack, 'Embedded'); // stands in for the BlocksBackend construct
+	(globalThis as any).CURRENT_BLOCKS_STACK = owner;
+	const deepScope = new Construct(new Construct(owner, 'agent'), 'runtime');
+
+	getConfigLocation(deepScope);
+
+	const t = Template.fromStack(stack);
+	const bucketIds = Object.keys(t.findResources('AWS::S3::Bucket'));
+	assert.strictEqual(bucketIds.length, 1, 'exactly one config bucket');
+	// Logical IDs encode the construct path — under the owner it's `EmbeddedBlocksConfigBucket…`,
+	// at the stack root it would be `BlocksConfigBucket…`. Pin that it follows the owner.
+	assert.ok(bucketIds[0].startsWith('Embedded'), `bucket should be nested under the owner, got ${bucketIds[0]}`);
+});
+
+test('getConfigLocation creates exactly one bucket across repeated calls (idempotent)', () => {
+	const app = new cdk.App();
+	const stack = new cdk.Stack(app, 'Idempotent');
+	const a = getConfigLocation(stack);
+	const b = getConfigLocation(stack);
+	assert.strictEqual(a.key, b.key, 'same config key');
+	assert.strictEqual(a.bucketName, b.bucketName, 'same bucket');
+	const t = Template.fromStack(stack);
+	assert.strictEqual(Object.keys(t.findResources('AWS::S3::Bucket')).length, 1, 'exactly one bucket');
+});

--- a/packages/core/src/cdk/config-registry.ts
+++ b/packages/core/src/cdk/config-registry.ts
@@ -9,9 +9,14 @@ import type { Compute } from './compute/compute.js';
 
 const REGISTRY_KEY = Symbol.for('BLOCKS_CONFIG_REGISTRY');
 
+/** The object key of the config JSON under {@link getConfigLocation}'s bucket. */
+const CONFIG_KEY = 'blocks-config.json';
+
 interface ConfigRegistryState {
 	entries: Map<string, unknown>;
 	finalized: boolean;
+	/** The shared config bucket, created once per stack by {@link getConfigLocation}. */
+	bucket?: s3.Bucket;
 }
 
 /**
@@ -46,6 +51,53 @@ export function registerConfig(scope: Construct, key: string, value: unknown): v
 }
 
 /**
+ * Ensure the shared config bucket exists and return where the config JSON lives
+ * (`{ bucketName, key }`). The bucket is created **once per stack** (memoized on
+ * the registry) and this is idempotent — the first caller creates it, later
+ * callers get the same bucket regardless of order.
+ *
+ * Any compute that loads config at runtime (`loadConfigToProcessEnv()`) injects
+ * these two values as `BLOCKS_CONFIG_BUCKET` / `BLOCKS_CONFIG_KEY`. The Lambda
+ * handler gets them from {@link finalizeConfigRegistry}; other compute that runs
+ * as the shared execution role (e.g. the Agent BB's AgentCore Runtime) calls this
+ * at construction to inject them too, so it loads the same app config the handler
+ * does. IAM is not granted here — `finalizeConfigRegistry` grants read on the config
+ * object to the shared execution role, which such compute inherits.
+ *
+ * @param scope - Any construct in the stack; the bucket is created under the stack.
+ */
+export function getConfigLocation(scope: Construct): { bucketName: string; key: string } {
+	return { bucketName: ensureConfigBucket(scope).bucketName, key: CONFIG_KEY };
+}
+
+/**
+ * Create-or-return the shared config bucket (memoized on the per-stack registry). Created under the
+ * owning `BlocksStack`/`BlocksBackend` (`globalThis.CURRENT_BLOCKS_STACK` — the construct finalize
+ * historically used), so its logical ID is stable regardless of which caller creates it first: a
+ * co-located BB (e.g. the AgentCore Runtime, a deep construct) may be the first to call it, and a
+ * `BlocksBackend` embedded in a customer stack must keep `Blocks/BlocksConfigBucket` (no replacement).
+ * Falls back to the stack when no owner is registered (isolated unit tests). Returns a concrete
+ * `s3.Bucket` so callers don't need a non-null assertion.
+ */
+function ensureConfigBucket(scope: Construct): s3.Bucket {
+	const stack = cdk.Stack.of(scope);
+	const registry = getRegistry(stack);
+	if (!registry.bucket) {
+		const owner = ((globalThis as any).CURRENT_BLOCKS_STACK as Construct | undefined) ?? stack;
+		registry.bucket = new s3.Bucket(owner, 'BlocksConfigBucket', {
+			removalPolicy: cdk.RemovalPolicy.DESTROY,
+			autoDeleteObjects: true,
+			encryption: s3.BucketEncryption.S3_MANAGED,
+			blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
+			lifecycleRules: [
+				{ noncurrentVersionExpiration: cdk.Duration.days(1) },
+			],
+		});
+	}
+	return registry.bucket;
+}
+
+/**
  * Finalize the config registry: create an S3 bucket, upload the config JSON,
  * grant read to the shared execution role, and stamp the config coordinates
  * (`BLOCKS_CONFIG_BUCKET` / `BLOCKS_CONFIG_KEY`) onto every compute.
@@ -75,19 +127,14 @@ export function finalizeConfigRegistry(
 	if (registry.finalized) return;
 	registry.finalized = true;
 
-	if (registry.entries.size === 0) return;
+	// Nothing to do only if no config was registered AND no bucket was created (via
+	// getConfigLocation). If a co-located BB created the bucket, still upload (even an empty {}) and
+	// wire the handler so that compute's loadConfigToProcessEnv() resolves instead of 404-ing forever.
+	if (registry.entries.size === 0 && !registry.bucket) return;
 
-	const configBucket = new s3.Bucket(root, 'BlocksConfigBucket', {
-		removalPolicy: cdk.RemovalPolicy.DESTROY,
-		autoDeleteObjects: true,
-		encryption: s3.BucketEncryption.S3_MANAGED,
-		blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
-		lifecycleRules: [
-			{ noncurrentVersionExpiration: cdk.Duration.days(1) },
-		],
-	});
-
-	const configKey = 'blocks-config.json';
+	// Ensure the bucket exists (a co-located BB may already have created it via getConfigLocation).
+	const configBucket = ensureConfigBucket(root);
+	const configKey = CONFIG_KEY;
 
 	const configObject = cdk.Lazy.any({
 		produce: () => Object.fromEntries(registry.entries),

--- a/packages/core/src/cdk/index.ts
+++ b/packages/core/src/cdk/index.ts
@@ -59,6 +59,12 @@ export interface CoreBlocksStackProps extends BlocksStackProps {
 export class BlocksStack extends cdk.Stack implements BaseBlocksStack {
   public readonly id: string;
   public readonly backendHandlerPath: string;
+  /**
+   * Path to the app's backend module (`props.backendCDKPath`). Exposed so Building Blocks that
+   * co-bundle the backend at synth (e.g. the Agent BB's AgentCore Runtime) can discover it via
+   * `globalThis.CURRENT_BLOCKS_STACK.backendModulePath`.
+   */
+  public readonly backendModulePath: string;
   /** Shared IAM role assumed by all Blocks compute. Building Blocks grant to this role. */
   public readonly executionRole: cdk.aws_iam.IRole;
   /** Infrastructure defaults for Building Blocks created under this stack. */
@@ -95,6 +101,7 @@ export class BlocksStack extends cdk.Stack implements BaseBlocksStack {
     this.id = id;
     this.backendHandlerPath = props.backendHandlerPath;
     this.defaults = props.defaults;
+    this.backendModulePath = props.backendCDKPath;
 
     // Set globalThis so Building Blocks attach directly to this stack
     (globalThis as any).CURRENT_BLOCKS_STACK = this;

--- a/packages/core/src/cdk/index.ts
+++ b/packages/core/src/cdk/index.ts
@@ -29,7 +29,7 @@ export {
 export { DEFAULT_NODE_RUNTIME } from './node-version.js';
 export { blocksNodejsBundling } from './bundling.js';
 export { SandboxDisableDeletionProtection } from './mixins.js';
-export { registerConfig, finalizeConfigRegistry } from './config-registry.js';
+export { registerConfig, finalizeConfigRegistry, getConfigLocation } from './config-registry.js';
 export { ensureApiGatewayAccount } from './apigateway-account.js';
 export {
   type BlocksDefaults,

--- a/packages/core/src/common/config.test.ts
+++ b/packages/core/src/common/config.test.ts
@@ -131,6 +131,27 @@ describe('config — S3 errors', () => {
 		assert.strictEqual(result, '', 'Should return empty string (empty config) on 404');
 	});
 
+	it('does not cache a not-found result — a later call re-fetches once the config exists', async () => {
+		process.env.BLOCKS_CONFIG_BUCKET = 'test-bucket';
+		process.env.BLOCKS_CONFIG_KEY = 'blocks-config.json';
+
+		// Simulate the transient post-deploy window: the object isn't written yet on the first
+		// fetch, then becomes available. A not-found result must NOT be cached, or the container
+		// would be poisoned with empty config for its lifetime.
+		let call = 0;
+		const notFound = new Error('The specified key does not exist.');
+		(notFound as any).name = 'NoSuchKey';
+		_setS3Fetcher(async () => {
+			call++;
+			if (call === 1) throw notFound;
+			return JSON.stringify({ READY_KEY: 'ready-value' });
+		});
+
+		assert.strictEqual(await getConfig('READY_KEY'), '', 'first call sees the not-yet-written config as empty');
+		assert.strictEqual(await getConfig('READY_KEY'), 'ready-value', 'later call re-fetches once the config exists');
+		assert.strictEqual(call, 2, 'a not-found result must not be cached — S3 is retried');
+	});
+
 	it('throws with clear message on S3 network error', async () => {
 		process.env.BLOCKS_CONFIG_BUCKET = 'test-bucket';
 		process.env.BLOCKS_CONFIG_KEY = 'blocks-config.json';

--- a/packages/core/src/common/config.ts
+++ b/packages/core/src/common/config.ts
@@ -157,6 +157,25 @@ export async function loadConfigToProcessEnv(): Promise<void> {
 }
 
 /**
+ * Whether a config load has resolved and cached a result.
+ *
+ * Returns `true` once `loadConfigFromS3()` has cached a config object — either a
+ * successful S3 load, a genuinely-empty `{}` config, or the no-bucket local-dev
+ * path (both of which cache `{}`). Returns `false` in the initial state AND
+ * after a transient not-found miss: the 404 path deliberately does NOT cache its
+ * empty result (see `loadConfigFromS3`), so a `false` return immediately after
+ * awaiting a load uniquely identifies the post-deploy S3 window where
+ * blocks-config.json isn't readable yet.
+ *
+ * Callers use this to tell a transient-empty load (retry on the next request)
+ * apart from a legitimately-config-less app (do nothing) without reaching into
+ * the module's private cache.
+ */
+export function isConfigResolved(): boolean {
+	return configCache !== null;
+}
+
+/**
  * Reset the config cache. **For testing only.**
  */
 export function _resetConfigCache(): void {

--- a/packages/core/src/common/config.ts
+++ b/packages/core/src/common/config.ts
@@ -60,9 +60,13 @@ async function loadConfigFromS3(): Promise<Record<string, string>> {
 			|| error?.Code === 'NoSuchKey'
 			|| error?.$metadata?.httpStatusCode === 404;
 		if (isNotFound) {
-			console.warn(`[Blocks] Config file not found in S3 (${bucket}/${key}), proceeding with empty config`);
-			configCache = {};
-			return configCache;
+			// Do NOT cache the empty result: a 404 right after deploy is usually the config file
+			// not being readable yet (the transient window before the BucketDeployment settles), not
+			// a genuinely config-less app. Caching {} here would poison the container for its whole
+			// lifetime. Returning without caching lets the next invocation re-fetch and pick up the
+			// real config once it's present. (Apps that truly have no config just re-check cheaply.)
+			console.warn(`[Blocks] Config file not found in S3 (${bucket}/${key}), proceeding with empty config (will retry on next request)`);
+			return {};
 		}
 		const msg = error instanceof Error ? error.message : String(error);
 		throw new Error(`[Blocks] Failed to load config from S3 (${bucket}/${key}): ${msg}`);

--- a/packages/core/src/common/index.ts
+++ b/packages/core/src/common/index.ts
@@ -338,6 +338,13 @@ export interface BlocksStackProps extends StackProps {
 
 export class BlocksStack {
 	public readonly id: string;
+	/**
+	 * Path to the app's backend module (`props.backendCDKPath`). A typed contract for Building
+	 * Blocks that co-bundle the backend at synth time and read it off
+	 * `globalThis.CURRENT_BLOCKS_STACK` (the CDK `BlocksStack` / `BlocksBackend` set it). Declared
+	 * here so those consumers can type against `BaseBlocksStack` instead of `any`.
+	 */
+	declare readonly backendModulePath: string;
 	constructor(scope: Construct, id: string, props: BlocksStackProps) {
 		this.id = id;
 	}

--- a/packages/core/src/common/index.ts
+++ b/packages/core/src/common/index.ts
@@ -342,7 +342,8 @@ export class BlocksStack {
 	 * Path to the app's backend module (`props.backendCDKPath`). A typed contract for Building
 	 * Blocks that co-bundle the backend at synth time and read it off
 	 * `globalThis.CURRENT_BLOCKS_STACK` (the CDK `BlocksStack` / `BlocksBackend` set it). Declared
-	 * here so those consumers can type against `BaseBlocksStack` instead of `any`.
+	 * here so those consumers can type against this shared `BlocksStack` contract — which the CDK
+	 * `BlocksStack` / `BlocksBackend` implements — instead of `any`.
 	 */
 	declare readonly backendModulePath: string;
 	constructor(scope: Construct, id: string, props: BlocksStackProps) {

--- a/packages/core/src/index.cdk.ts
+++ b/packages/core/src/index.cdk.ts
@@ -31,6 +31,7 @@ export {
 	DEFAULT_NODE_RUNTIME,
 	ensureApiGatewayAccount,
 	finalizeConfigRegistry,
+	getConfigLocation,
 	registerConfig,
 	SandboxDisableDeletionProtection,
 	Scope,

--- a/packages/core/src/lambda-handler.test.ts
+++ b/packages/core/src/lambda-handler.test.ts
@@ -29,6 +29,38 @@ async function invoke(backend: any, event: any): Promise<any> {
   return handler(event) as any;
 }
 
+// ── init self-heal (retry on failed initialization) ─────────────────────────
+
+describe('createLambdaHandler — init self-heal', () => {
+  it('retries initialize() on a later request instead of caching a failed init', async () => {
+    let initCalls = 0;
+    const backend = {
+      api: (_ctx: BlocksContext) => ({
+        async echo(msg: string) {
+          return { msg };
+        },
+      }),
+    };
+    // Fail the first initialization (e.g. config not readable yet in the brief post-deploy
+    // window), then succeed. The SAME handler instance must recover — a cached rejected
+    // initPromise would poison the container and fail every subsequent request.
+    const backendFactory = async () => {
+      initCalls++;
+      if (initCalls === 1) throw new Error('transient init failure');
+      return backend;
+    };
+    const handler = createLambdaHandler(backendFactory);
+
+    // 1st request: init fails, so the handler rejects.
+    await assert.rejects(() => handler(makeEvent()) as any, /transient init failure/);
+
+    // 2nd request: init is retried and succeeds → 200 (not a re-thrown cached rejection).
+    const res = (await handler(makeEvent())) as any;
+    assert.strictEqual(res.statusCode, 200);
+    assert.strictEqual(initCalls, 2, 'initialize() must be retried on the next request, not cached');
+  });
+});
+
 // ── RPC body tests ──────────────────────────────────────────────────────────
 
 describe('createLambdaHandler — RPC body handling', () => {

--- a/packages/core/src/lambda-handler.test.ts
+++ b/packages/core/src/lambda-handler.test.ts
@@ -3,10 +3,11 @@
 
 import { describe, it, beforeEach } from 'node:test';
 import assert from 'node:assert';
-import { createLambdaHandler, _resetCorsPatterns, requestCookies, isApiGatewayHttpEvent, computeHttpDeadlineMs, classifyEvent, buildEventUrl, isLoopbackForwardedHost } from './lambda-handler.js';
+import { createLambdaHandler, _resetCorsPatterns, requestCookies, isApiGatewayHttpEvent, computeHttpDeadlineMs, classifyEvent, buildEventUrl, isLoopbackForwardedHost, TransientConfigError } from './lambda-handler.js';
 import type { LambdaContext } from './lambda-handler.js';
 import { registerRoute, clearRouteRegistry } from './raw-route.js';
 import { decodeRpcResponse } from './rpc.js';
+import { _resetConfigCache, _setS3Fetcher } from './common/config.js';
 import type { BlocksContext } from './api.js';
 
 beforeEach(() => {
@@ -58,6 +59,113 @@ describe('createLambdaHandler — init self-heal', () => {
     const res = (await handler(makeEvent())) as any;
     assert.strictEqual(res.statusCode, 200);
     assert.strictEqual(initCalls, 2, 'initialize() must be retried on the next request, not cached');
+  });
+
+  it('recovers from a transient-empty (post-deploy 404) config load on the next request', async () => {
+    // Reproduces the poisoned-container bug: the first S3 load hits the transient
+    // post-deploy window (NoSuchKey), so config resolves empty; the handler must
+    // NOT lock in that empty config, and the NEXT request must re-fetch and pick
+    // up the now-present config.
+    _resetConfigCache();
+    process.env.BLOCKS_CONFIG_BUCKET = 'test-bucket';
+    process.env.BLOCKS_CONFIG_KEY = 'blocks-config.json';
+    delete process.env.SELFHEAL_KEY;
+
+    let fetchCall = 0;
+    const notFound = new Error('The specified key does not exist.');
+    (notFound as any).name = 'NoSuchKey';
+    _setS3Fetcher(async () => {
+      fetchCall++;
+      if (fetchCall === 1) throw notFound; // config not readable yet
+      return JSON.stringify({ SELFHEAL_KEY: 'ready' });
+    });
+
+    let backendImports = 0;
+    const handler = createLambdaHandler(async () => {
+      backendImports++;
+      return {
+        api: (_ctx: BlocksContext) => ({
+          async echo(msg: string) { return { msg, cfg: process.env.SELFHEAL_KEY }; },
+        }),
+      };
+    });
+
+    try {
+      // 1st request: transient-empty load → initialize() throws TransientConfigError
+      // BEFORE importing the backend (so we never lock in empty config), and the
+      // request rejects.
+      await assert.rejects(() => handler(makeEvent()) as any, TransientConfigError);
+      assert.strictEqual(backendImports, 0, 'backend must NOT be imported while config is unresolved');
+
+      // 2nd request: config now present → initialize() re-runs, re-fetches, and
+      // injects the config into process.env before importing the backend.
+      const res = (await handler(makeEvent())) as any;
+      assert.strictEqual(res.statusCode, 200);
+      const body = JSON.parse(res.body);
+      assert.strictEqual(body.result.cfg, 'ready', 'now-present config was injected on the retry');
+      assert.strictEqual(backendImports, 1, 'backend imported exactly once, on the successful retry');
+      assert.strictEqual(fetchCall, 2, 'S3 was re-fetched on the retry (transient miss is not cached)');
+    } finally {
+      _resetConfigCache();
+      delete process.env.BLOCKS_CONFIG_BUCKET;
+      delete process.env.BLOCKS_CONFIG_KEY;
+      delete process.env.SELFHEAL_KEY;
+    }
+  });
+
+  it('does NOT re-init for a config-less app (no bucket, local dev) — initialize runs once', async () => {
+    _resetConfigCache();
+    delete process.env.BLOCKS_CONFIG_BUCKET;
+    delete process.env.BLOCKS_CONFIG_KEY;
+
+    let backendImports = 0;
+    const handler = createLambdaHandler(async () => {
+      backendImports++;
+      return { api: (_ctx: BlocksContext) => ({ async echo(msg: string) { return { msg }; } }) };
+    });
+
+    try {
+      const r1 = (await handler(makeEvent())) as any;
+      const r2 = (await handler(makeEvent())) as any;
+      assert.strictEqual(r1.statusCode, 200);
+      assert.strictEqual(r2.statusCode, 200);
+      assert.strictEqual(backendImports, 1, 'no re-init for a genuinely config-less (local dev) app');
+    } finally {
+      _resetConfigCache();
+    }
+  });
+
+  it('does NOT re-init or spin for a genuinely-empty ({}) S3 config', async () => {
+    // A real, readable empty config must be treated as resolved — distinct from
+    // the transient 404 miss — so the container does not throw/retry forever nor
+    // re-fetch S3 on every request.
+    _resetConfigCache();
+    process.env.BLOCKS_CONFIG_BUCKET = 'test-bucket';
+    process.env.BLOCKS_CONFIG_KEY = 'blocks-config.json';
+
+    let fetchCall = 0;
+    _setS3Fetcher(async () => { fetchCall++; return JSON.stringify({}); });
+
+    let backendImports = 0;
+    const handler = createLambdaHandler(async () => {
+      backendImports++;
+      return { api: (_ctx: BlocksContext) => ({ async echo(msg: string) { return { msg }; } }) };
+    });
+
+    try {
+      const r1 = (await handler(makeEvent())) as any;
+      const r2 = (await handler(makeEvent())) as any;
+      const r3 = (await handler(makeEvent())) as any;
+      assert.strictEqual(r1.statusCode, 200);
+      assert.strictEqual(r2.statusCode, 200);
+      assert.strictEqual(r3.statusCode, 200);
+      assert.strictEqual(backendImports, 1, 'genuinely-empty config resolves; no re-init');
+      assert.strictEqual(fetchCall, 1, 'S3 fetched once and cached — no per-request re-fetch spin');
+    } finally {
+      _resetConfigCache();
+      delete process.env.BLOCKS_CONFIG_BUCKET;
+      delete process.env.BLOCKS_CONFIG_KEY;
+    }
   });
 });
 

--- a/packages/core/src/lambda-handler.ts
+++ b/packages/core/src/lambda-handler.ts
@@ -7,7 +7,7 @@ import { ApiError } from './errors.js';
 import { BLOCKS_RPC_PREFIX } from './constants.js';
 import { matchRoute, lockRouteRegistry } from './raw-route.js';
 import { registerBuiltinRoutes } from './builtin-routes.js';
-import { loadConfigToProcessEnv } from './common/config.js';
+import { loadConfigToProcessEnv, isConfigResolved } from './common/config.js';
 import {
   parseRpcRequest,
   successResponse,
@@ -297,6 +297,26 @@ export function createLambdaHandler(backendFactory: () => Promise<any>) {
   async function initialize() {
     await loadConfigToProcessEnv();
 
+    // If the app has config coordinates (BLOCKS_CONFIG_BUCKET/KEY set) but the
+    // load didn't actually resolve the config, we're in the transient post-deploy
+    // S3 window where blocks-config.json isn't readable yet. loadConfigFromS3()
+    // deliberately does NOT cache that empty result, so throw a typed transient
+    // error here — BEFORE importing the backend — so the createLambdaHandler()
+    // catch resets initPromise and the next request re-runs initialize(), which
+    // re-fetches from S3 and picks up the now-present config. Without this throw,
+    // initialize() would succeed with empty config, `handler` would be assigned,
+    // and the `if (!handler)` guard below would never fire again, poisoning the
+    // container for its whole life (it would import the backend against empty
+    // process.env and serve "not configured" 500s forever).
+    //
+    // A genuinely config-less app does NOT throw: the no-bucket local-dev path
+    // and a real empty `{}` config both cache their result, so isConfigResolved()
+    // is true and the retry never spins. Once the blob is readable the successful
+    // load caches, so there is no unbounded per-request S3 re-fetch either.
+    if (process.env.BLOCKS_CONFIG_BUCKET && process.env.BLOCKS_CONFIG_KEY && !isConfigResolved()) {
+      throw new TransientConfigError();
+    }
+
     // Merge hosting-provided CORS origins into the main env var so the lazy
     // getCorsPatterns() sees a combined value on first access.
     // loadConfigToProcessEnv() won't override CORS_ALLOWED_ORIGINS if it's
@@ -398,6 +418,27 @@ class HandlerTimeoutError extends Error {
   constructor() {
     super('Handler timeout');
     this.name = 'HandlerTimeoutError';
+  }
+}
+
+/**
+ * Thrown by `initialize()` when the app has config coordinates
+ * (BLOCKS_CONFIG_BUCKET/KEY) but the S3 config load resolved empty because
+ * blocks-config.json wasn't readable yet — the transient window right after a
+ * deploy, before the BucketDeployment settles.
+ *
+ * It flows through the `createLambdaHandler()` init catch, which resets
+ * `initPromise` so the NEXT request re-runs `initialize()` and picks up the
+ * now-present config (config.ts does not cache a not-found result, so the retry
+ * re-fetches). A distinct type keeps the recovery path greppable and testable
+ * and separates it from real init failures, which surface with their own error.
+ *
+ * @internal Exported for testing only.
+ */
+export class TransientConfigError extends Error {
+  constructor() {
+    super('[Blocks] Config not readable yet (transient post-deploy S3 window); will retry on next request');
+    this.name = 'TransientConfigError';
   }
 }
 

--- a/packages/core/src/lambda-handler.ts
+++ b/packages/core/src/lambda-handler.ts
@@ -318,7 +318,18 @@ export function createLambdaHandler(backendFactory: () => Promise<any>) {
 
   return async (event: any, context?: LambdaContext) => {
     if (!handler) {
-      if (!initPromise) initPromise = initialize();
+      // Retry init on failure instead of caching the rejection. If initialize() throws (most often
+      // because loadConfigToProcessEnv() couldn't read blocks-config.json during the brief
+      // post-deploy window before it's readable), a memoized rejected promise would poison this
+      // container for its whole lifetime — every later request re-awaits the same rejection and 500s.
+      // Resetting initPromise lets the next invocation re-run initialize() (config.ts re-fetches,
+      // since it doesn't cache failures), so the handler self-heals once config is available.
+      if (!initPromise) {
+        initPromise = initialize().catch((err) => {
+          initPromise = null;
+          throw err;
+        });
+      }
       await initPromise;
     }
 


### PR DESCRIPTION
**Stacked PR 1 of 2** — AgentCore + Realtime migration. `main` → **this (core)** → bb-agent migration (#368).                                                                
                                                                                                                                                                                                               
## Problem                                                                                                                                                                                                     
The Agent BB ran its streaming loop on **Lambda + SQS + Realtime (API Gateway WebSocket)**. The fundamental ceiling is **Lambda's 15-minute max execution** — long-running / multi-step agents were not achievable on AWS. Bedrock AgentCore Runtime (sessions up to 8h) is purpose-built for this.

## Scope of this PR
Additive CDK-**core** changes with no consumer of their own (the loop move lands in #368), so behavior-preserving except the init-retry fix noted below:

1. **`backendModulePath` on `BlocksStack` / `BlocksBackend`** — exposes the app's `backendCDKPath` so a BB that co-bundles the backend at synth can find it via `globalThis.CURRENT_BLOCKS_STACK.backendModulePath`. (Consumed by #368's AgentCore Runtime co-bundle.)
2. **`getConfigLocation()`** — splits the config-bucket creation out of `finalizeConfigRegistry` into an eager, memoized helper returning `{ bucketName, key }`. The handler path is unchanged; a BB whose compute runs **as** the shared role but outside the handler (the AgentCore Runtime) uses it to inject `BLOCKS_CONFIG_BUCKET`/`BLOCKS_CONFIG_KEY` so its `loadConfigToProcessEnv()` loads the same app config the handler does. IAM is unchanged — the config-read grant is on the shared role, which such compute inherits.
3. **`BlocksRole` stays BB-agnostic** — core does **not** trust any compute beyond `lambda`. The role keeps its `CompositePrincipal` so a BB whose compute runs as the shared role adds its own trust principal from **its own** construct (the Agent BB adds `bedrock-agentcore` in #368) — same "each block augments the shared role" pattern as #356.
4. **`fix(core)`: the Lambda handler self-heals a failed init** instead of poisoning the container — see below.   

## Changes
- `packages/core/src/cdk/blocks-backend.ts` — assign `backendModulePath` from `props.backendCDKPath`; reword the `BlocksRole` `CompositePrincipal` comment (no `bedrock-agentcore` trust here — lambda only).
- `packages/core/src/cdk/config-registry.ts` — `getConfigLocation()` (eager memoized bucket); `finalizeConfigRegistry` reuses it and still uploads/wires when a bucket exists even with zero entries.
- `packages/core/src/cdk/index.ts` / `src/index.cdk.ts` — export `backendModulePath` + `getConfigLocation`.
- `packages/core/src/common/index.ts` — declare `backendModulePath` on the shared `BlocksStack` type.
- Tests: `blocks-backend.test.ts` (lambda-only trust + `backendModulePath`); `config-registry.test.ts` (getConfigLocation ↔ finalize, incl. empty-bucket upload + idempotency); `lambda-handler.test.ts` + `config.test.ts` (self-heal regressions).
                                                                                                                                                              
### 3. The handler self-heal fix                                                                                                                                                                               
**Bug (pre-existing):** `createLambdaHandler` memoized its init promise, including on **rejection**. If `initialize()` threw — most often because `loadConfigToProcessEnv()` can't read `blocks-config.json`   
during the brief post-deploy window before it's readable — the rejected promise was reused for the container's entire lifetime, so every later request returned a 500. A *transient* config blip became a      
*permanent* per-container outage: the whole API returns `undefined`, only appearing to "recover" as Lambda cycled in fresh containers.  

**Why that window exists:** the handler doesn't bundle its config — it **fetches `blocks-config.json` from S3 at cold-start** (Lambda env vars have a ~4 KB cap, so BB config is stored in S3). That file is   
produced by *separate* CloudFormation resources, so "the handler can serve" and "its config is readable" are **decoupled and race during a deploy**. Two things can briefly lag right after a fresh deploy:    
1. **The object isn't written yet** — it's uploaded by a CDK `BucketDeployment` custom resource that has *no ordering dependency* on the handler / API Gateway, which can become reachable first.              
2. **The read grant hasn't propagated** — the handler's `s3:GetObject` on the config bucket lives in a freshly-created (overflow) IAM policy, and IAM changes aren't instantaneous.

                                                                       
                                                                                                                                                                                                               
```ts                                                                                                                                                                                                          
// Before — a failed initialize() is cached forever; every later request re-awaits the rejection:                                                                                                              
if (!handler) {                                                                                                                                                                                                
  if (!initPromise) initPromise = initialize();                                                                                                                                                                
  await initPromise;                                                                                                                                                                                           
}                                                                                                                                                                                                              
                                                                                                                                                                                                               
// After — a failed init resets the promise so the next request retries:                                                                                                                                       
if (!handler) {                                                                                                                                                                                                
  if (!initPromise) {                                                                                                                                                                                          
    initPromise = initialize().catch((err) => {                                                                                                                                                                
      initPromise = null; // don't cache the rejection — let the next request re-run initialize()                                                                                                              
      throw err;                                                                                                                                                                                               
    });                                                                                                                                                                                                        
  }                                                                                                                                                                                                            
  await initPromise;                                                                                                                                                                                           
}                                                                                 
```                                                                                                                                                                                                                 
Paired with config.ts no longer caching a not-found result (a 404 is treated as a transient window, not a permanent empty-config poison), the handler self-heals as soon as the config object becomes readable.
                                                                                                                                                                                                               
Behavioral change: a failed init is now retried per-request rather than cached — a strict robustness win, but it does change failure semantics (a genuinely-broken deploy retries instead of failing fast).

## Validation
- Unit: `blocks-backend.test.ts`, `config-registry.test.ts`, `lambda-handler.test.ts`, `config.test.ts`; full core suite green.


## Checklist

- [x] PR description included
- [x] Tests are changed or added
- [x] Relevant documentation is changed or added (and PR referenced)

