### PR TITLE
ci(agent-bench): scope builder agent session to Bedrock-only (drop s3:PutObject)

### DIFF
--- a/.github/workflows/agent-bench.yml
+++ b/.github/workflows/agent-bench.yml
@@ -6,6 +6,15 @@ name: Agent Bench
 # + Converse on the bench model, and s3 Put/Get on bench/* in the registry bucket) and S3_BUCKET var.
 # Invoked by pr-agent-bench.yml, which owns the triggers + same-repo gate; the OIDC steps and
 # `environment: publish` live on the jobs here because a `uses:` caller job cannot set environment.
+#
+# LEAST PRIVILEGE: the bench job's initial OIDC session is narrowed to Bedrock only via
+# an inline session policy, so the shell-capable "2. Agent run" step (and judge/analysis) cannot
+# reach s3:PutObject even though the role grants it. The same role is re-assumed WITHOUT a session
+# policy immediately before "Persist to S3" so only that step regains the s3 write. See the
+# "Configure AWS credentials (OIDC)" step below for the canonical explanation of how the inline
+# session policy works (intersection semantics, why the shared AWS_ROLE_ARN is untouched, and the
+# exact allow-list). The `summary` job holds the full role (Bedrock + S3 baseline) but has no
+# shell-capable agent (tracked as follow-up).
 
 on:
   workflow_call:
@@ -156,6 +165,38 @@ jobs:
           # Extend the OIDC session past the ~1h default so it survives slow cells (AWS clamps
           # to the role's max if lower).
           role-duration-seconds: 7200
+          # LEAST PRIVILEGE (canonical explanation): the effective session permissions are the
+          # INTERSECTION of the role's policy and this inline policy, so this narrows the initial
+          # session to Bedrock Converse ONLY — steps 1→4b (agent, judge, per-cell analysis) run with
+          # no s3:PutObject. It cannot widen the role, so the shared AWS_ROLE_ARN and every other
+          # workflow that uses it are untouched — no new IAM roles or environment secrets. The
+          # allow-list is exactly the two model-invocation paths the harness uses: ConverseStream for
+          # the Strands BedrockModel (builder/judge stream — see the ModelStreamUpdateEvent hook in
+          # 2-agent-run.ts) and Converse for the CLI `bedrock-runtime converse` analysis. InvokeModel
+          # / InvokeModelWithResponseStream are intentionally omitted — no path uses them. Resources
+          # stay on model-invocation ARNs (inference-profile + foundation-model), robust to the us.*
+          # geo profile's cross-region routing and a BENCH_MODEL override — the role itself already
+          # pins the exact model. "Persist to S3" re-assumes the same role below WITHOUT this policy
+          # to regain the s3 write for that step.
+          inline-session-policy: >-
+            {
+              "Version": "2012-10-17",
+              "Statement": [
+                {
+                  "Sid": "BedrockInvokeOnly",
+                  "Effect": "Allow",
+                  "Action": [
+                    "bedrock:Converse",
+                    "bedrock:ConverseStream"
+                  ],
+                  "Resource": [
+                    "arn:aws:bedrock:*:*:inference-profile/*",
+                    "arn:aws:bedrock:*:*:application-inference-profile/*",
+                    "arn:aws:bedrock:*::foundation-model/*"
+                  ]
+                }
+              ]
+            }
 
       # BUILD-ONCE: pull the dist-registry/ build-blocks packed so "1. Init bench-app" can skip the
       # ~150s monorepo build. Best-effort: a download blip never reds the cell (init rebuilds it).
@@ -177,9 +218,11 @@ jobs:
         env:
           BLOCKS_TELEMETRY_CANARY_ID: ${{ secrets.BLOCKS_TELEMETRY_CANARY_ID }}
 
-      # SECURITY: this step runs an LLM agent (shell tool) with the live OIDC session, so a
-      # prompt-injected task could reach any AWS API in the role's scope. Bounded by the same-repo
-      # guard in pr-agent-bench.yml (fork PRs get no secrets/OIDC). See README "Security".
+      # SECURITY: this step runs an LLM agent (shell tool), so a prompt-injected task could reach any
+      # AWS API in the CURRENT session's scope — which the OIDC step's inline session policy has
+      # narrowed to Bedrock-only (the *session*, not the role), so s3:PutObject is NOT reachable here.
+      # Still bounded by the same-repo guard in pr-agent-bench.yml (fork PRs get no secrets/OIDC).
+      # See the "Configure AWS credentials (OIDC)" step above and README "Security" for the mechanism.
       - name: 2. Agent run
         id: agent
         continue-on-error: true
@@ -312,6 +355,24 @@ jobs:
           overwrite: true
           if-no-files-found: ignore
 
