### PR TITLE
fix(core): fail fast on missing AWS credentials before sandbox/deploy synth

### DIFF
--- a/.changeset/sandbox-credential-precheck.md
+++ b/.changeset/sandbox-credential-precheck.md
@@ -1,8 +1,11 @@
 ---
 "@aws-blocks/core": patch
 "@aws-blocks/blocks": patch
+"@aws-blocks/create-blocks-app": patch
 ---
 
 `sandbox` / `deploy`: fail fast with an actionable message when AWS credentials are missing or expired.
 
-Both commands previously spent ~10 seconds synthesizing the CDK app before the first AWS call, so an unconfigured or expired credential surfaced only afterwards — as an opaque CDK/CloudFormation error that didn't name the real cause. `startSandbox` and `deploy` now run an STS `GetCallerIdentity` check up front and, if it fails, exit immediately with guidance (configure `aws configure` / `aws sso login`, set `AWS_PROFILE`, or export `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`) instead of wasting the synth.
+Both commands previously spent ~10 seconds synthesizing the CDK app before the first AWS call, so an unconfigured or expired credential surfaced only afterwards — as an opaque CDK/CloudFormation error that didn't name the real cause. `startSandbox` and `deploy` now run a bounded STS `GetCallerIdentity` check up front and, on a real credential error (missing/expired/invalid), exit immediately with guidance (`aws configure` / `aws sso login`, `AWS_PROFILE`, or `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`) instead of wasting the synth.
+
+The check is deliberately conservative: it only blocks on a genuine credential error (surfacing the SDK error *name*, never the raw message, which can embed an ARN/account id); a network or service error warns and lets the deploy proceed; and it skips (with a warning) when no region is set in `AWS_REGION` / `AWS_DEFAULT_REGION`, rather than guessing a region in the wrong partition (GovCloud/China). The scaffolded `sandbox` template entrypoint now `.catch`es and exits cleanly, matching `deploy`, so the guidance prints without an unhandled-rejection stack trace.

--- a/.changeset/sandbox-credential-precheck.md
+++ b/.changeset/sandbox-credential-precheck.md
@@ -1,0 +1,8 @@
+---
+"@aws-blocks/core": patch
+"@aws-blocks/blocks": patch
+---
+
+`sandbox` / `deploy`: fail fast with an actionable message when AWS credentials are missing or expired.
+
+Both commands previously spent ~10 seconds synthesizing the CDK app before the first AWS call, so an unconfigured or expired credential surfaced only afterwards — as an opaque CDK/CloudFormation error that didn't name the real cause. `startSandbox` and `deploy` now run an STS `GetCallerIdentity` check up front and, if it fails, exit immediately with guidance (configure `aws configure` / `aws sso login`, set `AWS_PROFILE`, or export `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`) instead of wasting the synth.

--- a/package-lock.json
+++ b/package-lock.json
@@ -22867,7 +22867,6 @@
       "version": "3.1052.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.1052.0.tgz",
       "integrity": "sha512-3AWMsvWKi8ZvQU5EC/oBb6R5EKgjj715fK44ElZ/9l34tNuSubobb8IMMXkHE9nmo4qTv6Ca77hvaDIjK9qBBw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -55869,6 +55868,7 @@
         "@aws-blocks/pipeline": "*",
         "@aws-sdk/client-s3": "^3.700.0",
         "@aws-sdk/client-ssm": "^3.700.0",
+        "@aws-sdk/client-sts": "^3.700.0",
         "cross-spawn": "^7.0.6",
         "http-proxy": "^1.18.1"
       },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -80,6 +80,7 @@
     "@aws-blocks/pipeline": "*",
     "@aws-sdk/client-s3": "^3.700.0",
     "@aws-sdk/client-ssm": "^3.700.0",
+    "@aws-sdk/client-sts": "^3.700.0",
     "cross-spawn": "^7.0.6",
     "http-proxy": "^1.18.1"
   },

