### PR TITLE
feat(core): CloudFormation Express Mode (--express) for sandbox deploys

### DIFF
--- a/.changeset/sandbox-express-mode.md
+++ b/.changeset/sandbox-express-mode.md
@@ -6,6 +6,8 @@ Speed up sandbox deploys with CloudFormation **Express Mode**: `npm run sandbox`
 
 This is sandbox-only. The production deploy (`npm run deploy`) is unchanged — it keeps a reviewable CloudFormation change set and full stabilization with automatic rollback. Express Mode disables automatic rollback by default; we keep that default for the throwaway sandbox loop rather than forcing `--rollback`, so a failed sandbox deploy may leave the stack in a failed state until the next deploy.
 
+Observability trade-off: `--method direct` also drops some of the CDK CLI's per-resource progress output (it has no change set to report against), and Express Mode itself returns before resources finish stabilizing. Expect less granular deploy progress for sandbox deploys than the production path emits.
+
 Requires an `aws-cdk` CLI that supports `--express`, so the CLI dev-dependency floor is bumped to `^2.1138.0`.
 
 The sandbox deploy argv is built by the pure, unit-tested `buildSandboxDeployArgs` helper (mirroring the existing `buildCdkDeployArgs` for production).

--- a/.changeset/sandbox-express-mode.md
+++ b/.changeset/sandbox-express-mode.md
@@ -1,0 +1,9 @@
+---
+"@aws-blocks/core": patch
+---
+
+Speed up sandbox deploys with CDK "express mode": `npm run sandbox` now runs `cdk deploy` with `--method direct`, which skips CloudFormation change-set creation and calls `UpdateStack` directly. This trims a couple of change-set round-trips off every sandbox iteration while remaining a full CloudFormation deploy (all resource types — unlike `--hotswap`).
+
+This applies to the sandbox path only. The production deploy (`npm run deploy`) is unchanged and still goes through a reviewable change set, since a direct `UpdateStack` has no change set to inspect.
+
+The sandbox deploy argv is now built by the pure, unit-tested `buildSandboxDeployArgs` helper (mirroring the existing `buildCdkDeployArgs` for production).

--- a/.changeset/sandbox-express-mode.md
+++ b/.changeset/sandbox-express-mode.md
@@ -6,8 +6,8 @@ Speed up sandbox deploys with CloudFormation **Express Mode**: `npm run sandbox`
 
 This is sandbox-only. The production deploy (`npm run deploy`) is unchanged — it keeps a reviewable CloudFormation change set and full stabilization with automatic rollback. Express Mode disables automatic rollback by default; we keep that default for the throwaway sandbox loop rather than forcing `--rollback`, so a failed sandbox deploy may leave the stack in a failed state until the next deploy.
 
-Observability trade-off: `--method direct` also drops some of the CDK CLI's per-resource progress output (it has no change set to report against), and Express Mode itself returns before resources finish stabilizing. Expect less granular deploy progress for sandbox deploys than the production path emits.
+Observability trade-off: `--method direct` also drops some of the CDK CLI's per-resource progress output (it has no change set to report against), and Express Mode itself returns before resources finish stabilizing. Expect less granular deploy progress for sandbox deploys than the production path emits. Because the deploy returns before stabilization, a resource that is still propagating (e.g. a CloudFront distribution) may not be fully ready on the very first request right after `npm run sandbox` returns; this is an accepted trade for sandbox iteration speed.
 
-Requires an `aws-cdk` CLI that supports `--express`, so the CLI dev-dependency floor is bumped to `^2.1138.0`.
+Requires an `aws-cdk` CLI new enough to expose `--express`. The CLI dev-dependency floor is bumped to `^2.1138.0`, a version that has the flag (it is not necessarily the version that introduced it).
 
 The sandbox deploy argv is built by the pure, unit-tested `buildSandboxDeployArgs` helper (mirroring the existing `buildCdkDeployArgs` for production).

