### PR TITLE
[core] Retarget config registry to shared role + per-stack compute registry

### DIFF
--- a/.changeset/core-config-registry-shared-role.md
+++ b/.changeset/core-config-registry-shared-role.md
@@ -1,0 +1,26 @@
+---
+"@aws-blocks/core": patch
+---
+
+refactor(core): retarget the config registry to the shared role and every compute
+
+`finalizeConfigRegistry` no longer takes a single handler function. It now takes
+the owning construct plus the shared execution role and the stack's computes
+(`finalizeConfigRegistry(root, executionRole, computes)`) and:
+
+- grants `s3:GetObject` on the config object **once to the shared execution
+  role** instead of to one function's role, so every compute that assumes the
+  role can read it; and
+- stamps `BLOCKS_CONFIG_BUCKET` / `BLOCKS_CONFIG_KEY` on **every compute** via
+  `compute.setEnv(...)` rather than on a single hardcoded handler.
+
+Adds a per-stack compute registry (`registerCompute` / `getComputes`): computes
+self-register on their owning stack in the `Compute` base constructor (state
+keyed on the stack, resolved via `cdk.Stack.of()`, like the config registry), so
+a multi-stack synth keeps each stack's computes isolated. `BlocksStack.computes`
+/ `BlocksBackend.computes` read from it.
+
+Behavior-preserving for the default single-compute app: the same config object
+is written to S3, the same two coordinates reach the runtime, and the same
+`s3:GetObject` permission is available — now via the shared role. Internal
+refactor; no public API or runtime-config-loading change.

