### PR TITLE
fix(bb-lambda-compute): package metadata, prebuild, and pin dep ranges

### DIFF
--- a/.changeset/lambda-compute-package-metadata.md
+++ b/.changeset/lambda-compute-package-metadata.md
@@ -1,0 +1,19 @@
+---
+"@aws-blocks/bb-lambda-compute": patch
+"@aws-blocks/blocks": patch
+---
+
+fix(bb-lambda-compute): add package metadata, prebuild, and pin dependency ranges
+
+Bring `@aws-blocks/bb-lambda-compute`'s package.json in line with its siblings:
+
+- add the `repository` / `homepage` / `bugs` blocks. Without `repository.url`,
+  provenance publishing fails with `E422 … "repository.url" is ""` because npm
+  cannot match the package against the sigstore attestation's source repo;
+- add the `prebuild` version-generation script (`generate-version.mjs`);
+- pin `@aws-blocks/core` to `^0.2.0` instead of `*`, matching every other
+  package.
+
+Also pin the umbrella `@aws-blocks/blocks`'s dependency on
+`@aws-blocks/bb-lambda-compute` to `^0.2.0` instead of `*`, now that the package
+publishes a real version.

--- a/packages/bb-lambda-compute/package.json
+++ b/packages/bb-lambda-compute/package.json
@@ -1,6 +1,15 @@
 {
   "name": "@aws-blocks/bb-lambda-compute",
   "version": "0.2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/aws-devtools-labs/aws-blocks.git",
+    "directory": "packages/bb-lambda-compute"
+  },
+  "homepage": "https://github.com/aws-devtools-labs/aws-blocks/tree/main/packages/bb-lambda-compute#readme",
+  "bugs": {
+    "url": "https://github.com/aws-devtools-labs/aws-blocks/issues"
+  },
   "author": "Amazon Web Services",
   "license": "Apache-2.0",
   "type": "module",
@@ -24,11 +33,12 @@
     }
   },
   "scripts": {
+    "prebuild": "node ../../scripts/generate-version.mjs LambdaCompute",
     "build": "tsc --build",
     "test": "node --test dist/index.cdk.test.js"
   },
   "dependencies": {
-    "@aws-blocks/core": "*"
+    "@aws-blocks/core": "^0.2.0"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -85,7 +85,7 @@
     "@aws-blocks/bb-email-client": "^0.1.4",
     "@aws-blocks/bb-metrics": "^0.1.4",
     "@aws-blocks/bb-dashboard": "^0.1.3",
-    "@aws-blocks/bb-lambda-compute": "*"
+    "@aws-blocks/bb-lambda-compute": "^0.2.0"
   },
   "aws-blocks": {
     "vendorize": {


### PR DESCRIPTION
## Problem

The release publish for `@aws-blocks/bb-lambda-compute` fails with:

```
E422 … Error verifying sigstore provenance bundle: package.json: "repository.url" is "", expected to match "https://github.com/aws-devtools-labs/aws-blocks"
```

bb-lambda-compute was added after the earlier backfill (`f6b9cad7`) and is the only package missing the `repository` block, so provenance publishing rejects it — which also stranded the rest of the release run after it.

## Changes

- **bb-lambda-compute/package.json**
  - add `repository` / `homepage` / `bugs` (fixes the provenance `E422`);
  - add the `prebuild` version-generation script (`generate-version.mjs LambdaCompute`), matching siblings;
  - pin `@aws-blocks/core` to `^0.2.0` instead of `*`.
- **blocks/package.json** — pin the umbrella's `@aws-blocks/bb-lambda-compute` dependency to `^0.2.0` instead of `*`.
- Changeset (patch) for `@aws-blocks/bb-lambda-compute` + `@aws-blocks/blocks`.

## Release recovery

Merging this opens a Version PR (bb-lambda-compute 0.2.0→0.2.1, blocks patch). Merging that runs `changeset publish`, which republishes bb-lambda-compute (now provenance-valid) **and** catches up the ~20 packages stranded by the partial #339 run — `changeset publish` publishes every workspace version missing from npm, idempotently.

## Validation

- `prebuild` + build ✓ (generates `version.ts`)
- `lint:deps` ✓ · changeset guards (structure/coverage/umbrella/block-major) ✓