### PR TITLE
feat(bb-app-setting): customer-managed KMS key for secrets (kmsKeyArn)

### DIFF
--- a/.changeset/app-setting-cmk.md
+++ b/.changeset/app-setting-cmk.md
@@ -1,0 +1,8 @@
+---
+"@aws-blocks/bb-app-setting": minor
+"@aws-blocks/blocks": patch
+---
+
+`AppSetting`: support a customer-managed KMS key for secrets via `kmsKeyArn`.
+
+Secret (`SecureString`) parameters were always encrypted with the default `aws/ssm` AWS-managed key, so their decrypt scope couldn't be controlled (e.g. for cross-account access or a dedicated key policy). Passing `kmsKeyArn` now encrypts the secret with that customer-managed key: the bulk-init Custom Resource creates the parameter with the CMK, the shared handler is granted `kms:Decrypt`/`Encrypt`/`GenerateDataKey*` scoped to that specific key ARN (instead of the `aws/ssm` `ViaService` wildcard), and the runtime `put()` re-specifies the key on overwrite so it doesn't silently fall back to `aws/ssm`. `kmsKeyArn` is only valid with `secret: true`. The default (no `kmsKeyArn`) is unchanged.

--- a/.changeset/app-setting-cmk.md
+++ b/.changeset/app-setting-cmk.md
@@ -5,4 +5,11 @@
 
 `AppSetting`: support a customer-managed KMS key for secrets via `kmsKeyArn`.
 
-Secret (`SecureString`) parameters were always encrypted with the default `aws/ssm` AWS-managed key, so their decrypt scope couldn't be controlled (e.g. for cross-account access or a dedicated key policy). Passing `kmsKeyArn` now encrypts the secret with that customer-managed key: the bulk-init Custom Resource creates the parameter with the CMK, the shared handler is granted `kms:Decrypt`/`Encrypt`/`GenerateDataKey*` scoped to that specific key ARN (instead of the `aws/ssm` `ViaService` wildcard), and the runtime `put()` re-specifies the key on overwrite so it doesn't silently fall back to `aws/ssm`. `kmsKeyArn` is only valid with `secret: true`. The default (no `kmsKeyArn`) is unchanged.
+Secret (`SecureString`) parameters were always encrypted with the default `aws/ssm` AWS-managed key, so their decrypt scope couldn't be controlled (e.g. for cross-account access or a dedicated key policy). Passing `kmsKeyArn` (also accepted by `AppSetting.fromExisting`) now encrypts the secret with that customer-managed key:
+
+- the bulk-init Custom Resource creates the parameter with the CMK (`KeyId`);
+- the shared handler is granted `kms:Decrypt`/`Encrypt` scoped to that specific key ARN (instead of the `aws/ssm` `ViaService` wildcard);
+- the runtime `put()` re-specifies the key on overwrite so it doesn't silently fall back to `aws/ssm`;
+- adding/changing/removing `kmsKeyArn` on an already-deployed secret re-encrypts its current value under the new key at deploy time, so decryption keeps working after a key rotation.
+
+`kmsKeyArn` is only valid with `secret: true` and must be a non-empty ARN. The default (no `kmsKeyArn`) is unchanged.

