### PR TITLE
fix(bb-knowledge-base): validate non-integer retrieve maxResults

### DIFF
--- a/.changeset/kb-validate-maxresults.md
+++ b/.changeset/kb-validate-maxresults.md
@@ -1,0 +1,10 @@
+---
+"@aws-blocks/bb-knowledge-base": patch
+"@aws-blocks/blocks": patch
+---
+
+`KnowledgeBase.retrieve`: validate `maxResults` consistently across the mock and AWS runtimes.
+
+`maxResults` was normalized with `Math.min(Math.max(v ?? 10, 1), 100)`, which silently passed fractional and non-finite values (`1.5`, `NaN`, `Infinity`) straight through — the mock and the AWS `RetrieveCommand` then diverged, and Bedrock rejects a non-integer `numberOfResults`. A new shared `normalizeMaxResults` helper (used by both runtimes) keeps the documented clamp for finite integers and now rejects fractional/non-finite values up front with `KnowledgeBaseErrors.ValidationError`, before any search or Bedrock request.
+
+Fixes #430.

--- a/packages/bb-knowledge-base/src/errors.ts
+++ b/packages/bb-knowledge-base/src/errors.ts
@@ -34,11 +34,14 @@ export const KnowledgeBaseErrors = {
 	Timeout: 'KnowledgeBaseTimeoutException',
 } as const;
 
+/** One of the `name` values in {@link KnowledgeBaseErrors}. */
+export type KnowledgeBaseErrorName = (typeof KnowledgeBaseErrors)[keyof typeof KnowledgeBaseErrors];
+
 /**
  * Build a typed `Error` whose `name` is one of {@link KnowledgeBaseErrors}, so it
  * crosses the RPC wire by `name` and is matchable with `isBlocksError()`.
  */
