### PR TITLE
fix(core): stop leaking internal exception details in RPC error responses

### DIFF
--- a/.changeset/rpc-sanitize-internal-errors.md
+++ b/.changeset/rpc-sanitize-internal-errors.md
@@ -1,0 +1,12 @@
+---
+"@aws-blocks/core": patch
+"@aws-blocks/blocks": patch
+---
+
+`ApiNamespace` RPC: stop leaking internal exception details to clients.
+
+`errorResponseFromCatch` previously forwarded the raw `error.message` (and, for non-generic names, the exception class name in `data.name`) of **any** thrown value into the JSON-RPC error response. For the common case — a driver/SDK failure (Postgres, DynamoDB, …) rather than an `ApiError` — that put internal implementation details (table names, SQL fragments, ARNs, exception class names) on the wire to every caller.
+
+Now only `ApiError` reaches the client verbatim (its status, message, `name`, and `retriable` flag are the public, `isBlocksError`-matchable contract). Every other throw collapses to a stable generic `{ code: 500, message: "Internal error" }` with no `data`. The full error is still logged server-side by the Lambda handler and the dev server, so debuggability is unchanged.
+
+> Behavior change: clients that previously read the raw `message`/`data.name` of a non-`ApiError` failure now receive `"Internal error"` / code `500`. Throw an `ApiError` to send a specific, client-safe message.

--- a/packages/core/src/rpc.test.ts
+++ b/packages/core/src/rpc.test.ts
@@ -158,9 +158,28 @@ describe('ApiError status ↔ JSON-RPC error code', () => {
     assert.strictEqual(parsed.error.data.retriable, true);
   });
 
-  it('encodes a non-ApiError throw as code 500 with no data.name', () => {
+  it('collapses a non-ApiError throw to a generic 500 with no message or name leak', () => {
     const parsed = JSON.parse(errorResponseFromCatch(new Error('plain'), 2));
     assert.strictEqual(parsed.error.code, 500);
+    assert.strictEqual(parsed.error.message, 'Internal error');
+    assert.strictEqual(parsed.error.data, undefined);
+  });
+
+  it('never leaks a driver/SDK exception class name or raw message to the client', () => {
+    // Mimic a DynamoDB/Postgres driver throw: a real class name and a message
+    // that embeds internal detail (table names, SQL, ARNs, etc.).
+    const driverError = new Error(
+      'ResourceNotFoundException: Requested resource not found: Table: app-notes-prod not found',
+    );
+    driverError.name = 'ResourceNotFoundException';
+
+    const wire = JSON.stringify(JSON.parse(errorResponseFromCatch(driverError, 3)));
+    assert.doesNotMatch(wire, /ResourceNotFoundException/, 'exception class name must not reach the client');
+    assert.doesNotMatch(wire, /app-notes-prod|Table:/, 'raw driver message must not reach the client');
+
+    const parsed = JSON.parse(errorResponseFromCatch(driverError, 3));
+    assert.strictEqual(parsed.error.code, 500);
+    assert.strictEqual(parsed.error.message, 'Internal error');
     assert.strictEqual(parsed.error.data, undefined);
   });
 

--- a/packages/core/src/rpc.ts
+++ b/packages/core/src/rpc.ts
@@ -202,12 +202,20 @@ export function successResponse(result: unknown, id: string | number | null): st
  * use code 500.
  */
 export function errorResponseFromCatch(error: unknown, id: string | number | null): string {
-  const code = error instanceof ApiError ? error.status : 500;
-  const message = error instanceof Error ? error.message : String(error);
+  // Only `ApiError` is a deliberate, client-safe error: its status, message,
+  // `name`, and `retriable` flag are part of the public contract (clients match
+  // on `name` via `isBlocksError`). Any other throw is an internal failure —
+  // typically a driver/SDK exception whose class name and raw message can leak
+  // implementation details (table names, SQL, ARNs, `$metadata`). Collapse those
+  // to a stable, generic 500 so nothing internal reaches the wire; the caller
+  // logs the real error server-side (see lambda-handler.ts / dev-server.ts).
+  if (!(error instanceof ApiError)) {
+    return errorResponse(500, 'Internal error', id);
+  }
   const data: Record<string, unknown> = {};
-  if (error instanceof Error && error.name && error.name !== 'Error') data.name = error.name;
-  if (error instanceof ApiError && error.retriable) data.retriable = true;
-  return errorResponse(code, message, id, Object.keys(data).length > 0 ? data : undefined);
+  if (error.name && error.name !== 'Error') data.name = error.name;
+  if (error.retriable) data.retriable = true;
+  return errorResponse(error.status, error.message, id, Object.keys(data).length > 0 ? data : undefined);
 }
 
 /** Encode a "method not found" error. */


### PR DESCRIPTION
Fixes #227.

## Problem

`errorResponseFromCatch` (`packages/core/src/rpc.ts`) forwarded the raw `error.message` — and, for non-generic names, the exception **class name** as `data.name` — of *any* thrown value into the JSON-RPC error response. For the common case (a driver/SDK failure rather than an `ApiError`), that put internal implementation details on the wire to every caller: table names, SQL fragments, ARNs, `$metadata`, and the internal exception class name. It's both an information-disclosure issue (AGENTS core rules 5–6) and an error-quality one — clients got unstable, non-actionable shapes.

## Fix

Only `ApiError` reaches the client verbatim — its `status`, `message`, `name`, and `retriable` are the deliberate, `isBlocksError`-matchable public contract. Every other throw now collapses to a stable generic `{ code: 500, message: "Internal error" }` with no `data`. The full error is still logged server-side (`lambda-handler.ts:558` `console.error('Lambda Error:', …)` and `dev-server.ts` `[rpc-err]`), so debuggability is unchanged.

## Test (red → green)

Added two cases to `rpc.test.ts` (both fail on the old code):
- a non-`ApiError` throw encodes as `500` / `"Internal error"` with no `data` — previously the raw message (`"plain"`) leaked through unchecked;
- a driver-shaped error (`name = "ResourceNotFoundException"`, message embedding `Table: app-notes-prod`) never puts the class name or raw message on the wire.

`ApiError` round-tripping (status ↔ code, `name`/`retriable` in `data`, client re-hydration via `decodeRpcResponse`/`isBlocksError`) is unchanged and still covered.

## Verification

- `packages/core` unit suite: **699 pass / 0 fail**; `rpc.test.ts` 24/24.
- `npm run lint` 0 errors; umbrella-changeset guard ✅.

## Changeset

`@aws-blocks/core` patch + `@aws-blocks/blocks` patch (umbrella re-export).

> **Behavior change:** clients that previously read the raw `message`/`data.name` of a *non-`ApiError`* failure now receive `"Internal error"` / code `500`. To send a specific, client-safe message, throw an `ApiError` (that path is unchanged). This is the intended security fix, not a type/API-signature change.