### PR TITLE
fix(core,hosting,bb-lambda-compute): disable the API Gateway CloudWatch role

### DIFF
--- a/.changeset/apigw-cloudwatch-role-leak.md
+++ b/.changeset/apigw-cloudwatch-role-leak.md
@@ -1,0 +1,23 @@
+---
+"@aws-blocks/core": patch
+"@aws-blocks/hosting": patch
+"@aws-blocks/bb-lambda-compute": patch
+---
+
+`RestApi`: do not create the account-level API Gateway CloudWatch role.
+
+CDK sets `cloudWatchRole: true` by default on `RestApi`. This default creates two resources:
+
+- An IAM role with `RemovalPolicy.RETAIN`. The role stays after you delete the stack.
+- `AWS::ApiGateway::Account`. This resource is a singleton for each account and each region.
+
+Both resources cause failures in an account that deploys many stacks:
+
+- The retained roles increase until the account reaches the IAM limit of 1500 roles. Every new stack then fails with `ServiceLimitExceeded: RolesPerAccount 1500`.
+- Two deploys that run at the same time write the same singleton. API Gateway returns HTTP 429. The stack create fails and rolls back.
+
+The rollback makes the second failure permanent. CloudFormation deletes the S3 bucket before it creates the CDK auto-delete custom resource. The bucket keeps its object versions, so the delete fails and the stack stops in `DELETE_FAILED`. That stack retains every IAM role it holds, which makes the role leak worse.
+
+This change sets `cloudWatchRole: false` at all three `RestApi` call sites: `@aws-blocks/core` (`BlocksBackend`), `@aws-blocks/hosting` (the SSR origin), and `@aws-blocks/bb-lambda-compute`. No block turns on API Gateway execution logging, so the role has no use.
+
+**Behavior change:** a deploy no longer sets the account-level CloudWatch role for API Gateway. To use API Gateway execution logging, set that role one time for the account, outside the stack. Access logging on a stage does not use this role, and it continues to work.

--- a/.github/workflows/cleanup-stacks.yml
+++ b/.github/workflows/cleanup-stacks.yml
@@ -64,7 +64,20 @@ jobs:
               fi
             fi
 
+            # DynamoDB refuses deletion while protection is on, which wedges the
+            # stack permanently. Clear it first.
+            for TABLE in $(aws cloudformation list-stack-resources --stack-name "$STACK" \
+              --query "StackResourceSummaries[?ResourceType=='AWS::DynamoDB::Table'].PhysicalResourceId" \
+              --output text 2>/dev/null); do
+              aws dynamodb update-table --table-name "$TABLE" \
+                --no-deletion-protection-enabled >/dev/null 2>&1 \
+                && echo "   deletion protection off: $TABLE"
+            done
+
             echo "🗑️  Delete triggered: $STACK (created $CREATION_TIME)"
+            # Pace the calls. API Gateway's control plane returns 429 when many
+            # stacks delete at once, and a throttled RestApi delete wedges.
+            sleep 3
             if aws cloudformation delete-stack --stack-name "$STACK"; then
               DELETED=$((DELETED + 1))
               DELETED_STACKS="$DELETED_STACKS $STACK"
@@ -101,8 +114,46 @@ jobs:
             fi
           done
 
+          # --- Second pass: retain the leaf that refuses, free the stack ---
+          # Without this a single stuck resource keeps the whole stack, and every
+          # IAM role in it, forever. RetainResources is valid only for resources
+          # already in DELETE_FAILED. Retained resources are orphans, so name
+          # them explicitly rather than reporting a clean success.
+          RETRIED=""
+          ORPHANED=""
+          for STACK in $DELETE_FAILURES; do
+            [ -z "$STACK" ] && continue
+            STATUS=$(aws cloudformation describe-stacks --stack-name "$STACK" \
+              --query "Stacks[0].StackStatus" --output text 2>/dev/null || echo "GONE")
+            [ "$STATUS" != "DELETE_FAILED" ] && continue
+
+            STUCK=$(aws cloudformation list-stack-resources --stack-name "$STACK" \
+              --query "StackResourceSummaries[?ResourceStatus=='DELETE_FAILED'].LogicalResourceId" \
+              --output text 2>/dev/null)
+            [ -z "$STUCK" ] && continue
+
+            echo "♻️  Retrying $STACK, retaining: $STUCK"
+            if aws cloudformation delete-stack --stack-name "$STACK" --retain-resources $STUCK; then
+              RETRIED="$RETRIED $STACK"
+              ORPHANED="$ORPHANED $STACK:[$STUCK]"
+            fi
+            sleep 3
+          done
+
+          for STACK in $RETRIED; do
+            aws cloudformation wait stack-delete-complete --stack-name "$STACK" 2>/dev/null \
+              && echo "✅ $STACK deleted (leaf retained)" \
+              && ACTUALLY_DELETED=$((ACTUALLY_DELETED + 1))
+          done
+
           echo ""
           echo "## Stack Cleanup Summary" | tee -a "$GITHUB_STEP_SUMMARY"
