### PR TITLE
fix(bb-metrics): validate EMF values

### DIFF
--- a/.changeset/metrics-validate-emf-values.md
+++ b/.changeset/metrics-validate-emf-values.md
@@ -1,0 +1,5 @@
+---
+"@aws-blocks/bb-metrics": patch
+---
+
+Reject invalid metric values and timestamps before serializing Embedded Metric Format output.

--- a/packages/bb-metrics/API.md
+++ b/packages/bb-metrics/API.md
@@ -66,6 +66,8 @@ export interface MetricsEmitter {
 // @public
 export const MetricsErrors: {
     readonly InvalidMetricName: "InvalidMetricNameException";
+    readonly InvalidMetricValue: "InvalidMetricValueException";
+    readonly InvalidTimestamp: "InvalidTimestampException";
     readonly InvalidDimensions: "InvalidDimensionsException";
     readonly BatchTooLarge: "BatchTooLargeException";
     readonly InvalidNamespace: "InvalidNamespaceException";

--- a/packages/bb-metrics/DESIGN.md
+++ b/packages/bb-metrics/DESIGN.md
@@ -124,6 +124,8 @@ This is unique among Building Blocks. Most BBs need a mock because their AWS run
 
 All validation matches CloudWatch constraints:
 - **Metric name:** Non-empty, max 1024 characters
+- **Metric value:** Finite number between -2^360 and 2^360, inclusive
+- **Timestamp:** Valid `Date` when provided
 - **Dimensions:** Max 30 key-value pairs, non-empty keys and values, max 1024 chars each
 - **Batch size:** Max 100 metrics per `emitBatch` call (EMF document limit)
 

--- a/packages/bb-metrics/README.md
+++ b/packages/bb-metrics/README.md
@@ -37,7 +37,7 @@ const metrics = new Metrics(scope, id, options?)
 |--------|------|-------------|
 | `unit` | `MetricUnit` | Unit of the metric value. Defaults to `'None'`. |
 | `dimensions` | `Record<string, string>` | Dimensions for this data point (max 30 total including defaults). |
-| `timestamp` | `Date` | Timestamp for the data point. Defaults to now. |
+| `timestamp` | `Date` | Valid timestamp for the data point. Defaults to now. |
 | `resolution` | `MetricResolution` | `'standard'` (60s, default) or `'high'` (1s, higher cost). |
 
 ### MetricUnit
@@ -67,6 +67,8 @@ try {
 | Error | Condition |
 |-------|-----------|
 | `MetricsErrors.InvalidMetricName` | Metric name is empty or exceeds 1024 characters. |
+| `MetricsErrors.InvalidMetricValue` | Metric value is non-finite or outside the range from `-2^360` to `2^360`. |
+| `MetricsErrors.InvalidTimestamp` | Metric timestamp is an invalid `Date`. |
 | `MetricsErrors.InvalidDimensions` | Dimensions exceed 30 entries, or contain empty keys/values, or key/value exceeds 1024 chars. |
 | `MetricsErrors.BatchTooLarge` | Batch contains more than 100 metrics. |
 | `MetricsErrors.InvalidNamespace` | Namespace is empty, too long, contains invalid characters, or uses reserved `AWS/` prefix. |
@@ -166,6 +168,7 @@ This design means you can emit metrics anywhere — in hot loops, synchronous ca
 - Prefer `emitBatch` when recording multiple metrics in a single request
 - Use units to enable automatic conversions in CloudWatch dashboards
 - Use `child()` to avoid repeating dimensions across related metrics
+- Emit finite metric values between `-2^360` and `2^360`, and use valid `Date` timestamps
 
 ## Scaling & Cost (AWS)
 
@@ -180,6 +183,5 @@ This design means you can emit metrics anywhere — in hot loops, synchronous ca
 Metrics are written as EMF JSON to stdout — the same format as AWS. In local dev, you can see metric emissions in the terminal output. No disk persistence — metrics are ephemeral locally (unlike KVStore or DistributedTable which persist to `.bb-data/`).
 
 Delete nothing to reset — there's no local state to clear.
-
 
 

--- a/packages/bb-metrics/src/errors.ts
+++ b/packages/bb-metrics/src/errors.ts
@@ -21,6 +21,10 @@
 export const MetricsErrors = {
 	/** Metric name is empty or exceeds 1024 characters. */
 	InvalidMetricName: 'InvalidMetricNameException',
+	/** Metric value is non-finite or outside the CloudWatch-supported range. */
+	InvalidMetricValue: 'InvalidMetricValueException',
+	/** Metric timestamp is not a valid Date. */
+	InvalidTimestamp: 'InvalidTimestampException',
 	/** Dimensions exceed 30 entries, or contain empty keys/values, or key/value exceeds 1024 chars. */
 	InvalidDimensions: 'InvalidDimensionsException',
 	/** Batch contains more than 100 metrics. */

--- a/packages/bb-metrics/src/index.aws.ts
+++ b/packages/bb-metrics/src/index.aws.ts
@@ -16,6 +16,8 @@ import { MetricsErrors } from './errors.js';
 import { BB_NAME, BB_VERSION } from './version.js';
 import {
 	validateMetricName,
+	validateMetricValue,
+	validateTimestamp,
 	validateDimensions,
 	validateBatchSize,
 	validateNamespace,
@@ -108,9 +110,11 @@ export class Metrics extends Scope implements MetricsEmitter {
 	 * Record a single metric data point via EMF.
 	 *
 	 * @param name - Metric name (e.g., 'RequestCount', 'Latency'). Non-empty, max 1024 chars.
-	 * @param value - Numeric value to record.
+	 * @param value - Finite numeric value between -2^360 and 2^360.
 	 * @param options - Unit, dimensions, timestamp, and resolution.
 	 * @throws {MetricsErrors.InvalidMetricName} If the metric name is empty or exceeds 1024 characters.
+	 * @throws {MetricsErrors.InvalidMetricValue} If the metric value is non-finite or outside the CloudWatch-supported range.
+	 * @throws {MetricsErrors.InvalidTimestamp} If the timestamp is an invalid Date.
 	 * @throws {MetricsErrors.InvalidDimensions} If dimensions exceed 30 entries or contain empty keys/values.
 	 *
 	 * @example
@@ -125,6 +129,8 @@ export class Metrics extends Scope implements MetricsEmitter {
 	 */
 	emit(name: string, value: number, options?: EmitOptions): void {
 		validateMetricName(name);
+		validateMetricValue(value);
+		validateTimestamp(options?.timestamp);
 		const dims = mergeDimensions(this.defaultDimensions, options?.dimensions);
 		validateDimensions(dims);
 
@@ -144,6 +150,8 @@ export class Metrics extends Scope implements MetricsEmitter {
 	 *
 	 * @param metrics - Array of metric data points (max 100 per call).
 	 * @throws {MetricsErrors.InvalidMetricName} If any metric name is invalid.
+	 * @throws {MetricsErrors.InvalidMetricValue} If any metric value is non-finite or outside the CloudWatch-supported range.
+	 * @throws {MetricsErrors.InvalidTimestamp} If any metric timestamp is an invalid Date.
 	 * @throws {MetricsErrors.InvalidDimensions} If any metric's dimensions are invalid.
 	 * @throws {MetricsErrors.BatchTooLarge} If the batch exceeds 100 metrics.
 	 *
@@ -161,6 +169,8 @@ export class Metrics extends Scope implements MetricsEmitter {
 
 		for (const m of metrics) {
 			validateMetricName(m.name);
+			validateMetricValue(m.value);
+			validateTimestamp(m.timestamp);
 			const dims = mergeDimensions(this.defaultDimensions, m.dimensions);
 			validateDimensions(dims);
 		}
@@ -229,6 +239,8 @@ class ChildMetrics implements MetricsEmitter {
 
 	emit(name: string, value: number, options?: EmitOptions): void {
 		validateMetricName(name);
+		validateMetricValue(value);
+		validateTimestamp(options?.timestamp);
 		const dims = mergeDimensions(this.defaultDimensions, options?.dimensions);
 		validateDimensions(dims);
 
@@ -247,6 +259,8 @@ class ChildMetrics implements MetricsEmitter {
 
 		for (const m of metrics) {
 			validateMetricName(m.name);
+			validateMetricValue(m.value);
+			validateTimestamp(m.timestamp);
 			const dims = mergeDimensions(this.defaultDimensions, m.dimensions);
 			validateDimensions(dims);
 		}

--- a/packages/bb-metrics/src/index.test.ts
+++ b/packages/bb-metrics/src/index.test.ts
@@ -397,6 +397,66 @@ describe('validation', () => {
 			(err: Error) => err.name === MetricsErrors.InvalidDimensions,
 		);
 	});
+
+	test('emit rejects non-finite and out-of-range metric values without writing EMF', () => {
+		const m = new Metrics(fakeScope, 'app');
+		for (const value of [NaN, Infinity, -Infinity, 2 ** 361, -(2 ** 361)]) {
+			assert.throws(
+				() => m.emit('Count', value),
+				(err: Error) => err.name === MetricsErrors.InvalidMetricValue,
+			);
+		}
+		assert.strictEqual(stdoutLines.length, 0);
+	});
+
+	test('emit accepts metric values at the CloudWatch range boundaries', () => {
+		const m = new Metrics(fakeScope, 'app');
+		m.emit('Maximum', 2 ** 360);
+		m.emit('Minimum', -(2 ** 360));
+		assert.strictEqual(stdoutLines.length, 2);
+		assert.strictEqual(getEmfDoc(0).Maximum, 2 ** 360);
+		assert.strictEqual(getEmfDoc(1).Minimum, -(2 ** 360));
+	});
+
+	test('emit rejects an invalid timestamp without writing EMF', () => {
+		const m = new Metrics(fakeScope, 'app');
+		assert.throws(
+			() => m.emit('Count', 1, { timestamp: new Date('invalid') }),
+			(err: Error) => err.name === MetricsErrors.InvalidTimestamp,
+		);
+		assert.strictEqual(stdoutLines.length, 0);
+	});
+
+	test('emitBatch validates all values and timestamps before writing EMF', () => {
+		const m = new Metrics(fakeScope, 'app');
+		assert.throws(
+			() => m.emitBatch([
+				{ name: 'Count', value: 1 },
+				{ name: 'Invalid', value: NaN },
+			]),
+			(err: Error) => err.name === MetricsErrors.InvalidMetricValue,
+		);
+		assert.strictEqual(stdoutLines.length, 0);
+
+		assert.throws(
+			() => m.emitBatch([{ name: 'Count', value: 1, timestamp: new Date('invalid') }]),
+			(err: Error) => err.name === MetricsErrors.InvalidTimestamp,
+		);
+		assert.strictEqual(stdoutLines.length, 0);
+	});
+
+	test('child emitters validate metric values and timestamps', () => {
+		const child = new Metrics(fakeScope, 'app').child({ service: 'api' });
+		assert.throws(
+			() => child.emit('Count', Infinity),
+			(err: Error) => err.name === MetricsErrors.InvalidMetricValue,
+		);
+		assert.throws(
+			() => child.emitBatch([{ name: 'Count', value: 1, timestamp: new Date('invalid') }]),
+			(err: Error) => err.name === MetricsErrors.InvalidTimestamp,
+		);
+		assert.strictEqual(stdoutLines.length, 0);
+	});
 });
 
 // ── Namespace ───────────────────────────────────────────────────────────────
@@ -560,6 +620,8 @@ describe('flush', () => {
 describe('error constants', () => {
 	test('MetricsErrors has expected constants', () => {
 		assert.strictEqual(MetricsErrors.InvalidMetricName, 'InvalidMetricNameException');
+		assert.strictEqual(MetricsErrors.InvalidMetricValue, 'InvalidMetricValueException');
+		assert.strictEqual(MetricsErrors.InvalidTimestamp, 'InvalidTimestampException');
 		assert.strictEqual(MetricsErrors.InvalidDimensions, 'InvalidDimensionsException');
 		assert.strictEqual(MetricsErrors.BatchTooLarge, 'BatchTooLargeException');
 	});

--- a/packages/bb-metrics/src/types.ts
+++ b/packages/bb-metrics/src/types.ts
@@ -71,7 +71,7 @@ export interface EmitOptions {
 	 * Merged with `defaultDimensions` — per-emit dimensions take precedence.
 	 */
 	dimensions?: Record<string, string>;
-	/** Timestamp for the data point. Defaults to now. */
+	/** Valid timestamp for the data point. Defaults to now. */
 	timestamp?: Date;
 	/**
 	 * Storage resolution. 'standard' = 60-second aggregation (default).
@@ -86,13 +86,13 @@ export interface EmitOptions {
 export interface MetricDatum {
 	/** Metric name (non-empty, max 1024 characters). */
 	name: string;
-	/** Numeric value. */
+	/** Finite numeric value between -2^360 and 2^360. */
 	value: number;
 	/** Unit of the metric value. Defaults to 'None'. */
 	unit?: MetricUnit;
 	/** Dimensions to attach (max 30 total including defaults). */
 	dimensions?: Record<string, string>;
-	/** Timestamp for the data point. Defaults to now. */
+	/** Valid timestamp for the data point. Defaults to now. */
 	timestamp?: Date;
 	/** Storage resolution. Defaults to 'standard'. */
 	resolution?: MetricResolution;

--- a/packages/bb-metrics/src/validation.ts
+++ b/packages/bb-metrics/src/validation.ts
@@ -9,6 +9,31 @@ function blocksError(name: string, message: string): Error {
 	return err;
 }
 
+const MAX_METRIC_VALUE = 2 ** 360;
+
+/**
+ * Validate a metric value against CloudWatch constraints.
+ * - Must be finite
+ * - Must be between -2^360 and 2^360, inclusive
+ */
+export function validateMetricValue(value: number): void {
+	if (!Number.isFinite(value) || value < -MAX_METRIC_VALUE || value > MAX_METRIC_VALUE) {
+		throw blocksError(
+			MetricsErrors.InvalidMetricValue,
+			'Metric value must be finite and between -2^360 and 2^360',
+		);
+	}
+}
+
+/**
+ * Validate an optional metric timestamp.
+ */
+export function validateTimestamp(timestamp?: Date): void {
+	if (timestamp !== undefined && !Number.isFinite(timestamp.getTime())) {
+		throw blocksError(MetricsErrors.InvalidTimestamp, 'Metric timestamp must be a valid Date');
+	}
+}
+
 /**
  * Validate a metric name against CloudWatch constraints.
  * - Must be non-empty


### PR DESCRIPTION
## Problem

**Issue #, if available:** None found.

`Metrics.emit()` and `emitBatch()` accept non-finite metric values, out-of-range metric values, and invalid `Date` timestamps. When serialized as Embedded Metric Format (EMF), values such as `NaN` and `Infinity` become `null`, and an invalid timestamp becomes `_aws.Timestamp: null`.

CloudWatch does not support `NaN`, `+Infinity`, or `-Infinity`, and accepts metric values only from `-2^360` to `2^360`. These invalid inputs should fail before an EMF document is written.

## Changes

- Validate metric values as finite and within CloudWatch's supported range.
- Validate optional timestamps as valid `Date` instances.
- Apply validation consistently to single, batch, and child-emitter calls before stdout output.
- Add typed errors, generated API reference updates, user-facing documentation, and a patch changeset.

## Validation

- Reproduced the previous behavior: `NaN`, infinities, and invalid timestamps serialized to `null` in EMF output.
- Added unit coverage for rejected invalid values and timestamps, accepted inclusive boundaries, batch atomicity before stdout writes, and child emitters.
- `npm run build`
- `npm test --workspace @aws-blocks/bb-metrics`
- `npm run lint`
- `npm run lint:deps`
- `npm run check:exports-consistency`
- `npm run check:api`
- `npm run sync-docs:check`

## Checklist

- [x] PR description included
- [x] Tests are changed or added
- [x] Relevant documentation is changed or added (and PR referenced)

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._