### PR TITLE
ci(native/dart): Test each package on its SDK floor and stable

### DIFF
--- a/.github/workflows/native-dart-analysis.yml
+++ b/.github/workflows/native-dart-analysis.yml
@@ -20,6 +20,12 @@ concurrency:
 permissions:
   contents: read
 
+# The floor from every pubspec's `environment:` block. Same floor, two numbering
+# schemes: Flutter 3.41.0 ships Dart 3.11.0.
+env:
+  MIN_DART: '3.11.0'
+  MIN_FLUTTER: '3.41.0'
+
 jobs:
   analyze:
     name: ${{ matrix.package-name }} (${{ matrix.sdk }})
@@ -30,23 +36,19 @@ jobs:
       matrix:
         package-name: [blocks_runtime, blocks_codegen, blocks_runtime_flutter]
         sdk: [min, stable]
-        # min-version mirrors each pubspec's `environment:` floor — keep in sync.
         include:
           - package-name: blocks_runtime
             working-directory: native/dart/packages/blocks_runtime
             tool: dart
             runtime-override: false
-            min-version: '3.11.0'
           - package-name: blocks_codegen
             working-directory: native/dart/packages/blocks_codegen
             tool: dart
             runtime-override: true
-            min-version: '3.11.0'
           - package-name: blocks_runtime_flutter
             working-directory: native/dart/packages/blocks_runtime_flutter
             tool: flutter
             runtime-override: true
-            min-version: '3.41.0'
     steps:
       - uses: actions/checkout@v5
         with:
@@ -57,7 +59,7 @@ jobs:
         if: matrix.tool == 'dart'
         uses: dart-lang/setup-dart@v1
         with:
-          sdk: ${{ matrix.sdk == 'min' && matrix.min-version || 'stable' }}
+          sdk: ${{ matrix.sdk == 'min' && env.MIN_DART || 'stable' }}
 
       # Empty flutter-version means latest of the channel.
       - name: Setup Flutter
@@ -65,7 +67,7 @@ jobs:
         uses: subosito/flutter-action@v2
         with:
           channel: stable
-          flutter-version: ${{ matrix.sdk == 'min' && matrix.min-version || '' }}
+          flutter-version: ${{ matrix.sdk == 'min' && env.MIN_FLUTTER || '' }}
           cache: true
 
       # blocks_codegen and blocks_runtime_flutter depend on blocks_runtime,

--- a/.github/workflows/native-dart-analysis.yml
+++ b/.github/workflows/native-dart-analysis.yml
@@ -10,6 +10,7 @@ on:
   pull_request:
     paths:
       - 'native/dart/packages/**'
+      - '.github/workflows/native-dart-analysis.yml'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/native-dart-analysis.yml
+++ b/.github/workflows/native-dart-analysis.yml
@@ -21,25 +21,31 @@ permissions:
 
 jobs:
   analyze:
-    name: ${{ matrix.package-name }}
+    name: ${{ matrix.package-name }} (${{ matrix.sdk }})
     runs-on: ubuntu-latest
     timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
+        package-name: [blocks_runtime, blocks_codegen, blocks_runtime_flutter]
+        sdk: [min, stable]
+        # min-version mirrors each pubspec's `environment:` floor — keep in sync.
         include:
           - package-name: blocks_runtime
             working-directory: native/dart/packages/blocks_runtime
             tool: dart
             runtime-override: false
+            min-version: '3.11.0'
           - package-name: blocks_codegen
             working-directory: native/dart/packages/blocks_codegen
             tool: dart
             runtime-override: true
+            min-version: '3.11.0'
           - package-name: blocks_runtime_flutter
             working-directory: native/dart/packages/blocks_runtime_flutter
             tool: flutter
             runtime-override: true
+            min-version: '3.41.0'
     steps:
       - uses: actions/checkout@v5
         with:
@@ -50,13 +56,15 @@ jobs:
         if: matrix.tool == 'dart'
         uses: dart-lang/setup-dart@v1
         with:
