### PR TITLE
fix(core): count nameless custom Building Blocks in telemetry

### DIFF
--- a/.changeset/count-nameless-custom-blocks.md
+++ b/.changeset/count-nameless-custom-blocks.md
@@ -1,0 +1,5 @@
+---
+"@aws-blocks/core": patch
+---
+
+Fix custom Building Block telemetry counting so a Building Block authored by extending `Scope` without a `bbName` is counted in `customBlocksCount`. Previously only Blocks that passed a `bbName` were registered, so nameless custom Blocks were omitted from the count entirely. Plain `Scope` grouping nodes and framework-owned scopes (such as `RawRoute`) remain excluded.

--- a/packages/core/API.md
+++ b/packages/core/API.md
@@ -186,6 +186,8 @@ export interface ScopeOptions {
     bbName?: string;
     // (undocumented)
     bbVersion?: string;
+    // @internal
+    frameworkScope?: boolean;
     // (undocumented)
     parent?: ScopeParent;
 }

--- a/packages/core/src/common/index.ts
+++ b/packages/core/src/common/index.ts
@@ -12,6 +12,13 @@ export interface ScopeOptions {
   parent?: ScopeParent;
   bbName?: string;
   bbVersion?: string;
+  /**
+   * Internal marker for framework-owned `Scope` subclasses (e.g. `RawRoute`)
+   * that are not Building Blocks. Such scopes are excluded from the custom
+   * Building Block count even though they have no `bbName`.
+   * @internal
+   */
+  frameworkScope?: boolean;
 }
 
 export type ScopeParent = Scope | { id: string };
@@ -143,6 +150,14 @@ export class Scope {
   /** Static registry — collects BB names as they're instantiated */
   private static _bbRegistry: Map<string, { version: string; count: number }> = new Map();
 
+  /**
+   * Count of nameless custom Building Blocks — `Scope` subclasses instantiated
+   * without a `bbName`. Tracked separately from `_bbRegistry` because they have
+   * no name to key on. Excludes plain `Scope` grouping nodes and framework
+   * scopes (see the constructor).
+   */
+  private static _unnamedCustomCount = 0;
+
   constructor(id: string, options?: ScopeOptions) {
     this.id = id;
     this.parent = options?.parent || (globalThis as any).CURRENT_BLOCKS_STACK || {
@@ -157,6 +172,14 @@ export class Scope {
         version: options.bbVersion || 'unknown',
         count: (existing?.count || 0) + 1,
       });
+    } else if (this.constructor !== Scope && !options?.frameworkScope) {
+      // A nameless `Scope` *subclass* is a custom Building Block authored
+      // without BB metadata. It can never be an official BB (its name is
+      // unknown and never exposed), so it counts toward the custom total.
+      // Excluded: a plain `new Scope()` used purely for grouping
+      // (`this.constructor === Scope`) and framework-owned scopes such as
+      // `RawRoute` (`frameworkScope: true`).
+      Scope._unnamedCustomCount += 1;
     }
   }
 
@@ -165,6 +188,8 @@ export class Scope {
    *
    * Only official BB names (in OFFICIAL_BB_NAMES) are returned in `blocks`.
    * Custom BBs are counted in `customBlocksCount` but their names are never exposed.
+   * This includes both named custom BBs (a `bbName` not in OFFICIAL_BB_NAMES) and
+   * nameless custom BBs (`Scope` subclasses instantiated without a `bbName`).
    *
    * @returns Official blocks, total instance count, and total number of custom BB instances.
    * @internal
@@ -181,12 +206,17 @@ export class Scope {
         customBlocksCount += count;
       }
     }
