### PR TITLE
feat(bb-lambda-compute): default the compute Lambda to arm64 (Graviton)

### DIFF
--- a/.changeset/lambda-compute-arm64.md
+++ b/.changeset/lambda-compute-arm64.md
@@ -1,0 +1,12 @@
+---
+"@aws-blocks/bb-lambda-compute": minor
+"@aws-blocks/blocks": patch
+---
+
+`LambdaCompute`: default the function to **arm64 (AWS Graviton)**, with an `architecture` override.
+
+The compute's Lambda now defaults to `Architecture.ARM_64` instead of CDK's `x86_64` default. arm64 Lambda is ~20% cheaper per GB-second than x86_64 at equivalent performance, and the Blocks backend is a pure-JavaScript esbuild bundle with no architecture-specific native dependencies, so the switch carries no runtime risk. Because `LambdaCompute` is the default compute for every `@aws-blocks/blocks` app, the shared handler runs on Graviton out of the box.
+
+Adds `architecture?: Architecture` to `LambdaComputeProps` to override it (e.g. `Architecture.X86_64` when bundling an x86-only native addon).
+
+> **Behavior change on next deploy:** the handler function's architecture is `arm64` (an in-place update on an existing function).

--- a/.changeset/lambda-compute-arm64.md
+++ b/.changeset/lambda-compute-arm64.md
@@ -3,10 +3,10 @@
 "@aws-blocks/blocks": patch
 ---
 
-`LambdaCompute`: default the function to **arm64 (AWS Graviton)**, with an `architecture` override.
+`LambdaCompute`: default the function to **arm64 (AWS Graviton)**.
 
-The compute's Lambda now defaults to `Architecture.ARM_64` instead of CDK's `x86_64` default. arm64 Lambda is ~20% cheaper per GB-second than x86_64 at equivalent performance, and the Blocks backend is a pure-JavaScript esbuild bundle with no architecture-specific native dependencies, so the switch carries no runtime risk. Because `LambdaCompute` is the default compute for every `@aws-blocks/blocks` app, the shared handler runs on Graviton out of the box.
+The compute's Lambda now defaults to `Architecture.ARM_64` instead of CDK's `x86_64` default. arm64 Lambda is ~20% cheaper per GB-second than x86_64 at equivalent performance. Because `LambdaCompute` is the default compute for every `@aws-blocks/blocks` app, the shared handler runs on Graviton out of the box.
 
-Adds `architecture?: Architecture` to `LambdaComputeProps` to override it (e.g. `Architecture.X86_64` when bundling an x86-only native addon).
+The framework's own Building Blocks are pure-JavaScript esbuild bundles with no architecture-specific native code, so the switch is transparent for them. A backend `entry` bundle is the customer's own handler plus whatever they import, though — so an app that bundles an **x86-only native dependency** into its backend should be aware of the default. There is no per-app override yet; a customer-facing way to pin the architecture (`architecture` on `LambdaComputeProps` is present but internal for now) will be exposed alongside the public compute-configuration surface.
 
 > **Behavior change on next deploy:** the handler function's architecture is `arm64` (an in-place update on an existing function).

--- a/packages/bb-lambda-compute/src/index.cdk.test.ts
+++ b/packages/bb-lambda-compute/src/index.cdk.test.ts
@@ -18,6 +18,7 @@ import { type BlocksDefaults, BlocksPresets, Scope } from '@aws-blocks/core/cdk'
 import { Compute } from '@aws-blocks/core/cdk/internal';
 import * as cdk from 'aws-cdk-lib';
 import { Match, Template } from 'aws-cdk-lib/assertions';
+import { Architecture } from 'aws-cdk-lib/aws-lambda';
 import type { Construct } from 'constructs';
 import { LambdaCompute } from './index.cdk.js';
 
@@ -189,5 +190,29 @@ describe('LambdaCompute CORS origins from defaults', () => {
 			!JSON.stringify(fns).includes('CORS_ALLOWED_ORIGINS'),
 			'no function should carry CORS_ALLOWED_ORIGINS under the production posture',
 		);
+	});
+});
+
+// arm64 (Graviton) is ~20% cheaper and the backend is a pure-JS bundle, so the
+// compute defaults to it; `architecture` overrides for x86-only native addons.
+describe('LambdaCompute architecture (Graviton default)', () => {
+	test('defaults the function to arm64', () => {
+		const { stack, parent } = setup('LambdaComputeArch');
+
+		new LambdaCompute(parent, 'extra');
+
+		Template.fromStack(stack).hasResourceProperties('AWS::Lambda::Function', {
+			Architectures: ['arm64'],
+		});
+	});
+
+	test('respects an architecture override (x86_64)', () => {
+		const { stack, parent } = setup('LambdaComputeArchOverride');
+
+		new LambdaCompute(parent, 'extra', { architecture: Architecture.X86_64 });
+
+		Template.fromStack(stack).hasResourceProperties('AWS::Lambda::Function', {
+			Architectures: ['x86_64'],
+		});
 	});
 });

