### PR TITLE
fix(bb-auth-oidc): requireAuth throws ApiError(401) so handle401 redirect works

### DIFF
--- a/.changeset/oidc-requireauth-401.md
+++ b/.changeset/oidc-requireauth-401.md
@@ -1,0 +1,8 @@
+---
+"@aws-blocks/bb-auth-oidc": patch
+"@aws-blocks/blocks": patch
+---
+
+Make AuthOIDC `requireAuth()` throw `ApiError(401, NotAuthenticatedException)` so the documented `handle401()` 401-redirect pattern works for a signed-out protected call.
+
+Previously `requireAuth()` threw a bare `Error` with no `status`. Over the JSON-RPC boundary `errorResponseFromCatch` serializes a non-`ApiError` as code `500`, so the client received an `ApiError` with `status === 500`. The README's `if (handle401(e, provider)) return;` helper only acts on `err instanceof ApiError && err.status === 401`, so it never matched and the app never redirected to sign-in — the error just surfaced. This aligns AuthOIDC with AuthCognito, whose `requireAuth()` already throws `ApiError(401, …)`. The error name is preserved, so existing `isBlocksError(e, AuthOIDCErrors.NotAuthenticated)` checks are unaffected.

--- a/packages/bb-auth-oidc/src/auth-oidc.ts
+++ b/packages/bb-auth-oidc/src/auth-oidc.ts
@@ -642,11 +642,9 @@ function isValidUrl(s: string): boolean {
 }
 
 function notAuthenticated(): ApiError {
-	// Must be an `ApiError` with `status: 401` so that the browser `handle401()`
-	// helper (and any `err.status === 401` check) matches after this crosses the
-	// JSON-RPC boundary. A bare `Error` serializes with code 500, which silently
-	// defeats the documented 401-redirect pattern. Mirrors AuthCognito's
-	// `requireAuth()`, which already throws `ApiError(401, NotAuthenticated)`.
+	// A bare `Error` serializes across the JSON-RPC boundary as code 500, so the
+	// browser's `handle401()` (which matches `status === 401`) never fires. Must
+	// be an `ApiError(401)`, like AuthCognito's `requireAuth()`.
 	return new ApiError('Authentication required', 401, { name: 'NotAuthenticatedException' });
 }
 

--- a/packages/bb-auth-oidc/src/auth-oidc.ts
+++ b/packages/bb-auth-oidc/src/auth-oidc.ts
@@ -6,7 +6,7 @@
  * injecting their own `AuthEngine`.
  */
 
-import { Scope, type ScopeParent, type BlocksContext, ApiNamespace, BLOCKS_AUTH_PREFIX } from '@aws-blocks/core';
+import { Scope, type ScopeParent, type BlocksContext, ApiNamespace, ApiError, BLOCKS_AUTH_PREFIX } from '@aws-blocks/core';
 import type { AuthActionInput, AuthState, AuthAction, BlocksAuth } from '@aws-blocks/auth-common';
 import type { AuthEngine, ExchangeInput, ExchangeResult, AuthorizeParams, AuthorizeParamsRequest, BearerRefreshResult } from './engine.js';
 import type {
@@ -641,10 +641,13 @@ function isValidUrl(s: string): boolean {
 	}
 }
 
