### PR TITLE
docs(dart): Add dartdoc comments to blocks_codegen public API

### DIFF
--- a/native/dart/packages/blocks_codegen/lib/blocks_codegen.dart
+++ b/native/dart/packages/blocks_codegen/lib/blocks_codegen.dart
@@ -1,4 +1,4 @@
-/// Blocks Codegen — reads OpenRPC specs and generates typed Dart clients.
+/// Blocks Codegen: reads OpenRPC specs and generates typed Dart clients.
 library;
 
 export 'src/parser.dart';

--- a/native/dart/packages/blocks_codegen/lib/src/builder.dart
+++ b/native/dart/packages/blocks_codegen/lib/src/builder.dart
@@ -1,7 +1,7 @@
 import 'model.dart';
 
-/// Resolved type system — output of the builder stage.
-
+/// A type after the builder has resolved `$ref`s, deduplicated structurally
+/// identical shapes, and assigned a Dart name to everything that needs one.
 sealed class ResolvedType {
   const ResolvedType();
 }
@@ -24,8 +24,11 @@ class ListType extends ResolvedType {
 }
 
 class RecordType extends ResolvedType {
+  /// Mutable: collision resolution rewrites this in place when two distinct
+  /// shapes claim the same name.
   String name;
   final List<RecordField> fields;
+
   final ResolvedType? additionalProperties;
   RecordType({
     required this.name,
@@ -46,12 +49,14 @@ class RecordField {
 }
 
 class EnumType extends ResolvedType {
+  /// Mutable: rewritten in place by collision resolution.
   String name;
   final List<String> values;
   EnumType({required this.name, required this.values});
 }
 
 class SealedClassType extends ResolvedType {
+  /// Mutable: rewritten in place by collision resolution.
   String name;
   final String discriminant;
   final List<SealedVariant> variants;
@@ -87,6 +92,7 @@ class TransferableType extends ResolvedType {
 }
 
 class SchemaReference extends ResolvedType {
+  /// Mutable: kept in sync when the type it points at is renamed.
   String name;
   SchemaReference(this.name);
 }
@@ -103,8 +109,11 @@ class TupleType extends ResolvedType {
 
 /// A resolved operation (method) in the codegen model.
 class Operation {
+  /// The generated Dart method name, without the namespace.
   final String name;
-  final String fullName; // dotted name for RPC call
+
+  /// The dotted name sent on the wire, e.g. `api.createTodo`.
+  final String fullName;
   final List<OperationParam> params;
   final ResolvedType result;
   const Operation({
@@ -133,17 +142,25 @@ class Namespace {
   const Namespace({required this.name, required this.operations});
 }
 
-/// The complete codegen model — ready for code generation.
+/// The complete codegen model, ready for code generation.
 class CodegenModel {
   final String title;
   final String version;
+
+  /// Operations grouped by their RPC name's namespace, meaning everything
+  /// before the final dot. Methods with no dot land in `_default`.
   final List<Namespace> namespaces;
-  final Map<String, ResolvedType> types; // named types (from schemas + inline)
+
+  /// Every named type to emit, from spec schemas plus synthesized inline ones,
+  /// keyed by its final Dart name.
+  final Map<String, ResolvedType> types;
+
   final List<Server> servers;
 
   /// Non-fatal diagnostics emitted during the build (e.g. auto-disambiguated
   /// naming collisions). Callers (CLI / build_runner) surface these to the user.
   final List<String> warnings;
+
   const CodegenModel({
     required this.title,
     required this.version,
@@ -157,7 +174,9 @@ class CodegenModel {
 /// Thrown when two structurally distinct inline types resolve to the same
 /// generated Dart identifier and `autoDisambiguate` is not enabled.
 class NamingConflictException implements Exception {
+  /// A multi-line report naming each conflicting type and where it came from.
   final String message;
+
   NamingConflictException(this.message);
   @override
   String toString() => 'NamingConflictException: $message';
@@ -208,6 +227,10 @@ class CodegenModelBuilder {
   final List<String> _warnings = [];
   int _anonCounter = 0;
 
+  /// Resolves [rpc] into a model the generator can emit.
+  ///
+  /// Throws a [NamingConflictException] when [failOnCollision] is set and two
+  /// distinct inline types still claim the same Dart name.
   CodegenModel build(RpcModel rpc) {
     _types.clear();
     _origins.clear();

--- a/native/dart/packages/blocks_codegen/lib/src/generator.dart
+++ b/native/dart/packages/blocks_codegen/lib/src/generator.dart
@@ -5,6 +5,10 @@ import 'model.dart';
 class DartCodeGenerator {
   const DartCodeGenerator();
 
+  /// Emits the complete contents of one generated `.blocks.dart` library.
+  ///
+  /// Output is deterministic for a given [model], so it is safe to check in
+  /// and diff.
   String generate(CodegenModel model) {
     final buf = StringBuffer();
     buf.writeln('// GENERATED CODE — DO NOT MODIFY BY HAND');
@@ -1033,8 +1037,8 @@ class DartCodeGenerator {
 
   /// Per-value deserialization for a `Map<String, V>` entry value `v` (dynamic).
   /// Primitive value types keep the plain `v as T` cast (byte-identical to the
-  /// prior output); object-like value types (records, sealed classes) — and the
-  /// nullable variants thereof — are decoded via their generated `fromJson`.
+  /// prior output); object-like value types (records, sealed classes), and the
+  /// nullable variants thereof, are decoded via their generated `fromJson`.
   String _mapValueFromJson(
     String v,
     ResolvedType valueType,

--- a/native/dart/packages/blocks_codegen/lib/src/model.dart
+++ b/native/dart/packages/blocks_codegen/lib/src/model.dart
@@ -2,6 +2,8 @@
 /// TypeRef is a sealed class representing unresolved type references from the spec.
 library;
 
+/// Validation keywords carried across from a JSON Schema node, in the shapes
+/// JSON Schema uses. A field is null when the spec did not set that keyword.
 class Constraints {
   final String? format;
   final int? minLength;
@@ -41,20 +43,32 @@ class Constraints {
       maxItems == null;
 }
 
+/// A type reference straight from the spec, before names are assigned and
+/// `$ref`s are resolved. Switch over the subclasses exhaustively.
 sealed class TypeRef {
   const TypeRef();
 }
 
 class PrimitiveRef extends TypeRef {
-  final String dartType; // String, int, num, bool, dynamic
+  /// The Dart type name: `String`, `int`, `num`, `bool`, `void` or `dynamic`.
+  final String dartType;
+
   final Constraints? constraints;
+
   const PrimitiveRef(this.dartType, {this.constraints});
 }
 
+/// An object declared inline rather than under `components/schemas`. The
+/// builder synthesizes a record type and a name for it.
 class InlineObjectRef extends TypeRef {
+  /// In spec order, which fixes generated field order.
   final Map<String, TypeRef> properties;
+
   final Set<String> required;
+
   final TypeRef? additionalProperties;
+
+  /// [required] should only name keys that also appear in [properties].
   const InlineObjectRef({
     required this.properties,
     required this.required,
@@ -62,45 +76,72 @@ class InlineObjectRef extends TypeRef {
   });
 }
 
+/// A homogeneous list. Becomes `List<T>`.
 class ArrayRef extends TypeRef {
+  /// A spec `items` that is absent or empty becomes `dynamic`.
   final TypeRef items;
+
   final Constraints? constraints;
+
   const ArrayRef(this.items, {this.constraints});
 }
 
+/// A fixed-length positional tuple, from `prefixItems` or an array-form
+/// `items`. Becomes a Dart record.
 class TupleRef extends TypeRef {
+  /// Single-element tuples are unwrapped by the parser and never reach here.
   final List<TypeRef> items;
+
   const TupleRef(this.items);
 }
 
+/// An object with only `additionalProperties`. Becomes `Map<String, V>`.
 class MapRef extends TypeRef {
   final TypeRef valueType;
+
   const MapRef(this.valueType);
 }
 
+/// Marks [inner] as optional. Comes from a `oneOf` with a `{"type":"null"}`
+/// member.
 class NullableRef extends TypeRef {
   final TypeRef inner;
+
   const NullableRef(this.inner);
 }
 
+/// A `$ref` pointing at a named schema, resolved later by the builder.
 class SchemaRefRef extends TypeRef {
+  /// The schema's key under `components/schemas`: the `$ref` basename, not the
+  /// whole JSON pointer.
   final String name;
+
   const SchemaRefRef(this.name);
 }
 
+/// An `enum` on a string schema, or on one with no declared type. Becomes a
+/// Dart enum. An `enum` on any other primitive stays that primitive, since a
+/// Dart enum cannot have members named `true` or `false`.
 class UnionLiteralRef extends TypeRef {
+  /// In spec order, which fixes the generated enum's member order.
   final List<String> values;
+
   const UnionLiteralRef(this.values);
 }
 
+/// A `oneOf` whose arms are objects sharing a single-value enum field. Becomes
+/// a sealed class with one subclass per arm.
 class DiscriminatedUnionRef extends TypeRef {
   final String discriminant;
+
   final List<UnionVariant> variants;
 
   /// True when the discriminant is a boolean-enum (`{"type":"boolean",
   /// "enum":[true|false]}`) rather than the usual string enum. Drives bool
   /// (vs String) discriminant handling in the generator.
   final bool discriminantIsBoolean;
+
+  /// [variants] must be non-empty and share [discriminant].
   const DiscriminatedUnionRef({
     required this.discriminant,
     required this.variants,
@@ -109,10 +150,20 @@ class DiscriminatedUnionRef extends TypeRef {
 }
 
 class UnionVariant {
+  /// The discriminant literal that selects this arm, as a string even when the
+  /// discriminant is a boolean.
   final String discriminantValue;
+
+  /// This arm's properties, excluding the discriminant itself.
   final Map<String, TypeRef> properties;
+
+  /// Required property names, excluding the discriminant itself.
   final Set<String> required;
+
+  /// A nested union carried alongside [properties], for hybrid arms that mix
+  /// their own fields with a further `oneOf`.
   final DiscriminatedUnionRef? embeddedUnion;
+
   const UnionVariant({
     required this.discriminantValue,
     required this.properties,
@@ -121,9 +172,15 @@ class UnionVariant {
   });
 }
 
+/// A handle to a runtime capability (a realtime channel, a file transfer) that
+/// crosses the wire by reference and maps to a blocks_runtime type.
 class TransferableRef extends TypeRef {
-  final String blocksType; // e.g. "realtime/channel", "file-bucket/download"
+  /// The `x-blocks-transferable` tag, e.g. `realtime/channel` or
+  /// `file-bucket/download`.
+  final String blocksType;
+
   final List<TypeRef> typeArgs;
+
   const TransferableRef({required this.blocksType, this.typeArgs = const []});
 }
 
@@ -141,7 +198,9 @@ class RpcParam {
 
 /// An RPC method from the spec.
 class RpcMethod {
-  final String name; // dotted name e.g. "api.createTodo"
+  /// Dotted wire name, e.g. `api.createTodo`. Everything before the final dot
+  /// becomes the namespace.
+  final String name;
   final List<RpcParam> params;
   final TypeRef result;
 
@@ -170,7 +229,10 @@ class RpcModel {
   final String title;
   final String version;
   final List<RpcMethod> methods;
-  final Map<String, TypeRef> schemas; // components/schemas
+
+  /// Spec `components/schemas` entries, what [SchemaRefRef] resolves to.
+  final Map<String, TypeRef> schemas;
+
   final List<Server> servers;
   const RpcModel({
     required this.title,

--- a/native/dart/packages/blocks_codegen/lib/src/parser.dart
+++ b/native/dart/packages/blocks_codegen/lib/src/parser.dart
@@ -6,6 +6,10 @@ import 'model.dart';
 class OpenRpcParser {
   const OpenRpcParser();
 
+  /// Parses [jsonString] as an OpenRPC document.
+  ///
+  /// Throws a [FormatException] if the JSON is malformed or the `info` or
+  /// `methods` sections are missing or the wrong shape.
   RpcModel parse(String jsonString) {
     final dynamic decoded;
     try {


### PR DESCRIPTION
Adds docs to public API in `blocks_codegen`, mainly to improve https://pub.dev/packages/blocks_runtime/score
