### PR TITLE
ci: add missing concurrency groups to PR workflows

### DIFF
--- a/.github/workflows/block-catalog-check.yml
+++ b/.github/workflows/block-catalog-check.yml
@@ -9,6 +9,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: block-catalog-check-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/changeset-check-native.yml
+++ b/.github/workflows/changeset-check-native.yml
@@ -6,6 +6,10 @@ on:
       - 'native/kotlin/**'
       - 'native/swift/**'
 
+concurrency:
+  group: changeset-check-native-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -3,6 +3,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: changeset-check-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -2,6 +2,10 @@ name: 'Dependency Review'
 on:
   pull_request:
 
+concurrency:
+  group: dependency-review-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/publish-tag-swift-release.yml
+++ b/.github/workflows/publish-tag-swift-release.yml
@@ -5,6 +5,11 @@ on:
     types: [closed]
     branches: [main]
 
+# Not cancellable: the job pushes a git tag, so a run must not die part-way.
+concurrency:
+  group: tag-swift-release-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: write
 


### PR DESCRIPTION
## Problem

Five pull request workflows had no `concurrency` block. When a contributor pushes a new commit, the stale run stays in the queue. The new run waits behind it.

Amazon shares one pool of `ubuntu-latest` runners across all GitHub organizations. The pool is at its limit during US work hours. Jobs queue instead of failing, and `githubstatus.com` stays green, so the delay looks like slow CI in this repository.

## Change

Four check workflows get a group with `cancel-in-progress: true`:

- `block-catalog-check.yml`
- `changeset-check.yml`
- `changeset-check-native.yml`
- `dependency-review.yml`

Each group uses the pull request number, with `github.ref` as a fallback. This matches the nine pull request workflows that already have a group.

`publish-tag-swift-release.yml` gets a group with `cancel-in-progress: false`. This workflow runs on `pull_request: closed` and pushes a git tag. You must not stop this run part-way through. The pull request is already merged, so no newer commit can supersede the run.

## Scope

`agent-bench.yml` gets no group. It is a reusable workflow with only a `workflow_call` trigger. Its caller `pr-agent-bench.yml` already holds a group that covers the call tree. Inside a called workflow, `github.workflow` resolves to the name of the caller, and GitHub documents that a shared group value makes the called workflow cancel its caller.

## Effect

The saving is small. These four check workflows use approximately 100 runner minutes each week, against approximately 47,000 minutes for the repository. The change removes duplicate queued runs. It does not reduce total job volume.

## Risk

Low. Every change adds lines. No workflow logic changes, and no job or step is modified.

## Verification

- All 33 workflow files parse as YAML.
- All four changeset guards pass. No publishable package changes, so this pull request needs no changeset.
- `agent-bench.yml` excludes `.github/**` from its path allowlist, so this pull request starts no benchmark run.