+      # LEAST PRIVILEGE: re-assume the SAME role WITHOUT an inline session policy so only
+      # this persist step regains s3:PutObject on bench/*. Runs after the shell-capable agent step, so
+      # the s3 write is never live while the agent is. Best-effort: a re-assume failure just leaves the
+      # (Bedrock-only) session in place and the persist below degrades gracefully — never reds a cell.
+      # `!cancelled()` (not always()): on a cancelled run we deliberately do NOT re-widen the session,
+      # so a cancellation can never leave an S3-capable session active for a later step; it still runs
+      # on job failure so a failed cell can persist its partial result.json. No role-duration-seconds:
+      # unlike the initial assume (which must span the whole ~85min cell), this session is taken at the
+      # end and only needs to outlive the ~3min best-effort upload, so the ~1h default is ample.
+      - name: Re-assume role for S3 persist (drop Bedrock-only session policy)
+        id: oidc_s3
+        if: ${{ !cancelled() }}
+        continue-on-error: true
+        uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
       # Archive the raw per-cell result under a COMMIT-keyed prefix; the summary job builds the
       # aggregate + baseline from these.
       - name: Persist to S3 (best-effort)
@@ -321,7 +382,15 @@ jobs:
         env:
           BENCH_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
           BUCKET: ${{ vars.S3_BUCKET }}
+          # Surface (don't swallow) a silent archival gap: if the re-assume above failed, the session
+          # is still Bedrock-only and this upload will AccessDenied. That never reds the cell (the PR
+          # summary aggregates from GitHub artifacts, not S3), but it drops this cell's commit-keyed
+          # baseline entry — annotate it so a missing historical row isn't later read as "no results".
+          OIDC_S3_OUTCOME: ${{ steps.oidc_s3.outcome }}
         run: |
+          if [ "${OIDC_S3_OUTCOME}" != "success" ]; then
+            echo "::warning title=Bench S3 archive skipped::S3 re-assume outcome='${OIDC_S3_OUTCOME}' (not success); the Bedrock-only session is still active so this cell's baseline archive will likely fail — historical baseline entry for ${TASK}-${TEMPLATE} may be missing."
+          fi
           KEY="bench/runs/${BENCH_SHA}/cells/${TASK}-${TEMPLATE}.json"
           bash scripts/agent-bench/steps/lib/s3-put.sh /tmp/result.json "s3://${BUCKET}/$KEY" "cell archive"
 


### PR DESCRIPTION
Closes #97.

## Problem
The agent-bench `bench` job assumes `AWS_ROLE_ARN` once (the "Configure AWS credentials (OIDC)" step) and reuses that single OIDC session across every subsequent step — including the shell-capable **"2. Agent run"** step (a prompt-injectable LLM agent) and the terminal **"Persist to S3"** step. That role grants Bedrock invoke/converse **and** `s3:PutObject` on `bench/*`, so the agent step carries an S3 write it never needs.

## Why it matters
A prompt-injected builder agent could reach `s3:PutObject` while it runs. The risk is bounded today by the same-repo gate in `pr-agent-bench.yml` (fork PRs get no secrets/OIDC), but scoping the agent session to least privilege shrinks the blast radius even for same-repo runs — the hardening flagged as a should-fix in the PR #31 review.

## Fix (symptom → root cause → change)
- **Root cause:** one broad session (Bedrock + S3) is shared by the agent step and the persist step.
- **Change:** add a Bedrock-invoke/converse-only `inline-session-policy` to the initial OIDC step. Effective session perms are the **intersection** of the role and the session policy, so steps 1→4b (agent, judge, per-cell analysis) run with **no `s3:PutObject`**. Then re-assume the **same role without a session policy** immediately before "Persist to S3", so only that step regains the S3 write.
- A session policy only narrows the derived session (never the role), so the shared `AWS_ROLE_ARN` and every other workflow that uses it are **unaffected** — no new IAM roles or environment secrets.

Policy actions cover both Bedrock paths in the harness: the Strands `BedrockModel` (builder + judge) and the CLI `bedrock-runtime converse` (per-cell + roll-up analysis). Resources stay on model-invocation ARNs (`inference-profile/*`, `application-inference-profile/*`, `foundation-model/*`) so the `us.*` geo inference profile's cross-region routing and a `BENCH_MODEL` override keep working; the role itself already pins the exact model.

## Tests
N/A — CI workflow change. Validated: the workflow YAML parses and the inline session policy is valid JSON. No changeset required (the repo's changeset coverage guard only counts `packages/<name>/` changes; this touches only `.github/workflows/`).

## Manual verification
Cannot be fully exercised without a `bench` run against the real `AWS_ROLE_ARN`. On merge, confirm on a bench run that steps 1→4b succeed (Bedrock calls unaffected) and "Persist to S3" still writes the cell archive.

## Follow-up
The `summary` job holds the full role (Bedrock + S3 baseline read/write) but has **no shell-capable agent**, so it's lower risk; applying the same session-policy treatment there is left as a documented follow-up per the issue thread. Fully separate role identities (distinct CloudTrail principals / trust policies) remain a stronger future boundary if needed.
