### PR TITLE
fix(bb-knowledge-base): disable installLatestAwsSdk on ingestion custom resource

### DIFF
--- a/.changeset/kb-ingestion-install-latest-sdk.md
+++ b/.changeset/kb-ingestion-install-latest-sdk.md
@@ -1,0 +1,20 @@
+---
+"@aws-blocks/bb-knowledge-base": patch
+"@aws-blocks/blocks": patch
+---
+
+fix(bb-knowledge-base): disable `installLatestAwsSdk` on the ingestion custom resource
+
+The `StartIngestion` `AwsCustomResource` left `installLatestAwsSdk` at its default
+(`true`), so the provider Lambda ran an `npm install` of the AWS SDK on every
+invocation before it could call the API. That costs roughly 15-30s of extra cold
+start and forces the provider up to 512MB of memory.
+
+Nothing needed it. The resource calls `BedrockAgent.startIngestionJob`, a stable
+API already bundled in the Lambda runtime's AWS SDK v3, so the bundled client is
+sufficient and the install is pure overhead. Setting `installLatestAwsSdk: false`
+also silences CDK's `installLatestAwsSdkNotSpecified` synth-time warning for this
+construct.
+
+Internal construct wiring only — no public API change. The synthesized
+`Custom::AWS` resource now renders `InstallLatestAwsSdk: false`.

--- a/.changeset/kb-ingestion-install-latest-sdk.md
+++ b/.changeset/kb-ingestion-install-latest-sdk.md
@@ -8,7 +8,10 @@ fix(bb-knowledge-base): disable `installLatestAwsSdk` on the ingestion custom re
 The `StartIngestion` `AwsCustomResource` left `installLatestAwsSdk` at its default
 (`true`), so the provider Lambda ran an `npm install` of the AWS SDK on every
 invocation before it could call the API. That costs roughly 15-30s of extra cold
-start and forces the provider up to 512MB of memory.
+start and raises the shared provider Lambda to 512MB of memory, though that
+reduction is only realized once every `AwsCustomResource` in the stack opts out —
+the provider is a stack-level singleton and its `memorySize` is resolved once at
+synth. The per-resource cold-start saving applies regardless.
 
 Nothing needed it. The resource calls `BedrockAgent.startIngestionJob`, a stable
 API already bundled in the Lambda runtime's AWS SDK v3, so the bundled client is
@@ -23,3 +26,9 @@ since the client's initial release, not a recent addition.
 
 Internal construct wiring only — no public API change. The synthesized
 `Custom::AWS` resource now renders `InstallLatestAwsSdk: false`.
+
+Upgrade note: because `InstallLatestAwsSdk` renders as a property on the
+`Custom::AWS` resource while the `physicalResourceId` stays stable, the first
+deploy after upgrading is a CloudFormation *Update* and fires `onUpdate` — so one
+`startIngestionJob` kicks off. This is harmless (ingestion is idempotent and
+fire-and-forget), but expect to see an ingestion start right after upgrading.