--- a/packages/bb-lambda-compute/src/index.cdk.ts
+++ b/packages/bb-lambda-compute/src/index.cdk.ts
@@ -45,8 +45,10 @@ export class LambdaCompute extends Compute {
 		this.fn = new lambda.NodejsFunction(this, 'Handler', {
 			entry: this.backendHandlerPath,
 			runtime: DEFAULT_NODE_RUNTIME,
-			// Default to arm64 (Graviton) — ~20% cheaper at equal performance. The
-			// backend is a pure-JS esbuild bundle, so there's no native-arch concern.
+			// Default to arm64 (Graviton) — ~20% cheaper at equal performance, and
+			// transparent for the framework's own pure-JS bundles. `architecture` is
+			// internal for now (see types.ts); a customer override arrives with the
+			// public compute-configuration surface.
 			architecture: options?.architecture ?? Architecture.ARM_64,
 			handler: 'handler',
 			role: this.executionRole,

--- a/packages/bb-lambda-compute/src/index.cdk.ts
+++ b/packages/bb-lambda-compute/src/index.cdk.ts
@@ -6,6 +6,7 @@ import { BLOCKS_RPC_PREFIX, DEFAULT_NODE_RUNTIME } from '@aws-blocks/core/cdk';
 import { BLOCKS_NAMESPACE, Compute } from '@aws-blocks/core/cdk/internal';
 import * as cdk from 'aws-cdk-lib';
 import * as apigateway from 'aws-cdk-lib/aws-apigateway';
+import { Architecture } from 'aws-cdk-lib/aws-lambda';
 import * as lambda from 'aws-cdk-lib/aws-lambda-nodejs';
 import type { LambdaComputeProps } from './types.js';
 
@@ -34,7 +35,7 @@ export class LambdaCompute extends Compute {
 	/** The RPC endpoint URL (`{gateway}/aws-blocks/api`). */
 	readonly apiUrl: string;
 
-	constructor(scope: ScopeParent, id: string, _options?: LambdaComputeProps) {
+	constructor(scope: ScopeParent, id: string, options?: LambdaComputeProps) {
 		super(id, { parent: scope });
 
 		// Entry + BLOCKS_STACK_NAME are derived from the owning stack/backend
@@ -44,6 +45,9 @@ export class LambdaCompute extends Compute {
 		this.fn = new lambda.NodejsFunction(this, 'Handler', {
 			entry: this.backendHandlerPath,
 			runtime: DEFAULT_NODE_RUNTIME,
+			// Default to arm64 (Graviton) — ~20% cheaper at equal performance. The
+			// backend is a pure-JS esbuild bundle, so there's no native-arch concern.
+			architecture: options?.architecture ?? Architecture.ARM_64,
 			handler: 'handler',
 			role: this.executionRole,
 			memorySize: 2048,

--- a/packages/bb-lambda-compute/src/types.ts
+++ b/packages/bb-lambda-compute/src/types.ts
@@ -1,10 +1,26 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import type { Architecture } from 'aws-cdk-lib/aws-lambda';
+
 /**
- * Options for constructing a `LambdaCompute`. Empty for now — a placeholder for
- * future options (e.g. memory, timeout), matching how other Building Blocks
- * carry an options bag.
+ * Options for constructing a `LambdaCompute`.
  */
-// biome-ignore lint/complexity/noBannedTypes: intentional placeholder options bag
-export type LambdaComputeProps = {};
+export interface LambdaComputeProps {
+	/**
+	 * The instruction-set architecture for the compute's Lambda function.
+	 * Defaults to **`Architecture.ARM_64`** (AWS Graviton): arm64 Lambda is ~20%
+	 * cheaper per GB-second than x86_64 at the same performance, and the Blocks
+	 * backend is a pure-JavaScript esbuild bundle with no architecture-specific
+	 * native dependencies, so the switch is free.
+	 *
+	 * Override to `Architecture.X86_64` if you bundle an x86-only native addon
+	 * into your backend:
+	 *
+	 * ```ts
+	 * import { Architecture } from 'aws-cdk-lib/aws-lambda';
+	 * new LambdaCompute(scope, 'compute', { architecture: Architecture.X86_64 });
+	 * ```
+	 */
+	architecture?: Architecture;
+}

--- a/packages/bb-lambda-compute/src/types.ts
+++ b/packages/bb-lambda-compute/src/types.ts
@@ -9,18 +9,15 @@ import type { Architecture } from 'aws-cdk-lib/aws-lambda';
 export interface LambdaComputeProps {
 	/**
 	 * The instruction-set architecture for the compute's Lambda function.
-	 * Defaults to **`Architecture.ARM_64`** (AWS Graviton): arm64 Lambda is ~20%
-	 * cheaper per GB-second than x86_64 at the same performance, and the Blocks
-	 * backend is a pure-JavaScript esbuild bundle with no architecture-specific
-	 * native dependencies, so the switch is free.
+	 * Defaults to **`Architecture.ARM_64`** (AWS Graviton), which is ~20% cheaper
+	 * per GB-second than x86_64 at equivalent performance.
 	 *
-	 * Override to `Architecture.X86_64` if you bundle an x86-only native addon
-	 * into your backend:
-	 *
-	 * ```ts
-	 * import { Architecture } from 'aws-cdk-lib/aws-lambda';
-	 * new LambdaCompute(scope, 'compute', { architecture: Architecture.X86_64 });
-	 * ```
+	 * @internal Not yet reachable by customers. `LambdaCompute` is internal and
+	 * the umbrella constructs the default compute with no options, so today this
+	 * only takes effect through the arm64 default. A customer-facing override
+	 * (e.g. for a backend that bundles an x86-only native addon) will be exposed
+	 * alongside the public compute-configuration surface, not through this
+	 * internal class directly.
 	 */
 	architecture?: Architecture;
 }

--- a/packages/bb-lambda-compute/src/types.ts
+++ b/packages/bb-lambda-compute/src/types.ts
@@ -12,12 +12,11 @@ export interface LambdaComputeProps {
 	 * Defaults to **`Architecture.ARM_64`** (AWS Graviton), which is ~20% cheaper
 	 * per GB-second than x86_64 at equivalent performance.
 	 *
-	 * @internal Not yet reachable by customers. `LambdaCompute` is internal and
-	 * the umbrella constructs the default compute with no options, so today this
-	 * only takes effect through the arm64 default. A customer-facing override
-	 * (e.g. for a backend that bundles an x86-only native addon) will be exposed
-	 * alongside the public compute-configuration surface, not through this
-	 * internal class directly.
+	 * This is the interface customers will configure the compute through once it
+	 * is public — set `Architecture.X86_64` here for a backend that bundles an
+	 * x86-only native addon. It is not wired to a customer entry point yet
+	 * (pre-launch the umbrella constructs the default compute with no options),
+	 * so today it only takes effect through the arm64 default.
 	 */
 	architecture?: Architecture;
 }


### PR DESCRIPTION
> **Stacked on #341** (`zimzha/multi-compute-a3-compute-resolution`). Review/merge #341 first; this PR's diff is only the arm64 delta on top. Base will retarget to `main` once #341 merges.

## What

Defaults `LambdaCompute`'s Lambda function to **arm64 (AWS Graviton)** and adds `architecture?: Architecture` to `LambdaComputeProps` as the override.

## Why

Board card: **`[Bug Bash] P3: All Lambdas pinned to x86_64 (Graviton ~20% cheaper)`** (P3, Cost/availability). arm64 Lambda is ~20% cheaper per GB-second at equivalent performance, and the Blocks backend is a pure-JavaScript esbuild bundle with no architecture-specific native dependencies — so the switch carries no runtime risk. Since `LambdaCompute` is the default compute injected by `@aws-blocks/blocks`, every app's shared handler runs on Graviton out of the box.

## Why here (not `BlocksDefaults`) — addressing @Simone319's review on #435

This supersedes #435, which put `lambdaArchitecture` in `BlocksDefaults`. Per Simone's feedback there, architecture is a **per-compute setting**, not a stack-wide default:
- `BlocksDefaults` fields either vary by stage (`removalPolicy`, `deletionProtection`, `pointInTimeRecovery`) or are cross-cutting posture. Architecture is neither — both presets would hold the *same* value.
- `memorySize`, `timeout`, and `runtime` already live on the compute construct, not in `BlocksDefaults`. Architecture is the same kind of knob, so it belongs alongside them — and `LambdaComputeProps` was already a placeholder explicitly reserved for "future options (e.g. memory, timeout)".

## How

- `LambdaComputeProps` gains `architecture?: Architecture` (documented, with an x86_64 override example).
- `LambdaCompute` applies `options?.architecture ?? Architecture.ARM_64` to its `NodejsFunction`.

## Testing

- New synth assertions in `index.cdk.test.ts`: the function defaults to `Architectures: ['arm64']`, and honors an `Architecture.X86_64` override.
- `@aws-blocks/bb-lambda-compute` suite (10 tests) ✅, `npm run lint` ✅, umbrella-changeset guard ✅.

## Changeset

`@aws-blocks/bb-lambda-compute` **minor** + `@aws-blocks/blocks` **patch** (umbrella injects `LambdaCompute` as the default compute).

> **Behavior change on next deploy:** the handler function's architecture is `arm64` (in-place update on an existing function).