### PR TITLE
fix(hosting): reject incompatible compute placement

### DIFF
--- a/.changeset/reject-invalid-compute-placement.md
+++ b/.changeset/reject-invalid-compute-placement.md
@@ -1,0 +1,5 @@
+---
+"@aws-blocks/hosting": patch
+---
+
+Reject deployment manifests whose compute placement cannot be honored, instead of silently synthesizing a regional Lambda for a non-edge resource marked as global.

--- a/packages/hosting/src/constructs/hosting_construct.test.ts
+++ b/packages/hosting/src/constructs/hosting_construct.test.ts
@@ -7,7 +7,7 @@ import { App, CfnResource, Duration, Stack } from 'aws-cdk-lib';
 import { Annotations, Match, Template } from 'aws-cdk-lib/assertions';
 import { Certificate } from 'aws-cdk-lib/aws-certificatemanager';
 import { HostingConstruct } from './hosting_construct.js';
-import { DeployManifest } from '../manifest/types.js';
+import type { DeployManifest } from '../manifest/types.js';
 import { HostingError } from '../hosting_error.js';
 import { generateKvsRouterRequestCode } from './kvs_router.js';
 
@@ -1345,6 +1345,35 @@ void describe('HostingConstruct — Custom domain integration', () => {
 void describe('HostingConstruct — Error paths', () => {
   afterEach(() => {
     if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  void it('rejects compute placement that the construct cannot honor', () => {
+    const staticDir = createStaticDir();
+    const bundleDir = createBundleDir();
+    const stack = createStack();
+
+    const manifest: DeployManifest = {
+      ...ssrManifest(staticDir, bundleDir),
+      compute: {
+        default: {
+          type: 'handler',
+          bundle: bundleDir,
+          handler: 'index.handler',
+          placement: 'global',
+        },
+      },
+    };
+
+    assert.throws(
+      () => new HostingConstruct(stack, 'Hosting', { manifest }),
+      (err: unknown) => {
+        assert.ok(err instanceof HostingError);
+        assert.strictEqual(err.name, 'InvalidComputePlacementError');
+        assert.ok(err.message.includes("type 'handler'"));
+        assert.ok(err.message.includes("placement 'global'"));
+        return true;
+      },
+    );
   });
 
   void it('throws CacheComputeResourceNotFoundError when cache references non-existent compute', () => {

--- a/packages/hosting/src/constructs/hosting_construct.ts
+++ b/packages/hosting/src/constructs/hosting_construct.ts
@@ -459,6 +459,18 @@ export class HostingConstruct extends Construct {
     const hasCompute = computeEntries.length > 0;
 
     for (const [name, resource] of computeEntries) {
+      const expectedPlacement = resource.type === 'edge' ? 'global' : 'regional';
+      if (resource.placement !== expectedPlacement) {
+        throw new HostingError('InvalidComputePlacementError', {
+          message:
+            `Compute resource '${name}' has type '${resource.type}' with placement '${resource.placement}'. ` +
+            `That type must use '${expectedPlacement}' placement.`,
+          resolution:
+            "Use placement: 'global' only with type: 'edge'. " +
+            "Use placement: 'regional' with type: 'handler' or type: 'http-server'.",
+        });
+      }
+
       if (resource.type === 'edge') {
         const edgeConstruct = new ComputeConstruct(this, `Compute-${name}`, {
           name,

--- a/packages/hosting/src/manifest/schema.test.ts
+++ b/packages/hosting/src/manifest/schema.test.ts
@@ -1,7 +1,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
 import { deployManifestSchema } from './schema.js';
-import { DeployManifest } from './types.js';
+import type { DeployManifest } from './types.js';
 
 void describe('Deploy Manifest Schema', () => {
   void it('validates a valid SPA manifest', () => {
@@ -600,6 +600,31 @@ void describe('Deploy Manifest Schema', () => {
       issue,
       `Expected edge placement validation issue, got: ${JSON.stringify(result.error?.issues)}`,
     );
+  });
+
+  void it('rejects non-edge types with global placement', () => {
+    for (const type of ['handler', 'http-server'] as const) {
+      const result = deployManifestSchema.safeParse({
+        version: 1,
+        compute: {
+          default: {
+            type,
+            bundle: '/tmp/bundle',
+            handler: 'index.handler',
+            placement: 'global',
+          },
+        },
+        staticAssets: { directory: '/tmp/assets' },
+        routes: [{ pattern: '/*', target: 'default' }],
+      });
+      assert.ok(!result.success, `${type} type should reject global placement`);
+      assert.ok(
+        result.error?.issues.some((issue) =>
+          issue.message.includes('require placement to be "regional"'),
+        ),
+        `Expected non-edge placement validation issue, got: ${JSON.stringify(result.error?.issues)}`,
+      );
+    }
   });
 
   // ---- Duplicate route pattern validation ----

--- a/packages/hosting/src/manifest/schema.ts
+++ b/packages/hosting/src/manifest/schema.ts
@@ -41,6 +41,13 @@ export const computeResourceSchema = z
         path: ['placement'],
       });
     }
+    if (data.type !== 'edge' && data.placement !== 'regional') {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'handler and http-server types require placement to be "regional"',
+        path: ['placement'],
+      });
+    }
   });
 
 /**

--- a/packages/hosting/src/manifest/types.ts
+++ b/packages/hosting/src/manifest/types.ts
@@ -227,7 +227,12 @@ export type ComputeResource = {
   /** Port for http-server type */
   port?: number;
 
-  /** Where to deploy */
+  /**
+   * Where to deploy this compute resource.
+   *
+   * `global` deploys a Lambda@Edge function and is valid only with
+   * `type: 'edge'`. `handler` and `http-server` compute must use `regional`.
+   */
   placement: 'regional' | 'global';
 
   /** Whether to enable response streaming */


### PR DESCRIPTION
## Problem

A deployment manifest can declare a non-edge compute resource with `placement: global`. The schema accepted this combination, but `HostingConstruct` only uses the resource type to select Lambda@Edge. As a result, it silently synthesized a regional Lambda and ignored the requested placement.

The same construct-level gap existed for a manually assembled manifest with an edge resource marked `regional`: schema validation is not a runtime guard for direct `HostingConstruct` consumers.

**Issue #, if available:** n/a

## Changes

- Reject `placement: global` for `handler` and `http-server` resources in the manifest schema.
- Validate the type/placement pairing in `HostingConstruct`, so direct manifest consumers receive an `InvalidComputePlacementError` instead of a deployment that does not honor their request.
- Document the valid combinations on the public `ComputeResource.placement` property.
- Add schema and construct regression coverage, plus a patch changeset for `@aws-blocks/hosting`.
- Mark existing type-only imports in the touched files explicitly, satisfying the repository lint rule without changing runtime behavior.

## Validation

- Reproduced on current `main`: `handler` plus `global` passed schema validation and synthesized only the regional stack, with no Edge stack.
- `npm run build --workspace @aws-blocks/hosting`
- `npm test --workspace @aws-blocks/hosting` — 844 passed, 0 failed
- `npm run lint`
- `npx changeset status --since=origin/main`

## Checklist

- [x] PR description included
- [x] Tests are changed or added
- [x] Relevant documentation is changed or added (public JSDoc and changeset)

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._