--- a/packages/bb-app-setting/API.md
+++ b/packages/bb-app-setting/API.md
@@ -32,6 +32,7 @@ export const AppSettingErrors: {
 
 // @public
 export interface AppSettingOptions<T = string> {
+    kmsKeyArn?: string;
     logger?: ChildLogger;
     name?: string;
     schema?: StandardSchemaV1<T>;

--- a/packages/bb-app-setting/API.md
+++ b/packages/bb-app-setting/API.md
@@ -17,6 +17,7 @@ export class AppSetting<T = string> extends Scope {
     static fromExisting<T = string>(scope: ScopeParent, id: string, options: {
         name: string;
         secret?: boolean;
+        kmsKeyArn?: string;
     }): AppSetting<T>;
     get(): Promise<T>;
     // @internal

--- a/packages/bb-app-setting/DESIGN.md
+++ b/packages/bb-app-setting/DESIGN.md
@@ -27,17 +27,17 @@ CloudFormation cannot natively create SSM SecureString parameters. The CDK imple
   - Uses `lambda.Code.fromInline()` with `@aws-sdk/client-ssm` and `crypto`
   - On `Create`: generates a **random** secret via `crypto.randomBytes(32).toString('base64url')` and calls `PutParameterCommand` with `Type: 'SecureString'`, `Overwrite: false` (no serialized initial value — secrets never come from source)
   - On `Delete`: calls `DeleteParameterCommand` to clean up the parameter
-  - On `Update`: generates a random secret for newly added names (same as `Create`) **and** deletes parameters for names removed since the previous deployment (not a no-op); existing values are left untouched and managed at runtime via `put()`
-  - Granted `ssm:PutParameter` and `ssm:DeleteParameter` scoped to the parameter ARN, plus `kms:Encrypt`/`kms:GenerateDataKey*` (scoped by the `kms:ViaService` condition to `ssm.{region}`) so it can write the encrypted SecureString under either the default `aws/ssm` key or a customer-managed key
+  - On `Update`: generates a random secret for newly added names (same as `Create`) **and** deletes parameters for names removed since the previous deployment (not a no-op). Existing values are left untouched **unless the secret's `keyId` changed** (i.e. `kmsKeyArn` was added/changed/removed) — in that case it reads the current value (`GetParameter` with decryption) and rewrites it under the new key (`Overwrite: true`), so the value survives a key rotation and the handler's new key-scoped grant stays consistent
+  - Granted `ssm:GetParameter`/`ssm:PutParameter`/`ssm:DeleteParameter` scoped to the parameter ARN, plus `kms:Encrypt`/`kms:Decrypt` (scoped by the `kms:ViaService` condition to `ssm.{region}`) so it can create, read-when-re-keying, and re-encrypt SecureStrings under either the default `aws/ssm` key or a customer-managed key
   - A single shared Lambda + `CustomResource` is created per stack; each secret is appended to the resource's `Parameters` list as `{ name, keyId? }` — the optional `keyId` carries the customer-managed KMS key ARN and is passed as `KeyId` on `PutParameter`
 
-- **KMS encryption:** Uses the default `aws/ssm` managed KMS key (no custom key needed, $0/month). Set `kmsKeyArn` to encrypt with a **customer-managed key** instead: the bulk-init Custom Resource passes it as `KeyId` on `PutParameter`, the handler is granted `kms:Decrypt`/`Encrypt`/`GenerateDataKey*` on that specific key ARN, and the runtime `put()` re-specifies the key on overwrite (SSM would otherwise fall back to `aws/ssm`). The CMK's own key policy must permit the app's execution role.
+- **KMS encryption:** Uses the default `aws/ssm` managed KMS key (no custom key needed, $0/month). Set `kmsKeyArn` to encrypt with a **customer-managed key** instead: the bulk-init Custom Resource passes it as `KeyId` on `PutParameter`, the handler is granted `kms:Decrypt`/`Encrypt` on that specific key ARN, and the runtime `put()` re-specifies the key on overwrite (SSM would otherwise fall back to `aws/ssm`). Changing `kmsKeyArn` later re-encrypts the existing value (see the Update behavior above). The CMK's own key policy must permit the app's execution role.
 
 - **Handler permissions (the runtime `this.handler`):**
   - `ssm:GetParameter` on the parameter ARN
   - `ssm:PutParameter` on the parameter ARN
   - Default `aws/ssm` key: `kms:Decrypt` **and** `kms:Encrypt` with a `kms:ViaService` condition restricting usage to `ssm.{region}.amazonaws.com`
-  - Customer-managed key (`kmsKeyArn` set): `kms:Decrypt`, `kms:Encrypt`, `kms:GenerateDataKey*` scoped to that specific key ARN, with **no** `ViaService` condition (see *KMS encryption* above). The CMK's own key policy must also permit this role.
+  - Customer-managed key (`kmsKeyArn` set): `kms:Decrypt` **and** `kms:Encrypt` scoped to that specific key ARN, with **no** `ViaService` condition (see *KMS encryption* above). The CMK's own key policy must also permit this role.
 
 ## Serialization & Validation
 

--- a/packages/bb-app-setting/DESIGN.md
+++ b/packages/bb-app-setting/DESIGN.md
@@ -31,7 +31,7 @@ CloudFormation cannot natively create SSM SecureString parameters. The CDK imple
   - Granted `ssm:PutParameter` and `ssm:DeleteParameter` scoped to the parameter ARN, plus `kms:Encrypt` (with the `kms:ViaService` condition) so it can write the encrypted SecureString
   - A single shared Lambda + `CustomResource` is created per stack; each secret parameter name is appended to the resource's `ParameterNames` list
 
-- **KMS encryption:** Uses the default `aws/ssm` managed KMS key (no custom key needed, $0/month)
+- **KMS encryption:** Uses the default `aws/ssm` managed KMS key (no custom key needed, $0/month). Set `kmsKeyArn` to encrypt with a **customer-managed key** instead: the bulk-init Custom Resource passes it as `KeyId` on `PutParameter`, the handler is granted `kms:Decrypt`/`Encrypt`/`GenerateDataKey*` on that specific key ARN, and the runtime `put()` re-specifies the key on overwrite (SSM would otherwise fall back to `aws/ssm`). The CMK's own key policy must permit the app's execution role.
 
 - **Handler permissions (the runtime `this.handler`):**
   - `ssm:GetParameter` on the parameter ARN

--- a/packages/bb-app-setting/DESIGN.md
+++ b/packages/bb-app-setting/DESIGN.md
@@ -28,15 +28,16 @@ CloudFormation cannot natively create SSM SecureString parameters. The CDK imple
   - On `Create`: generates a **random** secret via `crypto.randomBytes(32).toString('base64url')` and calls `PutParameterCommand` with `Type: 'SecureString'`, `Overwrite: false` (no serialized initial value — secrets never come from source)
   - On `Delete`: calls `DeleteParameterCommand` to clean up the parameter
   - On `Update`: generates a random secret for newly added names (same as `Create`) **and** deletes parameters for names removed since the previous deployment (not a no-op); existing values are left untouched and managed at runtime via `put()`
-  - Granted `ssm:PutParameter` and `ssm:DeleteParameter` scoped to the parameter ARN, plus `kms:Encrypt` (with the `kms:ViaService` condition) so it can write the encrypted SecureString
-  - A single shared Lambda + `CustomResource` is created per stack; each secret parameter name is appended to the resource's `ParameterNames` list
+  - Granted `ssm:PutParameter` and `ssm:DeleteParameter` scoped to the parameter ARN, plus `kms:Encrypt`/`kms:GenerateDataKey*` (scoped by the `kms:ViaService` condition to `ssm.{region}`) so it can write the encrypted SecureString under either the default `aws/ssm` key or a customer-managed key
+  - A single shared Lambda + `CustomResource` is created per stack; each secret is appended to the resource's `Parameters` list as `{ name, keyId? }` — the optional `keyId` carries the customer-managed KMS key ARN and is passed as `KeyId` on `PutParameter`
 
 - **KMS encryption:** Uses the default `aws/ssm` managed KMS key (no custom key needed, $0/month). Set `kmsKeyArn` to encrypt with a **customer-managed key** instead: the bulk-init Custom Resource passes it as `KeyId` on `PutParameter`, the handler is granted `kms:Decrypt`/`Encrypt`/`GenerateDataKey*` on that specific key ARN, and the runtime `put()` re-specifies the key on overwrite (SSM would otherwise fall back to `aws/ssm`). The CMK's own key policy must permit the app's execution role.
 
 - **Handler permissions (the runtime `this.handler`):**
   - `ssm:GetParameter` on the parameter ARN
   - `ssm:PutParameter` on the parameter ARN
-  - `kms:Decrypt` **and** `kms:Encrypt` with a `kms:ViaService` condition restricting usage to `ssm.{region}.amazonaws.com`
+  - Default `aws/ssm` key: `kms:Decrypt` **and** `kms:Encrypt` with a `kms:ViaService` condition restricting usage to `ssm.{region}.amazonaws.com`
+  - Customer-managed key (`kmsKeyArn` set): `kms:Decrypt`, `kms:Encrypt`, `kms:GenerateDataKey*` scoped to that specific key ARN, with **no** `ViaService` condition (see *KMS encryption* above). The CMK's own key policy must also permit this role.
 
 ## Serialization & Validation
 
@@ -63,7 +64,7 @@ The 4 KB (4096 bytes) size limit applies to the **JSON-encoded** value of non-se
 - `put()` writes the value to disk immediately.
 - Schema validation on `put()` when configured, throws `ValidationFailedException`.
 - Validates 4 KB serialized value size limit for non-secret parameters.
-- `secret: true` behaves identically to non-secret (no encryption locally).
+- `secret: true` behaves identically to non-secret (no encryption locally); `kmsKeyArn` is ignored in the mock.
 
 ### Mock vs AWS Behavior Differences
 

--- a/packages/bb-app-setting/README.md
+++ b/packages/bb-app-setting/README.md
@@ -33,10 +33,12 @@ const setting = new AppSetting(scope, id, options)
 > **Customer-managed KMS key (`kmsKeyArn`):** Provide a CMK ARN to control the
 > decrypt/grant scope of a secret (e.g. cross-account access or a dedicated key
 > policy). The construct grants the shared handler `kms:Decrypt` (plus
-> `kms:Encrypt`/`kms:GenerateDataKey*` for secrets it writes) on that specific
-> key ARN. Because AWS Blocks does not own a bring-your-own key, **the key's own
-> key policy must also allow the app's Lambda execution role** to use it (or
-> delegate to IAM via the account-root statement CDK adds to same-account keys).
+> `kms:Encrypt` for secrets it writes) on that specific key ARN. Because AWS
+> Blocks does not own a bring-your-own key, **the key's own key policy must also
+> allow the app's Lambda execution role** to use it (or delegate to IAM via the
+> account-root statement CDK adds to same-account keys). Adding or changing
+> `kmsKeyArn` on an already-deployed secret re-encrypts its current value under
+> the new key on the next deploy, so decryption keeps working.
 
 > **Naming:** When you omit `name`, the framework derives a unique SSM path from
 > the construct scope tree (`/${fullId}`). This is the recommended approach — it

--- a/packages/bb-app-setting/README.md
+++ b/packages/bb-app-setting/README.md
@@ -26,8 +26,17 @@ const setting = new AppSetting(scope, id, options)
 | `name` | `string` | No | SSM parameter path. When omitted, derived from the scope tree as `/${fullId}`, guaranteeing uniqueness within the stack. |
 | `value` | `T` | No | Initial value. Required for non-secret parameters. Must not be provided when `secret` is set. |
 | `schema` | `StandardSchemaV1<T>` | No | Runtime validation schema (Zod, Valibot, ArkType). Infers `T` from the schema. Cannot be used with `secret`. |
