### PR TITLE
docs(bb-data): align infrastructure documentation with Data API implementation

### DIFF
--- a/packages/bb-data/DESIGN.md
+++ b/packages/bb-data/DESIGN.md
@@ -86,11 +86,11 @@ This enables PostgreSQL RLS policies to filter rows based on the authenticated u
 
 | Resource | Purpose |
 |----------|---------|
-| Aurora Serverless v2 cluster | PostgreSQL database |
-| VPC + private subnets | Network isolation |
-| RDS Proxy | Connection pooling |
-| Security group | Inbound 5432 from Lambda SG only |
+| Aurora Serverless v2 cluster | PostgreSQL database with the RDS Data API enabled |
+| VPC + isolated subnets | Network isolation for the database |
+| Security group | Allows PostgreSQL traffic from within the VPC |
 | Secrets Manager secret | Auto-generated credentials |
+| Runtime configuration | Cluster ARN, secret ARN, and database name for the application runtime |
 | Migration Lambda + CustomResource | Runs .sql files on deploy (retries with exponential backoff, 1s → 30s × 8, while the cluster is unreachable — a new cluster's writer coming up, or a scale-to-zero cluster resuming from auto-pause) |
 | IAM grants | `rds-data:*`, `secretsmanager:GetSecretValue` |
 
@@ -98,7 +98,7 @@ Removal policy: DESTROY in sandbox, RETAIN in production.
 
 ## Schema Migrations (External Databases)
 
-The Aurora path above runs `.sql` migrations from an **in-VPC Lambda CustomResource** (Aurora is unreachable from the deploy host). **External** connection-string databases (managed PostgreSQL, via `fromExisting()`) are publicly reachable, so their migrations run **host-side** as a pre-`cdk deploy` lifecycle step — reusing the same engine-agnostic `runMigrations` + `PgClientEngine` (no new runner). Code: `src/migrations/external-migrations.ts`, `src/migrations/baseline.ts`, and the lifecycle step in `@aws-blocks/core` (`scripts/external-migrations-step.ts`).
+The Aurora path above runs `.sql` migrations from a Lambda-backed CustomResource through the RDS Data API. **External** connection-string databases (managed PostgreSQL, via `fromExisting()`) run migrations **host-side** as a pre-`cdk deploy` lifecycle step — reusing the same engine-agnostic `runMigrations` + `PgClientEngine` (no new runner). Code: `src/migrations/external-migrations.ts`, `src/migrations/baseline.ts`, and the lifecycle step in `@aws-blocks/core` (`scripts/external-migrations-step.ts`).
 
 - **Where it runs:** `npm run dev` applies pending `./migrations` to the dev DB (and refreshes generated types); `npm run sandbox` / `npm run deploy` apply to the sandbox / production DB before `cdk deploy`. `core` invokes the `bb-data` CLI as a **subprocess** (core must not depend on bb-data — the dependency runs the other way); the connection string is passed via the `BLOCKS_MIGRATE_URL` env var, never argv.
 - **Session port:** the runner rewrites the stored runtime string to the **5432 session port** (`toSessionPortUrl`) — DDL, multi-statement file transactions, and a session-held advisory lock all need a stable session, which the 6543 transaction pooler doesn't guarantee.
@@ -113,11 +113,10 @@ The Aurora path above runs `.sql` migrations from an **in-VPC Lambda CustomResou
 
 | Behavior Difference | Impact | Mitigation |
 |------------|--------|------------|
-| No connection pooling | Connection exhaustion only surfaces in AWS | Sandbox testing |
+| No RDS Data API behavior | Data API limits and service errors only surface in AWS | Sandbox testing |
 | No VPC isolation | Network access control not enforced locally | Infrastructure concern |
 | PGlite is single-connection | No concurrent transaction behavior | Document; load test in sandbox |
 | No cold start penalty | Aurora 0-ACU cold start not simulated | Latency is a production concern |
-| No RDS Proxy behavior | Connection pinning, failover not simulated | Transparent to app code |
 | TLS cert verification default (`fromExisting` connection string) | Mock defaults to `rejectUnauthorized: false` (local/self-signed DBs); AWS runtime defaults to verifying (`PgClientEngine` → `rejectUnauthorized: true`) | Intentional. Pass `ssl` to override either layer; the `db pull`-generated wiring sets `ssl: resolveDbSsl()` for both, so the generated path is consistent. A hand-written `fromExisting({ connectionString })` with no `ssl` passes locally but verifies in AWS (pin a provider CA via `ssl.ca`). The mock warns once when `ssl` is omitted so this dev/prod gap surfaces locally. |
 | External migration *apply* | n/a — build/deploy lifecycle step, not a runtime method | No mock needed (intentional; see Schema Migrations above) |
 

--- a/packages/bb-data/INFRA.md
+++ b/packages/bb-data/INFRA.md
@@ -1,52 +1,37 @@
-# bb-data Infrastructure Roadmap
+# bb-data Infrastructure
 
-## Current State
+## Current Architecture
 
-Local development uses PGlite (WASM Postgres) - no cloud infrastructure needed.
+`Database` uses different engines for local development and deployed workloads:
 
-## Production Requirements
+- **Local development:** PGlite (WASM PostgreSQL) persists data under `.bb-data/`; no AWS resources are required.
+- **AWS-provisioned database:** `Database` provisions Aurora Serverless v2 and accesses it through the RDS Data API.
+- **Existing database:** `Database.fromExisting({ connectionString })` uses the PostgreSQL client engine for a database the application already owns, such as Supabase or Neon.
 
-To deploy to AWS, the following infrastructure is needed:
+The AWS-provisioned path is the default when no `connection` option is supplied.
 
-### Option A: Data API (Simpler)
+## AWS-Provisioned Database
 
-**Pros:** No VPC for Lambda, no connection pooling concerns
-**Cons:** Higher latency (~50-100ms), no LISTEN/NOTIFY support
+The CDK layer creates:
 
-Infrastructure:
-- Aurora Serverless v2 PostgreSQL with Data API enabled
-- Secrets Manager for credentials
-- Isolated VPC subnets (no NAT needed)
+- Aurora Serverless v2 PostgreSQL with the RDS Data API enabled
+- an isolated VPC and security group for the cluster
+- a Secrets Manager secret for database credentials
+- runtime configuration for the cluster ARN, secret ARN, and database name
+- IAM permissions for the application execution role to use the Data API and read the generated secret
 
-Runtime:
-- `@aws-sdk/client-rds-data` based Kysely dialect
-- Env vars: `BLOCKS_DATA_CLUSTER_ARN`, `BLOCKS_DATA_SECRET_ARN`, `BLOCKS_DATA_DATABASE`
+The application Lambda does not open a PostgreSQL connection to the cluster and this construct does not create an RDS Proxy. The RDS Data API manages request access to Aurora without placing the application Lambda in the database VPC.
 
-### Option B: Direct Connection (Recommended for Realtime)
+## Migrations
 
-**Pros:** Lower latency, supports LISTEN/NOTIFY for realtime
-**Cons:** More complex infra, VPC costs
+When `migrationsPath` is configured, the CDK layer adds a Lambda-backed CloudFormation custom resource. It packages the SQL migration files, runs pending migrations during deploy, and records applied files in the `_migrations` table. The custom resource waits for the Aurora writer instance before it runs.
 
-Infrastructure:
-- Aurora Serverless v2 PostgreSQL
-- RDS Proxy (connection pooling for Lambda)
-- VPC with NAT gateway or VPC endpoints
-- Secrets Manager for credentials
-- Lambda configured in VPC
+In local development, migrations run against PGlite before the first query. See [README.md](./README.md#migrations) for the migration workflow.
 
-Runtime:
-- `pg` driver based Kysely dialect
-- Connection string from Secrets Manager
+## Existing PostgreSQL Databases
 
-## Implementation Tasks
+`fromExisting({ connectionString })` is for a database managed outside this Building Block. The runtime uses the PostgreSQL client engine and the application owner remains responsible for network access, connection pooling or proxying, and the database lifecycle. TLS verification is enabled by default; see [README.md](./README.md#tls-certificate-verification) for the required CA configuration.
 
-1. [ ] Create production Kysely dialect (Data API or pg driver)
-2. [ ] Add environment detection (local vs Lambda)
-3. [ ] Implement `materialize()` in infra.ts
-4. [ ] Add `grantAccess()` helper for Lambda permissions
-5. [ ] Migration runner for production (currently local-only)
-6. [ ] Connection pooling strategy
+## Future Work
 
-## Decision: Data API vs Direct
-
-For future realtime support (LISTEN/NOTIFY), **direct connection with RDS Proxy** is recommended. Data API is acceptable for simpler use cases without realtime needs.
+The block does not currently provision a managed direct-connection architecture such as an RDS Proxy, VPC-connected application Lambda, or `LISTEN`/`NOTIFY` support. Those would be separate capabilities from the existing Aurora Data API path.

--- a/packages/bb-data/README.md
+++ b/packages/bb-data/README.md
@@ -235,12 +235,14 @@ try {
 
 ## What It Provisions (AWS)
 
-- **Aurora Serverless v2** — PostgreSQL-compatible, scales 0.5-128 ACUs
-- **VPC** — Private subnets (isolated, no NAT)
-- **RDS Proxy** — Connection pooling
-- **Secrets Manager** — Auto-generated credentials, auto-rotated
-- **Migration Lambda** — Runs `.sql` files on deploy via CustomResource
-- **IAM** — `rds-data:*` and `secretsmanager:GetSecretValue` granted to the app Lambda
+- **Aurora Serverless v2** — PostgreSQL-compatible, with the RDS Data API enabled
+- **VPC** — Isolated subnets for the database (no NAT)
+- **Secrets Manager** — Auto-generated database credentials
+- **Runtime configuration** — Cluster ARN, secret ARN, and database name loaded by the application runtime
+- **Migration Lambda** — Runs `.sql` files on deploy via a CustomResource when `migrationsPath` is set
+- **IAM** — RDS Data API actions and `secretsmanager:GetSecretValue` granted to the application execution role
+
+The application Lambda accesses an AWS-provisioned database through the RDS Data API. `Database` does not provision an RDS Proxy or place the application Lambda in the database VPC. For an existing PostgreSQL database, `fromExisting()` uses a direct PostgreSQL client connection; network access and connection pooling remain the application's responsibility.
 
 ## Local Development
 
@@ -279,10 +281,9 @@ interface DatabaseOptions {
 
 ## Performance
 
-- **Query latency:** 10-50ms (warm), ~500ms cold start from 0 ACUs
-- **Throughput:** Thousands of concurrent connections via RDS Proxy
+- **Connection management:** AWS-provisioned databases use the RDS Data API; the application Lambda does not maintain direct database connections
+- **Cold starts:** Aurora can require time to resume from zero ACUs
 - **Storage:** Up to 128 TiB, auto-scales in 10 GiB increments
 - **Cost:** ~$0.12/ACU-hour + ~$0.10/GB-month storage
 - **Durability:** 6 copies across 3 AZs, 99.99% availability
-
 


### PR DESCRIPTION
## Problem

The `bb-data` infrastructure documentation still describes an unimplemented roadmap and states that the block provisions an RDS Proxy, places the application Lambda in the database VPC, and runs Aurora migrations from an in-VPC Lambda. The current implementation instead provisions Aurora Serverless v2 with the RDS Data API, uses runtime configuration for the application Lambda, and runs migrations through a Lambda-backed CustomResource.

**Issue #, if available:** N/A

## Changes

- Document the current local, AWS-provisioned, and existing-database runtime paths in `INFRA.md`.
- Correct the README and design documentation to describe the RDS Data API path rather than an RDS Proxy deployment.
- Clarify migration behavior, IAM/configuration wiring, and the boundary for externally managed PostgreSQL connections.
- Preserve managed direct connection infrastructure as future work rather than describing it as available.

## Validation

- Ran `npx --yes markdown-link-check packages/bb-data/INFRA.md`.
- Ran `npx --yes markdown-link-check packages/bb-data/README.md`.
- Ran `npx --yes markdown-link-check packages/bb-data/DESIGN.md`.
- Ran `git diff --check`.
- Reviewed the documented behavior against `src/infra.ts` and `src/index.aws.ts`.

No automated tests were added because this is a documentation-only correction. No changeset is needed because no published package behavior changes.

## Checklist

- [x] PR description included
- [ ] Tests are changed or added
- [x] Relevant documentation is changed or added (and PR referenced)

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._