### PR TITLE
feat(core): default the shared handler Lambda to arm64 (Graviton)

### DIFF
--- a/.changeset/graviton-arm64-default.md
+++ b/.changeset/graviton-arm64-default.md
@@ -1,0 +1,17 @@
+---
+"@aws-blocks/core": minor
+"@aws-blocks/blocks": minor
+---
+
+Default the shared Blocks handler Lambda to **arm64 (AWS Graviton)**.
+
+Adds `lambdaArchitecture: Architecture` to `BlocksDefaults` (and to `BlocksPresets` — `Architecture.ARM_64` in both `sandbox` and `production`), and applies it to the framework-provisioned handler in `BlocksStack` / `BlocksBackend`. arm64 Lambda is ~20% cheaper per GB-second than x86_64 at equivalent performance, and the backend is a pure-JavaScript esbuild bundle with no architecture-specific native dependencies, so the switch carries no runtime risk.
+
+Override per stack when you bundle an x86-only native addon:
+
+```ts
+import { Architecture } from 'aws-cdk-lib/aws-lambda';
+defaults: { ...BlocksPresets.production, lambdaArchitecture: Architecture.X86_64 }
+```
+
+> **Behavior change on next deploy of an existing app:** the handler function's architecture flips from `x86_64` to `arm64` (an in-place update — no new function). This also adds a new field to the public `BlocksDefaults` `@aws-blocks/core/cdk` surface (both presets set it), which wants API-BR sign-off before release.

--- a/packages/core/src/cdk/blocks-backend.test.ts
+++ b/packages/core/src/cdk/blocks-backend.test.ts
@@ -7,6 +7,7 @@ import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import * as cdk from 'aws-cdk-lib';
 import { Template, Match } from 'aws-cdk-lib/assertions';
+import { Architecture } from 'aws-cdk-lib/aws-lambda';
 import { PolicyStatement } from 'aws-cdk-lib/aws-iam';
 import { BlocksBackend } from './blocks-backend.js';
 import { BlocksPresets } from './blocks-defaults.js';
@@ -368,5 +369,38 @@ describe('infrastructure defaults (backend-anchored)', () => {
     const inner = new Scope('inner', { parent: outer });
     assert.strictEqual(inner.defaults, backend.defaults);
     assert.strictEqual(inner.defaults, BlocksPresets.sandbox);
+  });
+});
+
+describe('handler Lambda architecture (Graviton default)', () => {
+  test('defaults the shared handler to arm64 (Graviton)', async () => {
+    const app = new cdk.App();
+    const stack = new cdk.Stack(app, 'ArmDefaultStack');
+
+    await BlocksBackend.create(stack, 'Blocks', {
+      backendHandlerPath: handlerPath,
+      backendCDKPath: sideEffectBackendPath,
+      defaults: BlocksPresets.production,
+    });
+
+    // The shared handler synthesizes with an arm64 architecture.
+    Template.fromStack(stack).hasResourceProperties('AWS::Lambda::Function', {
+      Architectures: ['arm64'],
+    });
+  });
+
+  test('respects a lambdaArchitecture override (x86_64)', async () => {
+    const app = new cdk.App();
+    const stack = new cdk.Stack(app, 'X86OverrideStack');
+
+    await BlocksBackend.create(stack, 'Blocks', {
+      backendHandlerPath: handlerPath,
+      backendCDKPath: sideEffectBackendPath,
+      defaults: { ...BlocksPresets.production, lambdaArchitecture: Architecture.X86_64 },
+    });
+
+    Template.fromStack(stack).hasResourceProperties('AWS::Lambda::Function', {
+      Architectures: ['x86_64'],
+    });
   });
 });

