### PR TITLE
fix(hosting): drop cloudfront-keyvaluestore:ListKeys from KvKeys custom resource

### DIFF
--- a/.changeset/hosting-drop-kvs-listkeys.md
+++ b/.changeset/hosting-drop-kvs-listkeys.md
@@ -1,0 +1,9 @@
+---
+"@aws-blocks/hosting": patch
+---
+
+Trim the `KvKeys` custom resource IAM policy to true least privilege: it now grants only `cloudfront-keyvaluestore:DescribeKeyValueStore` and `UpdateKeys` — the two actions the deploy-time handler actually calls. The previously-granted `ListKeys`, `GetKey`, `PutKey`, and `DeleteKey` are dropped.
+
+This also makes the hosting stack deployable under restrictive Service Control Policies (SCPs) / permission boundaries that deny `cloudfront-keyvaluestore:ListKeys`, which previously blocked the deploy.
+
+Behavior is preserved: `ListKeys` was only used to diff against the live store on Create, but the route-table `KeyValueStore` is created fresh with no `ImportSource`, so it is empty at Create time — the handler now diffs Create against `{}`. The Update path still diffs against the prior template's entries and Delete still drains via `deleteDrainSet()`, neither of which used `ListKeys`.

--- a/packages/hosting/src/constructs/kv_keys.ts
+++ b/packages/hosting/src/constructs/kv_keys.ts
@@ -29,9 +29,9 @@ export type KvKeysProps = {
   /** The CloudFront KeyValueStore to write into. */
   store: IKeyValueStore;
   /**
-   * Desired key→value map. The custom resource diffs this against what's in
-   * the store and applies the minimal set of put/delete operations (chunked to
-   * the 50-key / 3 MB UpdateKeys ceiling).
+   * Desired key→value map. The custom resource diffs this against the
+   * previously deployed entries (empty on Create) and applies the minimal set
+   * of put/delete operations, chunked to the 50-key / 3 MB UpdateKeys ceiling.
    */
   entries: Record<string, string>;
 };
@@ -65,15 +65,15 @@ export class KvKeys extends Construct {
       timeout: Duration.minutes(5),
     });
 