-| `secret` | `boolean` | No | When `true`, creates an SSM SecureString encrypted with the `aws/ssm` KMS key. Cannot be used with `schema` or `value`. |
+| `secret` | `boolean` | No | When `true`, creates an SSM SecureString encrypted with the default `aws/ssm` KMS key (or `kmsKeyArn` when set). Cannot be used with `schema` or `value`. |
+| `kmsKeyArn` | `string` | No | ARN of a customer-managed KMS key to encrypt the SecureString, instead of the default `aws/ssm` key. Only valid with `secret: true`. See the note below. |
 | `logger` | `ChildLogger` | No | Optional logger for internal operations. When omitted, a default Logger at error level is created. |
+
+> **Customer-managed KMS key (`kmsKeyArn`):** Provide a CMK ARN to control the
+> decrypt/grant scope of a secret (e.g. cross-account access or a dedicated key
+> policy). The construct grants the shared handler `kms:Decrypt` (plus
+> `kms:Encrypt`/`kms:GenerateDataKey*` for secrets it writes) on that specific
+> key ARN. Because AWS Blocks does not own a bring-your-own key, **the key's own
+> key policy must also allow the app's Lambda execution role** to use it (or
+> delegate to IAM via the account-root statement CDK adds to same-account keys).
 
 > **Naming:** When you omit `name`, the framework derives a unique SSM path from
 > the construct scope tree (`/${fullId}`). This is the recommended approach — it

--- a/packages/bb-app-setting/src/index.aws.test.ts
+++ b/packages/bb-app-setting/src/index.aws.test.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import assert from 'node:assert';
-import { describe, it, mock } from 'node:test';
+import { describe, test, mock } from 'node:test';
 import { SSMClient } from '@aws-sdk/client-ssm';
 import { Scope } from '@aws-blocks/core';
 import { AppSetting } from './index.aws.js';
