### PR TITLE
fix(hosting): use nodejs24.x for SSR framework compute and fail loudly on unknown runtimes (#361)

### DIFF
--- a/.changeset/hosting-nodejs24-framework-runtime.md
+++ b/.changeset/hosting-nodejs24-framework-runtime.md
@@ -1,0 +1,13 @@
+---
+"@aws-blocks/hosting": patch
+---
+
+fix(hosting): deploy SSR framework Lambdas on nodejs24.x and throw on unrecognized runtimes instead of silently falling back to nodejs20.x
+
+SSR framework compute (Nuxt/Nitro, Astro, SvelteKit, Next.js regional) now runs on
+`nodejs24.x` via a shared `FRAMEWORK_COMPUTE_RUNTIME` constant, and `resolveRuntime()`
+recognizes `nodejs24.x`, defaults to it when no runtime is declared, and throws
+`UnsupportedRuntimeError` for unrecognized runtimes rather than silently returning
+Node 20. Lambda@Edge compute intentionally stays on `nodejs20.x`
+(`FRAMEWORK_EDGE_COMPUTE_RUNTIME`) because the edge runtime set is narrower and the
+OpenNext edge bundle patch targets Node 20 ESM semantics.

--- a/.changeset/hosting-nodejs24-framework-runtime.md
+++ b/.changeset/hosting-nodejs24-framework-runtime.md
@@ -8,6 +8,9 @@ SSR framework compute (Nuxt/Nitro, Astro, SvelteKit, Next.js regional) now runs 
 `nodejs24.x` via a shared `FRAMEWORK_COMPUTE_RUNTIME` constant, and `resolveRuntime()`
 recognizes `nodejs24.x`, defaults to it when no runtime is declared, and throws
 `UnsupportedRuntimeError` for unrecognized runtimes rather than silently returning
-Node 20. Lambda@Edge compute intentionally stays on `nodejs20.x`
-(`FRAMEWORK_EDGE_COMPUTE_RUNTIME`) because the edge runtime set is narrower and the
-OpenNext edge bundle patch targets Node 20 ESM semantics.
+Node 20. Lambda@Edge compute (`FRAMEWORK_EDGE_COMPUTE_RUNTIME`) is bumped to
+`nodejs24.x` as well: Lambda@Edge draws Node.js versions from the same managed runtime
+table as regional Lambda, where `nodejs24.x` is supported and `nodejs20.x` is already
+past deprecation. The OpenNext edge bundle banner patch was revalidated — the crash it
+works around comes from ES Module namespace exports being non-writable per spec, not
+from any Node-20-specific behavior.

--- a/packages/hosting/src/adapters/astro.ts
+++ b/packages/hosting/src/adapters/astro.ts
@@ -35,6 +35,7 @@ import semver from 'semver';
 import { createJiti } from 'jiti';
 import { getPackageInfoSync, isPackageExists } from 'local-pkg';
 import { HostingError } from '../hosting_error.js';
+import { FRAMEWORK_COMPUTE_RUNTIME } from '../framework_runtime.js';
 import { DeployManifest, Redirect, RouteBehavior } from '../manifest/types.js';
 
 export type AstroAdapterOptions = {
@@ -992,7 +993,7 @@ const buildSsrManifest = (input: {
         entrypoint: path.posix.join(path.basename(serverDir), RUN_SH_FILENAME),
         port: ASTRO_SERVER_PORT,
         placement: 'regional',
-        runtime: 'nodejs20.x',
+        runtime: FRAMEWORK_COMPUTE_RUNTIME,
       },
     },
     staticAssets: {

--- a/packages/hosting/src/adapters/nextjs.test.ts
+++ b/packages/hosting/src/adapters/nextjs.test.ts
@@ -777,7 +777,7 @@ void describe('nextjsAdapter', () => {
           edgeFn1: {
             bundle: '.open-next/server-functions/edgeFn1',
             handler: 'index.handler',
-            runtime: 'nodejs20.x',
+            runtime: 'nodejs24.x',
           },
         },
         behaviors: [

--- a/packages/hosting/src/adapters/nextjs.ts
+++ b/packages/hosting/src/adapters/nextjs.ts
@@ -167,7 +167,10 @@ export const nextjsAdapter = (
     patchStreamingWrapperForApiGateway(openNextDir);
 
     // Patch each edge bundle's process import banner for Lambda@Edge
-    // compatibility. See patchEdgeBundleForLambdaEdge.
+    // compatibility. See patchEdgeBundleForLambdaEdge for the mechanics, and
+    // the FRAMEWORK_EDGE_COMPUTE_RUNTIME doc comment in framework_runtime.ts
+    // for why this patch is runtime-independent (ES Module namespace exports
+    // are non-writable per spec — it is not a Node-version quirk).
     patchEdgeBundlesForLambdaEdge(openNextDir);
 
     // Patch the image-optimization bundle for the Next.js 16 image-optimizer

--- a/packages/hosting/src/adapters/nextjs.ts
+++ b/packages/hosting/src/adapters/nextjs.ts
@@ -19,6 +19,10 @@ import fg from 'fast-glob';
 import semver from 'semver';
 import { getPackageInfoSync } from 'local-pkg';
 import { HostingError } from '../hosting_error.js';
+import {
+  FRAMEWORK_COMPUTE_RUNTIME,
+  FRAMEWORK_EDGE_COMPUTE_RUNTIME,
+} from '../framework_runtime.js';
 import type {
   ComputeResource,
   CustomHeader,
@@ -1945,7 +1949,7 @@ const translateOpenNextOutput = (
         handler: fn.handler ?? 'index.handler',
         placement: 'global',
         streaming: false,
-        runtime: 'nodejs20.x',
+        runtime: FRAMEWORK_EDGE_COMPUTE_RUNTIME,
       };
     }
   }
@@ -2076,7 +2080,7 @@ const mapOriginToCompute = (
       handler: origin.handler ?? 'index.handler',
       placement: 'regional',
       streaming: origin.streaming ?? true,
-      runtime: origin.runtime ?? 'nodejs20.x',
+      runtime: origin.runtime ?? FRAMEWORK_COMPUTE_RUNTIME,
       memorySize: origin.memorySize,
       timeout: origin.timeout,
       environment: origin.environment,
@@ -2091,7 +2095,7 @@ const mapOriginToCompute = (
       port: origin.port ?? 3000,
       placement: 'regional',
       streaming: origin.streaming ?? false,
-      runtime: origin.runtime ?? 'nodejs20.x',
+      runtime: origin.runtime ?? FRAMEWORK_COMPUTE_RUNTIME,
       environment: origin.environment,
     };
   }
@@ -2103,7 +2107,7 @@ const mapOriginToCompute = (
       handler: origin.handler ?? 'index.handler',
       placement: 'global',
       streaming: false,
-      runtime: origin.runtime ?? 'nodejs20.x',
+      runtime: origin.runtime ?? FRAMEWORK_EDGE_COMPUTE_RUNTIME,
       environment: origin.environment,
     };
   }
@@ -2115,7 +2119,7 @@ const mapOriginToCompute = (
     handler: 'index.handler',
     placement: 'regional',
     streaming: origin.streaming ?? true,
-    runtime: 'nodejs20.x',
+    runtime: FRAMEWORK_COMPUTE_RUNTIME,
   };
 };
 

--- a/packages/hosting/src/adapters/nextjs.ts
+++ b/packages/hosting/src/adapters/nextjs.ts
@@ -167,7 +167,7 @@ export const nextjsAdapter = (
     patchStreamingWrapperForApiGateway(openNextDir);
 
     // Patch each edge bundle's process import banner for Lambda@Edge
-    // nodejs20.x compatibility. See patchEdgeBundleForLambdaEdge.
+    // compatibility. See patchEdgeBundleForLambdaEdge.
     patchEdgeBundlesForLambdaEdge(openNextDir);
 
     // Patch the image-optimization bundle for the Next.js 16 image-optimizer
@@ -1335,18 +1335,20 @@ export const patchStreamingWrapperForApiGateway = (
 };
 
 /**
- * Patch every OpenNext edge bundle so it runs on Lambda@Edge nodejs20.x.
+ * Patch every OpenNext edge bundle so it runs on Lambda@Edge.
  *
  * OpenNext prepends each edge bundle with `import * as process from "node:process";`
- * (banner injected by createEdgeBundle.ts). Under Node 20 ESM the resulting
- * Module namespace's `env` binding is non-writable. The next-emitted Next.js
+ * (banner injected by createEdgeBundle.ts). Per the ECMAScript spec a Module
+ * namespace object's bindings are non-writable, so the next-emitted Next.js
  * shim then runs `process.env = e.g.process.env` and crashes with:
  *
  * TypeError: Cannot assign to read only property 'env' of object '[object Module]'
  *
  * Replace the namespace import with a default import so `process` is the
  * live mutable singleton (default export of `node:process`). Idempotent —
- * re-running on an already-patched file finds no banner to swap.
+ * re-running on an already-patched file finds no banner to swap. Version-
+ * agnostic: it relies only on top-level `await import(...)` and the
+ * `node:process` default export, both stable across Node 18–24.
  *
  * Affects only edge functions (Lambda@Edge); the regional `default` bundle
  * uses a different banner and is unaffected.
@@ -1401,7 +1403,7 @@ export const patchEdgeBundlesForLambdaEdge = (openNextDir: string): void => {
     });
   }
   process.stderr.write(
-    `\u{1F527} Patched ${total} edge bundle(s) for Lambda@Edge nodejs20.x compatibility.\n`,
+    `\u{1F527} Patched ${total} edge bundle(s) for Lambda@Edge compatibility.\n`,
   );
 };
 

--- a/packages/hosting/src/adapters/nitro.ts
+++ b/packages/hosting/src/adapters/nitro.ts
@@ -27,6 +27,7 @@ import fg from 'fast-glob';
 import semver from 'semver';
 import { getPackageInfoSync, isPackageExists } from 'local-pkg';
 import { HostingError } from '../hosting_error.js';
+import { FRAMEWORK_COMPUTE_RUNTIME } from '../framework_runtime.js';
 import type {
   ComputeResource,
   DeployManifest,
@@ -1378,7 +1379,7 @@ const presetToCompute = (
       entrypoint: 'index.mjs',
       port: 3000,
       placement: 'regional',
-      runtime: 'nodejs20.x',
+      runtime: FRAMEWORK_COMPUTE_RUNTIME,
     };
   }
 
@@ -1392,7 +1393,7 @@ const presetToCompute = (
     handler: 'index.handler',
     placement: 'regional',
     streaming: awsLambdaStreaming,
-    runtime: 'nodejs20.x',
+    runtime: FRAMEWORK_COMPUTE_RUNTIME,
   };
 };
 

--- a/packages/hosting/src/adapters/sveltekit.ts
+++ b/packages/hosting/src/adapters/sveltekit.ts
@@ -36,6 +36,7 @@ import semver from 'semver';
 import { createJiti } from 'jiti';
 import { getPackageInfoSync } from 'local-pkg';
 import { HostingError } from '../hosting_error.js';
+import { FRAMEWORK_COMPUTE_RUNTIME } from '../framework_runtime.js';
 import type {
   ComputeResource,
   DeployManifest,
@@ -790,7 +791,7 @@ const buildManifest = (input: {
       entrypoint: RUN_SH_FILENAME,
       port: SVELTEKIT_SERVER_PORT,
       placement: 'regional',
-      runtime: 'nodejs20.x',
+      runtime: FRAMEWORK_COMPUTE_RUNTIME,
       /* eslint-disable @typescript-eslint/naming-convention */
       environment: {
         // Behind CloudFront the SSR server must reconstruct the public origin

--- a/packages/hosting/src/constructs/compute_construct.test.ts
+++ b/packages/hosting/src/constructs/compute_construct.test.ts
@@ -42,7 +42,7 @@ const handlerResource = (bundle: string): ComputeResource => ({
   handler: 'index.handler',
   placement: 'regional',
   streaming: true,
-  runtime: 'nodejs20.x',
+  runtime: 'nodejs24.x',
 });
 
 const httpServerResource = (bundle: string): ComputeResource => ({
@@ -52,7 +52,7 @@ const httpServerResource = (bundle: string): ComputeResource => ({
   port: 3000,
   placement: 'regional',
   streaming: false,
-  runtime: 'nodejs20.x',
+  runtime: 'nodejs24.x',
 });
 
 const edgeResource = (bundle: string): ComputeResource => ({
@@ -61,7 +61,7 @@ const edgeResource = (bundle: string): ComputeResource => ({
   handler: 'index.handler',
   placement: 'global',
   streaming: false,
-  runtime: 'nodejs20.x',
+  runtime: 'nodejs24.x',
 });
 
 // ================================================================
@@ -89,7 +89,7 @@ void describe('ComputeConstruct', () => {
       const template = Template.fromStack(stack);
 
       template.hasResourceProperties('AWS::Lambda::Function', {
-        Runtime: 'nodejs20.x',
+        Runtime: 'nodejs24.x',
         Handler: 'index.handler',
       });
 
@@ -236,6 +236,62 @@ void describe('ComputeConstruct', () => {
     });
   });
 
+  // ---- Runtime resolution ----
+
+  void describe('runtime resolution', () => {
+    void it('defaults to nodejs24.x when no runtime is declared', () => {
+      const bundle = createBundleDir();
+      const stack = createStack();
+
+      const { runtime: _omitted, ...withoutRuntime } = handlerResource(bundle);
+
+      new ComputeConstruct(stack, 'Compute', {
+        name: 'default',
+        computeResource: withoutRuntime as ComputeResource,
+      });
+
+      Template.fromStack(stack).hasResourceProperties('AWS::Lambda::Function', {
+        Runtime: 'nodejs24.x',
+      });
+    });
+
+    void it('honors explicitly declared supported runtimes', () => {
+      const bundle = createBundleDir();
+      const stack = createStack();
+
+      new ComputeConstruct(stack, 'Compute', {
+        name: 'default',
+        computeResource: { ...handlerResource(bundle), runtime: 'nodejs22.x' },
+      });
+
+      Template.fromStack(stack).hasResourceProperties('AWS::Lambda::Function', {
+        Runtime: 'nodejs22.x',
+      });
+    });
+
+    void it('throws UnsupportedRuntimeError for an unrecognized runtime', () => {
+      const bundle = createBundleDir();
+      const stack = createStack();
+
+      assert.throws(
+        () =>
+          new ComputeConstruct(stack, 'Compute', {
+            name: 'default',
+            computeResource: {
+              ...handlerResource(bundle),
+              runtime: 'python3.12',
+            },
+          }),
+        (error: unknown) => {
+          assert.ok(error instanceof HostingError);
+          assert.strictEqual(error.code, 'UnsupportedRuntimeError');
+          assert.match(error.message, /python3\.12/);
+          return true;
+        },
+      );
+    });
+  });
+
   // ---- Edge type ----
 
   void describe('edge compute type', () => {
@@ -250,7 +306,7 @@ void describe('ComputeConstruct', () => {
       const template = Template.fromStack(stack);
 
       template.hasResourceProperties('AWS::Lambda::Function', {
-        Runtime: 'nodejs20.x',
+        Runtime: 'nodejs24.x',
         Handler: 'index.handler',
       });
     });

--- a/packages/hosting/src/constructs/compute_construct.test.ts
+++ b/packages/hosting/src/constructs/compute_construct.test.ts
@@ -276,7 +276,7 @@ void describe('ComputeConstruct', () => {
       assert.throws(
         () =>
           new ComputeConstruct(stack, 'Compute', {
-            name: 'default',
+            name: 'serverFn',
             computeResource: {
               ...handlerResource(bundle),
               runtime: 'python3.12',
@@ -286,6 +286,7 @@ void describe('ComputeConstruct', () => {
           assert.ok(error instanceof HostingError);
           assert.strictEqual(error.code, 'UnsupportedRuntimeError');
           assert.match(error.message, /python3\.12/);
+          assert.match(error.message, /serverFn/);
           return true;
         },
       );

--- a/packages/hosting/src/constructs/compute_construct.ts
+++ b/packages/hosting/src/constructs/compute_construct.ts
@@ -342,16 +342,27 @@ export class ComputeConstruct extends Construct {
   }
 
   private resolveRuntime(runtime?: string): Runtime {
-    if (!runtime || runtime === 'nodejs20.x') {
-      return Runtime.NODEJS_20_X;
+    if (!runtime) {
+      return Runtime.NODEJS_24_X;
+    }
+    if (runtime === 'nodejs24.x') {
+      return Runtime.NODEJS_24_X;
     }
     if (runtime === 'nodejs22.x') {
       return Runtime.NODEJS_22_X;
     }
+    if (runtime === 'nodejs20.x') {
+      return Runtime.NODEJS_20_X;
+    }
     if (runtime === 'nodejs18.x') {
       return Runtime.NODEJS_18_X;
     }
-    return Runtime.NODEJS_20_X;
+    throw new HostingError('UnsupportedRuntimeError', {
+      message: `Unsupported compute runtime '${runtime}'.`,
+      resolution:
+        'Use one of: nodejs24.x, nodejs22.x, nodejs20.x, nodejs18.x. ' +
+        'Omit the runtime to use the default (nodejs24.x).',
+    });
   }
 
   private validateWebAdapterRegion(

--- a/packages/hosting/src/constructs/compute_construct.ts
+++ b/packages/hosting/src/constructs/compute_construct.ts
@@ -212,7 +212,7 @@ export class ComputeConstruct extends Construct {
     if (computeResource.type === 'handler') {
       // Native Lambda handler — no Web Adapter needed
       this.function = new LambdaFunction(this, 'Function', {
-        runtime: this.resolveRuntime(computeResource.runtime),
+        runtime: this.resolveRuntime(computeResource.runtime, props.name),
         handler: computeResource.handler ?? 'index.handler',
         code: Code.fromAsset(computeResource.bundle),
         architecture,
@@ -236,7 +236,7 @@ export class ComputeConstruct extends Construct {
       const port = computeResource.port ?? SSR_DEFAULT_PORT;
 
       this.function = new LambdaFunction(this, 'Function', {
-        runtime: this.resolveRuntime(computeResource.runtime),
+        runtime: this.resolveRuntime(computeResource.runtime, props.name),
         handler: computeResource.entrypoint ?? 'run.sh',
         code: Code.fromAsset(computeResource.bundle),
         architecture,
@@ -290,7 +290,7 @@ export class ComputeConstruct extends Construct {
         this,
         `EdgeFunction-${props.name}`,
         {
-          runtime: this.resolveRuntime(computeResource.runtime),
+          runtime: this.resolveRuntime(computeResource.runtime, props.name),
           handler: computeResource.handler ?? 'index.handler',
           code: Code.fromAsset(computeResource.bundle),
           architecture,
@@ -341,7 +341,7 @@ export class ComputeConstruct extends Construct {
     }
   }
 
-  private resolveRuntime(runtime?: string): Runtime {
+  private resolveRuntime(runtime: string | undefined, name: string): Runtime {
     if (!runtime) {
       return Runtime.NODEJS_24_X;
     }
@@ -358,7 +358,7 @@ export class ComputeConstruct extends Construct {
       return Runtime.NODEJS_18_X;
     }
     throw new HostingError('UnsupportedRuntimeError', {
-      message: `Unsupported compute runtime '${runtime}'.`,
+      message: `Compute resource '${name}' declares an unsupported runtime '${runtime}'.`,
       resolution:
         'Use one of: nodejs24.x, nodejs22.x, nodejs20.x, nodejs18.x. ' +
         'Omit the runtime to use the default (nodejs24.x).',

--- a/packages/hosting/src/constructs/constructs.test.ts
+++ b/packages/hosting/src/constructs/constructs.test.ts
@@ -329,7 +329,7 @@ void describe('Cache (ISR) provisioning', () => {
     template.hasResourceProperties('AWS::Lambda::Function', {
       MemorySize: 256,
       Timeout: 30,
-      Runtime: 'nodejs20.x',
+      Runtime: 'nodejs24.x',
     });
   });
 });

--- a/packages/hosting/src/constructs/hosting_construct.atomic_deploy.test.ts
+++ b/packages/hosting/src/constructs/hosting_construct.atomic_deploy.test.ts
@@ -234,7 +234,7 @@ void describe('Atomic deploy - build-id cutover waits for asset uploads', () => 
           handler: 'index.handler',
           placement: 'regional',
           streaming: true,
-          runtime: 'nodejs20.x',
+          runtime: 'nodejs24.x',
         },
       },
       staticAssets: {

--- a/packages/hosting/src/constructs/hosting_construct.standalone.test.ts
+++ b/packages/hosting/src/constructs/hosting_construct.standalone.test.ts
@@ -74,7 +74,7 @@ void describe('Standalone CDK usage (standalone CDK)', () => {
         handler: 'index.handler',
         placement: 'regional',
         streaming: true,
-        runtime: 'nodejs20.x',
+        runtime: 'nodejs24.x',
       },
     },
     staticAssets: { directory: staticDir },
@@ -177,7 +177,7 @@ void describe('Standalone CDK usage (standalone CDK)', () => {
 
       const template = Template.fromStack(stack);
       template.hasResourceProperties('AWS::Lambda::Function', {
-        Runtime: 'nodejs20.x',
+        Runtime: 'nodejs24.x',
         Handler: 'index.handler',
       });
     });

--- a/packages/hosting/src/constructs/hosting_construct.test.ts
+++ b/packages/hosting/src/constructs/hosting_construct.test.ts
@@ -53,7 +53,7 @@ const ssrManifest = (staticDir: string, bundleDir: string): DeployManifest => ({
       handler: 'index.handler',
       placement: 'regional',
       streaming: true,
-      runtime: 'nodejs20.x',
+      runtime: 'nodejs24.x',
     },
   },
   staticAssets: { directory: staticDir },
@@ -148,7 +148,7 @@ void describe('HostingConstruct — SSR mode', () => {
 
     const template = Template.fromStack(stack);
     template.hasResourceProperties('AWS::Lambda::Function', {
-      Runtime: 'nodejs20.x',
+      Runtime: 'nodejs24.x',
       Handler: 'index.handler',
     });
   });
@@ -190,7 +190,7 @@ void describe('HostingConstruct — SSR mode', () => {
           entrypoint: 'server.js',
           port: 3000,
           placement: 'regional',
-          runtime: 'nodejs20.x',
+          runtime: 'nodejs24.x',
         },
       },
       staticAssets: { directory: staticDir },
@@ -233,7 +233,7 @@ void describe('HostingConstruct — SSR mode', () => {
           bundle: bundleDir,
           handler: 'index.handler',
           placement: 'regional',
-          runtime: 'nodejs20.x',
+          runtime: 'nodejs24.x',
         },
       },
       staticAssets: { directory: staticDir },
@@ -1010,7 +1010,7 @@ void describe('HostingConstruct — Multi-compute', () => {
           handler: 'index.handler',
           placement: 'regional',
           streaming: true,
-          runtime: 'nodejs20.x',
+          runtime: 'nodejs24.x',
         },
         api: {
           type: 'handler',
@@ -1018,7 +1018,7 @@ void describe('HostingConstruct — Multi-compute', () => {
           handler: 'index.handler',
           placement: 'regional',
           streaming: false,
-          runtime: 'nodejs20.x',
+          runtime: 'nodejs24.x',
         },
       },
       staticAssets: { directory: staticDir },
@@ -2212,7 +2212,7 @@ void describe('HostingConstruct — custom environment variables (M4)', () => {
           handler: 'index.handler',
           placement: 'regional',
           streaming: true,
-          runtime: 'nodejs20.x',
+          runtime: 'nodejs24.x',
         },
       },
       staticAssets: { directory: staticDir },

--- a/packages/hosting/src/constructs/hosting_construct.ts
+++ b/packages/hosting/src/constructs/hosting_construct.ts
@@ -34,7 +34,6 @@ import {
   FunctionUrl,
   IVersion,
   Function as LambdaFunction,
-  Runtime,
 } from 'aws-cdk-lib/aws-lambda';
 import { SqsEventSource } from 'aws-cdk-lib/aws-lambda-event-sources';
 import { Rule, RuleTargetInput, Schedule } from 'aws-cdk-lib/aws-events';
@@ -52,6 +51,7 @@ import { HostingResources } from '../types.js';
 import { ERROR_PAGE_KEY, NOT_FOUND_PAGE_KEY, generateBuildId } from '../defaults.js';
 import { StorageConstruct } from './storage_construct.js';
 import { ComputeConstruct } from './compute_construct.js';
+import { DEFAULT_NODE_RUNTIME } from './node_runtime.js';
 import { WafConstruct } from './waf_construct.js';
 import { DnsConstruct } from './dns_construct.js';
 import { createSecurityHeadersPolicy } from './security_headers.js';
@@ -603,7 +603,7 @@ export class HostingConstruct extends Construct {
           this,
           'RevalidationFunction',
           {
-            runtime: Runtime.NODEJS_20_X,
+            runtime: DEFAULT_NODE_RUNTIME,
             handler: manifest.cache.revalidationFunction.handler,
             code: Code.fromAsset(manifest.cache.revalidationFunction.bundle),
             timeout: Duration.seconds(30),
@@ -718,7 +718,7 @@ export class HostingConstruct extends Construct {
         // handler: it reads its bundled `dynamodb-cache.json` and writes the
         // build's tag→path rows into CACHE_DYNAMO_TABLE on create/update.
         const initFn = new LambdaFunction(this, 'IsrTagTableSeedFn', {
-          runtime: Runtime.NODEJS_20_X,
+          runtime: DEFAULT_NODE_RUNTIME,
           handler: manifest.cache.initFunction.handler,
           code: Code.fromAsset(manifest.cache.initFunction.bundle),
           timeout: Duration.minutes(5),

--- a/packages/hosting/src/constructs/node_runtime.ts
+++ b/packages/hosting/src/constructs/node_runtime.ts
@@ -11,10 +11,11 @@ import { Runtime } from 'aws-cdk-lib/aws-lambda';
  * the runtime is bumped.
  *
  * Scope: this governs ONLY hosting-owned handlers. It deliberately does NOT
- * govern the SSR/edge bundles the adapters emit (Astro/Nuxt/OpenNext), which
- * pin `nodejs20.x` to match the Node version the framework compiled the bundle
- * against — bumping those independently of the bundle would break them. That is
- * why the adapters emit a literal rather than importing this constant.
+ * govern the SSR/edge bundles the adapters emit (Astro/Nuxt/OpenNext). Those
+ * use their own shared constants — `FRAMEWORK_COMPUTE_RUNTIME` (regional) and
+ * `FRAMEWORK_EDGE_COMPUTE_RUNTIME` (Lambda@Edge) in `../framework_runtime.js` —
+ * because framework compute is a fixed, separately-versioned choice: nothing
+ * detects the Node version a framework compiled its bundle against.
  *
  * Mirrors `@aws-blocks/core`'s `DEFAULT_NODE_RUNTIME`; kept local because
  * hosting does not depend on core. Bump both together. This controls only the

--- a/packages/hosting/src/framework_runtime.ts
+++ b/packages/hosting/src/framework_runtime.ts
@@ -8,7 +8,8 @@
  * `nodejs*.x` literal into the manifest, so a runtime bump is a one-line change.
  *
  * Scope: REGIONAL framework compute only. Lambda@Edge compute uses
- * {@link FRAMEWORK_EDGE_COMPUTE_RUNTIME}, which lags behind by design.
+ * {@link FRAMEWORK_EDGE_COMPUTE_RUNTIME}, which is tracked separately because
+ * Lambda@Edge can only associate a subset of Lambda's managed runtimes.
  */
 export const FRAMEWORK_COMPUTE_RUNTIME = 'nodejs24.x';
 
@@ -16,19 +17,23 @@ export const FRAMEWORK_COMPUTE_RUNTIME = 'nodejs24.x';
  * Runtime for framework compute placed at the edge (Lambda@Edge / CloudFront
  * `placement: 'global'`).
  *
- * Deliberately pinned to `nodejs20.x` and NOT bumped in lockstep with
- * {@link FRAMEWORK_COMPUTE_RUNTIME} for two reasons:
+ * Tracked as its own constant because Lambda@Edge supports only a subset of
+ * Lambda's managed runtimes (see
+ * https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/lambda-at-edge-function-restrictions.html);
+ * emitting an unsupported runtime fails the CloudFront association at deploy
+ * time, not at synth. For Node.js, Lambda@Edge draws from the same managed
+ * runtime table as regional Lambda: `nodejs24.x` is supported (deprecates
+ * 2028-04-30), while `nodejs20.x` is already past its 2026-04-30 deprecation
+ * and can no longer back newly-created edge functions.
  *
- * 1. Lambda@Edge supports only a subset of Lambda's managed runtimes (see
- *    https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/lambda-at-edge-function-restrictions.html)
- *    and trails the general Lambda runtime catalog. Emitting an unsupported
- *    runtime makes the CloudFront association fail at deploy time, not at synth.
- * 2. `patchEdgeBundlesForLambdaEdge` in the Next.js adapter rewrites the
- *    OpenNext `node:process` namespace-import banner specifically for the Node 20
- *    ESM semantics this runtime provides; bumping the runtime without revalidating
- *    that patch would risk a cold-start `TypeError` on `process.env` assignment.
+ * `patchEdgeBundlesForLambdaEdge` in the Next.js adapter, which rewrites the
+ * OpenNext `node:process` namespace-import banner, was revalidated against this
+ * runtime: the crash it fixes stems from ES Module namespace exports being
+ * non-writable per the ECMAScript spec — not from a Node 20 quirk — and its
+ * replacement relies only on top-level `await import(...)` plus the long-stable
+ * `node:process` default export. Both behave identically on Node 20/22/24.
  *
  * Bump only after confirming Lambda@Edge support AND re-validating the edge
  * bundle patch against the target Node version.
  */
-export const FRAMEWORK_EDGE_COMPUTE_RUNTIME = 'nodejs20.x';
+export const FRAMEWORK_EDGE_COMPUTE_RUNTIME = 'nodejs24.x';

--- a/packages/hosting/src/framework_runtime.ts
+++ b/packages/hosting/src/framework_runtime.ts
@@ -1,0 +1,34 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Single source of truth for the AWS-managed Node.js runtime that executes the
+ * SSR/server bundles the framework adapters emit (Next.js/OpenNext, Nitro,
+ * Astro, SvelteKit). Adapters must reference this constant instead of writing a
+ * `nodejs*.x` literal into the manifest, so a runtime bump is a one-line change.
+ *
+ * Scope: REGIONAL framework compute only. Lambda@Edge compute uses
+ * {@link FRAMEWORK_EDGE_COMPUTE_RUNTIME}, which lags behind by design.
+ */
+export const FRAMEWORK_COMPUTE_RUNTIME = 'nodejs24.x';
+
+/**
+ * Runtime for framework compute placed at the edge (Lambda@Edge / CloudFront
+ * `placement: 'global'`).
+ *
+ * Deliberately pinned to `nodejs20.x` and NOT bumped in lockstep with
+ * {@link FRAMEWORK_COMPUTE_RUNTIME} for two reasons:
+ *
+ * 1. Lambda@Edge supports only a subset of Lambda's managed runtimes (see
+ *    https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/lambda-at-edge-function-restrictions.html)
+ *    and trails the general Lambda runtime catalog. Emitting an unsupported
+ *    runtime makes the CloudFront association fail at deploy time, not at synth.
+ * 2. `patchEdgeBundlesForLambdaEdge` in the Next.js adapter rewrites the
+ *    OpenNext `node:process` namespace-import banner specifically for the Node 20
+ *    ESM semantics this runtime provides; bumping the runtime without revalidating
+ *    that patch would risk a cold-start `TypeError` on `process.env` assignment.
+ *
+ * Bump only after confirming Lambda@Edge support AND re-validating the edge
+ * bundle patch against the target Node version.
+ */
+export const FRAMEWORK_EDGE_COMPUTE_RUNTIME = 'nodejs20.x';

--- a/packages/hosting/src/framework_runtime.ts
+++ b/packages/hosting/src/framework_runtime.ts
@@ -10,6 +10,11 @@
  * Scope: REGIONAL framework compute only. Lambda@Edge compute uses
  * {@link FRAMEWORK_EDGE_COMPUTE_RUNTIME}, which is tracked separately because
  * Lambda@Edge can only associate a subset of Lambda's managed runtimes.
+ *
+ * Note: this constant and {@link FRAMEWORK_EDGE_COMPUTE_RUNTIME} currently hold
+ * the same value by coincidence, not by design — they are governed by different
+ * support tables and must be evaluated and bumped independently. Do not collapse
+ * them into a single constant.
  */
 export const FRAMEWORK_COMPUTE_RUNTIME = 'nodejs24.x';
 

--- a/packages/hosting/src/manifest/schema.test.ts
+++ b/packages/hosting/src/manifest/schema.test.ts
@@ -32,7 +32,7 @@ void describe('Deploy Manifest Schema', () => {
           handler: 'index.handler',
           placement: 'regional',
           streaming: true,
-          runtime: 'nodejs20.x',
+          runtime: 'nodejs24.x',
         },
       },
       staticAssets: { directory: '/tmp/assets' },


### PR DESCRIPTION
## Summary

Fixes #361. AWS Blocks Hosting was deploying SSR framework Lambdas (Nuxt/Nitro, Astro, SvelteKit, Next.js) on the deprecated `nodejs20.x` runtime, and `resolveRuntime()` silently fell back to Node 20 for any runtime it didn't recognize — masking the problem and making a partial fix ineffective.

## Changes

- **New shared constants** (`framework_runtime.ts`): `FRAMEWORK_COMPUTE_RUNTIME = 'nodejs24.x'` for regional SSR compute and `FRAMEWORK_EDGE_COMPUTE_RUNTIME = 'nodejs24.x'` for Lambda@Edge. Adapters reference these instead of hardcoded literals, so future bumps are a one-line change.
- **`resolveRuntime()`** now recognizes `nodejs24.x`, defaults to `nodejs24.x` when no runtime is declared, and **throws `UnsupportedRuntimeError`** (with the list of supported values) instead of silently returning `NODEJS_20_X`.
- Updated adapters: `nitro.ts` (both presets), `astro.ts`, `sveltekit.ts`, `nextjs.ts` (regional/server-function **and** Lambda@Edge paths).
- Corrected a misleading comment in `node_runtime.ts` that implied the adapters detect the framework's compiled Node version (they don't — the runtime is a fixed shared constant).
- Also fixed two hosting-owned handlers (ISR revalidation worker + tag-table seed) that were pinned to Node 20 against the stated `DEFAULT_NODE_RUNTIME` contract.

## Lambda@Edge: also bumped to nodejs24.x

An earlier revision of this PR left the edge path on `nodejs20.x` out of caution. That decision has been revised — the edge path is now bumped too:

1. **Lambda@Edge supports Node 24.** For Node.js, Lambda@Edge draws from the same managed runtime table as regional Lambda: `nodejs24.x` is supported (deprecates 2028-04-30), while `nodejs20.x` is already past its 2026-04-30 deprecation, so it can no longer back newly-created edge functions. Staying on Node 20 was the riskier option.
2. **The OpenNext banner patch was revalidated.** `patchEdgeBundlesForLambdaEdge` rewrites OpenNext's `import * as process from "node:process"` banner. The `TypeError: Cannot assign to read only property 'env' of object '[object Module]'` it works around is **spec-level** behavior — ES Module namespace object bindings are non-writable per ECMA-262 — not a Node 20 quirk. Its replacement (`const process = (await import("node:process")).default;`) relies only on top-level `await import(...)` and the long-stable `node:process` default export, both of which behave identically on Node 20, 22, and 24. There is no Node-version-specific assumption in the patch, so no fallback to `nodejs22.x` was needed.

Code comments in `framework_runtime.ts` and `nextjs.ts` were updated to record this reasoning and to drop the now-inaccurate "Node 20 ESM semantics" framing.

## Testing

- `npm run build` — clean (`tsc --build` + handler bundling), Node 22
- `npm test` — **832/832 pass**, 0 fail (+3 new tests): default runtime resolves to `nodejs24.x`; explicit `nodejs22.x` honored; unrecognized runtime (`python3.12`) throws `UnsupportedRuntimeError`.
- Existing tests asserting `nodejs20.x` (regional and edge) updated to `nodejs24.x`.

Note: `resolveRuntime()` still *accepts* explicit `nodejs20.x`/`nodejs18.x` from a user-supplied manifest — this change only moves the framework-emitted defaults.