--- a/packages/core/src/cdk/blocks-backend.ts
+++ b/packages/core/src/cdk/blocks-backend.ts
@@ -96,6 +96,10 @@ export function setupBlocksInfra(scope: Construct, props: BlocksBackendProps, id
   const handler = new lambda.NodejsFunction(scope, 'Handler', {
     entry: props.backendHandlerPath,
     runtime: DEFAULT_NODE_RUNTIME,
+    // Default to arm64 (Graviton) — ~20% cheaper at equal performance. The
+    // backend is a pure-JS esbuild bundle, so there's no native-arch concern.
+    // Overridable via the stack-wide `defaults.lambdaArchitecture`.
+    architecture: props.defaults.lambdaArchitecture,
     handler: 'handler',
     role: executionRole,
     memorySize: 2048,

--- a/packages/core/src/cdk/blocks-defaults.test.ts
+++ b/packages/core/src/cdk/blocks-defaults.test.ts
@@ -10,6 +10,7 @@
 import { test, describe } from 'node:test';
 import assert from 'node:assert';
 import { RemovalPolicy } from 'aws-cdk-lib';
+import { Architecture } from 'aws-cdk-lib/aws-lambda';
 import { BlocksPresets } from './blocks-defaults.js';
 
 describe('BlocksPresets', () => {
@@ -23,5 +24,10 @@ describe('BlocksPresets', () => {
 		assert.strictEqual(BlocksPresets.production.removalPolicy, RemovalPolicy.RETAIN);
 		assert.strictEqual(BlocksPresets.production.deletionProtection, true);
 		assert.strictEqual(BlocksPresets.production.pointInTimeRecovery, true);
+	});
+
+	test('both presets default Lambda compute to arm64 (Graviton)', () => {
+		assert.strictEqual(BlocksPresets.sandbox.lambdaArchitecture, Architecture.ARM_64);
+		assert.strictEqual(BlocksPresets.production.lambdaArchitecture, Architecture.ARM_64);
 	});
 });

--- a/packages/core/src/cdk/blocks-defaults.ts
+++ b/packages/core/src/cdk/blocks-defaults.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { RemovalPolicy } from 'aws-cdk-lib';
+import { Architecture } from 'aws-cdk-lib/aws-lambda';
 
 /**
  * Default values for every Amazon-authored Building Block created within a
@@ -39,6 +40,24 @@ export interface BlocksDefaults {
 	 * 1–35 days). Backups only have a window when on, so the two are one field.
 	 */
 	pointInTimeRecovery: boolean | { retentionDays: number };
+
+	/**
+	 * The instruction-set architecture for framework-provisioned Lambda compute
+	 * (the shared Blocks handler). Defaults to **`Architecture.ARM_64`** (AWS
+	 * Graviton) in every preset: arm64 Lambda is ~20% cheaper per GB-second than
+	 * x86_64 at the same performance, and the Blocks handler is a pure-JavaScript
+	 * esbuild bundle with no architecture-specific native dependencies, so the
+	 * switch is free.
+	 *
+	 * Override to `Architecture.X86_64` if you bundle an x86-only native addon
+	 * into your backend:
+	 *
+	 * ```ts
+	 * import { Architecture } from 'aws-cdk-lib/aws-lambda';
+	 * defaults: { ...BlocksPresets.production, lambdaArchitecture: Architecture.X86_64 }
+	 * ```
+	 */
+	lambdaArchitecture: Architecture;
 }
 
 /**
@@ -55,11 +74,13 @@ export const BlocksPresets = {
 		removalPolicy: RemovalPolicy.DESTROY,
 		deletionProtection: false,
 		pointInTimeRecovery: false,
+		lambdaArchitecture: Architecture.ARM_64,
 	},
 	/** Durable, protected posture for permanent deployments. */
 	production: {
 		removalPolicy: RemovalPolicy.RETAIN,
 		deletionProtection: true,
 		pointInTimeRecovery: true,
+		lambdaArchitecture: Architecture.ARM_64,
 	},
 } satisfies Record<string, BlocksDefaults>;


### PR DESCRIPTION
## What

Makes the framework-provisioned Blocks handler Lambda run on **arm64 (AWS Graviton)** by default, via a new `lambdaArchitecture` field on `BlocksDefaults` (set to `Architecture.ARM_64` in both `BlocksPresets`).

## Why

Board card: **`[Bug Bash] P3: All Lambdas pinned to x86_64 (Graviton ~20% cheaper)`** (P3, Cost/availability). Verified against `main`: `blocks-backend.ts` created the shared `Handler` with no `architecture` prop → CDK's `x86_64` default. arm64 Lambda is ~20% cheaper per GB-second at equivalent performance, and the handler is a pure-JavaScript esbuild bundle (`--conditions=aws-runtime`, `minify`) with no architecture-specific native dependencies — so the switch carries no runtime risk.

## How

- **`BlocksDefaults`** gains `lambdaArchitecture: Architecture` (fully documented on the interface). Both presets — `sandbox` and `production` — default it to `Architecture.ARM_64`. This follows the exact precedent of the recently-added `pointInTimeRecovery` default field.
- **`setupBlocksInfra`** applies `props.defaults.lambdaArchitecture` to the shared `Handler`.
- Override per stack:
  ```ts
  import { Architecture } from 'aws-cdk-lib/aws-lambda';
  defaults: { ...BlocksPresets.production, lambdaArchitecture: Architecture.X86_64 }
  ```

### Scope (deliberately narrow)

This changes **only the shared handler** — the one Lambda every Blocks app runs, and the biggest cost lever. It intentionally does **not** touch:
- **Hosting SSR compute** (`@aws-blocks/hosting`) — those adapters can bundle architecture-specific native binaries (e.g. `sharp` for Next image optimization), so flipping them to arm64 needs its own verification.
- **BB-owned auxiliary Lambdas** (`bb-data` / `bb-distributed-data` migration fns, `bb-app-setting` init fn, `bb-lambda-compute`) — these can read the same `defaults.lambdaArchitecture` in a follow-up, mirroring how `#302` adopted `BlocksDefaults` in one block first.

## Testing

- New synth assertions in `blocks-backend.test.ts`: handler synthesizes with `Architectures: ['arm64']` by default, and `['x86_64']` when overridden.
- `blocks-defaults.test.ts`: both presets assert `Architecture.ARM_64`.
- Full `@aws-blocks/core` suite (689 tests) ✅, `npm run lint` ✅, `lint:deps` ✅, `check:api` ✅, umbrella-changeset guard ✅.

## Changeset

`@aws-blocks/core` **minor** + `@aws-blocks/blocks` **minor** (umbrella re-exports `BlocksDefaults`/`BlocksPresets`).

> **Maintainer note:** Two things worth an explicit call before release — (1) making `arm64` the *default* is a behavior change (the handler's architecture flips `x86_64`→`arm64` on next deploy; in-place update, no new function), and (2) it adds a required field to the public `BlocksDefaults` `@aws-blocks/core/cdk` surface (both presets set it, matching the `pointInTimeRecovery` precedent), which wants API-BR sign-off.