@@ -20,7 +20,7 @@ function captureSend() {
 }
 
 describe('AWS runtime put() KMS key', () => {
-	it('passes the CMK as KeyId when a secret is backed by kmsKeyArn', async () => {
+	test('passes the CMK as KeyId when a secret is backed by kmsKeyArn', async () => {
 		const { inputs, restore } = captureSend();
 		try {
 			const setting = new AppSetting(new Scope('app'), 'cmk', { secret: true, kmsKeyArn: TEST_CMK });
@@ -33,7 +33,7 @@ describe('AWS runtime put() KMS key', () => {
 		}
 	});
 
-	it('omits KeyId for a default-key secret', async () => {
+	test('omits KeyId for a default-key secret', async () => {
 		const { inputs, restore } = captureSend();
 		try {
 			const setting = new AppSetting(new Scope('app'), 'plain', { secret: true });
@@ -45,7 +45,7 @@ describe('AWS runtime put() KMS key', () => {
 		}
 	});
 
-	it('omits KeyId for a non-secret String parameter', async () => {
+	test('omits KeyId for a non-secret String parameter', async () => {
 		const { inputs, restore } = captureSend();
 		try {
 			const setting = new AppSetting<string>(new Scope('app'), 'cfg', { value: 'init' });

--- a/packages/bb-app-setting/src/index.aws.test.ts
+++ b/packages/bb-app-setting/src/index.aws.test.ts
@@ -1,0 +1,59 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import assert from 'node:assert';
+import { describe, it, mock } from 'node:test';
+import { SSMClient } from '@aws-sdk/client-ssm';
+import { Scope } from '@aws-blocks/core';
+import { AppSetting } from './index.aws.js';
+
+const TEST_CMK = 'arn:aws:kms:us-east-1:111122223333:key/abcd1234-5678-90ab-cdef-1234567890ab';
+
+/** Capture the input of the next PutParameterCommand sent by the runtime. */
+function captureSend() {
+	const inputs: any[] = [];
+	const m = mock.method(SSMClient.prototype, 'send', async (cmd: any) => {
+		inputs.push(cmd.input);
+		return {};
+	});
+	return { inputs, restore: () => m.mock.restore() };
+}
+
+describe('AWS runtime put() KMS key', () => {
+	it('passes the CMK as KeyId when a secret is backed by kmsKeyArn', async () => {
+		const { inputs, restore } = captureSend();
+		try {
+			const setting = new AppSetting(new Scope('app'), 'cmk', { secret: true, kmsKeyArn: TEST_CMK });
+			await setting.put('rotated-value');
+			assert.strictEqual(inputs.length, 1);
+			assert.strictEqual(inputs[0].Type, 'SecureString');
+			assert.strictEqual(inputs[0].KeyId, TEST_CMK, 'overwrite must re-specify the CMK, not fall back to aws/ssm');
+		} finally {
+			restore();
+		}
+	});
+
+	it('omits KeyId for a default-key secret', async () => {
+		const { inputs, restore } = captureSend();
+		try {
+			const setting = new AppSetting(new Scope('app'), 'plain', { secret: true });
+			await setting.put('v');
+			assert.strictEqual(inputs[0].Type, 'SecureString');
+			assert.strictEqual(inputs[0].KeyId, undefined);
+		} finally {
+			restore();
+		}
+	});
+
+	it('omits KeyId for a non-secret String parameter', async () => {
+		const { inputs, restore } = captureSend();
+		try {
+			const setting = new AppSetting<string>(new Scope('app'), 'cfg', { value: 'init' });
+			await setting.put('next');
+			assert.strictEqual(inputs[0].Type, 'String');
+			assert.strictEqual(inputs[0].KeyId, undefined);
+		} finally {
+			restore();
+		}
+	});
+});

--- a/packages/bb-app-setting/src/index.aws.ts
+++ b/packages/bb-app-setting/src/index.aws.ts
@@ -76,6 +76,7 @@ export class AppSetting<T = string> extends Scope {
 	readonly bbName = BB_NAME;
 	private schema?: StandardSchemaV1<T>;
 	private isSecret: boolean;
+	private kmsKeyArn?: string;
 	private client: SSMClient;
 
 	/** @internal Logger for internal operations. Defaults to error-level when not provided. */
@@ -88,6 +89,7 @@ export class AppSetting<T = string> extends Scope {
 		const parameterName = options.name ?? `/${this.fullId}`;
 		this.schema = options.schema;
 		this.isSecret = options.secret ?? false;
+		this.kmsKeyArn = options.kmsKeyArn;
 		this.client = new SSMClient({
 			customUserAgent: this.buildUserAgentChain(),
 		});
@@ -160,6 +162,9 @@ export class AppSetting<T = string> extends Scope {
 			Value: serialized,
 			Type: this.isSecret ? 'SecureString' : 'String',
 			Overwrite: true,
+			// Re-specify the CMK on overwrite: SSM falls back to the default aws/ssm
+			// key when KeyId is omitted, which would silently downgrade encryption.
+			...(this.isSecret && this.kmsKeyArn ? { KeyId: this.kmsKeyArn } : {}),
 		}));
 	}
 }

--- a/packages/bb-app-setting/src/index.aws.ts
+++ b/packages/bb-app-setting/src/index.aws.ts
@@ -67,7 +67,7 @@ export class AppSetting<T = string> extends Scope {
 	static fromExisting<T = string>(
 		scope: ScopeParent,
 		id: string,
-		options: { name: string; secret?: boolean },
+		options: { name: string; secret?: boolean; kmsKeyArn?: string },
 	): AppSetting<T> {
 		const opts: InternalAppSettingOptions<T> = { ...options, external: true };
 		return new AppSetting<T>(scope, id, opts);

--- a/packages/bb-app-setting/src/index.cdk.test.ts
+++ b/packages/bb-app-setting/src/index.cdk.test.ts
@@ -251,9 +251,10 @@ test('CDK: secret with kmsKeyArn grants handler KMS on the specific CMK ARN (not
 			if (resStr.includes(TEST_CMK)) {
 				found = true;
 				assert.ok(actions.includes('kms:Encrypt'), 'stack-managed CMK secret should grant kms:Encrypt');
+				// Standard-tier SecureStrings only use Encrypt/Decrypt — no GenerateDataKey.
 				assert.ok(
-					actions.some((a: string) => a.startsWith('kms:GenerateDataKey')),
-					'CMK secret should grant kms:GenerateDataKey*',
+					!actions.some((a: string) => a.startsWith('kms:GenerateDataKey')),
+					'CMK grant should not include kms:GenerateDataKey* (advanced-tier only)',
 				);
 				assert.strictEqual(stmt.Condition, undefined, 'CMK grant should not use a ViaService wildcard condition');
 			}
@@ -293,5 +294,56 @@ test('CDK: kmsKeyArn without secret throws ValidationFailed', () => {
 	assert.throws(
 		() => new AppSetting(parent, 'bad', { value: 'x', name: '/app/bad', kmsKeyArn: TEST_CMK }),
 		/only valid with 'secret: true'/,
+	);
+});
+
+test('CDK: fromExisting with kmsKeyArn grants read-only KMS scoped to the CMK ARN (Decrypt, no Encrypt)', () => {
+	const { stack, parent } = setup();
+	AppSetting.fromExisting(parent, 'ext-cmk', { name: '/ext/cmk-secret', secret: true, kmsKeyArn: TEST_CMK });
+	const template = Template.fromStack(stack);
+	const policies = template.findResources('AWS::IAM::Policy');
+
+	let found = false;
+	for (const logicalId of Object.keys(policies)) {
+		const statements = policies[logicalId]?.Properties?.PolicyDocument?.Statement;
+		if (!Array.isArray(statements)) continue;
+		for (const stmt of statements) {
+			const actions = Array.isArray(stmt.Action) ? stmt.Action : [stmt.Action];
+			if (JSON.stringify(stmt.Resource).includes(TEST_CMK) && actions.includes('kms:Decrypt')) {
+				found = true;
+				assert.ok(!actions.includes('kms:Encrypt'), 'external (read-only) CMK secret must not grant kms:Encrypt');
+			}
+		}
+	}
+	assert.ok(found, 'external CMK secret should grant kms:Decrypt scoped to the CMK ARN');
+});
+
+test('CDK: bulk-init role can read + re-key secrets (ssm:GetParameter + kms:Encrypt/Decrypt), no GenerateDataKey', () => {
+	// The re-encrypt-on-key-change path reads the current value (GetParameter +
+	// Decrypt) and rewrites it under the new key (Encrypt). The bulk-init statement
+	// is uniquely identified by ssm:AddTagsToResource.
+	const { stack, parent } = setup();
+	new AppSetting(parent, 'cmk-secret', { secret: true, name: '/app/cmk-secret', kmsKeyArn: TEST_CMK });
+	const template = Template.fromStack(stack);
+	const policies = template.findResources('AWS::IAM::Policy');
+
+	let bulkSsm: string[] | undefined;
+	let bulkKms: string[] | undefined;
+	for (const logicalId of Object.keys(policies)) {
+		const statements = policies[logicalId]?.Properties?.PolicyDocument?.Statement;
+		if (!Array.isArray(statements)) continue;
+		for (const stmt of statements) {
+			const actions: string[] = Array.isArray(stmt.Action) ? stmt.Action : [stmt.Action];
+			if (actions.includes('ssm:AddTagsToResource')) bulkSsm = actions;
+			if (actions.includes('kms:Encrypt') && stmt.Condition?.StringEquals?.['kms:ViaService']) bulkKms = actions;
+		}
+	}
+	assert.ok(bulkSsm, 'expected the bulk-init ssm statement (identified by AddTagsToResource)');
+	assert.ok(bulkSsm?.includes('ssm:GetParameter'), 'bulk-init needs ssm:GetParameter to read a value when re-keying');
+	assert.ok(bulkKms, 'expected the bulk-init KMS statement (ViaService-scoped)');
+	assert.ok(bulkKms?.includes('kms:Decrypt'), 'bulk-init needs kms:Decrypt to read the current value when re-keying');
+	assert.ok(
+		!bulkKms?.some((a) => a.startsWith('kms:GenerateDataKey')),
+		'no GenerateDataKey* — standard-tier SecureStrings do not use it',
 	);
 });

--- a/packages/bb-app-setting/src/index.cdk.test.ts
+++ b/packages/bb-app-setting/src/index.cdk.test.ts
@@ -230,3 +230,68 @@ test('CDK: fromExisting still registers the runtime config key (BLOCKS_SSM_PARAM
 	);
 	assert.equal(registry.entries.get('BLOCKS_SSM_PARAM_DB_URL'), '/blocks/sandbox/db-abc-connection-string');
 });
+
+const TEST_CMK = 'arn:aws:kms:us-east-1:111122223333:key/abcd1234-5678-90ab-cdef-1234567890ab';
+
+test('CDK: secret with kmsKeyArn grants handler KMS on the specific CMK ARN (not a ViaService wildcard)', () => {
+	const { stack, parent } = setup();
+	new AppSetting(parent, 'cmk-secret', { secret: true, name: '/app/cmk-secret', kmsKeyArn: TEST_CMK });
+	const template = Template.fromStack(stack);
+	const policies = template.findResources('AWS::IAM::Policy');
+
+	let found = false;
+	for (const logicalId of Object.keys(policies)) {
+		const statements = policies[logicalId]?.Properties?.PolicyDocument?.Statement;
+		if (!Array.isArray(statements)) continue;
+		for (const stmt of statements) {
+			const actions = Array.isArray(stmt.Action) ? stmt.Action : [stmt.Action];
+			if (!actions.includes('kms:Decrypt')) continue;
+			// The CMK grant scopes to the exact key ARN and carries no ViaService condition.
+			const resStr = JSON.stringify(stmt.Resource);
+			if (resStr.includes(TEST_CMK)) {
+				found = true;
+				assert.ok(actions.includes('kms:Encrypt'), 'stack-managed CMK secret should grant kms:Encrypt');
+				assert.ok(
+					actions.some((a: string) => a.startsWith('kms:GenerateDataKey')),
+					'CMK secret should grant kms:GenerateDataKey*',
+				);
+				assert.strictEqual(stmt.Condition, undefined, 'CMK grant should not use a ViaService wildcard condition');
+			}
+		}
+	}
+	assert.ok(found, `Expected a handler KMS grant scoped to the CMK ARN ${TEST_CMK}`);
+});
+
+test('CDK: secret with kmsKeyArn passes the KeyId to the bulk secret custom resource', () => {
+	const { stack, parent } = setup();
+	new AppSetting(parent, 'cmk-secret', { secret: true, name: '/app/cmk-secret', kmsKeyArn: TEST_CMK });
+	const template = Template.fromStack(stack);
+
+	const crs = template.findResources('AWS::CloudFormation::CustomResource');
+	const bulk = Object.values(crs).find((r) => Array.isArray(r?.Properties?.Parameters));
+	assert.ok(bulk, 'Expected a bulk-secrets custom resource with a Parameters list');
+	const params = bulk.Properties.Parameters as Array<{ name: string; keyId?: string }>;
+	const entry = params.find((p) => p.name === '/app/cmk-secret');
+	assert.ok(entry, 'the secret should appear in the bulk Parameters');
+	assert.strictEqual(entry?.keyId, TEST_CMK, 'the CMK ARN must be passed through as keyId');
+});
+
+test('CDK: a default-key secret carries no keyId in the bulk Parameters', () => {
+	const { stack, parent } = setup();
+	new AppSetting(parent, 'plain-secret', { secret: true, name: '/app/plain-secret' });
+	const template = Template.fromStack(stack);
+	const crs = template.findResources('AWS::CloudFormation::CustomResource');
+	const bulk = Object.values(crs).find((r) => Array.isArray(r?.Properties?.Parameters));
+	const params = bulk?.Properties?.Parameters as Array<{ name: string; keyId?: string }>;
+	const entry = params.find((p) => p.name === '/app/plain-secret');
+	assert.ok(entry, 'the secret should appear in the bulk Parameters');
+	assert.strictEqual(entry?.keyId, undefined, 'a default-key secret must not set keyId');
+});
+
+test('CDK: kmsKeyArn without secret throws ValidationFailed', () => {
+	const { parent } = setup();
+	assert.throws(
+		() => new AppSetting(parent, 'bad', { value: 'x', name: '/app/bad', kmsKeyArn: TEST_CMK }),
+		/only valid with 'secret: true'/,
+	);
+});

--- a/packages/bb-app-setting/src/index.cdk.ts
+++ b/packages/bb-app-setting/src/index.cdk.ts
@@ -42,7 +42,7 @@ export class AppSetting<T = string> extends Scope {
 	static fromExisting<T = string>(
 		scope: ScopeParent,
 		id: string,
-		options: { name: string; secret?: boolean },
+		options: { name: string; secret?: boolean; kmsKeyArn?: string },
 	): AppSetting<T> {
 		const opts: InternalAppSettingOptions<T> = { ...options, external: true };
 		return new AppSetting<T>(scope, id, opts);
@@ -74,13 +74,23 @@ export class AppSetting<T = string> extends Scope {
 			throw err;
 		}
 
-		if (options.kmsKeyArn && !options.secret) {
-			const err = new Error(
-				`AppSetting '${id}': 'kmsKeyArn' is only valid with 'secret: true'. ` +
-				`Non-secret String parameters are not encrypted.`
-			);
-			err.name = AppSettingErrors.ValidationFailed;
-			throw err;
+		if (options.kmsKeyArn !== undefined) {
+			if (!options.secret) {
+				const err = new Error(
+					`AppSetting '${id}': 'kmsKeyArn' is only valid with 'secret: true'. ` +
+					`Non-secret String parameters are not encrypted.`
+				);
+				err.name = AppSettingErrors.ValidationFailed;
+				throw err;
+			}
+			if (options.kmsKeyArn.trim() === '') {
+				const err = new Error(
+					`AppSetting '${id}': 'kmsKeyArn' must be a non-empty KMS key ARN. ` +
+					`Omit it to use the default aws/ssm key.`
+				);
+				err.name = AppSettingErrors.ValidationFailed;
+				throw err;
+			}
 		}
 
 		if (options.secret && options.value !== undefined) {
@@ -145,16 +155,15 @@ export class AppSetting<T = string> extends Scope {
 			}
 
 			// Grant the handler KMS access. External secrets are read-only (Decrypt
-			// only); stack-managed secrets also need Encrypt/GenerateDataKey* so the
-			// app can write the value via put().
+			// only); stack-managed secrets also need Encrypt so the app can write the
+			// value via put(). Standard-tier SecureStrings only use Encrypt/Decrypt
+			// (no GenerateDataKey — that's advanced-tier envelope encryption).
 			if (options.kmsKeyArn) {
 				// Customer-managed key: grant on the specific key ARN. NOTE: the key's
 				// own key policy must also allow this role (we can't edit a BYO key's
 				// policy from here) — see the README.
 				this.executionRole.addToPrincipalPolicy(new iam.PolicyStatement({
-					actions: external
-						? ['kms:Decrypt']
-						: ['kms:Decrypt', 'kms:Encrypt', 'kms:GenerateDataKey*'],
+					actions: external ? ['kms:Decrypt'] : ['kms:Decrypt', 'kms:Encrypt'],
 					resources: [options.kmsKeyArn],
 				}));
 			} else {
@@ -229,54 +238,78 @@ function registerSecret(stack: cdk.Stack, parameterName: string, keyId?: string)
 		runtime: DEFAULT_NODE_RUNTIME,
 		handler: 'index.handler',
 		code: lambda.Code.fromInline(`
-			const { SSMClient, PutParameterCommand, DeleteParameterCommand, AddTagsToResourceCommand } = require('@aws-sdk/client-ssm');
-			const crypto = require('crypto');
-			const client = new SSMClient({});
-			async function putSecret(p, tags) {
-				const secret = crypto.randomBytes(32).toString('base64url');
-				const input = { Name: p.name, Value: secret, Type: 'SecureString', Overwrite: false, Tags: tags };
-				// A CMK ARN pins the SecureString to a customer-managed key; omit for the default aws/ssm key.
-				if (p.keyId) input.KeyId = p.keyId;
-				try {
+				const { SSMClient, GetParameterCommand, PutParameterCommand, DeleteParameterCommand, AddTagsToResourceCommand } = require('@aws-sdk/client-ssm');
+				const crypto = require('crypto');
+				const client = new SSMClient({});
+				async function putSecret(p, tags) {
+					const secret = crypto.randomBytes(32).toString('base64url');
+					const input = { Name: p.name, Value: secret, Type: 'SecureString', Overwrite: false, Tags: tags };
+					// A CMK ARN pins the SecureString to a customer-managed key; omit for the default aws/ssm key.
+					if (p.keyId) input.KeyId = p.keyId;
+					try {
+						await client.send(new PutParameterCommand(input));
+					} catch (e) {
+						if (e.name !== 'ParameterAlreadyExists') throw e;
+						if (tags.length) {
+							await client.send(new AddTagsToResourceCommand({ ResourceType: 'Parameter', ResourceId: p.name, Tags: tags }));
+						}
+					}
+				}
+				// Re-encrypt an EXISTING secret under a new (or removed) KMS key, preserving its
+				// current value. Without this, changing kmsKeyArn leaves the value encrypted under
+				// the old key while the app's IAM grant flips to the new key, so the next get()
+				// fails with AccessDenied.
+				async function reencrypt(p) {
+					const cur = await client.send(new GetParameterCommand({ Name: p.name, WithDecryption: true }));
+					const value = cur.Parameter && cur.Parameter.Value;
+					if (value === undefined || value === null) return;
+					const input = { Name: p.name, Value: value, Type: 'SecureString', Overwrite: true };
+					if (p.keyId) input.KeyId = p.keyId; // omit => back to the default aws/ssm key
 					await client.send(new PutParameterCommand(input));
-				} catch (e) {
-					if (e.name !== 'ParameterAlreadyExists') throw e;
-					if (tags.length) {
-						await client.send(new AddTagsToResourceCommand({ ResourceType: 'Parameter', ResourceId: p.name, Tags: tags }));
-					}
 				}
-			}
-			exports.handler = async (event) => {
-				const params = event.ResourceProperties.Parameters || [];
-				const stackName = event.ResourceProperties.StackName || '';
-				const tags = stackName ? [{ Key: 'aws-blocks-stack', Value: stackName }] : [];
-				const oldParams = (event.OldResourceProperties || {}).Parameters || [];
-				const names = params.map(p => p.name);
-				const oldNames = oldParams.map(p => p.name);
-				if (event.RequestType === 'Delete') {
-					for (const name of names) {
-						try { await client.send(new DeleteParameterCommand({ Name: name })); } catch {}
+				// A pre-CMK deployment stored ParameterNames (string[]); map it to the {name} shape.
+				function readOld(op) {
+					if (Array.isArray(op.Parameters)) return op.Parameters;
+					if (Array.isArray(op.ParameterNames)) return op.ParameterNames.map((n) => ({ name: n }));
+					return [];
+				}
+				exports.handler = async (event) => {
+					const params = event.ResourceProperties.Parameters || [];
+					const stackName = event.ResourceProperties.StackName || '';
+					const tags = stackName ? [{ Key: 'aws-blocks-stack', Value: stackName }] : [];
+					const oldParams = readOld(event.OldResourceProperties || {});
+					const names = params.map(p => p.name);
+					const oldByName = Object.fromEntries(oldParams.map(p => [p.name, p]));
+					if (event.RequestType === 'Delete') {
+						for (const name of names) {
+							try { await client.send(new DeleteParameterCommand({ Name: name })); } catch {}
+						}
+						return { PhysicalResourceId: 'bb-secrets-bulk' };
+					}
+					if (event.RequestType === 'Create') {
+						for (const p of params) await putSecret(p, tags);
+						return { PhysicalResourceId: 'bb-secrets-bulk' };
+					}
+					if (event.RequestType === 'Update') {
+						for (const p of params) {
+							const old = oldByName[p.name];
+							if (!old) { await putSecret(p, tags); continue; }        // newly added
+							if ((old.keyId || '') !== (p.keyId || '')) await reencrypt(p); // key changed => re-key, preserving value
+							// else: unchanged — leave the runtime-managed value alone
+						}
+						for (const name of Object.keys(oldByName)) {
+							if (!names.includes(name)) { try { await client.send(new DeleteParameterCommand({ Name: name })); } catch {} }
+						}
+						return { PhysicalResourceId: 'bb-secrets-bulk' };
 					}
 					return { PhysicalResourceId: 'bb-secrets-bulk' };
-				}
-				if (event.RequestType === 'Create') {
-					for (const p of params) await putSecret(p, tags);
-					return { PhysicalResourceId: 'bb-secrets-bulk' };
-				}
-				if (event.RequestType === 'Update') {
-					for (const p of params) { if (!oldNames.includes(p.name)) await putSecret(p, tags); }
-					for (const name of oldNames) {
-						if (!names.includes(name)) { try { await client.send(new DeleteParameterCommand({ Name: name })); } catch {} }
-					}
-					return { PhysicalResourceId: 'bb-secrets-bulk' };
-				}
-				return { PhysicalResourceId: 'bb-secrets-bulk' };
-			};
-		`),
+				};
+			`),
 	});
 
 	secretInitFn.addToRolePolicy(new iam.PolicyStatement({
-		actions: ['ssm:PutParameter', 'ssm:DeleteParameter', 'ssm:AddTagsToResource'],
+		// GetParameter is needed to read a secret's current value when re-keying it.
+		actions: ['ssm:GetParameter', 'ssm:PutParameter', 'ssm:DeleteParameter', 'ssm:AddTagsToResource'],
 		resources: cdk.Lazy.list({
 			produce: () => state!.params.map(p =>
 				stack.formatArn({
@@ -291,9 +324,10 @@ function registerSecret(stack: cdk.Stack, parameterName: string, keyId?: string)
 	// SSM SecureString encryption goes through KMS via the SSM service. Scoping to
 	// `kms:ViaService = ssm.<region>` covers both the default aws/ssm key and any
 	// customer-managed key used above (the CMK's own key policy must also allow
-	// this role). `GenerateDataKey*` is required when a CMK is in play.
+	// this role). Encrypt = create/re-key; Decrypt = read the current value when
+	// re-keying. Standard-tier SecureStrings don't use GenerateDataKey.
 	secretInitFn.addToRolePolicy(new iam.PolicyStatement({
-		actions: ['kms:Encrypt', 'kms:GenerateDataKey*'],
+		actions: ['kms:Encrypt', 'kms:Decrypt'],
 		resources: ['*'],
 		conditions: {
 			StringEquals: {

--- a/packages/bb-app-setting/src/index.cdk.ts
+++ b/packages/bb-app-setting/src/index.cdk.ts
@@ -21,7 +21,9 @@ export type { AppSettingOptions } from './types.js';
  * - String parameters use `aws-cdk-lib/aws-ssm.StringParameter` directly.
  * - SecureString parameters use a Custom Resource Lambda because
  *   CloudFormation cannot natively create SecureString parameters.
- * - SecureString parameters are encrypted with the default `aws/ssm` KMS key.
+ * - SecureString parameters are encrypted with the default `aws/ssm` KMS key,
+ *   or with a customer-managed key when `kmsKeyArn` is provided (the handler is
+ *   then granted `kms:Decrypt`/`Encrypt` on that specific key ARN).
  */
 export class AppSetting<T = string> extends Scope {
 	/**
@@ -67,6 +69,15 @@ export class AppSetting<T = string> extends Scope {
 			const err = new Error(
 				`AppSetting '${id}': a schema is provided but no value. ` +
 				`Provide a value that conforms to the schema so the SSM parameter is valid on first deploy.`
+			);
+			err.name = AppSettingErrors.ValidationFailed;
+			throw err;
+		}
+
+		if (options.kmsKeyArn && !options.secret) {
+			const err = new Error(
+				`AppSetting '${id}': 'kmsKeyArn' is only valid with 'secret: true'. ` +
+				`Non-secret String parameters are not encrypted.`
 			);
 			err.name = AppSettingErrors.ValidationFailed;
 			throw err;
@@ -130,21 +141,34 @@ export class AppSetting<T = string> extends Scope {
 			// then fail tagging it (AddTagsToResource needs ssm:GetParameters).
 			// We only need runtime read access, granted below.
 			if (!external) {
-				registerSecret(cdk.Stack.of(this), parameterName);
+				registerSecret(cdk.Stack.of(this), parameterName, options.kmsKeyArn);
 			}
 
-			// Grant handler KMS access for the default aws/ssm key. External secrets
-			// are read-only (Decrypt only); stack-managed secrets also need Encrypt
-			// so the app can write the value via put().
-			this.executionRole.addToPrincipalPolicy(new iam.PolicyStatement({
-				actions: external ? ['kms:Decrypt'] : ['kms:Decrypt', 'kms:Encrypt'],
-				resources: ['*'],
-				conditions: {
-					StringEquals: {
-						'kms:ViaService': `ssm.${cdk.Stack.of(this).region}.amazonaws.com`,
+			// Grant the handler KMS access. External secrets are read-only (Decrypt
+			// only); stack-managed secrets also need Encrypt/GenerateDataKey* so the
+			// app can write the value via put().
+			if (options.kmsKeyArn) {
+				// Customer-managed key: grant on the specific key ARN. NOTE: the key's
+				// own key policy must also allow this role (we can't edit a BYO key's
+				// policy from here) — see the README.
+				this.executionRole.addToPrincipalPolicy(new iam.PolicyStatement({
+					actions: external
+						? ['kms:Decrypt']
+						: ['kms:Decrypt', 'kms:Encrypt', 'kms:GenerateDataKey*'],
+					resources: [options.kmsKeyArn],
+				}));
+			} else {
+				// Default aws/ssm key: scope the wildcard with a ViaService condition.
+				this.executionRole.addToPrincipalPolicy(new iam.PolicyStatement({
+					actions: external ? ['kms:Decrypt'] : ['kms:Decrypt', 'kms:Encrypt'],
+					resources: ['*'],
+					conditions: {
+						StringEquals: {
+							'kms:ViaService': `ssm.${cdk.Stack.of(this).region}.amazonaws.com`,
+						},
 					},
-				},
-			}));
+				}));
+			}
 		} else if (!external) {
 			// ── String parameter via CDK construct ──────────────────────────
 			const param = new ssm.StringParameter(this, 'Param', {
@@ -174,24 +198,31 @@ export class AppSetting<T = string> extends Scope {
 
 const SECRET_BULK_KEY = Symbol.for('BLOCKS_SECRET_BULK_INIT');
 
+interface SecretParam {
+	name: string;
+	/** Customer-managed KMS key ARN, or undefined for the default aws/ssm key. */
+	keyId?: string;
+}
+
 interface SecretBulkState {
-	parameterNames: string[];
+	params: SecretParam[];
 }
 
 /**
- * Register a secret parameter name. On first call, creates the shared Lambda,
- * Provider, and a single CustomResource. All subsequent calls just append to
- * the parameter list (resolved lazily at synth time).
+ * Register a secret parameter (and its optional customer-managed KMS key). On
+ * first call, creates the shared Lambda, Provider, and a single CustomResource.
+ * All subsequent calls just append to the parameter list (resolved lazily at
+ * synth time).
  */
-function registerSecret(stack: cdk.Stack, parameterName: string): void {
+function registerSecret(stack: cdk.Stack, parameterName: string, keyId?: string): void {
 	let state = (stack as any)[SECRET_BULK_KEY] as SecretBulkState | undefined;
 	if (state) {
-		state.parameterNames.push(parameterName);
+		state.params.push({ name: parameterName, keyId });
 		return;
 	}
 
 	// First secret in this stack — create all shared infrastructure
-	state = { parameterNames: [parameterName] };
+	state = { params: [{ name: parameterName, keyId }] };
 	(stack as any)[SECRET_BULK_KEY] = state;
 
 	const secretInitFn = new lambda.Function(stack, 'BlocksSecretInitFn', {
@@ -201,11 +232,27 @@ function registerSecret(stack: cdk.Stack, parameterName: string): void {
 			const { SSMClient, PutParameterCommand, DeleteParameterCommand, AddTagsToResourceCommand } = require('@aws-sdk/client-ssm');
 			const crypto = require('crypto');
 			const client = new SSMClient({});
+			async function putSecret(p, tags) {
+				const secret = crypto.randomBytes(32).toString('base64url');
+				const input = { Name: p.name, Value: secret, Type: 'SecureString', Overwrite: false, Tags: tags };
+				// A CMK ARN pins the SecureString to a customer-managed key; omit for the default aws/ssm key.
+				if (p.keyId) input.KeyId = p.keyId;
+				try {
+					await client.send(new PutParameterCommand(input));
+				} catch (e) {
+					if (e.name !== 'ParameterAlreadyExists') throw e;
+					if (tags.length) {
+						await client.send(new AddTagsToResourceCommand({ ResourceType: 'Parameter', ResourceId: p.name, Tags: tags }));
+					}
+				}
+			}
 			exports.handler = async (event) => {
-				const names = event.ResourceProperties.ParameterNames || [];
+				const params = event.ResourceProperties.Parameters || [];
 				const stackName = event.ResourceProperties.StackName || '';
 				const tags = stackName ? [{ Key: 'aws-blocks-stack', Value: stackName }] : [];
-				const oldNames = (event.OldResourceProperties || {}).ParameterNames || [];
+				const oldParams = (event.OldResourceProperties || {}).Parameters || [];
+				const names = params.map(p => p.name);
+				const oldNames = oldParams.map(p => p.name);
 				if (event.RequestType === 'Delete') {
 					for (const name of names) {
 						try { await client.send(new DeleteParameterCommand({ Name: name })); } catch {}
@@ -213,39 +260,13 @@ function registerSecret(stack: cdk.Stack, parameterName: string): void {
 					return { PhysicalResourceId: 'bb-secrets-bulk' };
 				}
 				if (event.RequestType === 'Create') {
-					for (const name of names) {
-						const secret = crypto.randomBytes(32).toString('base64url');
-						try {
-							await client.send(new PutParameterCommand({
-								Name: name, Value: secret, Type: 'SecureString', Overwrite: false, Tags: tags,
-							}));
-						} catch (e) {
-							if (e.name !== 'ParameterAlreadyExists') throw e;
-							if (tags.length) {
-								await client.send(new AddTagsToResourceCommand({ ResourceType: 'Parameter', ResourceId: name, Tags: tags }));
-							}
-						}
-					}
+					for (const p of params) await putSecret(p, tags);
 					return { PhysicalResourceId: 'bb-secrets-bulk' };
 				}
 				if (event.RequestType === 'Update') {
-					const added = names.filter(n => !oldNames.includes(n));
-					const removed = oldNames.filter(n => !names.includes(n));
-					for (const name of added) {
-						const secret = crypto.randomBytes(32).toString('base64url');
-						try {
-							await client.send(new PutParameterCommand({
-								Name: name, Value: secret, Type: 'SecureString', Overwrite: false, Tags: tags,
-							}));
-						} catch (e) {
-							if (e.name !== 'ParameterAlreadyExists') throw e;
-							if (tags.length) {
-								await client.send(new AddTagsToResourceCommand({ ResourceType: 'Parameter', ResourceId: name, Tags: tags }));
-							}
-						}
-					}
-					for (const name of removed) {
-						try { await client.send(new DeleteParameterCommand({ Name: name })); } catch {}
+					for (const p of params) { if (!oldNames.includes(p.name)) await putSecret(p, tags); }
+					for (const name of oldNames) {
+						if (!names.includes(name)) { try { await client.send(new DeleteParameterCommand({ Name: name })); } catch {} }
 					}
 					return { PhysicalResourceId: 'bb-secrets-bulk' };
 				}
@@ -257,18 +278,22 @@ function registerSecret(stack: cdk.Stack, parameterName: string): void {
 	secretInitFn.addToRolePolicy(new iam.PolicyStatement({
 		actions: ['ssm:PutParameter', 'ssm:DeleteParameter', 'ssm:AddTagsToResource'],
 		resources: cdk.Lazy.list({
-			produce: () => state!.parameterNames.map(name =>
+			produce: () => state!.params.map(p =>
 				stack.formatArn({
 					service: 'ssm',
 					resource: 'parameter',
-					resourceName: name.replace(/^\//, ''),
+					resourceName: p.name.replace(/^\//, ''),
 				})
 			),
 		}),
 	}));
 
+	// SSM SecureString encryption goes through KMS via the SSM service. Scoping to
+	// `kms:ViaService = ssm.<region>` covers both the default aws/ssm key and any
+	// customer-managed key used above (the CMK's own key policy must also allow
+	// this role). `GenerateDataKey*` is required when a CMK is in play.
 	secretInitFn.addToRolePolicy(new iam.PolicyStatement({
-		actions: ['kms:Encrypt'],
+		actions: ['kms:Encrypt', 'kms:GenerateDataKey*'],
 		resources: ['*'],
 		conditions: {
 			StringEquals: {
@@ -284,7 +309,7 @@ function registerSecret(stack: cdk.Stack, parameterName: string): void {
 	new cdk.CustomResource(stack, 'BlocksSecretsBulk', {
 		serviceToken: provider.serviceToken,
 		properties: {
-			ParameterNames: cdk.Lazy.list({ produce: () => state!.parameterNames }),
+			Parameters: cdk.Lazy.any({ produce: () => state!.params }),
 			StackName: (() => { let s = stack; while (s.nestedStackParent) s = s.nestedStackParent; return s.stackName; })(),
 		},
 	});

--- a/packages/bb-app-setting/src/index.mock.ts
+++ b/packages/bb-app-setting/src/index.mock.ts
@@ -86,7 +86,7 @@ export class AppSetting<T = string> extends Scope {
 	static fromExisting<T = string>(
 		scope: ScopeParent,
 		id: string,
-		options: { name: string; secret?: boolean },
+		options: { name: string; secret?: boolean; kmsKeyArn?: string },
 	): AppSetting<T> {
 		const opts: InternalAppSettingOptions<T> = { ...options, external: true };
 		return new AppSetting<T>(scope, id, opts);

--- a/packages/bb-app-setting/src/types.ts
+++ b/packages/bb-app-setting/src/types.ts
@@ -27,8 +27,23 @@ export interface AppSettingOptions<T = string> {
 	value?: T;
 	/** Runtime validation schema. Accepts any StandardSchemaV1 implementation (Zod, Valibot, ArkType). When provided, T is inferred from the schema. */
 	schema?: StandardSchemaV1<T>;
-	/** When true, creates an SSM SecureString parameter encrypted with the default aws/ssm KMS key. */
+	/** When true, creates an SSM SecureString parameter. Encrypted with the default `aws/ssm` KMS key unless `kmsKeyArn` is set. */
 	secret?: boolean;
+	/**
+	 * ARN of a **customer-managed KMS key** used to encrypt this secret's
+	 * SecureString value. When omitted, SSM uses the default `aws/ssm`
+	 * AWS-managed key. Use a CMK when you need to control the decrypt/grant scope
+	 * (e.g. cross-account access, key rotation, or a dedicated key policy).
+	 *
+	 * Only valid together with `secret: true`. The CDK layer grants the shared
+	 * handler `kms:Decrypt` (plus `kms:Encrypt`/`kms:GenerateDataKey*` for
+	 * stack-managed secrets it writes) on this key, and the runtime `put()` passes
+	 * the key so an overwrite does not silently fall back to the default key.
+	 *
+	 * @example
+	 * new AppSetting(scope, 'apiKey', { secret: true, kmsKeyArn: myKey.keyArn });
+	 */
+	kmsKeyArn?: string;
 	/** Optional logger for internal operations. When omitted, a default Logger at error level is created. */
 	logger?: ChildLogger;
 }

--- a/packages/bb-app-setting/src/types.ts
+++ b/packages/bb-app-setting/src/types.ts
@@ -36,9 +36,10 @@ export interface AppSettingOptions<T = string> {
 	 * (e.g. cross-account access, key rotation, or a dedicated key policy).
 	 *
 	 * Only valid together with `secret: true`. The CDK layer grants the shared
-	 * handler `kms:Decrypt` (plus `kms:Encrypt`/`kms:GenerateDataKey*` for
-	 * stack-managed secrets it writes) on this key, and the runtime `put()` passes
-	 * the key so an overwrite does not silently fall back to the default key.
+	 * handler `kms:Decrypt` (plus `kms:Encrypt` for stack-managed secrets it
+	 * writes) on this key, and the runtime `put()` passes the key so an overwrite
+	 * does not silently fall back to the default key. Changing this on an existing
+	 * secret re-encrypts its current value under the new key at deploy time.
 	 *
 	 * @example
 	 * new AppSetting(scope, 'apiKey', { secret: true, kmsKeyArn: myKey.keyArn });


### PR DESCRIPTION
## Card

Bug Bash board (Starter Kit, Security P1): **"core: SSM SecureString uses default `alias/aws/ssm` KMS key"** — *"Should use a CMK so cross-account/decrypt scope can be controlled."*
🔗 https://github.com/orgs/aws-amplify/projects/141/views/15?pane=issue&itemId=195530935

The on-`main` manifestation of this card is `bb-app-setting` (its secrets are the SecureString params; the hosting `secret()` CLI isn't on `main` yet).

## Problem

`AppSetting` secrets (`secret: true`) were always encrypted with the default `aws/ssm` AWS-managed key, and the handler got `kms:Decrypt`/`Encrypt` on `*` (scoped only by a `kms:ViaService` condition). There was no way to pin a secret to a **customer-managed key** to control its decrypt/grant scope (cross-account, dedicated key policy, rotation).

## Change

New optional `kmsKeyArn?: string` on `AppSettingOptions` (only valid with `secret: true`):

- **CDK** — the per-stack bulk-init Custom Resource now carries a `keyId` per parameter and passes it as `KeyId` on `PutParameter`; the handler is granted `kms:Decrypt`/`Encrypt`/`GenerateDataKey*` scoped to that **specific key ARN** (no `ViaService` wildcard). Default-key secrets are unchanged.
- **Runtime** — `put()` re-specifies `KeyId` on overwrite. Without this, SSM silently falls back to `aws/ssm` on every write, downgrading the encryption.
- **Mock** — unaffected (no encryption locally).

Because a BYO key isn't owned by AWS Blocks, **the CMK's key policy must also allow the app's execution role** — documented in the README/DESIGN.

## Tests (all new, red→green)

- CDK synth: CMK secret grants KMS on the exact key ARN (with `GenerateDataKey*`, no `ViaService` condition); the bulk CR `Parameters` carries the `keyId`; a default-key secret carries **no** `keyId`; `kmsKeyArn` without `secret` throws `ValidationFailed`.
- AWS runtime (`SSMClient` mock): `put()` sends `KeyId` for a CMK secret, and omits it for a default-key secret and for a non-secret String.

## Verification

- `@aws-blocks/bb-app-setting` suite: **66 pass / 0 fail** (was 59).
- `npm run lint` 0 errors · `lint:deps` ✅ · conditional-export parity 21/21 · umbrella-changeset guard ✅.
- `API.md` regenerated (`update:api`) — adds `kmsKeyArn`. (Local `check:api` shows only a CRLF-vs-LF artifact; `diff -w` is clean — CI on Linux emits LF.)

## Changeset

`@aws-blocks/bb-app-setting` **minor** + `@aws-blocks/blocks` **patch** (umbrella re-export). Additive/opt-in — no behavior change when `kmsKeyArn` is omitted.
## Scope & follow-up (not in this PR)

This PR is the foundational primitive (`AppSetting`-level `kmsKeyArn`), intentionally **not** the whole framework fix. Other SecureString writers still use the default `aws/ssm` key and are left for follow-up work:

- **`bb-auth-cognito` / `bb-auth-oidc` / `bb-auth-basic`** — their session / cookie / JWT signing secrets are created via an internal `new AppSetting(…, { secret: true })` and don't yet forward a key.
- **`core/scripts/ensure-secrets.ts`** — the DB connection-string provisioner `PutParameter`s a SecureString with no `KeyId`.

Recommended follow-up: a single stack-level `secretsKmsKey` that every secret writer consumes, rather than sprinkling `kmsKeyArn` across each API. This PR is the layer that work builds on.
