### PR TITLE
fix(bb-async-job): validate delay seconds

### DIFF
--- a/.changeset/async-job-validate-delay-seconds.md
+++ b/.changeset/async-job-validate-delay-seconds.md
@@ -1,0 +1,5 @@
+---
+"@aws-blocks/bb-async-job": patch
+---
+
+Validate delayed job submissions before queueing them, matching Amazon SQS delay constraints.

--- a/packages/bb-async-job/DESIGN.md
+++ b/packages/bb-async-job/DESIGN.md
@@ -68,9 +68,9 @@ Local Mock
 
 ### D-AJ-4: Client-side validation before enqueue
 
-**Decision:** `submit()`/`submitBatch()` validate the schema (when configured) and the 256 KB payload size before calling SQS. `submitBatch` rejects an empty batch first, then validates *every* payload before enqueuing any of them.
+**Decision:** `submit()`/`submitBatch()` validate `delaySeconds` as an integer from 0 to 900, the schema (when configured), and the 256 KB payload size before calling SQS. `submitBatch` rejects an empty or over-cap batch first, then validates the delay and *every* payload before enqueuing any of them.
 
-**Rationale:** Failing fast on the caller's side produces a precise typed error (`PayloadTooLarge`, `ValidationFailed`, `BatchEmpty`) instead of a generic SQS rejection, and avoids a network round-trip for input that cannot succeed. Validating the whole batch up front means one bad payload fails the call without half-submitting the batch. The mock applies identical checks so violations surface the same `error.name` in local dev.
+**Rationale:** Failing fast on the caller's side produces a precise typed error (`PayloadTooLarge`, `ValidationFailed`, `BatchEmpty`) instead of a generic SQS rejection, and avoids a network round-trip for input that cannot succeed. Validating the whole batch up front means one invalid delay or payload fails the call without half-submitting the batch. The mock applies identical checks so violations surface the same `error.name` in local dev.
 
 ### D-AJ-4a: `submitBatch` auto-chunks; a multi-chunk submit is not atomic
 
@@ -149,7 +149,7 @@ No `fromExisting()` — wrapping a pre-existing SQS queue is not supported. Asyn
 
 ## Mock Implementation
 
-- An in-process queue drives processing via `setTimeout(…, 0)`; `delaySeconds` is honored with a deferred timer.
+- An in-process queue drives processing via `setTimeout(…, 0)`; an integer `delaySeconds` from 0 to 900 is honored with a deferred timer.
 - Job IDs are a 13-character slice of `randomUUID()`.
 - Retry semantics mirror AWS: on handler error the entry is retried until `receiveCount >= maxRetries`, then moved to an in-memory `failed` (DLQ) list with `failedAt` and `lastError` recorded.
 - Queue state is exposed on `_queue` (`pending`, `processing`, `delayed`, `failed`, `totalSubmitted`, `totalCompleted`) for dev-server inspection.

--- a/packages/bb-async-job/README.md
+++ b/packages/bb-async-job/README.md
@@ -103,7 +103,7 @@ import { AsyncJobErrors } from '@aws-blocks/bb-async-job';
 AsyncJobErrors.PayloadTooLarge    // payload > 256 KB
 AsyncJobErrors.BatchEmpty         // submitBatch([]) called with no items
 AsyncJobErrors.BatchTooLarge      // submitBatch() over the 10,000-payload soft cap
-AsyncJobErrors.ValidationFailed   // schema validation failed
+AsyncJobErrors.ValidationFailed   // schema validation or an invalid delaySeconds value
 AsyncJobErrors.BatchSubmitFailed  // one or more messages failed to enqueue
 AsyncJobErrors.Timeout            // waitUntilComplete() gave up before the job settled
 AsyncJobErrors.StatusNotTracked   // status method called without trackStatus: true