-    // Data-plane KVS access: describe/list to diff, update to apply.
+    // Data-plane KVS access. The handler reads the store's current ETag
+    // (DescribeKeyValueStore) and writes the route-table diff in batches
+    // (UpdateKeys) — the only two actions it calls. Previous state is read from
+    // this custom resource's CloudFormation properties, not from the store, so
+    // no key-read (ListKeys/GetKey) or single-key write (PutKey/DeleteKey) is used.
     handler.addToRolePolicy(
       new iam.PolicyStatement({
         actions: [
           'cloudfront-keyvaluestore:DescribeKeyValueStore',
-          'cloudfront-keyvaluestore:ListKeys',
-          'cloudfront-keyvaluestore:GetKey',
-          'cloudfront-keyvaluestore:PutKey',
-          'cloudfront-keyvaluestore:DeleteKey',
           'cloudfront-keyvaluestore:UpdateKeys',
         ],
         resources: [props.store.keyValueStoreArn],

--- a/packages/hosting/src/constructs/kv_keys_handler.ts
+++ b/packages/hosting/src/constructs/kv_keys_handler.ts
@@ -25,7 +25,6 @@
 import {
   CloudFrontKeyValueStoreClient,
   DescribeKeyValueStoreCommand,
-  ListKeysCommand,
   UpdateKeysCommand,
 } from '@aws-sdk/client-cloudfront-keyvaluestore';
 // The cloudfront-keyvaluestore data-plane API signs with SigV4a (region-
@@ -161,22 +160,6 @@ async function applyUpdate(
   }
 }
 
-/** Read every existing key so Delete can fully drain the store. */
-async function listAll(kvsArn: string): Promise<Entries> {
-  const out: Entries = {};
-  let next: string | undefined;
-  do {
-    const res = await client.send(
-      new ListKeysCommand({ KvsARN: kvsArn, NextToken: next }),
-    );
-    for (const item of res.Items ?? []) {
-      if (item.Key !== undefined) out[item.Key] = item.Value ?? '';
-    }
-    next = res.NextToken;
-  } while (next);
-  return out;
-}
-
 /**
  * The set of keys to drain on a Delete. CloudFormation does NOT populate
  * `OldResourceProperties` on Delete — the last-deployed props arrive in
@@ -199,12 +182,15 @@ export async function handler(event: Event): Promise<{ PhysicalResourceId: strin
   }
 
   const desired = JSON.parse(entriesJson) as Entries;
-  // On Update, diff against the previous template's entries; on Create, diff
-  // against what's actually in the store (handles re-create over a dirty store).
+  // Previous state is taken from CloudFormation properties, not read from the
+  // store: on Update, the prior template's Entries; on Create, empty (the store
+  // is created fresh with no ImportSource). The diff of desired vs. previous
+  // therefore only adds/overwrites keys and deletes keys the prior template
+  // had; keys present in the store but in neither template are left untouched.
   const previous: Entries =
     event.RequestType === 'Update' && event.OldResourceProperties?.Entries
       ? (JSON.parse(event.OldResourceProperties.Entries) as Entries)
-      : await listAll(KvsArn);
+      : {};
 
   await applyUpdate(KvsArn, desired, previous);
   return { PhysicalResourceId: physicalId };


### PR DESCRIPTION
## Problem

AWS Blocks **Hosting** fails to deploy into accounts governed by a restrictive Service Control Policy (SCP) whose managed policy **denies `cloudfront-keyvaluestore:ListKeys`**. The `KvKeys` custom resource requests that action, so the stack can't be granted it and the deploy fails.

This blocks affected users from deploying stock Blocks Hosting ahead of an upcoming launch. A user worked around it by editing the hosting code locally; this PR fixes it properly in the package.

## Root cause

`KvKeys` (`packages/hosting/src/constructs/kv_keys.ts`) granted **six** KVS data-plane actions, but the handler (`kv_keys_handler.ts`) only ever calls **two**:

| Action | Used by handler? |
|---|---|
| `DescribeKeyValueStore` | ✅ `currentEtag()` |
| `UpdateKeys` | ✅ `applyUpdate()` |
| `ListKeys` | ⚠️ only `listAll()`, on the **Create** path |
| `GetKey` | ❌ never |
| `PutKey` | ❌ never |
| `DeleteKey` | ❌ never |

`ListKeys` was used solely to diff the *desired* entries against the *live* store on Create. But the `KeyValueStore` (`cdn_construct.ts`) is created **fresh with no `ImportSource`**, so at Create time the store is empty and the live read returns nothing. The normal redeploy (Update) path already diffs against `OldResourceProperties.Entries`, and Delete uses `deleteDrainSet()` — neither touches `ListKeys`.

## Fix

- Trim the IAM policy to **`DescribeKeyValueStore` + `UpdateKeys`** (least privilege; also drops the 3 dead actions).
- On **Create**, treat previous state as `{}` instead of a live `ListKeys` read.
- Remove the now-unused `listAll()` and the `ListKeysCommand` import.

## Trade-off

A re-create over a store that still holds **orphan** keys (e.g. an out-of-band manual write) will no longer auto-drain them. The route table is regenerated wholesale each deploy, so new/changed keys are still written — only keys absent from `desired` could linger, which does not happen for a CDK-managed store created fresh per stack. If we want to keep that safety net, we can gate a `ListKeys` drain behind an opt-in flag that is **off by default**.

## Verification

- `npm run build -w packages/hosting` — typecheck + handler bundle ✅
- `npm test -w packages/hosting` — **842 passed, 0 failed** ✅
- No test pinned the six IAM actions (no `kv_keys.test.ts`), and the handler unit tests only cover `computeDiff`/`batches`, so nothing else depends on the removed code.

## Open item before merge

Confirm with the reporter that the SCP denies **only** `ListKeys`, not also `DescribeKeyValueStore`/`UpdateKeys`. If those are denied too, KVS can't be written under that SCP at all and a different approach (or an SCP exception) is needed. Opening as **draft** pending that confirmation.



---

## End-to-end validation

Deployed a real Nuxt SSR app whose hosting stack links this branch's `@aws-blocks/hosting`, to confirm the reduced permission set still produces a working deploy.

- **Linked & confirmed at byte level** — the app loads the patched `kv_keys.js`; deploy-time IAM policy grants only `cloudfront-keyvaluestore:DescribeKeyValueStore` + `UpdateKeys` (no `ListKeys`/`GetKey`/`PutKey`/`DeleteKey`), and the handler carries no `ListKeysCommand`/`listAll`.
- **Deployed** to stack `stress-nuxt-prod-default` (us-west-2) → `UPDATE_COMPLETE`. The synthesized CloudFormation template grants the KvKeys resource only the two actions, and the **`RouteStoreKeys` custom resource completed successfully** — i.e. the KVS route table was written **without `ListKeys`**.
- **App serves correctly** — `/` → 308 → `/myapp/` → 200 (Nuxt SSR), confirming the KVS-driven edge routing works with the trimmed policy. Live: https://drz7zx8m0esrg.cloudfront.net/myapp/ (disposable sandbox stack).
- **E2e (`ssr-hosting-e2e`, Nuxt suite): 77 passed / 6 skipped / 2 failed.** All routing, CloudFront-behavior, asset, cache, redirect, and URL-safety tests passed (these exercise the KVS route table end-to-end). The 6 skipped are non-Nuxt framework-gated tests. The 2 failures are a pre-existing Vue SSR **hydration mismatch** in the sample app — unrelated to this change, which touches only an IAM policy and the handler's Create-path diff (no path affects Vue hydration, and no routing/KVS test failed).

**Conclusion:** the fix deploys cleanly and the route-table custom resource succeeds with the reduced permission set — so it will deploy under a restrictive SCP that denies `cloudfront-keyvaluestore:ListKeys`.