--- a/.changeset/kb-ingestion-install-latest-sdk.md
+++ b/.changeset/kb-ingestion-install-latest-sdk.md
@@ -16,5 +16,10 @@ sufficient and the install is pure overhead. Setting `installLatestAwsSdk: false
 also silences CDK's `installLatestAwsSdkNotSpecified` synth-time warning for this
 construct.
 
+The tradeoff being accepted: the provider now uses whichever SDK v3 the Lambda
+runtime bundles at deploy time rather than installing the newest one. That is safe
+here because `startIngestionJob` is a foundational Bedrock Agent operation present
+since the client's initial release, not a recent addition.
+
 Internal construct wiring only — no public API change. The synthesized
 `Custom::AWS` resource now renders `InstallLatestAwsSdk: false`.

--- a/packages/bb-knowledge-base/src/index.cdk.test.ts
+++ b/packages/bb-knowledge-base/src/index.cdk.test.ts
@@ -271,9 +271,8 @@ test('CDK (s3:// source): DATA_SOURCE_ID config is wired to the data source id (
 test('CDK: the ingestion AwsCustomResource opts out of installing the latest AWS SDK (InstallLatestAwsSdk: false)', () => {
   const template = synth();
 
-  // startIngestionJob is a stable BedrockAgent API bundled in the Lambda
-  // runtime's SDK v3 — the provider must NOT npm-install the SDK at invoke time
-  // (the default true adds cold-start latency and bumps the provider to 512MB).
+  // StartIngestion is the only Custom::AWS resource in this template, so an
+  // unscoped match is unambiguous.
   template.hasResourceProperties('Custom::AWS', Match.objectLike({ InstallLatestAwsSdk: false }));
 });
 

--- a/packages/bb-knowledge-base/src/index.cdk.test.ts
+++ b/packages/bb-knowledge-base/src/index.cdk.test.ts
@@ -272,7 +272,10 @@ test('CDK: the ingestion AwsCustomResource opts out of installing the latest AWS
   const template = synth();
 
   // StartIngestion is the only Custom::AWS resource in this template, so an
-  // unscoped match is unambiguous.
+  // unscoped match is unambiguous. Enforce that rather than assume it: without
+  // the count assertion a second opted-out AwsCustomResource would let this pass
+  // even if StartIngestion itself regressed to the default.
+  template.resourceCountIs('Custom::AWS', 1);
   template.hasResourceProperties('Custom::AWS', Match.objectLike({ InstallLatestAwsSdk: false }));
 });
 

--- a/packages/bb-knowledge-base/src/index.cdk.test.ts
+++ b/packages/bb-knowledge-base/src/index.cdk.test.ts
@@ -268,6 +268,15 @@ test('CDK (s3:// source): DATA_SOURCE_ID config is wired to the data source id (
   );
 });
 
+test('CDK: the ingestion AwsCustomResource opts out of installing the latest AWS SDK (InstallLatestAwsSdk: false)', () => {
+  const template = synth();
+
+  // startIngestionJob is a stable BedrockAgent API bundled in the Lambda
+  // runtime's SDK v3 — the provider must NOT npm-install the SDK at invoke time
+  // (the default true adds cold-start latency and bumps the provider to 512MB).
+  template.hasResourceProperties('Custom::AWS', Match.objectLike({ InstallLatestAwsSdk: false }));
+});
+
 test('CDK: calling a runtime method throws an actionable synth-time error (not a cryptic TypeError)', () => {
   const { kb } = buildStack();
   const construct = kb as unknown as Record<string, (...args: unknown[]) => unknown>;

--- a/packages/bb-knowledge-base/src/index.cdk.ts
+++ b/packages/bb-knowledge-base/src/index.cdk.ts
@@ -431,6 +431,10 @@ export class KnowledgeBase extends Scope {
 				},
 				physicalResourceId: cr.PhysicalResourceId.of(stableIngestId),
 			},
+			// startIngestionJob is a stable BedrockAgent API bundled in the Lambda
+			// runtime's AWS SDK v3, so skip the provider's npm-install of the SDK at
+			// invoke time (the default true adds ~15-30s cold start and forces 512MB).
+			installLatestAwsSdk: false,
 			policy: cr.AwsCustomResourcePolicy.fromStatements([
 				new iam.PolicyStatement({
 					actions: ['bedrock:StartIngestionJob'],

--- a/packages/bb-knowledge-base/src/index.cdk.ts
+++ b/packages/bb-knowledge-base/src/index.cdk.ts
@@ -431,9 +431,8 @@ export class KnowledgeBase extends Scope {
 				},
 				physicalResourceId: cr.PhysicalResourceId.of(stableIngestId),
 			},
-			// startIngestionJob is a stable BedrockAgent API bundled in the Lambda
-			// runtime's AWS SDK v3, so skip the provider's npm-install of the SDK at
-			// invoke time (the default true adds ~15-30s cold start and forces 512MB).
+			// Stable BedrockAgent API bundled in the Lambda runtime's SDK v3 — skip the
+			// npm-install at invoke time (avoids ~15-30s cold start + 512MB bump).
 			installLatestAwsSdk: false,
 			policy: cr.AwsCustomResourcePolicy.fromStatements([
 				new iam.PolicyStatement({

--- a/packages/bb-knowledge-base/src/index.cdk.ts
+++ b/packages/bb-knowledge-base/src/index.cdk.ts
@@ -432,7 +432,8 @@ export class KnowledgeBase extends Scope {
 				physicalResourceId: cr.PhysicalResourceId.of(stableIngestId),
 			},
 			// Stable BedrockAgent API bundled in the Lambda runtime's SDK v3 — skip the
-			// npm-install at invoke time (avoids ~15-30s cold start + 512MB bump).
+			// npm-install at invoke time (avoids ~15-30s cold start). The shared provider
+			// only drops back off 512MB once every AwsCustomResource in the stack opts out.
 			installLatestAwsSdk: false,
 			policy: cr.AwsCustomResourcePolicy.fromStatements([
 				new iam.PolicyStatement({


### PR DESCRIPTION
## Problem

The `StartIngestion` `AwsCustomResource` in `bb-knowledge-base` left
`installLatestAwsSdk` at its CDK default of `true`. With that default, the
`AWS679f53fac002430cb0da5b7982bd2287` provider Lambda runs an `npm install` of
the AWS SDK on every invocation before it can call the API. That costs roughly
15-30s of extra cold start and forces the provider up to 512MB of memory.

None of that is needed here: the resource calls
`BedrockAgent.startIngestionJob`, a stable API already bundled in the Lambda
runtime's AWS SDK v3. The default also causes CDK to emit an
`installLatestAwsSdkNotSpecified` warning at synth time.

**Issue #, if available:** N/A

## Changes

- `packages/bb-knowledge-base/src/index.cdk.ts` — added `installLatestAwsSdk: false`
  to the `new cr.AwsCustomResource(this, 'StartIngestion', { ... })` options, with a
  short comment explaining why the bundled SDK is sufficient.
- `packages/bb-knowledge-base/src/index.cdk.test.ts` — added a regression test
  asserting the synthesized `Custom::AWS` resource renders
  `InstallLatestAwsSdk: false`.
- `.changeset/kb-ingestion-install-latest-sdk.md` — patch bump for
  `@aws-blocks/bb-knowledge-base` and the `@aws-blocks/blocks` umbrella (which
  re-exports `KnowledgeBase`).

Internal construct wiring only — no public API change, so `API.md` is untouched.

Scope note: the `packages/hosting/src/cdn_construct.ts` `DeployInvalidation`
custom resource has the same anti-pattern. It is intentionally left out of this
PR.

## Validation

**Clean build** (`rm -rf dist *.tsbuildinfo && npm run build`, Node 22.22.3): exit 0.

**Unit tests** (`npm test -w packages/bb-knowledge-base`, Node 22.22.3):
130 passed / 0 failed across 15 suites. The `index.cdk.test.js` file alone is
9 passed / 0 failed, including the new assertion.

**Synth evidence.** Synthesizing the construct and dumping `Custom::AWS` shows
the property actually rendering in the CloudFormation template:

```json
=== Custom::AWS logical id: appdocsStartIngestion693D6A58 ===
{
  "InstallLatestAwsSdk": false,
  "Create": {
    "Fn::Join": ["", [
      "{\"service\":\"BedrockAgent\",\"action\":\"startIngestionJob\",\"parameters\":{\"knowledgeBaseId\":\"",
      { "Fn::GetAtt": ["appdocsKB240A965D", "KnowledgeBaseId"] },
      "\",\"dataSourceId\":\"",
      { "Fn::GetAtt": ["appdocsDataSource4AE12091", "DataSourceId"] },
      "\"},\"physicalResourceId\":{\"id\":\"", "..." , "-ingest\"}}"
    ]]
  }
}
```

The `installLatestAwsSdkNotSpecified` synth-time warning is no longer emitted
for this construct (grep of synth stderr returns nothing).

**Non-vacuity (red/green).** With the `installLatestAwsSdk: false` line removed
and the package rebuilt, the new test fails (`# pass 0 / # fail 1`) — before the
change the property is absent from the synthesized template. Restoring the line
returns it to green.

## Checklist

- [x] PR description included
- [x] Tests are changed or added
- [x] Relevant documentation is changed or added (and PR referenced) — n/a, no public API or doc surface changed; changeset added

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