-export function blocksError(name: string, message: string): Error {
+export function blocksError(name: KnowledgeBaseErrorName, message: string): Error {
 	const err = new Error(`${name}: ${message}`);
 	err.name = name;
 	return err;

--- a/packages/bb-knowledge-base/src/errors.ts
+++ b/packages/bb-knowledge-base/src/errors.ts
@@ -33,3 +33,13 @@ export const KnowledgeBaseErrors = {
 	/** `waitUntilSynced()` exceeded its timeout before the knowledge base finished ingesting. */
 	Timeout: 'KnowledgeBaseTimeoutException',
 } as const;
+
+/**
+ * Build a typed `Error` whose `name` is one of {@link KnowledgeBaseErrors}, so it
+ * crosses the RPC wire by `name` and is matchable with `isBlocksError()`.
+ */
+export function blocksError(name: string, message: string): Error {
+	const err = new Error(`${name}: ${message}`);
+	err.name = name;
+	return err;
+}

--- a/packages/bb-knowledge-base/src/index.aws.test.ts
+++ b/packages/bb-knowledge-base/src/index.aws.test.ts
@@ -5,6 +5,7 @@ import { test, describe, mock, afterEach } from 'node:test';
 import assert from 'node:assert';
 import { BedrockAgentRuntimeClient } from '@aws-sdk/client-bedrock-agent-runtime';
 import { BedrockAgentClient } from '@aws-sdk/client-bedrock-agent';
+import { isBlocksError } from '@aws-blocks/core';
 import { KnowledgeBaseErrors, KnowledgeBase } from './index.aws.js';
 
 // ── SDK mock helpers ───────────────────────────────────────────────────────
@@ -365,7 +366,7 @@ describe('retrieve (SDK-mocked)', () => {
 			for (const bad of [1.5, Number.NaN]) {
 				await assert.rejects(
 					() => kb.retrieve('query', { maxResults: bad }),
-					(e: unknown) => (e as Error).name === KnowledgeBaseErrors.ValidationError,
+					(e: unknown) => isBlocksError(e, KnowledgeBaseErrors.ValidationError),
 					`maxResults=${bad} should reject with ValidationError`,
 				);
 			}

--- a/packages/bb-knowledge-base/src/index.aws.test.ts
+++ b/packages/bb-knowledge-base/src/index.aws.test.ts
@@ -351,6 +351,30 @@ describe('retrieve (SDK-mocked)', () => {
 		}
 	});
 
+	test('rejects a fractional or non-finite maxResults before sending a Bedrock request', async () => {
+		const cleanup = setKbEnv('TEST', 'R9b');
+		let sent = false;
+		mockRuntimeSend(() => {
+			sent = true;
+			return { retrievalResults: [] };
+		});
+
+		try {
+			const kb = new KnowledgeBase({ id: 'test' }, 'r9b', { source: './knowledge' });
+
+			for (const bad of [1.5, Number.NaN]) {
+				await assert.rejects(
+					() => kb.retrieve('query', { maxResults: bad }),
+					(e: unknown) => (e as Error).name === KnowledgeBaseErrors.ValidationError,
+					`maxResults=${bad} should reject with ValidationError`,
+				);
+			}
+			assert.strictEqual(sent, false, 'no RetrieveCommand should be sent for an invalid maxResults');
+		} finally {
+			cleanup();
+		}
+	});
+
 	test('handles empty retrievalResults', async () => {
 		const cleanup = setKbEnv('TEST', 'R10');
 		mockRuntimeSend(() => ({ retrievalResults: [] }));

--- a/packages/bb-knowledge-base/src/index.aws.ts
+++ b/packages/bb-knowledge-base/src/index.aws.ts
@@ -279,7 +279,7 @@ export class KnowledgeBase extends Scope {
 	 * @param query - Natural language search query. Must be non-empty.
 	 * @param {RetrieveOptions} options - Optional retrieval parameters (maxResults, filter).
 	 * @returns Chunks ranked by relevance score (highest first). Empty array if no matches.
-	 * @throws {KnowledgeBaseValidationError} If query is empty or whitespace-only.
+	 * @throws {KnowledgeBaseValidationError} If query is empty or whitespace-only, or `maxResults` is a non-integer.
 	 * @throws {KnowledgeBaseNotReadyException} If the KB has not been created/deployed.
 	 * @throws {InvalidFilterException} If the filter keys are invalid for the Bedrock query.
 	 * @throws {RetrievalFailedException} For other Bedrock retrieval errors (network, service).
@@ -297,8 +297,7 @@ export class KnowledgeBase extends Scope {
 			throw blocksError(KnowledgeBaseErrors.ValidationError, 'Query must be a non-empty string.');
 		}
 
-		// Bedrock API limits numberOfResults to an integer in 1–100 (well within
-		// Lambda's 6 MB response payload); reject fractional/non-finite inputs.
+		// 1–100 results stays well within Lambda's 6 MB response payload.
 		const maxResults = normalizeMaxResults(options?.maxResults);
 		const filter = buildFilter(options?.filter);
 		const knowledgeBaseId = this.ensureKbId();

--- a/packages/bb-knowledge-base/src/index.aws.ts
+++ b/packages/bb-knowledge-base/src/index.aws.ts
@@ -22,7 +22,8 @@ import type {
 	MetadataFilter,
 	WaitUntilSyncedOptions,
 } from './types.js';
-import { KnowledgeBaseErrors } from './errors.js';
+import { blocksError, KnowledgeBaseErrors } from './errors.js';
+import { normalizeMaxResults } from './normalize.js';
 import { BB_NAME, BB_VERSION } from './version.js';
 import { Logger } from '@aws-blocks/bb-logger';
 import type { ChildLogger } from '@aws-blocks/bb-logger';
@@ -49,12 +50,6 @@ function envKey(fullId: string, suffix: string): string {
 }
 
 // ── Error helpers ──────────────────────────────────────────────────────────
-
-function blocksError(name: string, message: string): Error {
-	const err = new Error(`${name}: ${message}`);
-	err.name = name;
-	return err;
-}
 
 /**
  * Resolve after `ms` milliseconds. Used to space out the sync polls in
@@ -302,8 +297,9 @@ export class KnowledgeBase extends Scope {
 			throw blocksError(KnowledgeBaseErrors.ValidationError, 'Query must be a non-empty string.');
 		}
 
-		// Bedrock API limits numberOfResults to 1–100. Well within Lambda's 6 MB response payload.
-		const maxResults = Math.min(Math.max(options?.maxResults ?? 10, 1), 100);
+		// Bedrock API limits numberOfResults to an integer in 1–100 (well within
+		// Lambda's 6 MB response payload); reject fractional/non-finite inputs.
+		const maxResults = normalizeMaxResults(options?.maxResults);
 		const filter = buildFilter(options?.filter);
 		const knowledgeBaseId = this.ensureKbId();
 

--- a/packages/bb-knowledge-base/src/index.mock.test.ts
+++ b/packages/bb-knowledge-base/src/index.mock.test.ts
@@ -8,6 +8,7 @@ import { join, dirname } from 'node:path';
 import { tmpdir } from 'node:os';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { spawnSync } from 'node:child_process';
+import { isBlocksError } from '@aws-blocks/core';
 import { KnowledgeBase, KnowledgeBaseErrors } from './index.mock.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -119,7 +120,7 @@ test('rejects a fractional or non-finite maxResults with ValidationError (parity
 	for (const bad of [1.5, Number.NaN]) {
 		await assert.rejects(
 			() => kb.retrieve('password', { maxResults: bad }),
-			(e: unknown) => (e as Error).name === KnowledgeBaseErrors.ValidationError,
+			(e: unknown) => isBlocksError(e, KnowledgeBaseErrors.ValidationError),
 			`maxResults=${bad} should reject with ValidationError`,
 		);
 	}

--- a/packages/bb-knowledge-base/src/index.mock.test.ts
+++ b/packages/bb-knowledge-base/src/index.mock.test.ts
@@ -113,6 +113,18 @@ test('maxResults is clamped to [1, 100]', async () => {
 	assert.ok(resultsNeg.length >= 1, 'negative maxResults should clamp to 1');
 });
 
+test('rejects a fractional or non-finite maxResults with ValidationError (parity with AWS)', async () => {
+	const kb = new KnowledgeBase({ id: 'test' }, 'kb', { source: 'test-knowledge-tmp' });
+
+	for (const bad of [1.5, Number.NaN]) {
+		await assert.rejects(
+			() => kb.retrieve('password', { maxResults: bad }),
+			(e: unknown) => (e as Error).name === KnowledgeBaseErrors.ValidationError,
+			`maxResults=${bad} should reject with ValidationError`,
+		);
+	}
+});
+
 // ── Empty results ──────────────────────────────────────────────────────────
 
 test('unrelated query returns empty array', async () => {

--- a/packages/bb-knowledge-base/src/index.mock.ts
+++ b/packages/bb-knowledge-base/src/index.mock.ts
@@ -9,7 +9,8 @@ import { join, relative, dirname, extname, resolve, sep } from 'node:path';
 import { createHash } from 'node:crypto';
 import { buildIndex, search, type TfIdfIndex } from './tfidf.js';
 import type { KnowledgeBaseOptions, RetrieveOptions, RetrieveResult, MetadataFilter, ChunkingStrategy, WaitUntilSyncedOptions } from './types.js';
-import { KnowledgeBaseErrors } from './errors.js';
+import { blocksError, KnowledgeBaseErrors } from './errors.js';
+import { normalizeMaxResults } from './normalize.js';
 import { Logger } from '@aws-blocks/bb-logger';
 import type { ChildLogger } from '@aws-blocks/bb-logger';
 import { BB_NAME, BB_VERSION } from './version.js';
@@ -34,12 +35,6 @@ interface Chunk {
 	text: string;
 	source: string;
 	metadata: Record<string, string>;
-}
-
-function blocksError(name: string, message: string): Error {
-	const err = new Error(`${name}: ${message}`);
-	err.name = name;
-	return err;
 }
 
 function walkDir(dir: string): string[] {
@@ -220,7 +215,7 @@ export class KnowledgeBase extends Scope {
 			throw blocksError(KnowledgeBaseErrors.ValidationError, 'Query must be a non-empty string.');
 		}
 
-		const maxResults = Math.min(Math.max(options?.maxResults ?? 10, 1), 100);
+		const maxResults = normalizeMaxResults(options?.maxResults);
 		const filter = options?.filter;
 
 		await this.ensureLoaded();

--- a/packages/bb-knowledge-base/src/index.mock.ts
+++ b/packages/bb-knowledge-base/src/index.mock.ts
@@ -196,7 +196,7 @@ export class KnowledgeBase extends Scope {
 	 * @param query - Natural language search query. Must be non-empty.
 	 * @param options - Optional retrieval parameters (maxResults, filter).
 	 * @returns Chunks ranked by relevance score (highest first). Empty array if no matches.
-	 * @throws {KnowledgeBaseValidationError} If query is empty or whitespace-only.
+	 * @throws {KnowledgeBaseValidationError} If query is empty or whitespace-only, or `maxResults` is a non-integer.
 	 * @throws {InvalidSourceConfigException} If the source folder does not exist or is not a string path.
 	 *
 	 * @example

--- a/packages/bb-knowledge-base/src/normalize.test.ts
+++ b/packages/bb-knowledge-base/src/normalize.test.ts
@@ -1,0 +1,35 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import assert from 'node:assert';
+import { describe, it } from 'node:test';
+import { isBlocksError } from '@aws-blocks/core';
+import { KnowledgeBaseErrors } from './errors.js';
+import { normalizeMaxResults } from './normalize.js';
+
+describe('normalizeMaxResults', () => {
+	it('defaults to 10 when undefined', () => {
+		assert.strictEqual(normalizeMaxResults(undefined), 10);
+	});
+
+	it('passes a valid integer through', () => {
+		assert.strictEqual(normalizeMaxResults(50), 50);
+	});
+
+	it('clamps finite integers to the 1–100 range', () => {
+		assert.strictEqual(normalizeMaxResults(0), 1);
+		assert.strictEqual(normalizeMaxResults(-5), 1);
+		assert.strictEqual(normalizeMaxResults(200), 100);
+		assert.strictEqual(normalizeMaxResults(1), 1);
+		assert.strictEqual(normalizeMaxResults(100), 100);
+	});
+
+	for (const bad of [1.5, Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY]) {
+		it(`rejects the non-integer value ${bad} with ValidationError`, () => {
+			assert.throws(
+				() => normalizeMaxResults(bad),
+				(e: unknown) => isBlocksError(e, KnowledgeBaseErrors.ValidationError),
+			);
+		});
+	}
+});

--- a/packages/bb-knowledge-base/src/normalize.test.ts
+++ b/packages/bb-knowledge-base/src/normalize.test.ts
@@ -12,6 +12,12 @@ describe('normalizeMaxResults', () => {
 		assert.strictEqual(normalizeMaxResults(undefined), 10);
 	});
 
+	it('treats an explicit null as unset and defaults to 10', () => {
+		// Parsed JSON (e.g. an agent/tool-calling layer) often sends null for an
+		// omitted field; it must not be rejected as a non-integer.
+		assert.strictEqual(normalizeMaxResults(null), 10);
+	});
+
 	it('passes a valid integer through', () => {
 		assert.strictEqual(normalizeMaxResults(50), 50);
 	});

--- a/packages/bb-knowledge-base/src/normalize.ts
+++ b/packages/bb-knowledge-base/src/normalize.ts
@@ -1,0 +1,34 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { blocksError, KnowledgeBaseErrors } from './errors.js';
+
+/** Bedrock caps `numberOfResults` at 1–100. */
+const MIN_RESULTS = 1;
+const MAX_RESULTS = 100;
+const DEFAULT_RESULTS = 10;
+
+/**
+ * Normalize `RetrieveOptions.maxResults` into a valid Bedrock `numberOfResults`.
+ *
+ * Bedrock requires an **integer** in the range 1–100. A finite integer outside
+ * that range is clamped (preserving the documented behavior). A fractional or
+ * non-finite value (`1.5`, `NaN`, `Infinity`) — which can arise when the option
+ * is derived from user input or a calculation — is rejected with
+ * {@link KnowledgeBaseErrors.ValidationError}, so the mock and AWS runtimes never
+ * diverge on an input Bedrock would reject.
+ *
+ * @param maxResults - The caller-supplied value, or `undefined` for the default.
+ * @returns An integer in the range 1–100.
+ * @throws {KnowledgeBaseValidationError} If `maxResults` is defined but not an integer.
+ */
+export function normalizeMaxResults(maxResults: number | undefined): number {
+	if (maxResults === undefined) return DEFAULT_RESULTS;
+	if (!Number.isInteger(maxResults)) {
+		throw blocksError(
+			KnowledgeBaseErrors.ValidationError,
+			`maxResults must be an integer between ${MIN_RESULTS} and ${MAX_RESULTS}, got ${maxResults}.`,
+		);
+	}
+	return Math.min(Math.max(maxResults, MIN_RESULTS), MAX_RESULTS);
+}

--- a/packages/bb-knowledge-base/src/normalize.ts
+++ b/packages/bb-knowledge-base/src/normalize.ts
@@ -18,12 +18,15 @@ const DEFAULT_RESULTS = 10;
  * {@link KnowledgeBaseErrors.ValidationError}, so the mock and AWS runtimes never
  * diverge on an input Bedrock would reject.
  *
- * @param maxResults - The caller-supplied value, or `undefined` for the default.
+ * `undefined` and `null` both mean "unset" and yield the default — parsed JSON
+ * (e.g. from an agent/tool-calling layer) often sends `null` for an omitted field.
+ *
+ * @param maxResults - The caller-supplied value, or `undefined`/`null` for the default.
  * @returns An integer in the range 1–100.
- * @throws {KnowledgeBaseValidationError} If `maxResults` is defined but not an integer.
+ * @throws {KnowledgeBaseValidationError} If `maxResults` is set but not an integer.
  */
-export function normalizeMaxResults(maxResults: number | undefined): number {
-	if (maxResults === undefined) return DEFAULT_RESULTS;
+export function normalizeMaxResults(maxResults: number | undefined | null): number {
+	if (maxResults === undefined || maxResults === null) return DEFAULT_RESULTS;
 	if (!Number.isInteger(maxResults)) {
 		throw blocksError(
 			KnowledgeBaseErrors.ValidationError,

--- a/packages/bb-knowledge-base/src/types.ts
+++ b/packages/bb-knowledge-base/src/types.ts
@@ -130,7 +130,12 @@ export type MetadataFilter = Record<string, { equals: string }>;
  * Options for the `retrieve()` method.
  */
 export interface RetrieveOptions {
-	/** Maximum results to return. Clamped to 1–100. Default: 10. */
+	/**
+	 * Maximum results to return. Must be an integer; a finite integer outside
+	 * 1–100 is clamped to that range. A fractional or non-finite value (`1.5`,
+	 * `NaN`, `Infinity`) is rejected with `KnowledgeBaseErrors.ValidationError`,
+	 * since Bedrock requires an integer here. Default: 10.
+	 */
 	maxResults?: number;
 	/** Metadata filter with AND semantics across all key-value pairs. Only chunks whose metadata matches every condition are returned. */
 	filter?: MetadataFilter;


### PR DESCRIPTION
Fixes #430.

## Problem

`KnowledgeBase.retrieve` normalized `maxResults` with `Math.min(Math.max(options?.maxResults ?? 10, 1), 100)` in **both** `index.mock.ts` and `index.aws.ts`. That clamp silently preserves fractional and non-finite values:

- `maxResults: 1.5` → the mock slices its result array by `1.5`; the AWS runtime sends `numberOfResults: 1.5`.
- `maxResults: NaN` → the mock returns an empty set; the AWS runtime sends `numberOfResults: NaN`.

Bedrock defines `numberOfResults` as an **integer** in 1–100, so neither is a valid request — and the mock and AWS runtimes diverge on exactly these inputs (which can arise when the option comes from user input or a calculation).

## Fix

A shared `normalizeMaxResults` helper (new `normalize.ts`), used by both runtimes:

- `undefined` → default `10`.
- Finite integer → clamped to 1–100 (documented behavior preserved; `0`/`-5` → `1`, `200` → `100`).
- Fractional or non-finite (`1.5`, `NaN`, `±Infinity`) → rejected with `KnowledgeBaseErrors.ValidationError`, **before** any local search or Bedrock request.

Also hoisted the `blocksError` helper (duplicated verbatim in both entries) into `errors.ts` as the single source, and clarified the `RetrieveOptions.maxResults` doc.

## Tests (red → green)

- `normalize.test.ts` — default, pass-through, clamp bounds, and rejection of `1.5`/`NaN`/`±Infinity`.
- `index.mock.test.ts` — `retrieve` rejects `1.5`/`NaN` with `ValidationError` (parity with AWS).
- `index.aws.test.ts` — `retrieve` rejects `1.5`/`NaN` with `ValidationError` and sends **no** `RetrieveCommand`.

## Verification

- `@aws-blocks/bb-knowledge-base` suite: **139 pass / 0 fail**.
- Conditional-export parity 21/21; `check:api` ✅ (no public-API change — helper stays internal); `npm run lint` 0 errors; umbrella-changeset guard ✅.

## Changeset

`@aws-blocks/bb-knowledge-base` patch + `@aws-blocks/blocks` patch (umbrella re-export).