--- a/.changeset/sandbox-express-mode.md
+++ b/.changeset/sandbox-express-mode.md
@@ -2,8 +2,10 @@
 "@aws-blocks/core": patch
 ---
 
-Speed up sandbox deploys with CDK "express mode": `npm run sandbox` now runs `cdk deploy` with `--method direct`, which skips CloudFormation change-set creation and calls `UpdateStack` directly. This trims a couple of change-set round-trips off every sandbox iteration while remaining a full CloudFormation deploy (all resource types — unlike `--hotswap`).
+Speed up sandbox deploys with CloudFormation **Express Mode**: `npm run sandbox` now runs `cdk deploy --method direct --express`. Express Mode reports each stack operation complete as soon as the resource's configuration is applied, without waiting for full stabilization — a substantial speedup for the sandbox iteration loop.
 
-This applies to the sandbox path only. The production deploy (`npm run deploy`) is unchanged and still goes through a reviewable change set, since a direct `UpdateStack` has no change set to inspect.
+This is sandbox-only. The production deploy (`npm run deploy`) is unchanged — it keeps a reviewable CloudFormation change set and full stabilization with automatic rollback. Express Mode disables automatic rollback by default; we keep that default for the throwaway sandbox loop rather than forcing `--rollback`, so a failed sandbox deploy may leave the stack in a failed state until the next deploy.
 
-The sandbox deploy argv is now built by the pure, unit-tested `buildSandboxDeployArgs` helper (mirroring the existing `buildCdkDeployArgs` for production).
+Requires an `aws-cdk` CLI that supports `--express`, so the CLI dev-dependency floor is bumped to `^2.1138.0`.
+
+The sandbox deploy argv is built by the pure, unit-tested `buildSandboxDeployArgs` helper (mirroring the existing `buildCdkDeployArgs` for production).

--- a/package-lock.json
+++ b/package-lock.json
@@ -72,7 +72,7 @@
         "@mermaid-js/mermaid-cli": "^11.12.0",
         "@microsoft/api-extractor": "^7.58.1",
         "@types/node": "^20.0.0",
-        "aws-cdk": "^2.1117.0",
+        "aws-cdk": "^2.1138.0",
         "aws-cdk-lib": "2.257.0",
         "constructs": "^10.6.0",
         "esbuild": "^0.27.1",
