### PR TITLE
fix(bb-file-bucket): validate presigned URL expiry

### DIFF
--- a/.changeset/file-bucket-presigned-url-expiry.md
+++ b/.changeset/file-bucket-presigned-url-expiry.md
@@ -1,0 +1,5 @@
+---
+"@aws-blocks/bb-file-bucket": patch
+---
+
+Validate presigned URL expiration values before creating local tokens or AWS signatures. `getUrl`, `putUrl`, and upload/download handles now reject values that are not whole seconds between 1 and 604800 with `ValidationFailed`, matching Signature Version 4 requirements.

--- a/packages/bb-file-bucket/README.md
+++ b/packages/bb-file-bucket/README.md
@@ -48,6 +48,10 @@ const bucket = new FileBucket(scope, id, options?)
 | `metadata` | `Record<string, string>` | Custom metadata key-value pairs. |
 | `cacheControl` | `string` | Cache-Control header value. |
 
+### Presigned URL options
+
+`getUrl`, `putUrl`, `getFileHandle`, and `createUploadHandle` accept `expiresIn` in seconds. It must be an integer from `1` to `604800` (seven days); the default is `3600`.
+
 ### CorsRule
 
 CORS configuration for browser-based access. Supplied via the `corsRules` option.
@@ -226,6 +230,5 @@ export const api = new ApiNamespace(scope, 'api', (context) => ({
 ## Local Development
 
 Mock data persists to disk at `.bb-data/{fullId}/` across dev server restarts. Internal data is segregated into sibling roots so it never collides with your keys: file bodies live under `content/`, metadata under `meta/`, and version history under `versions/`. Wipe with `rm -rf .bb-data`. Presigned URLs are served by the dev server at `/.bb-file-bucket/{fullId}/{path}?token=...`. Versioning is fully supported locally. Lifecycle rules and CORS have no effect locally.
-
 
 

--- a/packages/bb-file-bucket/package.json
+++ b/packages/bb-file-bucket/package.json
@@ -47,7 +47,7 @@
   "scripts": {
     "prebuild": "node ../../scripts/generate-version.mjs FileBucket",
     "build": "tsc --build",
-    "test": "node --test dist/index.test.js dist/index.cdk.test.js dist/scan.test.js dist/file-server.test.js dist/url-encoding.test.js dist/path-containment.test.js dist/bucket-name.test.js"
+    "test": "node --test dist/index.test.js dist/index.cdk.test.js dist/scan.test.js dist/file-server.test.js dist/url-encoding.test.js dist/path-containment.test.js dist/bucket-name.test.js dist/presigned-url.test.js"
   },
   "dependencies": {
     "@aws-blocks/bb-logger": "^0.1.4",

--- a/packages/bb-file-bucket/src/index.aws.ts
+++ b/packages/bb-file-bucket/src/index.aws.ts
@@ -15,6 +15,7 @@ import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { Scope, registerSdkIdentifiers, getSdkIdentifiers } from '@aws-blocks/core';
 import type { ScopeParent } from '@aws-blocks/core';
 import { BB_NAME, BB_VERSION } from './version.js';
+import { validatePresignedUrlExpiry } from './presigned-url.js';
 import type {
 	FileBucketOptions, PutOptions, PutUrlOptions, ScanOptions,
 	FileContent, FileInfo, ExternalBucketRef,
@@ -124,18 +125,20 @@ export class FileBucket<O extends FileBucketOptions = FileBucketOptions> extends
 
 	async getUrl(path: string, options?: GetUrlOptionsFor<O>): Promise<string> {
 		const opts = options as any;
+		const expiresIn = validatePresignedUrlExpiry(opts?.expiresIn ?? 3600);
 		return getSignedUrl(this.s3, new GetObjectCommand({
 			Bucket: getSdkIdentifiers(this).bucketName, Key: path,
 			...(opts?.versionId ? { VersionId: opts.versionId } : {}),
 		}), {
-			expiresIn: opts?.expiresIn ?? 3600,
+			expiresIn,
 		});
 	}
 
 	async putUrl(path: string, options?: PutUrlOptions): Promise<string> {
+		const expiresIn = validatePresignedUrlExpiry(options?.expiresIn ?? 3600);
 		return getSignedUrl(this.s3, new PutObjectCommand({
 			Bucket: getSdkIdentifiers(this).bucketName, Key: path, ContentType: options?.contentType,
-		}), { expiresIn: options?.expiresIn ?? 3600 });
+		}), { expiresIn });
 	}
 
 	async getFileHandle(path: string, options?: GetUrlOptionsFor<O>): Promise<FileDownloadClient> {

--- a/packages/bb-file-bucket/src/presigned-url.test.ts
+++ b/packages/bb-file-bucket/src/presigned-url.test.ts
@@ -1,0 +1,48 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { Scope, isBlocksError } from '@aws-blocks/core';
+import { FileBucket as AwsFileBucket } from './index.aws.js';
+import { FileBucket as MockFileBucket } from './index.mock.js';
+import { validatePresignedUrlExpiry } from './presigned-url.js';
+
+test('accepts presigned URL expiration values supported by Signature Version 4', () => {
+	assert.strictEqual(validatePresignedUrlExpiry(1), 1);
+	assert.strictEqual(validatePresignedUrlExpiry(604800), 604800);
+});
+
+test('rejects invalid presigned URL expiration values', () => {
+	for (const expiresIn of [0, -1, 1.5, NaN, Infinity, 604801]) {
+		assert.throws(
+			() => validatePresignedUrlExpiry(expiresIn),
+			(err: unknown) => isBlocksError(err, 'ValidationFailed') && /integer between 1 and 604800 seconds/.test((err as Error).message),
+			`expiresIn=${String(expiresIn)} should throw ValidationFailed`,
+		);
+	}
+});
+
+test('mock and AWS runtimes reject invalid expiration values before URL generation', async () => {
+	const scope = new Scope('presigned-url-validation');
+	const buckets = [
+		new MockFileBucket(scope, 'mock'),
+		new AwsFileBucket(scope, 'aws'),
+	];
+
+	for (const expiresIn of [0, -1, 1.5, NaN, Infinity, 604801]) {
+		for (const bucket of buckets) {
+			for (const createUrl of [
+				() => bucket.getUrl('file.txt', { expiresIn }),
+				() => bucket.putUrl('file.txt', { expiresIn }),
+				() => bucket.createUploadHandle('file.txt', { expiresIn }),
+			]) {
+				await assert.rejects(
+					createUrl(),
+					(err: unknown) => isBlocksError(err, 'ValidationFailed') && /integer between 1 and 604800 seconds/.test((err as Error).message),
+					`expiresIn=${String(expiresIn)} should be rejected`,
+				);
+			}
+		}
+	}
+});

--- a/packages/bb-file-bucket/src/presigned-url.ts
+++ b/packages/bb-file-bucket/src/presigned-url.ts
@@ -1,0 +1,28 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+const MIN_PRESIGNED_URL_EXPIRY_SECONDS = 1;
+const MAX_PRESIGNED_URL_EXPIRY_SECONDS = 7 * 24 * 60 * 60;
+
+function blocksError(name: string, message: string): Error {
+	const err = new Error(`${name}: ${message}`);
+	err.name = name;
+	return err;
+}
+
+/**
+ * Validate the TTL used in an S3 presigned URL.
+ *
+ * Signature Version 4 requires X-Amz-Expires to be an integer between one
+ * second and seven days. Validate before creating either a local token or an
+ * AWS signature so both runtimes fail consistently for invalid input.
+ */
+export function validatePresignedUrlExpiry(expiresIn: number): number {
+	if (!Number.isInteger(expiresIn) || expiresIn < MIN_PRESIGNED_URL_EXPIRY_SECONDS || expiresIn > MAX_PRESIGNED_URL_EXPIRY_SECONDS) {
+		throw blocksError(
+			'ValidationFailed',
+			`Presigned URL expiration must be an integer between ${MIN_PRESIGNED_URL_EXPIRY_SECONDS} and ${MAX_PRESIGNED_URL_EXPIRY_SECONDS} seconds.`,
+		);
+	}
+	return expiresIn;
+}

--- a/packages/bb-file-bucket/src/tokens.ts
+++ b/packages/bb-file-bucket/src/tokens.ts
@@ -3,6 +3,7 @@
 
 import { createHmac, randomBytes } from 'node:crypto';
 import { constantTimeEquals } from '@aws-blocks/core/bb-utils';
+import { validatePresignedUrlExpiry } from './presigned-url.js';
 
 // ── Token helpers ───────────────────────────────────────────────────────────
 
@@ -40,6 +41,7 @@ export function mintFileToken(
 	secret: string,
 	contentType?: string,
 ): string {
+	validatePresignedUrlExpiry(expiresIn);
 	const payload: FileTokenPayload = {
 		fullId,
 		path,

--- a/packages/bb-file-bucket/src/types.ts
+++ b/packages/bb-file-bucket/src/types.ts
@@ -53,12 +53,12 @@ export interface PutOptions {
 }
 
 export interface GetUrlOptions {
-	/** URL expiration in seconds. Default: 3600. */
+	/** URL expiration in whole seconds. Must be an integer from 1 to 604800. Default: 3600. */
 	expiresIn?: number;
 }
 
 export interface PutUrlOptions {
-	/** URL expiration in seconds. Default: 3600. */
+	/** URL expiration in whole seconds. Must be an integer from 1 to 604800. Default: 3600. */
 	expiresIn?: number;
 	/** Required content type for the upload. */
 	contentType?: string;


### PR DESCRIPTION
## Problem

**Issue #, if available:** None found.

`FileBucket` accepts any JavaScript `number` for `expiresIn`. Before this change, the local mock minted a token for values such as `0`, negative numbers, fractional values, `NaN`, and values over seven days. The AWS path delegated directly to the S3 presigner, which only rejects values over one week and can otherwise generate a URL with an invalid `X-Amz-Expires` value.

Signature Version 4 requires `X-Amz-Expires` to be an integer from 1 to 604800 seconds. The result was inconsistent and could let local development appear to work with a URL that S3 will reject.

## Changes

- Add a shared presigned-URL expiration validator.
- Apply it before AWS URL signing and before local token minting.
- Reject invalid values with the existing `ValidationFailed` convention.
- Document the accepted range for `GetUrlOptions` and `PutUrlOptions`.
- Add runtime-parity regression coverage for `getUrl`, `putUrl`, and upload/download handles.

## Validation

- `npm run build`
- `npm run lint`
- `npm run lint:deps`
- `npm run check:exports-consistency`
- `npm run check:api`
- `npm test --workspace @aws-blocks/bb-file-bucket` (95 passing)

## Checklist

- [x] PR description included
- [x] Tests are changed or added
- [x] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.