### PR TITLE
fix(bb-knowledge-base): honor aborted signals in mock

### DIFF
--- a/.changeset/knowledge-base-mock-abort-signal.md
+++ b/.changeset/knowledge-base-mock-abort-signal.md
@@ -1,0 +1,5 @@
+---
+"@aws-blocks/bb-knowledge-base": patch
+---
+
+Make the local `waitUntilSynced()` mock reject with an already-aborted `AbortSignal`, matching the AWS runtime cancellation contract.

--- a/packages/bb-knowledge-base/src/index.mock.test.ts
+++ b/packages/bb-knowledge-base/src/index.mock.test.ts
@@ -1036,7 +1036,7 @@ describe('unicode / multilingual retrieval', () => {
 //
 // The local corpus loads synchronously on first retrieve(), so there is no
 // asynchronous ingestion window — isSynced() is always true and
-// waitUntilSynced() resolves immediately (options are ignored).
+// waitUntilSynced() resolves immediately (except for an already-aborted signal).
 
 describe('sync', () => {
 	test('isSynced() resolves true immediately', async () => {
@@ -1054,9 +1054,21 @@ describe('sync', () => {
 		assert.strictEqual(await kb.isSynced(), true);
 	});
 
-	test('waitUntilSynced() ignores options and resolves immediately', async () => {
+	test('waitUntilSynced() ignores timing options and resolves immediately', async () => {
 		const kb = new KnowledgeBase({ id: 'test' }, 'waitopts', { source: 'test-knowledge-tmp' });
 		await kb.waitUntilSynced({ timeoutMs: 1, pollIntervalMs: 1 });
+	});
+
+	test('waitUntilSynced() rejects with an already-aborted signal reason', async () => {
+		const kb = new KnowledgeBase({ id: 'test' }, 'waitabort', { source: 'test-knowledge-tmp' });
+		const controller = new AbortController();
+		const reason = new Error('request cancelled');
+		controller.abort(reason);
+
+		await assert.rejects(
+			() => kb.waitUntilSynced({ signal: controller.signal }),
+			(err: unknown) => err === reason,
+		);
 	});
 });
 

--- a/packages/bb-knowledge-base/src/index.mock.ts
+++ b/packages/bb-knowledge-base/src/index.mock.ts
@@ -271,12 +271,14 @@ export class KnowledgeBase extends Scope {
 	 * Resolve once the knowledge base is synced with your latest data.
 	 *
 	 * Local development has no asynchronous ingestion window (see {@link isSynced}),
-	 * so this resolves immediately. The options are accepted for API parity
-	 * with the AWS runtime and are otherwise ignored locally.
+	 * so this resolves immediately. Timing options are ignored locally, but an
+	 * already-aborted signal still rejects to preserve the cancellation contract
+	 * shared with the AWS runtime.
 	 *
-	 * @param {WaitUntilSyncedOptions} _options - Accepted for API parity; ignored in local development.
+	 * @param {WaitUntilSyncedOptions} options - Timing options are ignored locally; an aborted signal rejects.
 	 */
-	async waitUntilSynced(_options?: WaitUntilSyncedOptions): Promise<void> {
+	async waitUntilSynced(options?: WaitUntilSyncedOptions): Promise<void> {
+		options?.signal?.throwIfAborted();
 		// No-op: the local corpus loads synchronously, so there is nothing to wait for.
 	}
 


### PR DESCRIPTION
## Problem

The local KnowledgeBase mock documented waitUntilSynced(options?) as API-compatible with the AWS runtime, but it ignored AbortSignal entirely. A caller that passed an already-aborted signal therefore observed a successful local call while the AWS runtime rejected before polling.

**Issue #, if available:** None found.

## Changes

- Make the local mock call signal.throwIfAborted() before its synchronous no-op completion.
- Keep the mock immediate for non-aborted signals and continue to ignore timing-only options.
- Add a regression test that asserts the original abort reason is preserved.
- Add a patch changeset for @aws-blocks/bb-knowledge-base.

## Validation

- npm run build
- npm test --workspace @aws-blocks/bb-knowledge-base (131 passing)
- npm run lint:deps
- npm run check:exports-consistency
- npx biome lint packages/bb-knowledge-base/src/index.mock.ts packages/bb-knowledge-base/src/index.mock.test.ts
- git diff --check

## Checklist

- [x] PR description included
- [x] Tests are changed or added
- [x] Relevant documentation is changed or added (the mock method JSDoc now documents the cancellation behavior)

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._