### PR TITLE
fix(bb-distributed-table): validate query and scan limits

### DIFF
--- a/.changeset/distributed-table-limit-validation.md
+++ b/.changeset/distributed-table-limit-validation.md
@@ -1,0 +1,5 @@
+---
+"@aws-blocks/bb-distributed-table": patch
+---
+
+Reject invalid `query` and `scan` limits consistently before either the local mock or DynamoDB runtime reads data.

--- a/packages/bb-distributed-table/README.md
+++ b/packages/bb-distributed-table/README.md
@@ -108,7 +108,7 @@ for await (const order of orders.query({
 |-------|------|----------|-------------|
 | `index` | `keyof Indexes` | No | GSI to query. Omit to query the primary key. |
 | `where` | `KeyCondition<T, K>` | Yes | Key conditions. Partition key requires `{ equals }`. Sort key supports `equals`, `greaterThan`, `lessThan`, `between`, `beginsWith`, etc. |
-| `limit` | `number` | No | Maximum number of items to return. |
+| `limit` | `number` | No | Maximum number of items to return. Must be a positive integer. |
 | `order` | `'asc' \| 'desc'` | No | Sort direction on the sort key. Defaults to `'asc'`. |
 
 ### Conditional Operations
@@ -180,7 +180,7 @@ Errors thrown by DistributedTable carry an `error.name` you can match with `isBl
 |----------|--------------|-------------|
 | `DistributedTableErrors.ConditionalCheckFailed` | `ConditionalCheckFailedException` | An `ifNotExists` / `ifExists` / `ifFieldEquals` condition failed. |
 | `DistributedTableErrors.ValidationFailed` | `ValidationFailedException` | An item failed the configured `schema` validation on `put()` / `putBatch()`. |
-| `DistributedTableErrors.InvalidQuery` | `InvalidQueryException` | The query/condition shape is wrong: missing `where`, partition key not given as `{ equals }`, unknown index, multiple sort-key conditions, or an empty `ifFieldEquals`. A caller bug. |
+| `DistributedTableErrors.InvalidQuery` | `InvalidQueryException` | The request/condition shape is wrong: missing `where`, partition key not given as `{ equals }`, unknown index, multiple sort-key conditions, an invalid `limit`, or an empty `ifFieldEquals`. A caller bug. |
 | `DistributedTableErrors.ItemTooLarge` | `ItemTooLargeException` | A `put`/`putBatch` item exceeds DynamoDB's 400 KB per-item size limit. |
 | `DistributedTableErrors.BatchIncomplete` | `BatchIncompleteException` | A batch op left entries unprocessed after the retry budget (sustained throttling). AWS runtime only. |
 
@@ -382,6 +382,3 @@ const events = new DistributedTable(scope, 'events', {
 ## Local Development
 
 Mock data persists to disk at `.bb-data/{fullId}/` across dev server restarts. Wipe with `rm -rf .bb-data`. The mock validates the 400 KB item size limit, schema validation, and conditional check failures, matching AWS behavior. Index queries are implemented via in-memory filtering — correctness is preserved but performance characteristics differ from DynamoDB.
-
-
-

--- a/packages/bb-distributed-table/src/errors.ts
+++ b/packages/bb-distributed-table/src/errors.ts
@@ -50,10 +50,11 @@ export const DistributedTableErrors = {
 	ConditionalCheckFailed: 'ConditionalCheckFailedException',
 	ValidationFailed: 'ValidationFailedException',
 	/**
-	 * The query or condition shape is invalid and was rejected before reaching
+	 * The request or condition shape is invalid and was rejected before reaching
 	 * DynamoDB: a missing `where` clause, a partition key not given as
-	 * `{ equals: value }`, an unknown index, more than one sort-key condition, or
-	 * an empty `ifFieldEquals`. These are all caller bugs — something the caller
+	 * `{ equals: value }`, an unknown index, more than one sort-key condition, an
+	 * empty `ifFieldEquals`, or a non-positive/non-integer `limit`. These are all
+	 * caller bugs — something the caller
 	 * can fix by correcting the call. Catchable via
 	 * `isBlocksError(e, DistributedTableErrors.InvalidQuery)`.
 	 *
@@ -142,6 +143,8 @@ export const DistributedTableMessages = {
 	multipleSortKeyConditions: (conditionKeys: string[]) =>
 		`Only one sort key condition is allowed per query (DynamoDB limitation). ` +
 		`Got: ${conditionKeys.join(', ')}. Use "between" for range queries.`,
+	invalidLimit: (limit: unknown) =>
+		`limit must be a positive integer (>= 1); received ${String(limit)}`,
 	emptyIfFieldEquals: 'ifFieldEquals must contain at least one field with a non-undefined value',
 	itemTooLarge: (bytes: number) =>
 		`Item size has exceeded the maximum allowed size of 400 KB (got ${bytes} bytes)`,
@@ -149,6 +152,19 @@ export const DistributedTableMessages = {
 		`${operation} did not complete: ${remaining} entr${remaining === 1 ? 'y' : 'ies'} still unprocessed ` +
 		`after ${attempts} attempts (DynamoDB throttling or response-size limits). Retry with backoff.`,
 } as const;
+
+/**
+ * Validate a DynamoDB request limit before either runtime starts yielding
+ * items. A truthiness guard in the local mock would otherwise treat zero or
+ * NaN as an unlimited query, while DynamoDB rejects them.
+ */
+export function validateLimit(limit: number | undefined): number | undefined {
+	if (limit === undefined) return undefined;
+	if (!Number.isInteger(limit) || limit < 1) {
+		throw blocksError(DistributedTableErrors.InvalidQuery, DistributedTableMessages.invalidLimit(limit));
+	}
+	return limit;
+}
 
 /**
  * @internal Re-map DynamoDB's generic `ValidationException` to the intent-revealing

--- a/packages/bb-distributed-table/src/index.aws.ts
+++ b/packages/bb-distributed-table/src/index.aws.ts
@@ -47,7 +47,7 @@ import type {
 	TableKey,
 	ReadValidationMode,
 } from './types.js';
-import { DistributedTableErrors, DistributedTableMessages, blocksError, normalizeSortKeyCondition, remapItemTooLarge, applyReadValidation } from './errors.js';
+import { DistributedTableErrors, DistributedTableMessages, blocksError, normalizeSortKeyCondition, remapItemTooLarge, applyReadValidation, validateLimit } from './errors.js';
 import type { KeyCondition, QueryOptions } from './types.js';
 import { Logger } from '@aws-blocks/bb-logger';
 import type { ChildLogger } from '@aws-blocks/bb-logger';
@@ -158,6 +158,7 @@ export class DistributedTable<
 	async *query(
 		options: QueryOptions<T, K, Indexes>,
 	): AsyncIterable<T> {
+		const limit = validateLimit(options.limit);
 		const indexConfig = options.index ? this.indexes[options.index as keyof Indexes] : this.keyConfig;
 		if (!indexConfig) throw blocksError(DistributedTableErrors.InvalidQuery, DistributedTableMessages.indexNotFound(options.index));
 
@@ -183,12 +184,12 @@ export class DistributedTable<
 		let count = 0;
 
 		do {
-			const command = this.buildQueryCommand(options.index, pkField, pkValue, skField, skCondition, lastEvaluatedKey, options);
+			const command = this.buildQueryCommand(options.index, pkField, pkValue, skField, skCondition, lastEvaluatedKey, { limit, order: options.order });
 			const result = await this.docClient.send(command);
 
 			for (const item of result.Items ?? []) {
 				yield (await this.reconcileRead(item as T)) as T;
-				if (options.limit && ++count >= options.limit) return;
+				if (limit !== undefined && ++count >= limit) return;
 			}
 
 			lastEvaluatedKey = result.LastEvaluatedKey;
@@ -196,6 +197,7 @@ export class DistributedTable<
 	}
 
 	async *scan(options?: ScanOptions): AsyncIterable<T> {
+		const limit = validateLimit(options?.limit);
 		let lastEvaluatedKey: Record<string, any> | undefined;
 		let count = 0;
 
@@ -203,12 +205,12 @@ export class DistributedTable<
 			const result = await this.docClient.send(new ScanCommand({
 				TableName: getSdkIdentifiers(this).tableName,
 				ExclusiveStartKey: lastEvaluatedKey,
-				Limit: options?.limit,
+				Limit: limit,
 			}));
 
 			for (const item of result.Items ?? []) {
 				yield (await this.reconcileRead(item as T)) as T;
-				if (options?.limit && ++count >= options.limit) return;
+				if (limit !== undefined && ++count >= limit) return;
 			}
 
 			lastEvaluatedKey = result.LastEvaluatedKey;
@@ -422,4 +424,3 @@ export class DistributedTable<
 }
 
 // ── Query input helper type ─────────────────────────────────────────────────
-

--- a/packages/bb-distributed-table/src/index.mock.ts
+++ b/packages/bb-distributed-table/src/index.mock.ts
@@ -38,7 +38,7 @@ import type {
 	TableKey,
 	ReadValidationMode,
 } from './types.js';
-import { DistributedTableErrors, DistributedTableMessages, blocksError, normalizeSortKeyCondition, applyReadValidation } from './errors.js';
+import { DistributedTableErrors, DistributedTableMessages, blocksError, normalizeSortKeyCondition, applyReadValidation, validateLimit } from './errors.js';
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -226,6 +226,7 @@ export class DistributedTable<
 	async *query(
 		options: QueryOptions<T, K, Indexes>,
 	): AsyncIterable<T> {
+		const limit = validateLimit(options.limit);
 		const indexConfig = options.index ? this.indexes[options.index as keyof Indexes] : this.keyConfig;
 		if (!indexConfig) throw blocksError(DistributedTableErrors.InvalidQuery, DistributedTableMessages.indexNotFound(options.index));
 
@@ -273,15 +274,16 @@ export class DistributedTable<
 		let count = 0;
 		for (const item of items) {
 			yield (await this.reconcileRead(item)) as T;
-			if (options.limit && ++count >= options.limit) return;
+			if (limit !== undefined && ++count >= limit) return;
 		}
 	}
 
 	async *scan(options?: ScanOptions): AsyncIterable<T> {
+		const limit = validateLimit(options?.limit);
 		let count = 0;
 		for (const item of this.data.values()) {
 			yield (await this.reconcileRead(item)) as T;
-			if (options?.limit && ++count >= options.limit) return;
+			if (limit !== undefined && ++count >= limit) return;
 		}
 	}
 
@@ -385,4 +387,3 @@ export class DistributedTable<
 import type { PartitionKeyCondition, SortKeyCondition as SKC, KeyCondition, QueryOptions } from './types.js';
 import { Logger } from '@aws-blocks/bb-logger';
 import type { ChildLogger } from '@aws-blocks/bb-logger';
-

--- a/packages/bb-distributed-table/src/index.test.ts
+++ b/packages/bb-distributed-table/src/index.test.ts
@@ -523,6 +523,18 @@ describe('DistributedTable', () => {
 			assert.deepEqual(items.map(i => i.createdAt), [1000, 2000]);
 		});
 
+		test('rejects non-positive and non-integer limits before returning data', async () => {
+			const table = numTable();
+			await seedNumeric(table);
+
+			for (const limit of [0, -1, 1.5, Number.NaN, Number.POSITIVE_INFINITY]) {
+				await assert.rejects(
+					collect(table.query({ index: 'byUser', where: { userId: { equals: 'u1' } }, limit })),
+					(err: Error) => err.name === DistributedTableErrors.InvalidQuery,
+				);
+			}
+		});
+
 		test('filter + limit combined', async () => {
 			const table = numTable();
 			await seedNumeric(table);
@@ -711,6 +723,21 @@ describe('DistributedTable', () => {
 			await table.put({ userId: 'u2', email: 'b@b.com', name: 'B', createdAt: 2000 });
 			await table.put({ userId: 'u3', email: 'c@b.com', name: 'C', createdAt: 3000 });
 			assert.equal((await collect(table.scan({ limit: 2 }))).length, 2);
+		});
+
+		test('rejects non-positive and non-integer limits before scanning data', async () => {
+			const table = new DistributedTable(testScope(), 'users', {
+				schema: userSchema,
+				key: { partitionKey: 'userId', sortKey: 'createdAt' },
+			});
+			await table.put({ userId: 'u1', email: 'a@b.com', name: 'A', createdAt: 1000 });
+
+			for (const limit of [0, -1, 1.5, Number.NaN, Number.POSITIVE_INFINITY]) {
+				await assert.rejects(
+					collect(table.scan({ limit })),
+					(err: Error) => err.name === DistributedTableErrors.InvalidQuery,
+				);
+			}
 		});
 
 		test('empty table returns nothing', async () => {

--- a/packages/bb-distributed-table/src/parity.test.ts
+++ b/packages/bb-distributed-table/src/parity.test.ts
@@ -673,6 +673,44 @@ describe('AWS query rejects multiple sort key conditions before issuing a Dynamo
 	});
 });
 
+describe('query and scan reject invalid limits before issuing DynamoDB commands', () => {
+	const schema = z.object({ pk: z.string(), sk: z.number(), data: z.string() });
+	const options = { schema, key: { partitionKey: 'pk', sortKey: 'sk' } };
+	const invalidLimits = [0, -1, 1.5, Number.NaN, Number.POSITIVE_INFINITY];
+
+	test('query rejects every invalid limit before sending a QueryCommand', async () => {
+		let sendCount = 0;
+		const table = awsTableWithFakeClient('aws-invalid-query-limit', options, async () => {
+			sendCount++;
+			return { Items: [] };
+		});
+
+		for (const limit of invalidLimits) {
+			await assert.rejects(
+				() => collect(table.query({ where: { pk: { equals: 'a' } }, limit })),
+				(err: unknown) => isBlocksError(err, DistributedTableErrors.InvalidQuery),
+			);
+		}
+		assert.strictEqual(sendCount, 0, 'must reject invalid limits before sending a query to DynamoDB');
+	});
+
+	test('scan rejects every invalid limit before sending a ScanCommand', async () => {
+		let sendCount = 0;
+		const table = awsTableWithFakeClient('aws-invalid-scan-limit', options, async () => {
+			sendCount++;
+			return { Items: [] };
+		});
+
+		for (const limit of invalidLimits) {
+			await assert.rejects(
+				() => collect(table.scan({ limit })),
+				(err: unknown) => isBlocksError(err, DistributedTableErrors.InvalidQuery),
+			);
+		}
+		assert.strictEqual(sendCount, 0, 'must reject invalid limits before scanning DynamoDB');
+	});
+});
+
 describe('the 400 KB item-size overflow is a distinct ItemTooLarge error, not the generic InvalidQuery bucket', () => {
 	// R2: the size overflow is a runtime data condition (the item may be too big for
 	// reasons outside the caller's control), so it must be catchable separately from

--- a/packages/bb-distributed-table/src/types.ts
+++ b/packages/bb-distributed-table/src/types.ts
@@ -269,7 +269,7 @@ export type QueryOptions<
 		index: Name;
 		/** Key conditions for the query. */
 		where: KeyCondition<T, Indexes[Name]>;
-		/** Maximum number of items to return. */
+		/** Maximum number of items to return. Must be a positive integer. */
 		limit?: number;
 		/** Sort order. Defaults to 'asc'. */
 		order?: 'asc' | 'desc';
@@ -278,14 +278,14 @@ export type QueryOptions<
 	index?: undefined;
 	/** Key conditions for the primary key query. */
 	where: KeyCondition<T, K>;
-	/** Maximum number of items to return. */
+	/** Maximum number of items to return. Must be a positive integer. */
 	limit?: number;
 	/** Sort order. Defaults to 'asc'. */
 	order?: 'asc' | 'desc';
 };
 
 export interface ScanOptions {
-	/** Maximum number of items to return. */
+	/** Maximum number of items to return. Must be a positive integer. */
 	limit?: number;
 }
 
@@ -298,5 +298,4 @@ export type DeleteOptions<T> =
 	| { ifExists: true; ifFieldEquals?: never }
 	| { ifExists?: never; ifFieldEquals: Partial<T> }
 	| Record<string, never>;
-
 


### PR DESCRIPTION
## Problem

`DistributedTable` handled invalid `limit` values differently across runtimes. The local mock used truthiness checks, so `0` and `NaN` removed the cap and returned all matching data; the AWS runtime forwarded those values to DynamoDB, whose `Query` and `Scan` APIs require a positive integer. Negative and fractional values also produced divergent behavior.

**Issue #, if available:** None found.

## Changes

- Validate `query()` and `scan()` limits as positive integers before either runtime reads data.
- Return the existing `InvalidQueryException` consistently for `0`, negative, fractional, `NaN`, and infinite limits.
- Add mock and AWS-runtime parity tests that also verify invalid values issue no DynamoDB command.
- Document the positive-integer constraint and add a patch changeset for `@aws-blocks/bb-distributed-table`.

## Validation

- `npm run build`
- `npm test --workspace @aws-blocks/bb-distributed-table` (145 passing)
- `npm run lint:deps`
- `npm run check:exports-consistency`
- `npx biome lint` on the changed source and test files (no errors; existing warnings only)
- `git diff --check`

## Checklist

- [x] PR description included
- [x] Tests are changed or added
- [x] Relevant documentation is changed or added (DistributedTable README and API option comments)

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._