--- a/packages/bb-auth-cognito/src/index.cdk.test.ts
+++ b/packages/bb-auth-cognito/src/index.cdk.test.ts
@@ -35,7 +35,12 @@ function synth(build: (stack: cdk.Stack) => void) {
 	(globalThis as any).CURRENT_BLOCKS_STACK = stack;
 	try {
 		build(stack);
-		finalizeConfigRegistry(stack, handler);
+		// Grant config read to the handler's role and stamp the `BLOCKS_CONFIG_*`
+		// coordinates on the handler function — the same target as before the
+		// shared-role refactor, so the template assertions are unchanged.
+		finalizeConfigRegistry(stack, handler.role!, [
+			{ setEnv: (key: string, value: string) => handler.addEnvironment(key, value) } as any,
+		]);
 		return Template.fromStack(stack);
 	} finally {
 		delete (globalThis as any).CURRENT_BLOCKS_STACK;
@@ -78,7 +83,7 @@ const handler = new lambda.Function(stack, 'Handler', {
 stack.handler = handler;
 globalThis.CURRENT_BLOCKS_STACK = stack;
 new AuthCognito(stack, 'auth');
-finalizeConfigRegistry(stack, handler);
+finalizeConfigRegistry(stack, handler.role, [{ setEnv: (k, v) => handler.addEnvironment(k, v) }]);
 
 const resources = Template.fromStack(stack).toJSON().Resources;
 const tables = Object.entries(resources)

--- a/packages/bb-knowledge-base/src/index.cdk.test.ts
+++ b/packages/bb-knowledge-base/src/index.cdk.test.ts
@@ -177,7 +177,11 @@ test('CDK: registers the DATA_SOURCE_ID config (wired to the data source) and su
   // BucketDeployment; the rendered config blob in the synthesized template
   // carries the DATA_SOURCE_ID key bound to the data source's DataSourceId, and
   // the handler is wired to read it from S3. (Mirrors bb-auth-cognito's CDK test.)
-  finalizeConfigRegistry(stack, stack.handler);
+  // Grant config read to the handler's role and stamp the coordinates on the
+  // handler — the same target as before the shared-role refactor.
+  finalizeConfigRegistry(stack, stack.handler.role!, [
+    { setEnv: (k: string, v: string) => stack.handler.addEnvironment(k, v) } as any,
+  ]);
   const template = Template.fromStack(stack);
 
   const configBlob = JSON.stringify(

--- a/packages/core/src/cdk/blocks-backend.ts
+++ b/packages/core/src/cdk/blocks-backend.ts
@@ -12,6 +12,7 @@ import { finalizeConfigRegistry, registerConfig } from './config-registry.js';
 import type { BlocksDefaults } from './blocks-defaults.js';
 import { registerBuiltinRoutes } from '../builtin-routes.js';
 import type { Compute } from './compute/compute.js';
+import { getComputes } from './compute/compute-registry.js';
 import type { DefaultComputeFactory, LambdaShapedCompute } from './compute/default-compute-factory.js';
 
 /**
@@ -169,6 +170,14 @@ export class BlocksBackend extends Construct {
   /** The default compute (owns the Lambda function + API Gateway); set in `create()`. @internal */
   _defaultCompute?: Compute;
 
+  /**
+   * The computes in this backend.
+   * @internal
+   */
+  get computes(): readonly Compute[] {
+    return getComputes(this);
+  }
+
   /** The default compute's Lambda function. To be removed once consumers move to the multi-compute model. */
   get handler(): cdk.aws_lambda_nodejs.NodejsFunction {
     return this.requireDefaultCompute().fn;
@@ -264,7 +273,7 @@ export class BlocksBackend extends Construct {
     addBlocksStackMetadata(cdk.Stack.of(backend));
 
     // Finalize BB config → S3 (after all BBs have registered their config)
-    finalizeConfigRegistry(backend, backend.handler);
+    finalizeConfigRegistry(backend, backend.executionRole, backend.computes);
 
     return backend;
   }

--- a/packages/core/src/cdk/blocks-stack.test.ts
+++ b/packages/core/src/cdk/blocks-stack.test.ts
@@ -13,6 +13,7 @@ import type { ScopeParent } from '../common/index.js';
 import { BLOCKS_RPC_PREFIX } from '../constants.js';
 import { BlocksBackend } from './blocks-backend.js';
 import { Compute } from './compute/compute.js';
+import { getComputes } from './compute/compute-registry.js';
 import type { DefaultComputeFactory } from './compute/default-compute-factory.js';
 import { BlocksStack, BlocksPresets, Scope } from './index.js';
 
@@ -165,6 +166,25 @@ describe('root is bound to the owning stack (multi-stack synth)', () => {
 		assert.notStrictEqual(stackA.executionRole, stackB.executionRole, 'the two stacks have distinct roles');
 		assert.strictEqual(blockA.backendStackName, 'RootBindingA', 'blockA derives its own stack name');
 		assert.strictEqual(blockB.backendStackName, 'RootBindingB', 'blockB derives its own stack name');
+	});
+
+	test('each stack owns an isolated compute registry (no cross-stack bleed)', async () => {
+		// Computes self-register on their owning stack (keyed per stack, not a
+		// process-global list), so a multi-stack synth keeps each stack's computes
+		// separate — finalize steps for one stack never see another's compute.
+		const app = new cdk.App();
+
+		const stackA = await makeStack(app, 'ComputeRegistryA', sideEffectBackendPath);
+		const stackB = await makeStack(app, 'ComputeRegistryB', sideEffectBackendPath);
+
+		const computesA = getComputes(stackA);
+		const computesB = getComputes(stackB);
+
+		assert.strictEqual(computesA.length, 1, 'stackA registered exactly its default compute');
+		assert.strictEqual(computesB.length, 1, 'stackB registered exactly its default compute');
+		assert.strictEqual(computesA[0], stackA._defaultCompute, 'stackA lists its own default');
+		assert.strictEqual(computesB[0], stackB._defaultCompute, 'stackB lists its own default');
+		assert.notStrictEqual(computesA[0], computesB[0], 'the two stacks hold distinct computes');
 	});
 });
 

--- a/packages/core/src/cdk/compute/compute-registry.ts
+++ b/packages/core/src/cdk/compute/compute-registry.ts
@@ -1,0 +1,45 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import * as cdk from 'aws-cdk-lib';
+import type { Construct } from 'constructs';
+import type { Compute } from './compute.js';
+
+const REGISTRY_KEY = Symbol.for('BLOCKS_COMPUTE_REGISTRY');
+
+/**
+ * Get or create the compute list for a given stack. The list is stored on the
+ * stack object (keyed by a Symbol), so each stack in a multi-stack synth gets
+ * its own — a compute never leaks into another stack's list. Mirrors the config
+ * registry (`config-registry.ts`), which scopes its state the same way.
+ */
+function getRegistry(stack: cdk.Stack): Compute[] {
+	let list = (stack as any)[REGISTRY_KEY] as Compute[] | undefined;
+	if (!list) {
+		list = [];
+		(stack as any)[REGISTRY_KEY] = list;
+	}
+	return list;
+}
+
+/**
+ * Register a compute on its owning stack. Called from the {@link Compute} base
+ * constructor, so every compute self-registers the moment it is constructed —
+ * the finalize steps then enumerate them without a separate discovery pass
+ * (mirrors how `registerConfig` accumulates config during the backend import).
+ *
+ * @param compute - The compute to register (used to locate its stack).
+ */
+export function registerCompute(compute: Compute): void {
+	getRegistry(cdk.Stack.of(compute)).push(compute);
+}
+
+/**
+ * The computes registered on the stack that owns `scope`, in construction
+ * order. Returns an empty array before any compute is constructed.
+ *
+ * @param scope - Any construct in the stack (used to locate the stack).
+ */
+export function getComputes(scope: Construct): readonly Compute[] {
+	return getRegistry(cdk.Stack.of(scope));
+}

--- a/packages/core/src/cdk/compute/compute.ts
+++ b/packages/core/src/cdk/compute/compute.ts
@@ -1,7 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import type { ScopeOptions } from '../../common/index.js';
 import { Scope } from '../index.js';
+import { registerCompute } from './compute-registry.js';
 
 /**
  * Base class for a Blocks *compute* — a runtime that executes handler code
@@ -27,6 +29,14 @@ export abstract class Compute extends Scope {
 	 * unpopulated (no compute assignment surface yet).
 	 */
 	readonly namespaces: string[] = [];
+
+	constructor(id: string, options?: ScopeOptions) {
+		super(id, options);
+		// Self-register on the owning stack so finalize steps (config, routing,
+		// dashboards) can enumerate every compute without a separate discovery
+		// pass. Scoped per stack, so a multi-stack synth keeps lists isolated.
+		registerCompute(this);
+	}
 
 	/**
 	 * Inject a runtime configuration value (an environment variable) into this

--- a/packages/core/src/cdk/config-registry.ts
+++ b/packages/core/src/cdk/config-registry.ts
@@ -4,8 +4,8 @@
 import * as cdk from 'aws-cdk-lib';
 import * as s3 from 'aws-cdk-lib/aws-s3';
 import * as s3deploy from 'aws-cdk-lib/aws-s3-deployment';
-import * as iam from 'aws-cdk-lib/aws-iam';
 import type { Construct } from 'constructs';
+import type { Compute } from './compute/compute.js';
 
 const REGISTRY_KEY = Symbol.for('BLOCKS_CONFIG_REGISTRY');
 
@@ -47,19 +47,29 @@ export function registerConfig(scope: Construct, key: string, value: unknown): v
 
 /**
  * Finalize the config registry: create an S3 bucket, upload the config JSON,
- * set env vars on the handler, and grant read access.
+ * grant read to the shared execution role, and stamp the config coordinates
+ * (`BLOCKS_CONFIG_BUCKET` / `BLOCKS_CONFIG_KEY`) onto every compute.
+ *
+ * Read access is granted once to the shared role (`root.executionRole`) rather
+ * than to a single function, so every compute that assumes the role can read
+ * the object. The bucket/key coordinates can't live on a role (env vars are
+ * per-compute), so they are set on each compute via `setEnv`.
  *
  * Must be called after all BBs are constructed (i.e., after the backendCDKPath
  * import completes in BlocksStack.create() / BlocksBackend.create()).
  *
- * @param scope - The CDK construct to create resources under
- * @param handler - The Lambda function that needs to read the config
+ * @param root - The construct to create the config resources under (also used
+ *   to locate the owning stack).
+ * @param executionRole - The shared role every compute assumes; config read is
+ *   granted to it once.
+ * @param computes - The computes to stamp `BLOCKS_CONFIG_BUCKET` / `BLOCKS_CONFIG_KEY` on.
  */
 export function finalizeConfigRegistry(
-	scope: Construct,
-	handler: cdk.aws_lambda.IFunction,
+	root: Construct,
+	executionRole: cdk.aws_iam.IRole,
+	computes: readonly Compute[],
 ): void {
-	const stack = cdk.Stack.of(scope);
+	const stack = cdk.Stack.of(root);
 	const registry = getRegistry(stack);
 
 	if (registry.finalized) return;
@@ -67,7 +77,7 @@ export function finalizeConfigRegistry(
 
 	if (registry.entries.size === 0) return;
 
-	const configBucket = new s3.Bucket(scope, 'BlocksConfigBucket', {
+	const configBucket = new s3.Bucket(root, 'BlocksConfigBucket', {
 		removalPolicy: cdk.RemovalPolicy.DESTROY,
 		autoDeleteObjects: true,
 		encryption: s3.BucketEncryption.S3_MANAGED,
@@ -83,24 +93,20 @@ export function finalizeConfigRegistry(
 		produce: () => Object.fromEntries(registry.entries),
 	});
 
-	const deployment = new s3deploy.BucketDeployment(scope, 'BlocksConfigDeployment', {
+	new s3deploy.BucketDeployment(root, 'BlocksConfigDeployment', {
 		sources: [s3deploy.Source.jsonData(configKey, configObject)],
 		destinationBucket: configBucket,
 		prune: false,
 	});
 
-	(handler as cdk.aws_lambda.Function).addEnvironment(
-		'BLOCKS_CONFIG_BUCKET',
-		configBucket.bucketName,
-	);
-	(handler as cdk.aws_lambda.Function).addEnvironment(
-		'BLOCKS_CONFIG_KEY',
-		configKey,
-	);
+	// Grant read once to the shared role (scoped to the config key), so every
+	// compute assuming the role can read it.
+	configBucket.grantRead(executionRole, configKey);
 
-	// Scope IAM grant to the specific config key
-	(handler as cdk.aws_lambda.Function).addToRolePolicy(new iam.PolicyStatement({
-		actions: ['s3:GetObject'],
-		resources: [`${configBucket.bucketArn}/${configKey}`],
-	}));
+	// Stamp the config coordinates on every compute — env vars can't live on a
+	// role, so each compute needs them to locate the object at runtime.
+	for (const compute of computes) {
+		compute.setEnv('BLOCKS_CONFIG_BUCKET', configBucket.bucketName);
+		compute.setEnv('BLOCKS_CONFIG_KEY', configKey);
+	}
 }

--- a/packages/core/src/cdk/index.ts
+++ b/packages/core/src/cdk/index.ts
@@ -17,6 +17,7 @@ import { addBlocksStackMetadata } from './stack-metadata.js';
 import { finalizeConfigRegistry } from './config-registry.js';
 import { type BlocksDefaults, BlocksPresets } from './blocks-defaults.js';
 import type { Compute } from './compute/compute.js';
+import { getComputes } from './compute/compute-registry.js';
 import type { DefaultComputeFactory, LambdaShapedCompute } from './compute/default-compute-factory.js';
 
 export { BlocksBackend, type BlocksBackendProps } from './blocks-backend.js';
@@ -41,6 +42,14 @@ export class BlocksStack extends cdk.Stack implements BaseBlocksStack {
   public readonly defaults: BlocksDefaults;
   /** The default compute (owns the Lambda function + API Gateway); set in `create()`. @internal */
   _defaultCompute?: Compute;
+
+  /**
+   * The computes in this stack.
+   * @internal
+   */
+  get computes(): readonly Compute[] {
+    return getComputes(this);
+  }
 
   /** The default compute's Lambda function. To be removed once consumers move to the multi-compute model. */
   get handler(): cdk.aws_lambda_nodejs.NodejsFunction {
@@ -103,7 +112,7 @@ export class BlocksStack extends cdk.Stack implements BaseBlocksStack {
       }
     }
     // Finalize BB config → S3 (after all BBs have registered their config)
-    finalizeConfigRegistry(stack, stack.handler);
+    finalizeConfigRegistry(stack, stack.executionRole, stack.computes);
 
     new cdk.CfnOutput(stack, 'ApiUrl', { value: stack.apiUrl });
 


### PR DESCRIPTION
## Problem

The config registry granted `s3:GetObject` on `blocks-config.json` to a single hardcoded handler function and stamped `BLOCKS_CONFIG_BUCKET` / `BLOCKS_CONFIG_KEY` on that one function. That couples config delivery to one Lambda and doesn't generalize to the multi-compute model, where every compute must be able to read the shared config object.

This is Issue **B1** of Multi-Compute Phase 1. It stacks on **A3** (it consumes the `computes` list and default compute introduced there; its self-registration lives in the A2 `Compute` base).

## Changes

- **Retarget `finalizeConfigRegistry`** — signature is now `finalizeConfigRegistry(root, executionRole, computes)`:
  - grants `s3:GetObject` **once to the shared execution role** (so every compute that assumes the role can read the object), instead of to one function's role;
  - stamps `BLOCKS_CONFIG_BUCKET` / `BLOCKS_CONFIG_KEY` on **every compute** via `compute.setEnv(...)`.
  - The previous `ConfigFinalizeRoot` wrapper interface is removed in favor of three explicit parameters.
- **Per-stack compute registry** (`packages/core/src/cdk/compute/compute-registry.ts`, new): `registerCompute` / `getComputes`, with state stored on the owning stack keyed by a `Symbol` and resolved via `cdk.Stack.of()` — mirroring the config registry. This keeps each stack's computes isolated in a multi-stack synth (Amplify Gen2 nested stacks, Pipelines stages); a process-global list would let one stack's finalize see another's computes.
- **`Compute` base self-registers** — `registerCompute(this)` in its constructor, so every compute joins its stack's registry the moment it's constructed (no separate discovery pass).
- **`BlocksStack.computes` / `BlocksBackend.computes`** now read from the registry (`getComputes(this)`); `create()` passes `(root, root.executionRole, root.computes)` to finalize.
- Updated the two CDK test callers (`bb-auth-cognito`, `bb-knowledge-base`) to the new signature.

Behavior-preserving for the default single-compute app: the same config object is written to S3, the same two coordinates reach the runtime, and the same `s3:GetObject` permission is available — now via the shared role.

## Validation

- `npm run build` ✓
- Unit tests: `@aws-blocks/core` 656/656 (incl. a new multi-stack registry-isolation test), `bb-auth-cognito` 241/241, `bb-knowledge-base` 129/129 ✓
- `npm run lint` (zero blocking errors), `npm run lint:deps`, `npm run check:api` ✓
- `npm run test:e2e:local` 8/8 ✓

## Checklist

- [x] PR description included
- [x] Tests are changed or added
- [x] Relevant documentation is changed or added (changeset)