@@ -34881,9 +34881,9 @@
       "link": true
     },
     "node_modules/aws-cdk": {
-      "version": "2.1122.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1122.0.tgz",
-      "integrity": "sha512-AI2Ks9qioWLvBPD4IoEtTet3wUG/o/q6U3WR3VCQKH5sNYLLPALo8o9sermNpMnfd1OQkqhL20tp4cEyojrIZg==",
+      "version": "2.1138.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1138.0.tgz",
+      "integrity": "sha512-gZ5F8rmh+qc7ZNWsbaXYoV+p7jSYynRRg70s7FAn3VmzRaSkTE31ijpQHYroxCbDEtKSzgN63ORR/WuZmvXAwA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -115,19 +115,19 @@
     "@mermaid-js/mermaid-cli": "^11.12.0",
     "@microsoft/api-extractor": "^7.58.1",
     "@types/node": "^20.0.0",
-    "aws-cdk": "^2.1117.0",
+    "aws-cdk": "^2.1138.0",
     "aws-cdk-lib": "2.257.0",
     "constructs": "^10.6.0",
     "esbuild": "^0.27.1",
     "husky": "^9.1.7",
+    "jiti": "^2.7.0",
     "kysely": "^0.28.17",
     "marked": "^18.0.0",
     "marked-highlight": "^2.2.3",
     "md-to-pdf": "^5.2.5",
     "tsx": "^4.7.0",
     "typescript": "^5.3.0",
-    "yaml": "^2.4.2",
-    "jiti": "^2.7.0"
+    "yaml": "^2.4.2"
   },
   "optionalDependencies": {
     "@rollup/rollup-linux-x64-gnu": "^4.60.3"

--- a/packages/core/src/scripts/sandbox-args.test.ts
+++ b/packages/core/src/scripts/sandbox-args.test.ts
@@ -26,8 +26,19 @@ describe('buildSandboxDeployArgs — express mode (sandbox only)', () => {
     backendPath: 'aws-blocks/index.ts',
   });
 
-  it('deploys via direct UpdateStack (express mode) instead of a change set', () => {
+  it('enables CloudFormation Express Mode via --express', () => {
+    assert.ok(args.includes('--express'), `expected --express in: ${args.join(' ')}`);
+  });
+
+  it('pairs express mode with the direct deployment method', () => {
     assert.strictEqual(valueAfter(args, '--method'), 'direct');
+  });
+
+  it('leaves express-mode rollback at its default (off) — no --rollback', () => {
+    // Express Mode disables automatic rollback by default; we keep that default
+    // for the throwaway sandbox loop. Passing --rollback here would silently
+    // give up the speedup.
+    assert.ok(!args.includes('--rollback'), `sandbox must not force --rollback: ${args.join(' ')}`);
   });
 
   it('deploys every stack so Lambda@Edge apps synth cleanly', () => {
@@ -49,9 +60,11 @@ describe('buildSandboxDeployArgs — express mode (sandbox only)', () => {
   });
 
   it('does NOT leak express mode into the production deploy path', () => {
-    // A production deploy must keep a reviewable change set: `--method direct`
-    // is a sandbox-only speedup and must never appear in buildCdkDeployArgs.
+    // A production deploy must keep a reviewable change set and full
+    // stabilization with rollback: neither `--express` nor `--method direct`
+    // (both sandbox-only speedups) may appear in buildCdkDeployArgs.
     const prod = buildCdkDeployArgs({ projectRoot: '/app', outputsFile: '.blocks-sandbox/outputs.json' });
+    assert.ok(!prod.includes('--express'), `production deploy must not use --express: ${prod.join(' ')}`);
     assert.ok(!prod.includes('--method'), `production deploy must not use --method: ${prod.join(' ')}`);
   });
 });

--- a/packages/core/src/scripts/sandbox-args.test.ts
+++ b/packages/core/src/scripts/sandbox-args.test.ts
@@ -7,6 +7,18 @@ import assert from 'node:assert';
 import { buildSandboxDeployArgs } from './sandbox.js';
 import { buildCdkDeployArgs } from './deploy-stream.js';
 
+/**
+ * Return the value that follows `flag` in `args`, failing with a clear message
+ * if the flag is absent. Reading `args[indexOf(flag) + 1]` directly silently
+ * reads `args[0]` when the flag is missing (indexOf returns -1), which turns a
+ * dropped flag into a confusing value mismatch instead of a "flag missing".
+ */
+function valueAfter(args: string[], flag: string): string {
+  const i = args.indexOf(flag);
+  assert.ok(i !== -1, `expected ${flag} in: ${args.join(' ')}`);
+  return args[i + 1];
+}
+
 describe('buildSandboxDeployArgs — express mode (sandbox only)', () => {
   const args = buildSandboxDeployArgs({
     outDir: '.blocks-sandbox',
@@ -15,7 +27,7 @@ describe('buildSandboxDeployArgs — express mode (sandbox only)', () => {
   });
 
   it('deploys via direct UpdateStack (express mode) instead of a change set', () => {
-    assert.strictEqual(args[args.indexOf('--method') + 1], 'direct', `expected --method direct in: ${args.join(' ')}`);
+    assert.strictEqual(valueAfter(args, '--method'), 'direct');
   });
 
   it('deploys every stack so Lambda@Edge apps synth cleanly', () => {
@@ -24,16 +36,16 @@ describe('buildSandboxDeployArgs — express mode (sandbox only)', () => {
 
   it('keeps the non-interactive deploy contract and sandbox context', () => {
     assert.deepStrictEqual(args.slice(0, 4), ['exec', 'cdk', '--', 'deploy']);
-    assert.strictEqual(args[args.indexOf('--require-approval') + 1], 'never');
-    assert.strictEqual(args[args.indexOf('--outputs-file') + 1], '.blocks-sandbox/outputs.json');
+    assert.strictEqual(valueAfter(args, '--require-approval'), 'never');
+    assert.strictEqual(valueAfter(args, '--outputs-file'), '.blocks-sandbox/outputs.json');
     assert.ok(args.includes('sandboxMode=true'), `expected sandboxMode=true in: ${args.join(' ')}`);
-    assert.strictEqual(args[args.indexOf('--app') + 1], 'npm exec tsx -- -C cdk aws-blocks/index.ts');
+    assert.strictEqual(valueAfter(args, '--app'), 'npm exec tsx -- -C cdk aws-blocks/index.ts');
   });
 
   it('interpolates the provided outDir and projectRoot', () => {
     const custom = buildSandboxDeployArgs({ outDir: 'out', projectRoot: '/other', backendPath: 'b.ts' });
-    assert.strictEqual(custom[custom.indexOf('--outputs-file') + 1], 'out/outputs.json');
-    assert.strictEqual(custom[custom.indexOf('--context') + 1], 'projectRoot=/other');
+    assert.strictEqual(valueAfter(custom, '--outputs-file'), 'out/outputs.json');
+    assert.strictEqual(valueAfter(custom, '--context'), 'projectRoot=/other');
   });
 
   it('does NOT leak express mode into the production deploy path', () => {

--- a/packages/core/src/scripts/sandbox-args.test.ts
+++ b/packages/core/src/scripts/sandbox-args.test.ts
@@ -12,6 +12,11 @@ import { buildCdkDeployArgs } from './deploy-stream.js';
  * if the flag is absent. Reading `args[indexOf(flag) + 1]` directly silently
  * reads `args[0]` when the flag is missing (indexOf returns -1), which turns a
  * dropped flag into a confusing value mismatch instead of a "flag missing".
+ *
+ * NOTE: resolves only the FIRST occurrence of `flag`. `--context` legitimately
+ * appears twice in this argv (projectRoot, then sandboxMode=true), so do not
+ * use `valueAfter(args, '--context')` expecting the second value — it silently
+ * returns the first. Assert repeated flags with `args.includes(...)` instead.
  */
 function valueAfter(args: string[], flag: string): string {
   const i = args.indexOf(flag);

--- a/packages/core/src/scripts/sandbox-args.test.ts
+++ b/packages/core/src/scripts/sandbox-args.test.ts
@@ -4,7 +4,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
 
-import { buildSandboxDeployArgs } from './sandbox.js';
+import { buildSandboxDeployArgs, sandboxFailureRecoveryHint } from './sandbox.js';
 import { buildCdkDeployArgs } from './deploy-stream.js';
 
 /**
@@ -71,5 +71,22 @@ describe('buildSandboxDeployArgs — express mode (sandbox only)', () => {
     const prod = buildCdkDeployArgs({ projectRoot: '/app', outputsFile: '.blocks-sandbox/outputs.json' });
     assert.ok(!prod.includes('--express'), `production deploy must not use --express: ${prod.join(' ')}`);
     assert.ok(!prod.includes('--method'), `production deploy must not use --method: ${prod.join(' ')}`);
+  });
+});
+
+describe('sandboxFailureRecoveryHint — no silent dead-end after a failed express deploy', () => {
+  const hint = sandboxFailureRecoveryHint();
+
+  it('points to the repo-native destroy + redeploy recovery', () => {
+    assert.match(hint, /npm run sandbox:destroy/);
+    assert.match(hint, /npm run sandbox\b/);
+  });
+
+  it('covers the manual UPDATE_ROLLBACK_FAILED escape hatch', () => {
+    assert.match(hint, /continue-update-rollback/);
+  });
+
+  it('explains why (rollback is off under express mode)', () => {
+    assert.match(hint, /rollback is off|automatic rollback/i);
   });
 });

--- a/packages/core/src/scripts/sandbox-args.test.ts
+++ b/packages/core/src/scripts/sandbox-args.test.ts
@@ -1,0 +1,45 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+
+import { buildSandboxDeployArgs } from './sandbox.js';
+import { buildCdkDeployArgs } from './deploy-stream.js';
+
+describe('buildSandboxDeployArgs — express mode (sandbox only)', () => {
+  const args = buildSandboxDeployArgs({
+    outDir: '.blocks-sandbox',
+    projectRoot: '/app',
+    backendPath: 'aws-blocks/index.ts',
+  });
+
+  it('deploys via direct UpdateStack (express mode) instead of a change set', () => {
+    assert.strictEqual(args[args.indexOf('--method') + 1], 'direct', `expected --method direct in: ${args.join(' ')}`);
+  });
+
+  it('deploys every stack so Lambda@Edge apps synth cleanly', () => {
+    assert.ok(args.includes('--all'), `expected --all in: ${args.join(' ')}`);
+  });
+
+  it('keeps the non-interactive deploy contract and sandbox context', () => {
+    assert.deepStrictEqual(args.slice(0, 4), ['exec', 'cdk', '--', 'deploy']);
+    assert.strictEqual(args[args.indexOf('--require-approval') + 1], 'never');
+    assert.strictEqual(args[args.indexOf('--outputs-file') + 1], '.blocks-sandbox/outputs.json');
+    assert.ok(args.includes('sandboxMode=true'), `expected sandboxMode=true in: ${args.join(' ')}`);
+    assert.strictEqual(args[args.indexOf('--app') + 1], 'npm exec tsx -- -C cdk aws-blocks/index.ts');
+  });
+
+  it('interpolates the provided outDir and projectRoot', () => {
+    const custom = buildSandboxDeployArgs({ outDir: 'out', projectRoot: '/other', backendPath: 'b.ts' });
+    assert.strictEqual(custom[custom.indexOf('--outputs-file') + 1], 'out/outputs.json');
+    assert.strictEqual(custom[custom.indexOf('--context') + 1], 'projectRoot=/other');
+  });
+
+  it('does NOT leak express mode into the production deploy path', () => {
+    // A production deploy must keep a reviewable change set: `--method direct`
+    // is a sandbox-only speedup and must never appear in buildCdkDeployArgs.
+    const prod = buildCdkDeployArgs({ projectRoot: '/app', outputsFile: '.blocks-sandbox/outputs.json' });
+    assert.ok(!prod.includes('--method'), `production deploy must not use --method: ${prod.join(' ')}`);
+  });
+});

--- a/packages/core/src/scripts/sandbox.ts
+++ b/packages/core/src/scripts/sandbox.ts
@@ -73,7 +73,7 @@ export interface SandboxDeployArgsOptions {
  *   uses neither `--express` nor `--method direct`: it keeps a reviewable
  *   change set and full stabilization with rollback, which are exactly the
  *   safety signals a production deploy should keep. Requires an aws-cdk CLI
- *   that supports `--express` (>= 2.1138.0).
+ *   new enough to expose `--express`; our pinned `^2.1138.0` has it.
  */
 export function buildSandboxDeployArgs({ outDir, projectRoot, backendPath }: SandboxDeployArgsOptions): string[] {
   return [
@@ -87,6 +87,34 @@ export function buildSandboxDeployArgs({ outDir, projectRoot, backendPath }: San
     "--context", "sandboxMode=true",
     "--app", `npm exec tsx -- -C cdk ${backendPath}`,
   ];
+}
+
+/**
+ * Operator-facing recovery guidance printed when a sandbox deploy fails.
+ *
+ * Express Mode (see {@link buildSandboxDeployArgs}) disables CloudFormation's
+ * automatic rollback, so a failed deploy does NOT clean up after itself: a
+ * failed *first* deploy leaves the stack in `CREATE_FAILED`/`ROLLBACK_COMPLETE`
+ * and a failed update can land in `UPDATE_ROLLBACK_FAILED`. In those states
+ * CloudFormation refuses the next `UpdateStack`, so a plain re-run of
+ * `npm run sandbox` would hit the same wall — a silent dead-end for the fast
+ * loop. This spells out the exact way out instead of leaving the operator to
+ * discover it via a cryptic CloudFormation error.
+ *
+ * Kept pure so it can be asserted in a unit test.
+ */
+export function sandboxFailureRecoveryHint(): string {
+  return [
+    "",
+    "ℹ️  Express Mode leaves failed sandbox stacks in place (automatic rollback is off).",
+    "   If the next `npm run sandbox` reports the stack cannot be updated, recover with:",
+    "",
+    "     npm run sandbox:destroy   # tears the failed stack down (handles ROLLBACK_COMPLETE)",
+    "     npm run sandbox           # redeploy from a clean slate",
+    "",
+    "   If destroy reports UPDATE_ROLLBACK_FAILED, first run:",
+    "     aws cloudformation continue-update-rollback --stack-name <your-sandbox-stack>",
+  ].join("\n");
 }
 
 export async function startSandbox(options: SandboxOptions) {
@@ -142,6 +170,7 @@ export async function startSandbox(options: SandboxOptions) {
       error: { code: 'CDK_DEPLOY_FAILED', phase: 'deploy' },
     });
     console.error("\n❌ Deployment failed.");
+    console.error(sandboxFailureRecoveryHint());
     throw error;
   }
 

--- a/packages/core/src/scripts/sandbox.ts
+++ b/packages/core/src/scripts/sandbox.ts
@@ -59,8 +59,8 @@ export interface SandboxDeployArgsOptions {
  *   (`edge-lambda-stack-*`, region us-east-1) in addition to the main hosting
  *   stack. Without `--all`, CDK refuses with "specify which stacks to use".
  *   Deploying every stack in a sandbox app is the intended behavior.
- * - `--method direct` (**express mode, sandbox only**): skip CloudFormation
- *   change-set creation and call UpdateStack directly. This trims a couple of
+ * - `--method direct` (**express mode, sandbox only**): skips CloudFormation
+ *   change-set creation and calls UpdateStack directly. This trims a couple of
  *   change-set round-trips off every sandbox deploy — a meaningful speedup for
  *   the fast iteration loop — while remaining a full CloudFormation deploy (all
  *   resource types, unlike `--hotswap`). The production deploy path

--- a/packages/core/src/scripts/sandbox.ts
+++ b/packages/core/src/scripts/sandbox.ts
@@ -59,20 +59,28 @@ export interface SandboxDeployArgsOptions {
  *   (`edge-lambda-stack-*`, region us-east-1) in addition to the main hosting
  *   stack. Without `--all`, CDK refuses with "specify which stacks to use".
  *   Deploying every stack in a sandbox app is the intended behavior.
- * - `--method direct` (**express mode, sandbox only**): skips CloudFormation
- *   change-set creation and calls UpdateStack directly. This trims a couple of
- *   change-set round-trips off every sandbox deploy — a meaningful speedup for
- *   the fast iteration loop — while remaining a full CloudFormation deploy (all
- *   resource types, unlike `--hotswap`). The production deploy path
- *   (`deploy.ts`) deliberately does NOT use this: a direct UpdateStack has no
- *   reviewable change set, which is exactly the safety signal a production
- *   deploy should keep.
+ * - `--method direct`: skip CloudFormation change-set creation and call
+ *   UpdateStack directly. This is the baseline sandbox deployment method that
+ *   `--express` builds on.
+ * - `--express` (**CloudFormation Express Mode — sandbox only**): the real
+ *   speedup. CloudFormation reports each stack operation complete as soon as
+ *   the resource's configuration is applied, WITHOUT waiting for full
+ *   stabilization. Because it skips stabilization it also disables automatic
+ *   rollback by default, so a failed deploy can leave the stack in a failed
+ *   state — acceptable for the throwaway sandbox iteration loop, never for
+ *   production. We leave rollback at Express Mode's default (off) and do NOT
+ *   pass `--rollback`. The production deploy path (`deploy.ts`) deliberately
+ *   uses neither `--express` nor `--method direct`: it keeps a reviewable
+ *   change set and full stabilization with rollback, which are exactly the
+ *   safety signals a production deploy should keep. Requires an aws-cdk CLI
+ *   that supports `--express` (>= 2.1138.0).
  */
 export function buildSandboxDeployArgs({ outDir, projectRoot, backendPath }: SandboxDeployArgsOptions): string[] {
   return [
     "exec", "cdk", "--", "deploy",
     "--all",
     "--method", "direct",
+    "--express",
     "--require-approval", "never",
     "--outputs-file", `${outDir}/outputs.json`,
     "--context", `projectRoot=${projectRoot}`,
@@ -118,8 +126,8 @@ export async function startSandbox(options: SandboxOptions) {
   try {
     runSync(
       "npm",
-      // Argv (including sandbox-only express mode, `--method direct`) is built by
-      // buildSandboxDeployArgs — see its doc comment for why each flag is here.
+      // Argv (including sandbox-only CloudFormation Express Mode, `--express`)
+      // is built by buildSandboxDeployArgs — see its doc for why each flag exists.
       buildSandboxDeployArgs({ outDir, projectRoot: process.cwd(), backendPath }),
       {
         stdio: "inherit",

--- a/packages/core/src/scripts/sandbox.ts
+++ b/packages/core/src/scripts/sandbox.ts
@@ -38,6 +38,49 @@ export interface SandboxOptions {
   devCommand?: string;
 }
 
+export interface SandboxDeployArgsOptions {
+  /** Directory CDK writes stack outputs to (relative to the project root). */
+  outDir: string;
+  /** Project root passed to synth as `--context projectRoot=…` (usually `process.cwd()`). */
+  projectRoot: string;
+  /** Backend entry passed to `--app` so CDK synthesizes from the app definition. */
+  backendPath: string;
+}
+
+/**
+ * Build the `npm exec cdk -- deploy …` argv used by the sandbox deploy.
+ *
+ * Kept pure (no I/O) so the argv contract — in particular the flags below — can
+ * be asserted directly, the same way {@link buildCdkDeployArgs} is for the
+ * production path.
+ *
+ * - `--all`: an app that uses Lambda@Edge (e.g. a Next.js route with
+ *   `export const runtime = 'edge'`) synthesizes a SECOND stack
+ *   (`edge-lambda-stack-*`, region us-east-1) in addition to the main hosting
+ *   stack. Without `--all`, CDK refuses with "specify which stacks to use".
+ *   Deploying every stack in a sandbox app is the intended behavior.
+ * - `--method direct` (**express mode, sandbox only**): skip CloudFormation
+ *   change-set creation and call UpdateStack directly. This trims a couple of
+ *   change-set round-trips off every sandbox deploy — a meaningful speedup for
+ *   the fast iteration loop — while remaining a full CloudFormation deploy (all
+ *   resource types, unlike `--hotswap`). The production deploy path
+ *   (`deploy.ts`) deliberately does NOT use this: a direct UpdateStack has no
+ *   reviewable change set, which is exactly the safety signal a production
+ *   deploy should keep.
+ */
+export function buildSandboxDeployArgs({ outDir, projectRoot, backendPath }: SandboxDeployArgsOptions): string[] {
+  return [
+    "exec", "cdk", "--", "deploy",
+    "--all",
+    "--method", "direct",
+    "--require-approval", "never",
+    "--outputs-file", `${outDir}/outputs.json`,
+    "--context", `projectRoot=${projectRoot}`,
+    "--context", "sandboxMode=true",
+    "--app", `npm exec tsx -- -C cdk ${backendPath}`,
+  ];
+}
+
 export async function startSandbox(options: SandboxOptions) {
   const { backendPath, outDir = ".blocks-sandbox", clientPort = 3000, deployOnly = false, devCommand } = options;
   const sandboxStartTime = Date.now();
@@ -75,21 +118,9 @@ export async function startSandbox(options: SandboxOptions) {
   try {
     runSync(
       "npm",
-      [
-        "exec", "cdk", "--", "deploy",
-        // `--all`: an app that uses Lambda@Edge (e.g. a Next.js route with
-        // `export const runtime = 'edge'`) synthesizes a SECOND stack
-        // (`edge-lambda-stack-*`, region us-east-1) in addition to the main
-        // hosting stack. Without `--all`, CDK refuses with "specify which
-        // stacks to use". Deploying every stack in a sandbox app is the
-        // intended behavior, so select them all.
-        "--all",
-        "--require-approval", "never",
-        "--outputs-file", `${outDir}/outputs.json`,
-        "--context", `projectRoot=${process.cwd()}`,
-        "--context", "sandboxMode=true",
-        "--app", `npm exec tsx -- -C cdk ${backendPath}`,
-      ],
+      // Argv (including sandbox-only express mode, `--method direct`) is built by
+      // buildSandboxDeployArgs — see its doc comment for why each flag is here.
+      buildSandboxDeployArgs({ outDir, projectRoot: process.cwd(), backendPath }),
       {
         stdio: "inherit",
         env: { ...process.env, NODE_OPTIONS: "--conditions=cdk", ...getCdkTelemetryEnv('sandbox') },


### PR DESCRIPTION
## What

Enables **CloudFormation Express Mode** for **sandbox** deploys. `npm run sandbox` now runs:

```
cdk deploy --all --method direct --express --require-approval never …
```

Express Mode (`--express`) reports each stack operation complete as soon as the resource's configuration is applied, **without waiting for full stabilization** — a substantial speedup for the sandbox iteration loop. `--method direct` (skip change-set creation) is the baseline method it builds on.

## Scope: sandbox only

- ✅ `packages/core/src/scripts/sandbox.ts` (`npm run sandbox`) — gets `--method direct --express`.
- ❌ `packages/core/src/scripts/deploy.ts` (`npm run deploy`, production) — **unchanged**. Production keeps a reviewable change set and full stabilization with automatic rollback. A test asserts production uses neither `--express` nor `--method`.
- `cdk watch` (sandbox iterate loop) is unchanged.

## Rollback

Express Mode **disables automatic rollback by default**. For the throwaway sandbox loop we keep that default (no `--rollback`), trading rollback safety for speed — a failed sandbox deploy may leave the stack in a failed state until the next deploy. Production is untouched and still rolls back.

## CDK CLI version

`--express` is not present in older CLIs (our previous lockfile pinned `aws-cdk` 2.1122.0, which only has `--rollback`). It lands in `aws-cdk` **2.1138.0**, so the dev-dependency floor is bumped `^2.1117.0` → `^2.1138.0`. Lockfile change is scoped to the `aws-cdk` version fields only (no dependency-tree churn).

## Refactor

The sandbox deploy argv is built by a pure, unit-tested `buildSandboxDeployArgs` helper, mirroring the existing `buildCdkDeployArgs` used for production.

## Tests

`packages/core/src/scripts/sandbox-args.test.ts` (7 cases):
- enables `--express`
- pairs with `--method direct`
- leaves rollback at its default (no `--rollback`)
- `--all` present (Lambda@Edge second stack)
- non-interactive contract + `sandboxMode=true` + `--app` preserved
- `outDir` / `projectRoot` interpolation
- **guard:** production `buildCdkDeployArgs` includes neither `--express` nor `--method`

## History

An earlier revision of this PR used `--method direct` alone and described it as "express mode". That was inaccurate — `--method direct` only skips change-set creation and still waits for stabilization. This revision switches to the real `--express` flag.

## Checklist
- [x] Changeset added (`@aws-blocks/core`, patch)
- [x] `biome lint` clean on changed files
- [x] Build + unit tests pass
- [ ] Draft — pending review