### PR TITLE
fix(hosting): disable installLatestAwsSdk on CDN invalidation custom resource

### DIFF
--- a/.changeset/hosting-cdn-install-latest-sdk.md
+++ b/.changeset/hosting-cdn-install-latest-sdk.md
@@ -1,0 +1,24 @@
+---
+"@aws-blocks/hosting": patch
+---
+
+fix(hosting): disable installLatestAwsSdk on the CDN invalidation custom resource
+
+The `DeployInvalidation` `AwsCustomResource` in `CdnConstruct` left
+`installLatestAwsSdk` at its CDK default of `true`. That default makes the
+custom-resource provider Lambda `npm install` the AWS SDK at invoke time,
+adding roughly 15-30s of cold start and forcing a 512MB memory floor on the
+provider function.
+
+Nothing here needs a newer SDK than the runtime ships. The resource makes a
+single `CloudFront.createInvalidation` call — a long-stable API already bundled
+in the Lambda runtime's AWS SDK v3. And unlike a one-off resource, this one
+fires on *every* hosting deploy (its `CallerReference`/`physicalResourceId` are
+keyed on `buildId`), so the install cost was paid on every deploy rather than
+once.
+
+Setting `installLatestAwsSdk: false` removes that per-deploy penalty and also
+silences CDK's `installLatestAwsSdkNotSpecified` warning for this construct.
+No public API or template change beyond the `InstallLatestAwsSdk: false`
+property on the synthesized `Custom::AWS` resource; invalidation behavior,
+IAM policy, and deploy ordering are unchanged.

--- a/packages/hosting/src/constructs/cdn_construct.test.ts
+++ b/packages/hosting/src/constructs/cdn_construct.test.ts
@@ -3655,6 +3655,42 @@ void describe('CdnConstruct — deploy-time invalidation', () => {
     assert.match(blob, /\\"Items\\":\[\\"\/\*\\"\]/);
   });
 
+  // createInvalidation is bundled in the Lambda runtime's SDK v3, and this
+  // resource fires on EVERY deploy — the CDK default (true) would npm-install
+  // the SDK at invoke time each time. The `resourceCountIs('Custom::AWS', 1)`
+  // below establishes the only Custom::AWS here IS DeployInvalidation.
+  void it('pins the invalidation resource to the bundled SDK (no install at invoke)', () => {
+    const stack = createStack();
+    const bucket = new Bucket(stack, 'Bucket');
+    const policy = createSecurityHeadersPolicy(stack, 'SH', {});
+    const { fn, fnUrl } = createSsrFunction(stack);
+
+    new CdnConstruct(stack, 'Cdn', {
+      bucket,
+      manifest: ssrManifest,
+      securityHeadersPolicy: policy,
+      computeFunctionUrls: new Map([['default', fnUrl]]),
+      computeFunctions: new Map([['default', fn]]),
+    });
+
+    const template = Template.fromStack(stack);
+    template.resourceCountIs('Custom::AWS', 1);
+    // Assert on the resource that actually carries createInvalidation, so this
+    // cannot pass off some unrelated future Custom::AWS.
+    const customAws = Object.values(template.findResources('Custom::AWS'))[0] as {
+      Properties: { Create?: unknown; Update?: unknown; InstallLatestAwsSdk?: unknown };
+    };
+    assert.match(
+      JSON.stringify(customAws.Properties.Update ?? customAws.Properties.Create ?? ''),
+      /createInvalidation/,
+    );
+    assert.strictEqual(customAws.Properties.InstallLatestAwsSdk, false);
+    template.hasResourceProperties(
+      'Custom::AWS',
+      Match.objectLike({ InstallLatestAwsSdk: false }),
+    );
+  });
+
   void it('grants only cloudfront:CreateInvalidation to the invalidation resource', () => {
     const stack = createStack();
     const bucket = new Bucket(stack, 'Bucket');

--- a/packages/hosting/src/constructs/cdn_construct.ts
+++ b/packages/hosting/src/constructs/cdn_construct.ts
@@ -1312,6 +1312,11 @@ export class CdnConstruct extends Construct {
             resources: ['*'],
           }),
         ]),
+        // CloudFront.createInvalidation is a stable API bundled in the Lambda
+        // runtime's AWS SDK v3. This resource fires on every hosting deploy, so
+        // the default (true) would make the provider Lambda npm-install the SDK
+        // at invoke time on each deploy (~15-30s cold start + 512MB bump).
+        installLatestAwsSdk: false,
       });
       // Gate AFTER the atomic KVS cutover so we only flush the previous build's
       // pages (see ordering note above).