--- a/packages/core/src/scripts/deploy.ts
+++ b/packages/core/src/scripts/deploy.ts
@@ -6,6 +6,7 @@ import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
 import { join, resolve, dirname } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { ensureSecrets, loadProductionEnv } from './ensure-secrets.js';
+import { assertAwsCredentials } from './preflight-credentials.js';
 import { applyExternalMigrations } from './external-migrations-step.js';
 import { trackCommand } from '../telemetry/trackCommand.js';
 import { getCdkTelemetryEnv } from './cdk-telemetry-env.js';
@@ -24,6 +25,10 @@ export async function deploy(options: DeployOptions) {
     loadProductionEnv();
 
     process.env.BLOCKS_STAGE = 'production';
+
+    // Fail fast if AWS credentials are missing/expired, before generating the
+    // client and spending time in synth only to hit an opaque CDK credential error.
+    await assertAwsCredentials('deploy');
 
     // Provision secrets for production. projectRoot must match the root cdk
     // synth uses (passed as --context below) so the written parameter name

--- a/packages/core/src/scripts/preflight-credentials.test.ts
+++ b/packages/core/src/scripts/preflight-credentials.test.ts
@@ -2,64 +2,109 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import assert from 'node:assert';
-import { describe, it } from 'node:test';
-import { assertAwsCredentials } from './preflight-credentials.js';
+import { describe, it, mock } from 'node:test';
+import { assertAwsCredentials, resolveProbeRegion } from './preflight-credentials.js';
+
+const REGION_ENV = { AWS_REGION: 'us-east-1' } as NodeJS.ProcessEnv;
+
+/** Build an Error with a specific `name`, as the AWS SDK throws. */
+function namedError(name: string, message = 'raw sdk detail'): Error {
+	const err = new Error(message);
+	err.name = name;
+	return err;
+}
+
+describe('resolveProbeRegion', () => {
+	it('prefers AWS_REGION', () => {
+		assert.strictEqual(resolveProbeRegion({ AWS_REGION: 'eu-west-1', AWS_DEFAULT_REGION: 'us-east-2' }), 'eu-west-1');
+	});
+
+	it('falls back to AWS_DEFAULT_REGION', () => {
+		assert.strictEqual(resolveProbeRegion({ AWS_DEFAULT_REGION: 'ap-south-1' }), 'ap-south-1');
+	});
+
+	it('returns null when neither is set (caller then skips the probe)', () => {
+		assert.strictEqual(resolveProbeRegion({}), null);
+	});
+});
 
 describe('assertAwsCredentials', () => {
 	it('resolves silently when the credential probe succeeds', async () => {
-		let called = false;
+		let calledRegion: string | undefined;
 		await assert.doesNotReject(() =>
-			assertAwsCredentials('sandbox', async () => {
-				called = true;
-			}),
+			assertAwsCredentials(
+				'sandbox',
+				async (region) => {
+					calledRegion = region;
+				},
+				REGION_ENV,
+			),
 		);
-		assert.strictEqual(called, true);
+		assert.strictEqual(calledRegion, 'us-east-1');
 	});
 
-	it('throws an actionable error naming the command when the probe rejects', async () => {
-		const probeError = new Error('Could not load credentials from any providers');
+	it('throws actionable guidance on a real credential error, naming the command', async () => {
 		await assert.rejects(
-			() =>
-				assertAwsCredentials('sandbox', async () => {
-					throw probeError;
-				}),
+			() => assertAwsCredentials('sandbox', async () => { throw namedError('CredentialsProviderError'); }, REGION_ENV),
 			(err: Error) => {
-				// Names the failing command so the message is copy-pasteable.
 				assert.match(err.message, /npm run sandbox/);
-				// Points at concrete remediation, not just "failed".
 				assert.match(err.message, /aws configure|AWS_PROFILE|AWS_ACCESS_KEY_ID/);
-				// Preserves the underlying cause for debugging.
-				assert.match(err.message, /Could not load credentials from any providers/);
+				assert.match(err.message, /CredentialsProviderError/); // the name, for debugging
 				return true;
 			},
 		);
 	});
 
-	it('interpolates the command name (deploy vs sandbox)', async () => {
+	it('treats an expired token as a credential error', async () => {
 		await assert.rejects(
-			() =>
-				assertAwsCredentials('deploy', async () => {
-					throw new Error('boom');
-				}),
+			() => assertAwsCredentials('deploy', async () => { throw namedError('ExpiredToken'); }, REGION_ENV),
 			(err: Error) => {
 				assert.match(err.message, /npm run deploy/);
-				assert.doesNotMatch(err.message, /npm run sandbox/);
+				assert.match(err.message, /aws sso login|AWS_PROFILE/);
 				return true;
 			},
 		);
 	});
 
-	it('handles a non-Error rejection value without crashing', async () => {
+	it('does NOT leak the raw error message (ARN / account id)', async () => {
+		const arnMessage = 'User: arn:aws:iam::123456789012:user/alice is not authorized to perform sts:GetCallerIdentity';
 		await assert.rejects(
-			// Throw a non-Error to exercise the String(error) fallback branch.
-			() =>
-				assertAwsCredentials('deploy', async () => {
-					throw 'string failure';
-				}),
+			() => assertAwsCredentials('deploy', async () => { throw namedError('InvalidClientTokenId', arnMessage); }, REGION_ENV),
 			(err: Error) => {
-				assert.match(err.message, /string failure/);
+				assert.doesNotMatch(err.message, /arn:aws:iam/);
+				assert.doesNotMatch(err.message, /123456789012/);
 				return true;
 			},
 		);
+	});
+
+	it('does not throw on a network/service error — warns and continues', async () => {
+		const warn = mock.method(console, 'warn', () => {});
+		try {
+			await assert.doesNotReject(() =>
+				assertAwsCredentials('sandbox', async () => { throw namedError('TimeoutError'); }, REGION_ENV),
+			);
+			assert.ok(
+				warn.mock.calls.some((c) => String(c.arguments[0]).includes('Could not verify')),
+				'should warn that credentials could not be verified',
+			);
+		} finally {
+			warn.mock.restore();
+		}
+	});
+
+	it('skips the probe (with a warning) when no region is resolvable', async () => {
+		const warn = mock.method(console, 'warn', () => {});
+		let probed = false;
+		try {
+			await assertAwsCredentials('sandbox', async () => { probed = true; }, {});
+			assert.strictEqual(probed, false, 'probe must not run without a region');
+			assert.ok(
+				warn.mock.calls.some((c) => String(c.arguments[0]).includes('Skipping the AWS credential pre-check')),
+				'should warn that the pre-check was skipped',
+			);
+		} finally {
+			warn.mock.restore();
+		}
 	});
 });

--- a/packages/core/src/scripts/preflight-credentials.test.ts
+++ b/packages/core/src/scripts/preflight-credentials.test.ts
@@ -1,0 +1,65 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import assert from 'node:assert';
+import { describe, it } from 'node:test';
+import { assertAwsCredentials } from './preflight-credentials.js';
+
+describe('assertAwsCredentials', () => {
+	it('resolves silently when the credential probe succeeds', async () => {
+		let called = false;
+		await assert.doesNotReject(() =>
+			assertAwsCredentials('sandbox', async () => {
+				called = true;
+			}),
+		);
+		assert.strictEqual(called, true);
+	});
+
+	it('throws an actionable error naming the command when the probe rejects', async () => {
+		const probeError = new Error('Could not load credentials from any providers');
+		await assert.rejects(
+			() =>
+				assertAwsCredentials('sandbox', async () => {
+					throw probeError;
+				}),
+			(err: Error) => {
+				// Names the failing command so the message is copy-pasteable.
+				assert.match(err.message, /npm run sandbox/);
+				// Points at concrete remediation, not just "failed".
+				assert.match(err.message, /aws configure|AWS_PROFILE|AWS_ACCESS_KEY_ID/);
+				// Preserves the underlying cause for debugging.
+				assert.match(err.message, /Could not load credentials from any providers/);
+				return true;
+			},
+		);
+	});
+
+	it('interpolates the command name (deploy vs sandbox)', async () => {
+		await assert.rejects(
+			() =>
+				assertAwsCredentials('deploy', async () => {
+					throw new Error('boom');
+				}),
+			(err: Error) => {
+				assert.match(err.message, /npm run deploy/);
+				assert.doesNotMatch(err.message, /npm run sandbox/);
+				return true;
+			},
+		);
+	});
+
+	it('handles a non-Error rejection value without crashing', async () => {
+		await assert.rejects(
+			// Throw a non-Error to exercise the String(error) fallback branch.
+			() =>
+				assertAwsCredentials('deploy', async () => {
+					throw 'string failure';
+				}),
+			(err: Error) => {
+				assert.match(err.message, /string failure/);
+				return true;
+			},
+		);
+	});
+});

--- a/packages/core/src/scripts/preflight-credentials.ts
+++ b/packages/core/src/scripts/preflight-credentials.ts
@@ -1,0 +1,65 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Pre-deploy AWS credential check.
+ *
+ * `cdk deploy` spends ~10 seconds synthesizing the app before it makes its
+ * first AWS call, so a missing or expired credential surfaces only *after* that
+ * wasted synth — as an opaque CDK/CloudFormation error that doesn't name the
+ * real cause. Calling STS GetCallerIdentity up front turns that into an
+ * immediate, actionable message the moment a deploy command starts.
+ */
+
+/**
+ * Probe that resolves when valid AWS credentials are available and rejects
+ * otherwise. Injectable so the guard can be unit-tested without network or real
+ * credentials; production callers use the default {@link stsProbe}.
+ */
+export type CredentialProbe = () => Promise<void>;
+
+/**
+ * Default probe: STS GetCallerIdentity via the SDK's standard credential chain
+ * (env vars, shared config/credentials, SSO, container/instance roles).
+ *
+ * Dynamically imported so the STS client is only loaded when a deploy actually
+ * runs — never during dev-server startup or a mock unit test. A region is
+ * always supplied (falling back to `us-east-1`) so the probe never fails for a
+ * *missing region* — GetCallerIdentity is identity-only, so any region answers,
+ * and region correctness is validated later by the deploy itself.
+ */
+const stsProbe: CredentialProbe = async () => {
+	const { STSClient, GetCallerIdentityCommand } = await import('@aws-sdk/client-sts');
+	const region = process.env.AWS_REGION || process.env.AWS_DEFAULT_REGION || 'us-east-1';
+	const client = new STSClient({ region });
+	try {
+		await client.send(new GetCallerIdentityCommand({}));
+	} finally {
+		client.destroy();
+	}
+};
+
+/**
+ * Fail fast when AWS credentials are unavailable or invalid, before a deploy
+ * command spends time synthesizing.
+ *
+ * @param command - The npm script name, used in the error message (e.g. `sandbox`, `deploy`).
+ * @param probe - Credential probe; defaults to STS GetCallerIdentity. Override in tests.
+ * @throws {Error} With actionable guidance when the probe rejects.
+ */
+export async function assertAwsCredentials(command: string, probe: CredentialProbe = stsProbe): Promise<void> {
+	try {
+		await probe();
+	} catch (error) {
+		const detail = error instanceof Error ? error.message : String(error);
+		throw new Error(
+			`No valid AWS credentials found for \`npm run ${command}\`.\n` +
+				'Configure credentials before deploying — for example:\n' +
+				'  • run `aws configure` (or `aws sso login`), or\n' +
+				'  • set AWS_PROFILE to a configured profile, or\n' +
+				'  • export AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY (and AWS_SESSION_TOKEN for temporary credentials).\n' +
+				`Then re-run \`npm run ${command}\`.\n` +
+				`(underlying error: ${detail})`,
+		);
+	}
+}

--- a/packages/core/src/scripts/preflight-credentials.ts
+++ b/packages/core/src/scripts/preflight-credentials.ts
@@ -9,29 +9,65 @@
  * wasted synth — as an opaque CDK/CloudFormation error that doesn't name the
  * real cause. Calling STS GetCallerIdentity up front turns that into an
  * immediate, actionable message the moment a deploy command starts.
+ *
+ * The check is intentionally conservative: it fails fast **only** on a real
+ * credential problem (missing/expired/invalid). A network or service error
+ * (STS unreachable, throttled, disabled in a region) is not treated as a
+ * credential failure — it warns and lets the deploy proceed, since blocking on
+ * an unverifiable probe would reject a deploy that might have worked.
  */
 
 /**
- * Probe that resolves when valid AWS credentials are available and rejects
- * otherwise. Injectable so the guard can be unit-tested without network or real
- * credentials; production callers use the default {@link stsProbe}.
+ * Error `name`s that mean the credentials themselves are missing, expired, or
+ * invalid — the cases where the "configure your credentials" remediation is
+ * correct. Anything else (network, throttling, an explicit `AccessDenied` — which
+ * actually proves the identity resolved) is surfaced as itself instead.
  */
-export type CredentialProbe = () => Promise<void>;
+const CREDENTIAL_ERROR_NAMES = new Set([
+	'CredentialsProviderError',
+	'ExpiredToken',
+	'ExpiredTokenException',
+	'InvalidClientTokenId',
+	'UnrecognizedClientException',
+	'SignatureDoesNotMatch',
+	'TokenRefreshRequired',
+]);
+
+/**
+ * Resolve the region for the STS probe from the environment. Returns `null`
+ * when neither `AWS_REGION` nor `AWS_DEFAULT_REGION` is set — the caller then
+ * skips the probe rather than guessing a region, because a hardcoded guess
+ * (e.g. `us-east-1`) belongs to a different **partition** than GovCloud
+ * (`us-gov-*`) or China (`cn-*`) and would fail against a partition the user
+ * isn't even deploying to.
+ */
+export function resolveProbeRegion(env: NodeJS.ProcessEnv = process.env): string | null {
+	return env.AWS_REGION || env.AWS_DEFAULT_REGION || null;
+}
+
+/**
+ * Probe that resolves when valid AWS credentials are available for `region` and
+ * rejects otherwise. Injectable so the guard can be unit-tested without network
+ * or real credentials; production callers use the default {@link stsProbe}.
+ */
+export type CredentialProbe = (region: string) => Promise<void>;
 
 /**
  * Default probe: STS GetCallerIdentity via the SDK's standard credential chain
  * (env vars, shared config/credentials, SSO, container/instance roles).
  *
  * Dynamically imported so the STS client is only loaded when a deploy actually
- * runs — never during dev-server startup or a mock unit test. A region is
- * always supplied (falling back to `us-east-1`) so the probe never fails for a
- * *missing region* — GetCallerIdentity is identity-only, so any region answers,
- * and region correctness is validated later by the deploy itself.
+ * runs — never during dev-server startup or a mock unit test. Bounded with a
+ * short request timeout and a single attempt (matching `common/config.ts`) so a
+ * bad network can't make this hang *longer* than the synth it's replacing.
  */
-const stsProbe: CredentialProbe = async () => {
+const stsProbe: CredentialProbe = async (region) => {
 	const { STSClient, GetCallerIdentityCommand } = await import('@aws-sdk/client-sts');
-	const region = process.env.AWS_REGION || process.env.AWS_DEFAULT_REGION || 'us-east-1';
-	const client = new STSClient({ region });
+	const client = new STSClient({
+		region,
+		maxAttempts: 1,
+		requestHandler: { connectionTimeout: 2000, requestTimeout: 3000 },
+	});
 	try {
 		await client.send(new GetCallerIdentityCommand({}));
 	} finally {
@@ -40,26 +76,56 @@ const stsProbe: CredentialProbe = async () => {
 };
 
 /**
- * Fail fast when AWS credentials are unavailable or invalid, before a deploy
- * command spends time synthesizing.
+ * Verify AWS credentials before a deploy command spends time synthesizing, and
+ * fail fast with actionable guidance when they're missing, expired, or invalid.
  *
- * @param command - The npm script name, used in the error message (e.g. `sandbox`, `deploy`).
+ * Skips silently (with a warning) when no region can be resolved from the
+ * environment, and treats network/service errors as non-fatal — see the module
+ * doc for the rationale.
+ *
+ * @param command - The npm script name, used in the messages (e.g. `sandbox`, `deploy`).
  * @param probe - Credential probe; defaults to STS GetCallerIdentity. Override in tests.
- * @throws {Error} With actionable guidance when the probe rejects.
+ * @param env - Environment to resolve the region from. Defaults to `process.env`.
+ * @throws {Error} With actionable guidance when the probe reports a credential error.
  */
-export async function assertAwsCredentials(command: string, probe: CredentialProbe = stsProbe): Promise<void> {
+export async function assertAwsCredentials(
+	command: string,
+	probe: CredentialProbe = stsProbe,
+	env: NodeJS.ProcessEnv = process.env,
+): Promise<void> {
+	const region = resolveProbeRegion(env);
+	if (!region) {
+		console.warn(
+			`⚠️  Skipping the AWS credential pre-check for \`npm run ${command}\`: ` +
+				'no region set in AWS_REGION / AWS_DEFAULT_REGION. The deploy will surface any credential error itself.',
+		);
+		return;
+	}
+
 	try {
-		await probe();
+		await probe(region);
 	} catch (error) {
-		const detail = error instanceof Error ? error.message : String(error);
-		throw new Error(
-			`No valid AWS credentials found for \`npm run ${command}\`.\n` +
-				'Configure credentials before deploying — for example:\n' +
-				'  • run `aws configure` (or `aws sso login`), or\n' +
-				'  • set AWS_PROFILE to a configured profile, or\n' +
-				'  • export AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY (and AWS_SESSION_TOKEN for temporary credentials).\n' +
-				`Then re-run \`npm run ${command}\`.\n` +
-				`(underlying error: ${detail})`,
+		// Use the error *name* only — never the raw message, which for an STS
+		// authorization failure embeds the caller ARN and account id (and this
+		// Error propagates through telemetry).
+		const name = error instanceof Error && error.name ? error.name : 'UnknownError';
+
+		if (CREDENTIAL_ERROR_NAMES.has(name)) {
+			throw new Error(
+				`AWS credentials could not be verified for \`npm run ${command}\` (${name}).\n` +
+					'Configure AWS credentials — for example:\n' +
+					'  • run `aws configure` (or `aws sso login`), or\n' +
+					'  • set AWS_PROFILE to a configured profile, or\n' +
+					'  • export AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY (and AWS_SESSION_TOKEN for temporary credentials).\n' +
+					`Then re-run \`npm run ${command}\`.`,
+			);
+		}
+
+		// Not a credential problem (network, throttling, STS disabled in-region, …).
+		// Don't block a deploy that might still work — warn and continue.
+		console.warn(
+			`⚠️  Could not verify AWS credentials for \`npm run ${command}\` (${name}); ` +
+				'continuing — the deploy will report any real error.',
 		);
 	}
 }

--- a/packages/core/src/scripts/sandbox.ts
+++ b/packages/core/src/scripts/sandbox.ts
@@ -10,6 +10,7 @@ import { assertAwsCredentials } from './preflight-credentials.js';
 import { applyExternalMigrations } from './external-migrations-step.js';
 import { trackCommand } from '../telemetry/trackCommand.js';
 import { buildAndSendEvent } from '../telemetry/client.js';
+import { classifyError } from '../telemetry/trackCommand.js';
 import { getCdkTelemetryEnv } from './cdk-telemetry-env.js';
 import { runSync, spawnCommand } from './run-command.js';
 import { terminateProcessTree } from './process-tree.js';
@@ -130,8 +131,21 @@ export async function startSandbox(options: SandboxOptions) {
   process.env.BLOCKS_STAGE = 'sandbox';
 
   // Fail fast if AWS credentials are missing/expired, before spending ~10s in
-  // synth only to hit an opaque CDK credential error.
-  await assertAwsCredentials('sandbox');
+  // synth only to hit an opaque CDK credential error. Unlike deploy(), startSandbox
+  // isn't wrapped in trackCommand, so emit the FAIL event manually (mirroring the
+  // CDK-deploy failure path below) before rethrowing — otherwise a no-creds abort
+  // sends no telemetry.
+  try {
+    await assertAwsCredentials('sandbox');
+  } catch (error) {
+    buildAndSendEvent({
+      command: 'sandbox',
+      state: 'FAIL',
+      duration: Date.now() - sandboxStartTime,
+      error: classifyError(error),
+    });
+    throw error;
+  }
 
   // Provision connection string to SSM SecureString.
   // On first deploy, creates the parameter. On subsequent deploys, updates if changed.

--- a/packages/core/src/scripts/sandbox.ts
+++ b/packages/core/src/scripts/sandbox.ts
@@ -6,6 +6,7 @@ import { writeFileSync, mkdirSync, readFileSync } from "node:fs";
 import { join, resolve, dirname } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { ensureSecrets, loadEnvFile } from './ensure-secrets.js';
+import { assertAwsCredentials } from './preflight-credentials.js';
 import { applyExternalMigrations } from './external-migrations-step.js';
 import { trackCommand } from '../telemetry/trackCommand.js';
 import { buildAndSendEvent } from '../telemetry/client.js';
@@ -48,6 +49,10 @@ export async function startSandbox(options: SandboxOptions) {
   }
 
   process.env.BLOCKS_STAGE = 'sandbox';
+
+  // Fail fast if AWS credentials are missing/expired, before spending ~10s in
+  // synth only to hit an opaque CDK credential error.
+  await assertAwsCredentials('sandbox');
 
   // Provision connection string to SSM SecureString.
   // On first deploy, creates the parameter. On subsequent deploys, updates if changed.

--- a/packages/create-blocks-app/templates/auth-cognito/aws-blocks/scripts/sandbox.ts
+++ b/packages/create-blocks-app/templates/auth-cognito/aws-blocks/scripts/sandbox.ts
@@ -7,4 +7,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 startSandbox({
   backendPath: join(__dirname, '..', 'index.cdk.ts'),
   devCommand: 'npx tsx watch aws-blocks/scripts/server.ts',
+}).catch((error) => {
+  console.error(error);
+  process.exit(1);
 });

--- a/packages/create-blocks-app/templates/backend/aws-blocks/scripts/sandbox.ts
+++ b/packages/create-blocks-app/templates/backend/aws-blocks/scripts/sandbox.ts
@@ -6,4 +6,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 
 startSandbox({
   backendPath: join(__dirname, '..', 'index.cdk.ts')
+}).catch((error) => {
+  console.error(error);
+  process.exit(1);
 });

--- a/packages/create-blocks-app/templates/bare/aws-blocks/scripts/sandbox.ts
+++ b/packages/create-blocks-app/templates/bare/aws-blocks/scripts/sandbox.ts
@@ -7,4 +7,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 startSandbox({
   backendPath: join(__dirname, '..', 'index.cdk.ts'),
   devCommand: 'npx tsx watch aws-blocks/scripts/server.ts',
+}).catch((error) => {
+  console.error(error);
+  process.exit(1);
 });

--- a/packages/create-blocks-app/templates/default/aws-blocks/scripts/sandbox.ts
+++ b/packages/create-blocks-app/templates/default/aws-blocks/scripts/sandbox.ts
@@ -7,4 +7,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 startSandbox({
   backendPath: join(__dirname, '..', 'index.cdk.ts'),
   devCommand: 'npx tsx watch aws-blocks/scripts/server.ts',
+}).catch((error) => {
+  console.error(error);
+  process.exit(1);
 });

--- a/packages/create-blocks-app/templates/demo/aws-blocks/scripts/sandbox.ts
+++ b/packages/create-blocks-app/templates/demo/aws-blocks/scripts/sandbox.ts
@@ -7,4 +7,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 startSandbox({
   backendPath: join(__dirname, '..', 'index.cdk.ts'),
   devCommand: 'npx tsx watch aws-blocks/scripts/server.ts',
+}).catch((error) => {
+  console.error(error);
+  process.exit(1);
 });

--- a/packages/create-blocks-app/templates/nextjs/aws-blocks/scripts/sandbox.ts
+++ b/packages/create-blocks-app/templates/nextjs/aws-blocks/scripts/sandbox.ts
@@ -7,4 +7,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 startSandbox({
   backendPath: join(__dirname, '..', 'index.cdk.ts'),
   devCommand: 'npx tsx watch aws-blocks/scripts/server.ts',
+}).catch((error) => {
+  console.error(error);
+  process.exit(1);
 });

--- a/packages/create-blocks-app/templates/react/aws-blocks/scripts/sandbox.ts
+++ b/packages/create-blocks-app/templates/react/aws-blocks/scripts/sandbox.ts
@@ -6,4 +6,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 
 startSandbox({
   backendPath: join(__dirname, '..', 'index.cdk.ts')
+}).catch((error) => {
+  console.error(error);
+  process.exit(1);
 });


### PR DESCRIPTION
## What

`npm run sandbox` (`startSandbox`) and `npm run deploy` (`deploy`) spend ~10 seconds synthesizing the CDK app before making their first AWS call. When credentials are missing or expired, that surfaces only *after* the wasted synth — as an opaque CDK/CloudFormation error that never names the real cause.

This adds a fail-fast **STS `GetCallerIdentity`** pre-check at the very start of both commands. If credentials don't resolve, the command exits immediately with actionable guidance instead of burning the synth.

## Why

Board card: **`[Bug Bash] core: npm run sandbox has no credential pre-check (10s wasted on synth)`** (P3, DX). Verified against `main`: for the common DynamoDB template, `ensureSecrets` returns early with no AWS call, so the app does zero AWS work before `cdk deploy` — exactly the ~10s-wasted-then-opaque-error path the card describes.

## How

- New `packages/core/src/scripts/preflight-credentials.ts` — `assertAwsCredentials(command, probe?)`. The default probe calls STS `GetCallerIdentity` via the SDK's standard credential chain, dynamically imported (matching the existing `@aws-sdk/client-ssm` pattern in `ensure-secrets.ts`) so it's only loaded when a deploy actually runs. A region is always supplied (falling back to `us-east-1`) so the probe never fails for a *missing region* — `GetCallerIdentity` is identity-only, and region correctness is validated later by the deploy itself.
- The `probe` is injectable so the guard is unit-tested without network or real credentials.
- Wired into `startSandbox` and `deploy`, right after `BLOCKS_STAGE` is set and before any synth/secret work.
- Declared `@aws-sdk/client-sts` as a `@aws-blocks/core` dependency (it was already resolved transitively; sibling of the `client-s3`/`client-ssm` already used here).

### Error message

```
No valid AWS credentials found for `npm run sandbox`.
Configure credentials before deploying — for example:
  • run `aws configure` (or `aws sso login`), or
  • set AWS_PROFILE to a configured profile, or
  • export AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY (and AWS_SESSION_TOKEN for temporary credentials).
Then re-run `npm run sandbox`.
(underlying error: <cause>)
```

## Testing

- New `preflight-credentials.test.ts` (4 cases): silent pass on success; actionable throw naming the command; command-name interpolation (`deploy` vs `sandbox`); non-`Error` rejection handled.
- `npm run build`, full `@aws-blocks/core` suite (680 tests) ✅, `lint:deps` ✅, biome ✅, umbrella-changeset guard ✅.

## Changeset

`@aws-blocks/core` patch + `@aws-blocks/blocks` patch (umbrella re-exports `scripts`).