@@ -198,5 +198,3 @@ handler: async (payload, ctx) => {
 ```
 
 **Check the dead-letter queue:** Jobs that fail after `maxRetries` attempts land in the DLQ. In AWS, check the `{scope}-{id}-dlq` queue in the SQS console. In local dev, failed jobs are logged to the console with their full payload.
-
-

--- a/packages/bb-async-job/src/errors.ts
+++ b/packages/bb-async-job/src/errors.ts
@@ -13,7 +13,7 @@ export const AsyncJobErrors = {
 	BatchEmpty: 'BatchEmptyException',
 	/** Thrown when a batch exceeds the per-call payload soft cap (10,000). */
 	BatchTooLarge: 'BatchTooLargeException',
-	/** Thrown when schema validation fails. */
+	/** Thrown when schema or submission-option validation fails. */
 	ValidationFailed: 'ValidationFailedException',
 	/** Thrown when one or more messages in a batch fail to send (AWS only). */
 	BatchSubmitFailed: 'BatchSubmitFailedException',

--- a/packages/bb-async-job/src/index.aws.test.ts
+++ b/packages/bb-async-job/src/index.aws.test.ts
@@ -97,6 +97,26 @@ describe('AsyncJob (aws runtime): submitBatch chunking', () => {
 });
 
 describe('AsyncJob (aws runtime): submitBatch partial failure', () => {
+	test('rejects invalid delaySeconds before sending a single or batch message', async () => {
+		const scope = new Scope(`aj-${Math.random().toString(36).slice(2)}`);
+		const job = new AsyncJob<{ n: number }>(scope, 'batch', { handler: async () => {} });
+		registerSdkIdentifiers(job.fullId, { queueUrl: QUEUE_URL });
+		let sends = 0;
+		(job as any)._sqsClient = { send: async () => { sends++; return { MessageId: 'unused' }; } };
+
+		for (const delaySeconds of [-1, 1.5, NaN, Infinity, 901]) {
+			await assert.rejects(
+				() => job.submit({ n: 1 }, { delaySeconds }),
+				(err: Error) => err.name === AsyncJobErrors.ValidationFailed,
+			);
+		}
+		await assert.rejects(
+			() => job.submitBatch([{ n: 1 }, { n: 2 }], { delaySeconds: -1 }),
+			(err: Error) => err.name === AsyncJobErrors.ValidationFailed,
+		);
+		assert.strictEqual(sends, 0);
+	});
+
 	test('throws BatchSubmitFailed carrying jobIds (real ids + null) and failed[] across chunks', async () => {
 		// 15 payloads → chunks [0..9] and [10..14]; fail one entry in the second chunk.
 		const { job } = makeJob(new Set(['12']));

--- a/packages/bb-async-job/src/index.aws.ts
+++ b/packages/bb-async-job/src/index.aws.ts
@@ -17,6 +17,7 @@ import type {
 	WaitUntilCompleteOptions,
 } from './types.js';
 import { AsyncJobErrors, BatchSubmitFailedError } from './errors.js';
+import { validateDelaySeconds } from './validation.js';
 import { JobStatusTracker, statusNotTrackedError } from './status.js';
 import { BB_NAME, BB_VERSION } from './version.js';
 import { Logger } from '@aws-blocks/bb-logger';
@@ -201,6 +202,7 @@ export class AsyncJob<T = unknown> extends Scope {
 	}
 
 	async submit(payload: T, options?: SubmitOptions): Promise<{ jobId: string }> {
+		validateDelaySeconds(options?.delaySeconds);
 		this.ensureQueueUrl();
 		const messageBody = await this.validatePayload(payload);
 
@@ -320,8 +322,6 @@ export class AsyncJob<T = unknown> extends Scope {
 	}
 
 	async submitBatch(payloads: T[], options?: SubmitOptions): Promise<BatchSubmitResult> {
-		this.ensureQueueUrl();
-
 		if (payloads.length === 0) {
 			const err = new Error(
 				`${AsyncJobErrors.BatchEmpty}: Batch is empty, must contain at least 1 payload`
@@ -337,6 +337,9 @@ export class AsyncJob<T = unknown> extends Scope {
 			err.name = AsyncJobErrors.BatchTooLarge;
 			throw err;
 		}
+
+		validateDelaySeconds(options?.delaySeconds);
+		this.ensureQueueUrl();
 
 		// Validate and serialize every payload before enqueuing anything, so one bad
 		// payload fails the whole call rather than half-submitting the batch.

--- a/packages/bb-async-job/src/index.mock.ts
+++ b/packages/bb-async-job/src/index.mock.ts
@@ -15,6 +15,7 @@ import type {
 	WaitUntilCompleteOptions,
 } from './types.js';
 import { AsyncJobErrors } from './errors.js';
+import { validateDelaySeconds } from './validation.js';
 import { JobStatusTracker, statusNotTrackedError } from './status.js';
 import { Logger } from '@aws-blocks/bb-logger';
 import type { ChildLogger } from '@aws-blocks/bb-logger';
@@ -185,9 +186,10 @@ export class AsyncJob<T = unknown> extends Scope {
 	 * @param options - Optional. `delaySeconds` defers processing (0–900s).
 	 * @returns `{ jobId }` — unique identifier for tracking.
 	 * @throws {AsyncJobErrors.PayloadTooLarge} If serialized payload exceeds 256 KB.
-	 * @throws {AsyncJobErrors.ValidationFailed} If schema validation fails.
+	 * @throws {AsyncJobErrors.ValidationFailed} If schema validation fails or delaySeconds is not an integer from 0 to 900.
 	 */
 	async submit(payload: T, options?: SubmitOptions): Promise<{ jobId: string }> {
+		validateDelaySeconds(options?.delaySeconds);
 		await this.validatePayload(payload);
 		const jobId = randomUUID().slice(0, 13);
 		const sentAt = new Date().toISOString();
@@ -236,7 +238,7 @@ export class AsyncJob<T = unknown> extends Scope {
 	 * @throws {AsyncJobErrors.BatchEmpty} If payloads array is empty.
 	 * @throws {AsyncJobErrors.BatchTooLarge} If more than {@link MAX_BATCH_PAYLOADS} payloads.
 	 * @throws {AsyncJobErrors.PayloadTooLarge} If any payload exceeds 256 KB.
-	 * @throws {AsyncJobErrors.ValidationFailed} If any payload fails schema validation.
+	 * @throws {AsyncJobErrors.ValidationFailed} If any payload fails schema validation or delaySeconds is not an integer from 0 to 900.
 	 * @throws {AsyncJobErrors.BatchSubmitFailed} If one or more messages fail to send (AWS only). A multi-chunk submit is not atomic; the error's `failed` and `jobIds` properties carry the partial results across all chunks.
 	 */
 	async submitBatch(payloads: T[], options?: SubmitOptions): Promise<BatchSubmitResult> {
@@ -255,6 +257,8 @@ export class AsyncJob<T = unknown> extends Scope {
 			err.name = AsyncJobErrors.BatchTooLarge;
 			throw err;
 		}
+
+		validateDelaySeconds(options?.delaySeconds);
 
 		// Validate every payload before enqueuing any, so one bad payload fails the
 		// whole call rather than half-submitting the batch — matching the AWS runtime.

--- a/packages/bb-async-job/src/index.test.ts
+++ b/packages/bb-async-job/src/index.test.ts
@@ -5,6 +5,7 @@ import { test } from 'node:test';
 import assert from 'node:assert';
 import { setTimeout as sleep } from 'node:timers/promises';
 import { AsyncJob, AsyncJobErrors } from './index.mock.js';
+import { validateDelaySeconds } from './validation.js';
 
 // Helper: wait for async job processing to complete
 async function waitForJobs(ms = 100) {
@@ -379,6 +380,45 @@ test('AsyncJob - delayed job appears in _queue.delayed before processing', async
 
 	assert.strictEqual(job._queue.delayed.length, 1, 'job should be in delayed queue');
 	assert.ok(job._queue.delayed[0].delayedUntil, 'delayedUntil should be set');
+});
+
+test('AsyncJob - accepts delaySeconds at the SQS range boundaries', () => {
+	assert.doesNotThrow(() => validateDelaySeconds(0));
+	assert.doesNotThrow(() => validateDelaySeconds(900));
+});
+
+test('AsyncJob - submit rejects invalid delaySeconds before queueing work', async () => {
+	let handlerRan = false;
+	const job = new AsyncJob(null as any, 'test', {
+		handler: async () => { handlerRan = true; },
+	});
+
+	for (const delaySeconds of [-1, 1.5, NaN, Infinity, 901]) {
+		await assert.rejects(
+			() => job.submit({ x: 1 }, { delaySeconds }),
+			(err: Error) => err.name === AsyncJobErrors.ValidationFailed,
+		);
+	}
+
+	await waitForJobs();
+	assert.strictEqual(handlerRan, false);
+	assert.strictEqual(job._queue.totalSubmitted, 0);
+});
+
+test('AsyncJob - submitBatch rejects invalid delaySeconds before queueing any work', async () => {
+	let handlerRuns = 0;
+	const job = new AsyncJob(null as any, 'test', {
+		handler: async () => { handlerRuns++; },
+	});
+
+	await assert.rejects(
+		() => job.submitBatch([{ x: 1 }, { x: 2 }], { delaySeconds: -1 }),
+		(err: Error) => err.name === AsyncJobErrors.ValidationFailed,
+	);
+
+	await waitForJobs();
+	assert.strictEqual(handlerRuns, 0);
+	assert.strictEqual(job._queue.totalSubmitted, 0);
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/bb-async-job/src/types.ts
+++ b/packages/bb-async-job/src/types.ts
@@ -109,7 +109,7 @@ export interface WaitUntilCompleteOptions {
  * Options for submit() and submitBatch() calls.
  */
 export interface SubmitOptions {
-	/** Delay before the job becomes visible for processing. 0–900 seconds. Default: 0. */
+	/** Delay before the job becomes visible for processing. Integer from 0 to 900 seconds. Default: 0. */
 	delaySeconds?: number;
 }
 
@@ -122,4 +122,3 @@ export interface BatchSubmitResult {
 	/** Details of any entries that failed to enqueue. */
 	failed: Array<{ index: number; code: string; message: string }>;
 }
-

--- a/packages/bb-async-job/src/validation.ts
+++ b/packages/bb-async-job/src/validation.ts
@@ -1,0 +1,22 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { AsyncJobErrors } from './errors.js';
+
+const MAX_DELAY_SECONDS = 900;
+
+/**
+ * Validate the per-message delay accepted by Amazon SQS.
+ */
+export function validateDelaySeconds(delaySeconds?: number): void {
+	if (
+		delaySeconds !== undefined
+		&& (!Number.isInteger(delaySeconds) || delaySeconds < 0 || delaySeconds > MAX_DELAY_SECONDS)
+	) {
+		const err = new Error(
+			`${AsyncJobErrors.ValidationFailed}: \`delaySeconds\` must be an integer from 0 to ${MAX_DELAY_SECONDS} (received ${String(delaySeconds)})`,
+		);
+		err.name = AsyncJobErrors.ValidationFailed;
+		throw err;
+	}
+}


