### PR TITLE
fix(bb-data): honor CDK projectRoot in db pull wiring

### DIFF
--- a/.changeset/db-pull-project-root-context.md
+++ b/.changeset/db-pull-project-root-context.md
@@ -1,0 +1,5 @@
+---
+"@aws-blocks/bb-data": patch
+---
+
+Make `db pull`-generated database wiring honor CDK's `projectRoot` context when resolving the stack-scoped production connection parameter. This keeps direct CDK invocations from another working directory aligned with the standard Blocks deploy scripts.

--- a/packages/bb-data/src/db-pull.test.ts
+++ b/packages/bb-data/src/db-pull.test.ts
@@ -137,9 +137,12 @@ describe('generateIndexFile', () => {
     assert.ok(output.includes("Auth not configured"));
   });
 
-  test('includes stack-scoped AppSetting name (ref-independent)', () => {
+  test('includes stack-scoped AppSetting name using the CDK project root', () => {
     assert.ok(output.includes("if (!dbParameterName && process.env.BLOCKS_STAGE)"));
-    assert.ok(output.includes("dbConnectionParameterName(getStackName({ sandbox: process.env.BLOCKS_STAGE !== 'production' }))"));
+    assert.ok(output.includes("tryGetContext('projectRoot')"));
+    assert.ok(output.includes("projectRoot: typeof projectRoot === 'string' ? projectRoot : undefined"));
+    assert.ok(output.includes('dbConnectionParameterName(getStackName({'));
+    assert.ok(output.includes("sandbox: process.env.BLOCKS_STAGE !== 'production'"));
     assert.ok(output.includes("from '@aws-blocks/core/db-naming'"));
     assert.ok(output.includes("import { getStackName } from '@aws-blocks/core/scripts'"));
   });

--- a/packages/bb-data/src/db-pull/generate.ts
+++ b/packages/bb-data/src/db-pull/generate.ts
@@ -167,8 +167,8 @@ export function generateIndexFile(tables: TableInfo[], opts: { projectRef?: stri
   const rlsLine = hasRls ? `  rlsPolicy: 'enforce',\n` : '';
 
   // Parameter name resolution differs by phase:
-  //  - At deploy/synth, BLOCKS_STAGE is set and process.cwd() is the project root
-  //    (cdk runs there), so compute the stack-scoped name
+  //  - At deploy/synth, BLOCKS_STAGE is set; use the CDK project's root context
+  //    when present (falling back to process.cwd()) to compute the stack-scoped name
   //    (/<stackName>-db-url) from the committed .blocks/config.json — the SAME
   //    `getStackName` + `dbConnectionParameterName` the deploy script's
   //    `ensureSecrets` uses to WRITE the value, so written name == read name. The
@@ -181,17 +181,19 @@ export function generateIndexFile(tables: TableInfo[], opts: { projectRef?: stri
   //    already stamped — loadConfigToProcessEnv() places BLOCKS_SSM_PARAM_DB_URL
   //    in process.env before this module imports, so the ?? fallback never runs
   //    at runtime.
-  // TODO: Thread `projectRoot` CDK context into the generated wiring instead
-  // of relying on process.cwd(). Currently works only because deploy orchestrators
-  // set cwd === --context projectRoot. Direct `cdk` invocation from another dir
-  // with --context projectRoot=X would diverge stack name vs db param name.
   const paramBlock =
     `// At Lambda runtime, the parameter name is stamped by CDK into process.env.\n` +
     `// At synth/deploy, BLOCKS_STAGE is set and we compute it from committed config.\n` +
     `// At local dev, neither is set — the mock reads from .env.local, so the name is unused.\n` +
     `let dbParameterName = process.env.BLOCKS_SSM_PARAM_DB_URL;\n` +
     `if (!dbParameterName && process.env.BLOCKS_STAGE) {\n` +
-    `  dbParameterName = dbConnectionParameterName(getStackName({ sandbox: process.env.BLOCKS_STAGE !== 'production' }));\n` +
+    `  const projectRoot = (scope as unknown as {\n` +
+    `    node?: { tryGetContext(key: string): unknown };\n` +
+    `  }).node?.tryGetContext('projectRoot');\n` +
+    `  dbParameterName = dbConnectionParameterName(getStackName({\n` +
+    `    sandbox: process.env.BLOCKS_STAGE !== 'production',\n` +
+    `    projectRoot: typeof projectRoot === 'string' ? projectRoot : undefined,\n` +
+    `  }));\n` +
     `}\n` +
     `const dbUrl = AppSetting.fromExisting(scope, 'db-url', { name: dbParameterName ?? 'local', secret: true });\n\n`;
 

--- a/test-apps/db-pull-typecheck/generated/index.ts
+++ b/test-apps/db-pull-typecheck/generated/index.ts
@@ -15,7 +15,13 @@ const scope = new Scope('supabase');
 // At local dev, neither is set — the mock reads from .env.local, so the name is unused.
 let dbParameterName = process.env.BLOCKS_SSM_PARAM_DB_URL;
 if (!dbParameterName && process.env.BLOCKS_STAGE) {
-  dbParameterName = dbConnectionParameterName(getStackName({ sandbox: process.env.BLOCKS_STAGE !== 'production' }));
+  const projectRoot = (scope as unknown as {
+    node?: { tryGetContext(key: string): unknown };
+  }).node?.tryGetContext('projectRoot');
+  dbParameterName = dbConnectionParameterName(getStackName({
+    sandbox: process.env.BLOCKS_STAGE !== 'production',
+    projectRoot: typeof projectRoot === 'string' ? projectRoot : undefined,
+  }));
 }
 const dbUrl = AppSetting.fromExisting(scope, 'db-url', { name: dbParameterName ?? 'local', secret: true });
 


### PR DESCRIPTION
## Problem

**Issue #, if available:**

The `db pull`-generated `aws-blocks/supabase.ts` derives its stack-scoped SSM parameter name with `getStackName()` but does not pass CDK's `projectRoot` context. Standard Blocks scripts happen to run CDK from the project root, but a direct CDK invocation from another working directory with `--context projectRoot=/path/to/app` reads `.blocks/config.json` from the wrong directory. That can derive a different stack name from the one `ensureSecrets` used when it wrote the connection parameter.

## Changes

- Read `projectRoot` from the generated scope's CDK context during synth/deploy and pass it to `getStackName()`.
- Preserve the existing `process.cwd()` fallback when no context is supplied.
- Add generator regression assertions and refresh the checked-in generated wiring snapshot.
- Add a patch changeset for `@aws-blocks/bb-data`.

## Validation

- `npm run build`
- `npm test --workspace @aws-blocks/bb-data` (369 passed, 4 external-Supabase suites skipped)
- `npm run lint:deps`
- `npm run check:exports-consistency`
- `git diff --check`

## Checklist

- [x] PR description included
- [x] Tests are changed or added
- [ ] Relevant documentation is changed or added (not needed: generated deployment wiring behavior only)

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._