### PR TITLE
fix(dart): Lower `build_runner`/`mockito` floors for Flutter 3.41

### DIFF
--- a/native/dart/packages/blocks_codegen/pubspec.yaml
+++ b/native/dart/packages/blocks_codegen/pubspec.yaml
@@ -14,6 +14,6 @@ dependencies:
   blocks_runtime: ^0.1.2
 
 dev_dependencies:
-  build_runner: ^2.16.0
+  build_runner: ^2.14.0
   lints: ^6.0.0
-  test: ^1.31.0
+  test: ^1.25.0

--- a/native/dart/packages/blocks_runtime_flutter/pubspec.yaml
+++ b/native/dart/packages/blocks_runtime_flutter/pubspec.yaml
@@ -18,8 +18,8 @@ dependencies:
   app_links: ^7.0.0
 
 dev_dependencies:
-  build_runner: ^2.16.0
+  build_runner: ^2.14.0
   flutter_test:
     sdk: flutter
   lints: ^6.0.0
-  mockito: ^5.8.1
+  mockito: ^5.6.0


### PR DESCRIPTION
Fixes the package version problem shown by https://github.com/aws-devtools-labs/aws-blocks/pull/375