### PR TITLE
fix(pipeline): cross-copy stage validation via Stack.isStack()

### DIFF
--- a/.changeset/pipeline-isstack-cross-copy.md
+++ b/.changeset/pipeline-isstack-cross-copy.md
@@ -1,0 +1,13 @@
+---
+"@aws-blocks/pipeline": patch
+---
+
+Fix `Pipeline.create()` failing with "stage '<name>' contains no stacks" when the
+consumer app resolves a different `aws-cdk-lib` copy than `@aws-blocks/pipeline`
+(monorepo, linked-package, or `file:` installs — e.g. an Amplify self-hosting app).
+
+`validateStageStacks` detected a stage's stacks with `instanceof cdk.Stack`, which
+returns `false` across module copies — so a `stageFactory` that *did* create a
+`Stack` was misdetected as empty and synth aborted. It now uses
+`cdk.Stack.isStack()`, which matches on a shared `Symbol.for` marker and is
+cross-copy-safe.

--- a/packages/pipeline/src/pipeline-construct.ts
+++ b/packages/pipeline/src/pipeline-construct.ts
@@ -489,9 +489,14 @@ function validateStageName<TConfig>(stageConfig: PipelineStageConfig<TConfig>): 
 }
 
 function validateStageStacks(stage: cdk.Stage, stageName: string, source: 'stageFactory' | 'appFile'): void {
-  const stacks = stage.node.children.filter(
-    (c): c is cdk.Stack => c instanceof cdk.Stack,
-  );
+  // Use `Stack.isStack()` (a `Symbol.for`-based marker) rather than `instanceof
+  // cdk.Stack`. The stageFactory runs in the CONSUMER's app, which may resolve a
+  // DIFFERENT aws-cdk-lib copy than this package (monorepo / linked-package /
+  // `file:` installs — e.g. Amplify self-hosting). Across copies `instanceof`
+  // returns false, so a stage that DID create a Stack is misdetected as empty and
+  // synth fails with "contains no stacks". `Stack.isStack()` matches on a shared
+  // `Symbol.for` marker and is cross-copy-safe.
+  const stacks = stage.node.children.filter((c): c is cdk.Stack => cdk.Stack.isStack(c));
 
   if (stacks.length === 0) {
     const hint = source === 'appFile'


### PR DESCRIPTION
## What

`validateStageStacks` in `@aws-blocks/pipeline` detected a stage's stacks with `instanceof cdk.Stack`. That returns **false** when the consumer app resolves a *different* `aws-cdk-lib` copy than the pipeline package — monorepo, linked-package, or `file:` installs (e.g. an Amplify self-hosting app). A `stageFactory` that *did* create a `Stack` was then misdetected as empty and synth aborted with:

```
Pipeline: stage '<name>' contains no stacks after running stageFactory.
```

Switched to `cdk.Stack.isStack()`, which matches on a shared `Symbol.for` marker and is **cross-copy-safe**.

## Why a standalone PR

Split out of the `secret()` / `config()` PR (#115) per the API bar-raiser review (B8: keep the fix isolated). It was **discovered via an e2e** on a `file:`-linked sample app, which hit exactly this failure when synthing a pipeline — confirming it's a functional bug, not a cosmetic change.

## Test

`@aws-blocks/pipeline` unit suite green (82/82); build clean; changeset added (patch). The cross-copy scenario is inherently multi-copy (can't be reproduced in a single-copy unit test), so the rationale is documented at the call site + changeset.