-function notAuthenticated(): Error {
-	const err = new Error('Authentication required');
-	err.name = 'NotAuthenticatedException';
-	return err;
+function notAuthenticated(): ApiError {
+	// Must be an `ApiError` with `status: 401` so that the browser `handle401()`
+	// helper (and any `err.status === 401` check) matches after this crosses the
+	// JSON-RPC boundary. A bare `Error` serializes with code 500, which silently
+	// defeats the documented 401-redirect pattern. Mirrors AuthCognito's
+	// `requireAuth()`, which already throws `ApiError(401, NotAuthenticated)`.
+	return new ApiError('Authentication required', 401, { name: 'NotAuthenticatedException' });
 }
 
 function providerNotConfigured(name: string): Error {

--- a/packages/bb-auth-oidc/src/index.browser.test.ts
+++ b/packages/bb-auth-oidc/src/index.browser.test.ts
@@ -3,7 +3,8 @@
 
 import { describe, test, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert';
-import { AuthOIDCClient, resolveApiBaseOrigin } from './index.browser.js';
+import { AuthOIDCClient, resolveApiBaseOrigin, handle401 } from './index.browser.js';
+import { ApiError } from '@aws-blocks/core/client';
 
 /**
  * Browser-client tests for `AuthOIDCClient.signIn()` redirect-target
@@ -651,5 +652,40 @@ describe('AuthOIDCClient.signOut — server-side (no window / BroadcastChannel)'
 		assert.strictEqual(signoutPosted, true, 'the server-side sign-out POST should still run');
 		assert.strictEqual(broadcasts.length, 0, 'no cross-tab broadcast should be attempted with no window');
 		assert.strictEqual(reloaded, false, 'no page reload server-side');
+	});
+});
+
+describe('handle401 — documented 401-redirect pattern', () => {
+	beforeEach(() => { installBrowserGlobals(CURRENT_PAGE); });
+	afterEach(() => { clearBrowserGlobals(); });
+
+	test('redirects to the provider sign-in route on a 401 ApiError (the requireAuth case)', () => {
+		// requireAuth() now throws ApiError(401, NotAuthenticatedException); across the
+		// JSON-RPC wire that arrives as an ApiError whose status is 401. Before the fix
+		// requireAuth threw a bare Error → serialized as code 500 → handle401 returned
+		// false and the app never redirected (the reported "silently does nothing" bug).
+		const err = new ApiError('Authentication required', 401, { name: 'NotAuthenticatedException' });
+		const handled = handle401(err, 'google');
+		assert.strictEqual(handled, true, 'handle401 must report it scheduled a redirect');
+		assert.strictEqual(navigatedTo, '/aws-blocks/auth/signin/google', 'should navigate to the provider sign-in route');
+	});
+
+	test('does not redirect on a non-401 error (returns false, no navigation)', () => {
+		const err = new ApiError('Boom', 500, { name: 'InternalError' });
+		const handled = handle401(err, 'google');
+		assert.strictEqual(handled, false);
+		assert.strictEqual(navigatedTo, '', 'must not navigate on a non-401');
+	});
+
+	test('regression: the pre-fix bare NotAuthenticated Error is NOT matched — why requireAuth must throw ApiError(401)', () => {
+		// This is exactly what the old notAuthenticated() produced. handle401 cannot
+		// act on it (not an ApiError, no status), which is the defect. The fix makes
+		// requireAuth throw ApiError(401) (see auth-oidc index.test.ts) so this shape
+		// no longer reaches callers.
+		const bare = new Error('Authentication required');
+		bare.name = 'NotAuthenticatedException';
+		const handled = handle401(bare, 'google');
+		assert.strictEqual(handled, false, 'a bare Error is not an ApiError(401) — handle401 cannot act on it');
+		assert.strictEqual(navigatedTo, '', 'no navigation for the un-typed error');
 	});
 });

--- a/packages/bb-auth-oidc/src/index.browser.test.ts
+++ b/packages/bb-auth-oidc/src/index.browser.test.ts
@@ -660,32 +660,27 @@ describe('handle401 — documented 401-redirect pattern', () => {
 	afterEach(() => { clearBrowserGlobals(); });
 
 	test('redirects to the provider sign-in route on a 401 ApiError (the requireAuth case)', () => {
-		// requireAuth() now throws ApiError(401, NotAuthenticatedException); across the
-		// JSON-RPC wire that arrives as an ApiError whose status is 401. Before the fix
-		// requireAuth threw a bare Error → serialized as code 500 → handle401 returned
-		// false and the app never redirected (the reported "silently does nothing" bug).
+		// The shape requireAuth() now throws (and the wire decodes to). Pre-fix it was
+		// a bare Error → serialized as 500 → handle401 no-op'd (the reported bug).
 		const err = new ApiError('Authentication required', 401, { name: 'NotAuthenticatedException' });
 		const handled = handle401(err, 'google');
-		assert.strictEqual(handled, true, 'handle401 must report it scheduled a redirect');
-		assert.strictEqual(navigatedTo, '/aws-blocks/auth/signin/google', 'should navigate to the provider sign-in route');
+		assert.strictEqual(handled, true);
+		assert.strictEqual(navigatedTo, '/aws-blocks/auth/signin/google');
 	});
 
 	test('does not redirect on a non-401 error (returns false, no navigation)', () => {
 		const err = new ApiError('Boom', 500, { name: 'InternalError' });
 		const handled = handle401(err, 'google');
 		assert.strictEqual(handled, false);
-		assert.strictEqual(navigatedTo, '', 'must not navigate on a non-401');
+		assert.strictEqual(navigatedTo, '');
 	});
 
-	test('regression: the pre-fix bare NotAuthenticated Error is NOT matched — why requireAuth must throw ApiError(401)', () => {
-		// This is exactly what the old notAuthenticated() produced. handle401 cannot
-		// act on it (not an ApiError, no status), which is the defect. The fix makes
-		// requireAuth throw ApiError(401) (see auth-oidc index.test.ts) so this shape
-		// no longer reaches callers.
+	test('regression: the pre-fix bare NotAuthenticated Error is NOT matched', () => {
+		// The old notAuthenticated() shape: not an ApiError, no status — the defect.
 		const bare = new Error('Authentication required');
 		bare.name = 'NotAuthenticatedException';
 		const handled = handle401(bare, 'google');
-		assert.strictEqual(handled, false, 'a bare Error is not an ApiError(401) — handle401 cannot act on it');
-		assert.strictEqual(navigatedTo, '', 'no navigation for the un-typed error');
+		assert.strictEqual(handled, false);
+		assert.strictEqual(navigatedTo, '');
 	});
 });

--- a/packages/bb-auth-oidc/src/index.test.ts
+++ b/packages/bb-auth-oidc/src/index.test.ts
@@ -7,7 +7,7 @@ import { rmSync, mkdtempSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { createServer, type Server } from 'node:http';
-import { clearRouteRegistry } from '@aws-blocks/core';
+import { clearRouteRegistry, ApiError } from '@aws-blocks/core';
 import type { BlocksContext } from '@aws-blocks/core';
 import { AuthOIDC, AuthOIDCErrors, stubIdp, google, customOidc, customOauth2, cognitoFederated } from './index.mock.js';
 import { handleDiscovery, handleJwks, handleAuthorize, handleAuthorizeSubmit, stubIssuerUrl } from './engines/stub-idp.js';
@@ -578,6 +578,28 @@ describe('requireAuth / checkAuth / getCurrentUser without session', () => {
 		await assert.rejects(
 			() => auth.requireAuth(ctx),
 			(e: Error) => e.name === AuthOIDCErrors.NotAuthenticated,
+		);
+	});
+
+	test('requireAuth throws an ApiError with status 401 (regression: handle401 / e.status===401 must match)', async () => {
+		// Regression for the "handle401 silently does nothing" bug. requireAuth()
+		// used to throw a bare Error (no status) named NotAuthenticatedException;
+		// over the JSON-RPC wire that serializes as code 500, so the documented
+		// `if (handle401(e, provider)) return;` redirect pattern never fired.
+		// The error MUST be an ApiError(401) — mirroring AuthCognito.requireAuth() —
+		// so both the in-process throw and the wire-decoded ApiError carry status 401.
+		const auth = new AuthOIDC(ROOT, unique('noauth401'), {
+			providers: [stubIdp({ name: unique('p') })],
+		});
+		const ctx = freshContext();
+		await assert.rejects(
+			() => auth.requireAuth(ctx),
+			(e: unknown) => {
+				assert.ok(e instanceof ApiError, `expected ApiError, got ${(e as { constructor?: { name?: string } })?.constructor?.name}`);
+				assert.strictEqual(e.status, 401, 'status must be 401 so handle401() and e.status===401 checks match');
+				assert.strictEqual(e.name, AuthOIDCErrors.NotAuthenticated, 'name must be preserved for isBlocksError()');
+				return true;
+			},
 		);
 	});
 

--- a/packages/bb-auth-oidc/src/index.test.ts
+++ b/packages/bb-auth-oidc/src/index.test.ts
@@ -662,12 +662,8 @@ describe('requireAuth / checkAuth / getCurrentUser without session', () => {
 	});
 
 	test('requireAuth throws an ApiError with status 401 (regression: handle401 / e.status===401 must match)', async () => {
-		// Regression for the "handle401 silently does nothing" bug. requireAuth()
-		// used to throw a bare Error (no status) named NotAuthenticatedException;
-		// over the JSON-RPC wire that serializes as code 500, so the documented
-		// `if (handle401(e, provider)) return;` redirect pattern never fired.
-		// The error MUST be an ApiError(401) — mirroring AuthCognito.requireAuth() —
-		// so both the in-process throw and the wire-decoded ApiError carry status 401.
+		// A bare Error serializes as 500 over JSON-RPC, so handle401 (status === 401)
+		// never fired. Must be ApiError(401); name preserved for isBlocksError().
 		const auth = new AuthOIDC(ROOT, unique('noauth401'), {
 			providers: [stubIdp({ name: unique('p') })],
 		});
@@ -676,8 +672,8 @@ describe('requireAuth / checkAuth / getCurrentUser without session', () => {
 			() => auth.requireAuth(ctx),
 			(e: unknown) => {
 				assert.ok(e instanceof ApiError, `expected ApiError, got ${(e as { constructor?: { name?: string } })?.constructor?.name}`);
-				assert.strictEqual(e.status, 401, 'status must be 401 so handle401() and e.status===401 checks match');
-				assert.strictEqual(e.name, AuthOIDCErrors.NotAuthenticated, 'name must be preserved for isBlocksError()');
+				assert.strictEqual(e.status, 401);
+				assert.strictEqual(e.name, AuthOIDCErrors.NotAuthenticated);
 				return true;
 			},
 		);


### PR DESCRIPTION
## Summary
AuthOIDC `requireAuth()` now throws `ApiError(401, NotAuthenticatedException)` instead of a bare `Error`, so the README's documented `if (handle401(e, provider)) return;` 401-redirect pattern actually fires for a signed-out protected call.

## Root cause
- `notAuthenticated()` (`packages/bb-auth-oidc/src/auth-oidc.ts`) returned a bare `Error` with `name: 'NotAuthenticatedException'` and **no `status`**.
- Across the JSON-RPC boundary, `errorResponseFromCatch` (`packages/core/src/rpc.ts`) serializes a non-`ApiError` as code **500**, so the browser receives an `ApiError` whose `status === 500`.
- `handle401()` (`packages/bb-auth-oidc/src/index.browser.ts`) only acts on `err instanceof ApiError && err.status === 401`, so it never matched — the error surfaced and the app never redirected to sign-in.

This mirrors the behavior already present in AuthCognito, whose `requireAuth()` throws `ApiError('Authentication required', 401, { name: NotAuthenticated })`.

## Fix
`notAuthenticated()` now returns `new ApiError('Authentication required', 401, { name: 'NotAuthenticatedException' })`. The error name is preserved, so existing `isBlocksError(e, AuthOIDCErrors.NotAuthenticated)` checks are unaffected; both the in-process throw and the wire-decoded error now carry `status === 401`.

## Tests
- `index.test.ts` — regression: `requireAuth()` rejects with an `ApiError` whose `status === 401` and name `NotAuthenticatedException`.
- `index.browser.test.ts` — new `handle401` block: redirects to `/aws-blocks/auth/signin/<provider>` on a 401 `ApiError`, returns `false` on a non-401, and (regression) does not match the pre-fix bare `Error` shape.
- Full `bb-auth-oidc` suite: 116/116 pass; repo-wide `tsc --build` clean.

Found during OIDC E2E (friction log #20; `docs/auth-testability-gaps.md` G-4).