### PR DESCRIPTION
## Problem

The `DeployInvalidation` `AwsCustomResource` in `CdnConstruct`
(`packages/hosting/src/constructs/cdn_construct.ts`) left `installLatestAwsSdk`
at its CDK default of `true`. With that default, the custom-resource provider
Lambda runs `npm install` for the AWS SDK at invoke time, which adds roughly
15-30s of cold start and forces a 512MB memory floor on the provider function.

Two things make this worse than a typical occurrence of the anti-pattern:

- The resource makes a single `CloudFront.createInvalidation` call — a
  long-stable API already bundled in the Lambda runtime's AWS SDK v3, so there
  is nothing to gain from a newer SDK.
- Unlike a one-off resource, this one fires on **every** hosting deploy (its
  `CallerReference` and `physicalResourceId` are keyed on `buildId`), so the
  install cost was paid on each deploy rather than once.

CDK also emits its `installLatestAwsSdkNotSpecified` warning for this construct
on every synth.

Sibling fix to #371 — same anti-pattern, different package. That PR covers the
`bb-knowledge-base` site; this one covers `hosting`. No overlap: this branch is
cut independently from `origin/main` and touches only `packages/hosting`.

**Issue #, if available:** n/a

## Changes

- `packages/hosting/src/constructs/cdn_construct.ts`: add
  `installLatestAwsSdk: false` to the `DeployInvalidation` `AwsCustomResource`
  options, with a short comment recording the rationale.
- `packages/hosting/src/constructs/cdn_construct.test.ts`: add a test asserting
  the synthesized `Custom::AWS` carries `InstallLatestAwsSdk: false`.
- Changeset: `@aws-blocks/hosting` patch. `@aws-blocks/blocks` is intentionally
  not included — it has no dependency on `@aws-blocks/hosting` and does not
  re-export the construct.

Invalidation behavior, the IAM policy (`cloudfront:CreateInvalidation` on `*`),
and the deploy ordering dependency on the KVS cutover are all unchanged. The
only synthesized-template delta is the `InstallLatestAwsSdk` property flipping
from `true` to `false`. No public API surface change, so `API.md` is untouched.

## Validation

**Clean build** (node 22.22.3), `rm -rf dist *.tsbuildinfo && npm run build` in
`packages/hosting`: exit 0. No dependency blockers; `package.json` and
`package-lock.json` are unmodified (`git status` clean apart from the three
intended files).

**Tests**: 839 pass / 0 fail (212 suites), including the new
`pins the invalidation resource to the bundled SDK (no install at invoke)`.

**Synth proof** — `DeployInvalidation` fragment from a synthesized SSR stack:

```json
"CdnDeployInvalidation5F20E44E": {
  "Type": "Custom::AWS",
  "Properties": {
    "ServiceToken": { "Fn::GetAtt": ["AWS679f53fac002430cb0da5b7982bd22872D164C4C", "Arn"] },
    "Create": { "Fn::Join": ["", [
      "{\"service\":\"CloudFront\",\"action\":\"createInvalidation\",\"parameters\":{\"DistributionId\":\"",
      { "Ref": "CdnHostingDistribution0C0AE0F7" },
      "\",\"InvalidationBatch\":{\"CallerReference\":\"blocks-test-ssr-1\",\"Paths\":{\"Quantity\":1,\"Items\":[\"/*\"]}}},\"physicalResourceId\":{\"id\":\"invalidation-test-ssr-1\"}}"
    ]]},
    "InstallLatestAwsSdk": false
  }
}
```

The CDK warning is also gone: synth reports 0 stack messages with the fix. That
check is not vacuous — reverting only the construct change reproduces exactly
one warning, `installLatestAwsSdkNotSpecified` at
`/TestStack/Cdn/DeployInvalidation`, and the fragment shows
`"InstallLatestAwsSdk": true`.

**Non-vacuity of the test**: with the construct change stashed, the suite is
838 pass / 1 fail, the single failure being the new assertion. With the change
applied it passes.

## Checklist

- [x] PR description included
- [x] Tests are changed or added
- [x] Relevant documentation is changed or added (and PR referenced) — no public API change, so no `API.md` update; rationale captured in a code comment and the changeset

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