-          sdk: '3.13.0'
+          sdk: ${{ matrix.sdk == 'min' && matrix.min-version || 'stable' }}
 
+      # Empty flutter-version means latest of the channel.
       - name: Setup Flutter
         if: matrix.tool == 'flutter'
         uses: subosito/flutter-action@v2
         with:
           channel: stable
+          flutter-version: ${{ matrix.sdk == 'min' && matrix.min-version || '' }}
           cache: true
 
       # blocks_codegen and blocks_runtime_flutter depend on blocks_runtime,
@@ -80,6 +88,7 @@ jobs:
       # version (3.11, from each package's sdk: ^3.11.0), making the result
       # deterministic and matching local runs.
       - name: Check formatting
+        if: matrix.sdk == 'stable'
         working-directory: ${{ matrix.working-directory }}
         run: dart format --output=none --set-exit-if-changed .
 
@@ -89,6 +98,7 @@ jobs:
       # follow-up `dart fix` pass will clear; flip this to blocking once the
       # tree analyzes clean.
       - name: Analyze (advisory — annotations only, non-blocking)
+        if: matrix.sdk == 'stable'
         continue-on-error: true
         working-directory: ${{ matrix.working-directory }}
         run: ${{ matrix.tool }} analyze .
@@ -100,6 +110,7 @@ jobs:
 
       # Report-only: prints the pub.dev package score and uploads the report.
       - name: Package score
+        if: matrix.sdk == 'stable'
         continue-on-error: true
         uses: ./.github/composite_actions/package_score
         with:

--- a/native/dart/packages/blocks_codegen/pubspec.yaml
+++ b/native/dart/packages/blocks_codegen/pubspec.yaml
@@ -14,6 +14,6 @@ dependencies:
   blocks_runtime: ^0.1.2
 
 dev_dependencies:
-  build_runner: ^2.16.0
+  build_runner: ^2.14.0
   lints: ^6.0.0
-  test: ^1.31.0
+  test: ^1.25.0

--- a/native/dart/packages/blocks_runtime_flutter/pubspec.yaml
+++ b/native/dart/packages/blocks_runtime_flutter/pubspec.yaml
@@ -17,9 +17,11 @@ dependencies:
   url_launcher: ^6.2.0
   app_links: ^7.0.0
 
+# Floors stay low on purpose: build_runner 2.15.2+ and mockito 5.8.0+ need
+# analyzer 13.3+, hence meta 1.18.3+, which only Flutter 3.47+ pins. Don't raise.
 dev_dependencies:
-  build_runner: ^2.16.0
+  build_runner: ^2.14.0
   flutter_test:
     sdk: flutter
   lints: ^6.0.0
-  mockito: ^5.8.1
+  mockito: ^5.6.0

--- a/native/dart/packages/blocks_runtime_flutter/pubspec.yaml
+++ b/native/dart/packages/blocks_runtime_flutter/pubspec.yaml
@@ -17,8 +17,6 @@ dependencies:
   url_launcher: ^6.2.0
   app_links: ^7.0.0
 
-# Floors stay low on purpose: build_runner 2.15.2+ and mockito 5.8.0+ need
-# analyzer 13.3+, hence meta 1.18.3+, which only Flutter 3.47+ pins. Don't raise.
 dev_dependencies:
   build_runner: ^2.14.0
   flutter_test:


### PR DESCRIPTION
`channel: stable` floated to Flutter 3.47.0, which relaxed `meta` from `1.18.0` to `^1.18.3`. That let `build_runner ^2.16.0` / `mockito ^5.8.1` (analyzer 13.3+) resolve in CI while failing on every older Flutter — `pub get` and `pub publish` both break on 3.44.x and 3.41.x.

Each package now runs on its `environment:` floor as well as stable. `pub get` + `test` on both legs; format, analyze and score stay on stable only.

**Expected: `blocks_runtime_flutter (min)` fails at `Get dependencies`.** That's the point — the pubspec fix is a separate PR.