### PR DESCRIPTION
## Problem

**Issue #, if available:** None found.

`SubmitOptions.delaySeconds` is documented as a 0–900 second SQS delay, but neither runtime validates it. In local development, `delaySeconds: -1` is silently treated as no delay and executes the handler immediately. In AWS, invalid values are passed to SQS and fail only after attempting a request.

Amazon SQS accepts `DelaySeconds` as an integer from 0 through 900. Invalid values should fail consistently before queueing work: https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_SendMessage.html

## Changes

- Add a shared delay validator used by the AWS and mock runtimes.
- Reject non-integer, non-finite, negative, and greater-than-900 values with the existing `AsyncJobErrors.ValidationFailed` error before queueing or sending.
- Document the integer constraint and add a patch changeset.

## Validation

- Reproduced the previous local behavior: `delaySeconds: -1` completed the handler immediately without an error.
- Added unit coverage for the inclusive 0 and 900 boundaries, invalid values (`-1`, `1.5`, `NaN`, `Infinity`, and `901`), and batch rejection before any work is queued.
- `npm run build`
- `npm test --workspace @aws-blocks/bb-async-job`
- `npm run lint`
- `npm run lint:deps`
- `npm run check:exports-consistency`
- `npm run check:api`
- `npm run sync-docs:check`

## Checklist

- [x] PR description included
- [x] Tests are changed or added
- [x] Relevant documentation is changed or added (and PR referenced)

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._