+    // Nameless custom BBs have no registry key of their own, so fold their
+    // running count into both totals here.
+    totalCount += Scope._unnamedCustomCount;
+    customBlocksCount += Scope._unnamedCustomCount;
     return { blocks, totalCount, customBlocksCount };
   }
 
   /** Reset registry (useful for testing). */
   static _resetRegistry(): void {
     Scope._bbRegistry.clear();
+    Scope._unnamedCustomCount = 0;
   }
 
   get fullId(): string {

--- a/packages/core/src/raw-route.cdk.ts
+++ b/packages/core/src/raw-route.cdk.ts
@@ -49,7 +49,7 @@ export class RawRoute extends Scope {
   public readonly path: string;
 
   constructor(scope: ScopeParent, id: string, options: RawRouteOptions) {
-    super(id, { parent: scope });
+    super(id, { parent: scope, frameworkScope: true });
     this.path = resolveRoutePath(scope, id, options);
     registerRoute({ ...options, path: this.path });
   }

--- a/packages/core/src/raw-route.mock.ts
+++ b/packages/core/src/raw-route.mock.ts
@@ -49,7 +49,7 @@ export class RawRoute extends Scope {
   public readonly path: string;
 
   constructor(scope: ScopeParent, id: string, options: RawRouteOptions) {
-    super(id, { parent: scope });
+    super(id, { parent: scope, frameworkScope: true });
     this.path = resolveRoutePath(scope, id, options);
     registerRoute({ ...options, path: this.path });
   }

--- a/packages/core/src/telemetry/telemetry.test.ts
+++ b/packages/core/src/telemetry/telemetry.test.ts
@@ -1234,6 +1234,20 @@ class CustomTestBB extends Scope {
   }
 }
 
+/** Test subclass with NO bbName — a custom Building Block authored without BB metadata. */
+class NamelessCustomBB extends Scope {
+  constructor(parent: ScopeParent, id: string) {
+    super(id, { parent });
+  }
+}
+
+/** Test subclass that opts out of counting via the internal frameworkScope flag (as RawRoute does). */
+class FrameworkScopeBB extends Scope {
+  constructor(parent: ScopeParent, id: string) {
+    super(id, { parent, frameworkScope: true });
+  }
+}
+
 describe('Scope.getRegisteredBlocks', () => {
   afterEach(() => {
     Scope._resetRegistry();
@@ -1318,6 +1332,46 @@ describe('Scope.getRegisteredBlocks', () => {
   it('plain Scope (no bbName) does not appear in registry', () => {
     const parent = { id: 'test-app' };
     new Scope('plain-scope', { parent });
+
+    const result = Scope.getRegisteredBlocks();
+    assert.deepStrictEqual(result, { blocks: [], totalCount: 0, customBlocksCount: 0 });
+  });
+
+  it('nameless custom BB (Scope subclass without bbName) is counted as custom', () => {
+    const parent = { id: 'test-app' };
+    new NamelessCustomBB(parent, 'custom-1');
+
+    const result = Scope.getRegisteredBlocks();
+    assert.deepStrictEqual(result.blocks, []);
+    assert.strictEqual(result.totalCount, 1);
+    assert.strictEqual(result.customBlocksCount, 1);
+  });
+
+  it('multiple nameless custom BBs each count toward the custom total', () => {
+    const parent = { id: 'test-app' };
+    new NamelessCustomBB(parent, 'custom-1');
+    new NamelessCustomBB(parent, 'custom-2');
+
+    const result = Scope.getRegisteredBlocks();
+    assert.strictEqual(result.totalCount, 2);
+    assert.strictEqual(result.customBlocksCount, 2);
+  });
+
+  it('named and nameless custom BBs are both counted', () => {
+    const parent = { id: 'test-app' };
+    new OfficialTestBB(parent, 'store-1'); // official → blocks[]
+    new CustomTestBB(parent, 'named-custom'); // named custom → customBlocksCount
+    new NamelessCustomBB(parent, 'nameless-custom'); // nameless custom → customBlocksCount
+
+    const result = Scope.getRegisteredBlocks();
+    assert.deepStrictEqual(result.blocks, [{ name: 'KVStore', version: '1.0.0' }]);
+    assert.strictEqual(result.totalCount, 3);
+    assert.strictEqual(result.customBlocksCount, 2);
+  });
+
+  it('framework scopes (frameworkScope, e.g. RawRoute) are not counted as custom', () => {
+    const parent = { id: 'test-app' };
+    new FrameworkScopeBB(parent, 'raw-route');
 
     const result = Scope.getRegisteredBlocks();
     assert.deepStrictEqual(result, { blocks: [], totalCount: 0, customBlocksCount: 0 });


### PR DESCRIPTION
## What

Fixes the custom Building Block counter so a Building Block authored by extending `Scope` **without** a `bbName` is counted in `customBlocksCount`.

## The bug

`Scope` only registers an instance when a `bbName` is passed to `super(...)`:

```ts
if (options?.bbName) {
  // ...register in _bbRegistry
}
```

`getRegisteredBlocks()` derives `customBlocksCount` purely from that registry, so a custom Building Block created by extending `Scope` without BB metadata is never registered and is invisible to the count (it also never contributes to `totalCount`). Official Blocks are unaffected because they set a `bbName` in their runtime/mock layers.

## The fix

- `Scope` now also tracks nameless `Scope` **subclasses** as custom Building Blocks (a separate `_unnamedCustomCount`, since they have no name to key the registry by). `getRegisteredBlocks()` folds that into both `customBlocksCount` and `totalCount`.
- Excluded from the custom count:
  - a plain `new Scope(...)` used purely for grouping (`this.constructor === Scope`), e.g. the app root namespace, and
  - framework-owned scopes such as `RawRoute`, via a new internal `frameworkScope` option on `ScopeOptions` (marked `@internal`).
- Custom BB names are still never exposed. Only the count changes.

## Tests

Added to `packages/core/src/telemetry/telemetry.test.ts`:
- a nameless `Scope` subclass is counted as custom (single and multiple instances),
- named and nameless custom BBs are both counted while an official BB stays in `blocks[]`,
- framework scopes (`frameworkScope`) are not counted,
- the existing "plain `Scope` does not appear in registry" behavior is preserved.

## Verification (local)

- `npm run build` (full) clean.
- `npm run update:api` + `npm run check:api` pass; the only API report change is `packages/core/API.md` gaining the `@internal frameworkScope?` field.
- `core` telemetry suite passes (5/5 new cases green).
- The `bb-logger`, `bb-metrics`, `bb-tracer`, `bb-distributed-data`, `bb-auth-basic` "registers as an official block / not an unnamed custom block" tests still pass (those Blocks are named, so they remain official and uncounted as custom).