+          if [ -n "$ORPHANED" ]; then
+            echo "- ⚠️ Orphaned resources (retained, need manual cleanup):" | tee -a "$GITHUB_STEP_SUMMARY"
+            for ENTRY in $ORPHANED; do
+              echo "  - $ENTRY" | tee -a "$GITHUB_STEP_SUMMARY"
+            done
+          fi
           echo "- Delete triggered: $DELETED" | tee -a "$GITHUB_STEP_SUMMARY"
           echo "- Actually deleted: $ACTUALLY_DELETED" | tee -a "$GITHUB_STEP_SUMMARY"
           echo "- Failed to trigger: $FAILED" | tee -a "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -501,7 +501,12 @@ jobs:
         if: always()
         run: |
           cd ${{ matrix.app-dir }}
-          npx tsx test/sandbox-destroy.ts aws-blocks/index.cdk.ts || true
+          # A teardown failure leaks a stack and its retained roles. Warn in the
+          # job summary instead of `|| true`, which hid this for two months.
+          if ! npx tsx test/sandbox-destroy.ts aws-blocks/index.cdk.ts; then
+            echo "::warning::Teardown failed for ${{ matrix.framework }}; stack may be stuck in DELETE_FAILED"
+            echo "⚠️ Teardown failed for ${{ matrix.framework }}" >> "$GITHUB_STEP_SUMMARY"
+          fi
 
   e2e-telemetry:
     name: Telemetry E2E

