### PR TITLE
chore(repo): isolate typescript and @types/node from the dev-deps group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,11 @@
 #     and dev-dependencies (build/test only, low blast radius). Production deps
 #     and security fixes land as their own PRs so each shipped bump stays
 #     reviewable and mergeable on its own.
+#   - typescript and @types/node are toolchain foundations: a major bump is a
+#     deliberate migration, not routine hygiene (TS 7 / @types/node 26 broke the
+#     project-reference build in one grouped PR). So they are excluded from the
+#     dev-dependencies group (minor/patch arrive as their own PRs) and their
+#     major-version updates are ignored (bump them intentionally, by hand).
 version: 2
 updates:
   - package-ecosystem: npm
@@ -20,6 +25,11 @@ updates:
     schedule:
       interval: monthly
     open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@types/node"
+        update-types: ["version-update:semver-major"]
     groups:
       aws-sdk:
         patterns:
@@ -27,6 +37,9 @@ updates:
           - "@smithy/*"
       dev-dependencies:
         dependency-type: development
+        exclude-patterns:
+          - "typescript"
+          - "@types/node"
 
   # Keep the GitHub Actions used by CI patched. Low volume, batch into one PR.
   - package-ecosystem: github-actions


### PR DESCRIPTION
## Change

In `.github/dependabot.yml`:
- Exclude `typescript` and `@types/node` from the `dev-dependencies` group (`exclude-patterns`).
- Ignore major-version updates for both (`ignore` + `version-update:semver-major`).

## Rationale

The `dev-dependencies` group bumped `typescript` (5 -> 7) and `@types/node` (20 -> 26) inside one PR of 39 updates. TypeScript 7 changes how `import ts from 'typescript'` resolves under `moduleResolution: bundler`, and the new `@types/node` major shifts Node type resolution. The project-reference build failed at compile time (for example `packages/core/src/scripts/extract-ts-types.ts` and `packages/pipeline`), which blocked the whole group.

`typescript` and `@types/node` are toolchain foundations. A major bump is a deliberate migration, not routine hygiene, and it must not ride inside a grouped bump that then cannot merge.

## Behavior after this change

- Minor and patch updates for `typescript` and `@types/node` arrive as their own PRs.
- Major-version updates for both are not opened automatically. Bump them by hand when the codebase is ready.
- The rest of the `dev-dependencies` group stays batched and mergeable.

## Scope

Config only. No published package changed, so no changeset is required.