--- a/packages/bb-lambda-compute/src/index.cdk.ts
+++ b/packages/bb-lambda-compute/src/index.cdk.ts
@@ -57,6 +57,8 @@ export class LambdaCompute extends Compute {
 		this.apiGateway = new apigateway.RestApi(this, 'API', {
 			restApiName: 'Blocks API',
 			deployOptions: { cachingEnabled: false },
+			// Retained IAM role + account-level singleton. See blocks-backend.ts.
+			cloudWatchRole: false,
 		});
 
 		const integration = new apigateway.LambdaIntegration(this.fn);

--- a/packages/core/src/cdk/blocks-backend.test.ts
+++ b/packages/core/src/cdk/blocks-backend.test.ts
@@ -97,6 +97,38 @@ describe('synth shape (drop into existing stack)', () => {
     const template = Template.fromStack(parent);
     template.resourceCountIs('AWS::ApiGateway::RestApi', 2);
   });
+
+  test('no account-level API Gateway CloudWatch role is created', async () => {
+    const app = new cdk.App();
+    const parent = new cdk.Stack(app, 'NoCloudWatchRoleStack');
+
+    await BlocksBackend.create(parent, 'Backend', {
+      backendHandlerPath: handlerPath,
+      backendCDKPath: sideEffectBackendPath,
+      defaults: BlocksPresets.production,
+    });
+
+    // CDK's RestApi default retains this role after stack deletion, and the
+    // singleton below returns 429 when deploys run at the same time.
+    const template = Template.fromStack(parent);
+    template.resourceCountIs('AWS::ApiGateway::Account', 0);
+    const roles = template.findResources('AWS::IAM::Role', {
+      Properties: {
+        AssumeRolePolicyDocument: {
+          Statement: Match.arrayWith([
+            Match.objectLike({
+              Principal: { Service: 'apigateway.amazonaws.com' },
+            }),
+          ]),
+        },
+      },
+    });
+    assert.deepStrictEqual(
+      Object.keys(roles),
+      [],
+      'no IAM role should be assumable by apigateway.amazonaws.com',
+    );
+  });
 });
 
 describe('shared execution role', () => {

--- a/packages/core/src/cdk/blocks-backend.ts
+++ b/packages/core/src/cdk/blocks-backend.ts
@@ -134,6 +134,10 @@ export function setupBlocksInfra(scope: Construct, props: BlocksBackendProps, id
   const api = new apigateway.RestApi(scope, 'API', {
     restApiName: 'Blocks API',
     deployOptions: { cachingEnabled: false },
+    // CDK's default creates a RETAIN-ed IAM role that outlives the stack, plus
+    // the AWS::ApiGateway::Account singleton that 429s on concurrent deploys.
+    // Nothing here enables execution logging, so the role has no use.
+    cloudWatchRole: false,
   });
 
   const integration = new apigateway.LambdaIntegration(handler);

--- a/packages/hosting/src/constructs/cdn_construct.ts
+++ b/packages/hosting/src/constructs/cdn_construct.ts
@@ -408,6 +408,8 @@ export class CdnConstruct extends Construct {
       restApi = new RestApi(this, 'SsrRestApi', {
         endpointTypes: [EndpointType.REGIONAL],
         deployOptions: { stageName: 'prod' },
+        // Retained IAM role + account-level singleton. See core/blocks-backend.ts.
+        cloudWatchRole: false,
         // Treat all bodies as binary. Without this, API Gateway base64-encodes
         // request bodies (Lambda then sees 2× size) and re-encodes responses,
         // breaking binary uploads, downloads, and streaming.


### PR DESCRIPTION
## Problem

The shared CI account reached the IAM limit of 1500 roles. Every E2E job failed at stack create with `ServiceLimitExceeded: RolesPerAccount 1500`. 161 stacks also stopped in `DELETE_FAILED`. The scheduled cleanup job failed on 410 runs in sequence, from 2026-06-17 to 2026-08-25.

## Cause

CDK sets `cloudWatchRole: true` by default on `RestApi`. The default creates two resources:

1. An IAM role with `RemovalPolicy.RETAIN`. The role stays after CloudFormation deletes the stack.
2. `AWS::ApiGateway::Account`. This resource is one singleton for each account and each region.

Measured state before cleanup: 1492 of 1500 roles were in use. 1315 of those roles (88%) were API Gateway CloudWatch roles that no stack owned. `aws apigateway get-account` returned `cloudwatchRoleArn: None`, so no role was in use.

The two resources fail in different ways, and together they form a loop:

- The retained roles increase until the account reaches the limit. Every new stack then fails.
- Two deploys that run at the same time write the same singleton. API Gateway returns HTTP 429, and the stack create rolls back.
- The rollback deletes the S3 bucket before CloudFormation creates the CDK auto-delete custom resource. The bucket keeps its object versions, so the delete fails and the stack stops in `DELETE_FAILED`.
- That stack retains every IAM role it holds. The leak gets worse.

## Change

- Set `cloudWatchRole: false` at the three `RestApi` call sites: `@aws-blocks/core` (`BlocksBackend`), `@aws-blocks/hosting` (the SSR origin), and `@aws-blocks/bb-lambda-compute`.
- Cleanup workflow: clear DynamoDB deletion protection before a delete. Pace the delete calls to stay under the API Gateway rate limit. Retry a wedged stack and retain the leaf that refuses, then name each orphaned resource in the job summary.
- PR workflow: report a hosting teardown failure. The old code used `|| true`, which hid this problem for two months.

## Test

`blocks-backend.test.ts` asserts zero `AWS::ApiGateway::Account` resources, and zero IAM roles that `apigateway.amazonaws.com` can assume. The test fails when the fix is removed. I checked this.

`npm run build`, `npm run lint`, `npm run lint:deps`, `npm test`, and `npm run test:e2e:local` all pass.

## Impact

A deploy no longer sets the account-level CloudWatch role for API Gateway. No block turns on API Gateway execution logging, so no block loses function. To use execution logging, set that role one time for the account, outside the stack. Access logging on a stage does not use this role, and it continues to work.

## Review

**`cloudWatchRole: false` changes behavior for a downstream app, so it needs maintainer review.** An app that depends on Blocks to set the account-level role must now set it separately. An alternative is a new `BlocksDefaults` field to make the role opt-in. That choice adds public API surface, so I left it out.

## Notes

- DynamoDB deletion protection also wedged 8 stacks. That cause is already fixed at HEAD by #302, which made `test-apps/comprehensive` use `BlocksPresets.sandbox` without a condition. No change was needed.
- A separate one-off script cleared the backlog. Roles went from 1492 to 317, and `DELETE_FAILED` went from 161 to 19.
- Follow-up, not in this PR: alarm the scheduled cleanup job. 410 silent red runs are the reason this problem reached the account limit.
