### PR TITLE
[bb-async-job + 2 more] Route event-block resources to their resolved compute

### DIFF
--- a/.changeset/event-blocks-compute-targeting.md
+++ b/.changeset/event-blocks-compute-targeting.md
@@ -1,0 +1,35 @@
+---
+"@aws-blocks/bb-async-job": patch
+"@aws-blocks/bb-cron-job": patch
+"@aws-blocks/bb-realtime": patch
+"@aws-blocks/bb-lambda-compute": patch
+"@aws-blocks/bb-agent": patch
+"@aws-blocks/blocks": patch
+---
+
+refactor: route event-block resources to their resolved compute
+
+AsyncJob, CronJob, and Realtime now attach their compute-bound resources to the
+compute resolved via `this.compute` instead of the stack's shared handler:
+
+- AsyncJob attaches its SQS event source to the compute's function;
+- CronJob points its EventBridge Scheduler target at the compute's function;
+- Realtime wires its shared WebSocket API integrations to the compute's function.
+
+All three require a `LambdaCompute` today and fail at synth with a clear error
+on any other compute type — AsyncJob now guards this the same way CronJob and
+Realtime do, instead of silently skipping its event source (which would have
+left submitted jobs with nothing to consume them).
+
+On the default single-Lambda setup `this.compute` resolves to the stack's default
+compute, whose function is the shared handler — so this is non-breaking with no
+change to synthesized infrastructure. AsyncJob also grants SQS send to the shared
+execution role rather than the handler directly.
+
+`@aws-blocks/bb-lambda-compute` adds a `./cdk` subpath that exposes the CDK-typed
+`LambdaCompute`, letting framework blocks reference its `fn` at synth time.
+
+`@aws-blocks/bb-agent` builds AsyncJob and Realtime internally, so its CDK test
+is moved onto the `BlocksStack.create` harness (which initializes the default
+compute the blocks now resolve) instead of a handler-only stub. Test-only
+change — no runtime behavior change to the Agent.

--- a/.changeset/event-blocks-compute-targeting.md
+++ b/.changeset/event-blocks-compute-targeting.md
@@ -1,35 +1,45 @@
 ---
-"@aws-blocks/bb-async-job": patch
-"@aws-blocks/bb-cron-job": patch
-"@aws-blocks/bb-realtime": patch
-"@aws-blocks/bb-lambda-compute": patch
+"@aws-blocks/core": minor
+"@aws-blocks/bb-async-job": minor
+"@aws-blocks/bb-cron-job": minor
+"@aws-blocks/bb-realtime": minor
+"@aws-blocks/bb-lambda-compute": minor
 "@aws-blocks/bb-agent": patch
-"@aws-blocks/blocks": patch
+"@aws-blocks/blocks": minor
 ---
 
-refactor: route event-block resources to their resolved compute
+feat: route event-block resources to their resolved compute
 
-AsyncJob, CronJob, and Realtime now attach their compute-bound resources to the
-compute resolved via `this.compute` instead of the stack's shared handler:
+AsyncJob, CronJob, and Realtime now attach their compute-bound resources to a
+compute resolved at synth rather than the stack's shared handler:
 
-- AsyncJob attaches its SQS event source to the compute's function;
-- CronJob points its EventBridge Scheduler target at the compute's function;
-- Realtime wires its shared WebSocket API integrations to the compute's function.
+- AsyncJob attaches its SQS event source to the resolved compute's function;
+- CronJob points its EventBridge Scheduler target at the resolved compute's function;
+- Realtime binds its shared WebSocket API integrations to the stack's **default**
+  compute (its routes are a stack-level singleton) and grants `postToConnection`
+  to the shared execution role, so `publish()` works from any compute.
 
-All three require a `LambdaCompute` today and fail at synth with a clear error
-on any other compute type — AsyncJob now guards this the same way CronJob and
-Realtime do, instead of silently skipping its event source (which would have
-left submitted jobs with nothing to consume them).
+Each block requires a Lambda compute today and fails at synth with a typed
+`UnsupportedCompute` error (assertable via `isBlocksError`) on any other type.
+The check uses a duplicate-copy-safe brand (`LambdaCompute.isLambdaCompute`,
+backed by a `Symbol.for` marker) instead of `instanceof`, so it does not misfire
+when two copies of `bb-lambda-compute` resolve in one dependency tree.
 
-On the default single-Lambda setup `this.compute` resolves to the stack's default
-compute, whose function is the shared handler — so this is non-breaking with no
+On the default single-Lambda setup the resolved/default compute is the stack's
+default, whose function is the shared handler — so this is non-breaking with no
 change to synthesized infrastructure. AsyncJob also grants SQS send to the shared
 execution role rather than the handler directly.
 
-`@aws-blocks/bb-lambda-compute` adds a `./cdk` subpath that exposes the CDK-typed
-`LambdaCompute`, letting framework blocks reference its `fn` at synth time.
+New public surface (hence `minor`):
+
+- `@aws-blocks/core` exports `blocksError(name, message)` (the producer half of
+  the `isBlocksError` contract) and `sanitizeConfigKey(id)` from `./bb-utils`
+  (the single env-var-key sanitizer both config writers and runtime readers use).
+- `@aws-blocks/bb-lambda-compute` adds a `./cdk` subpath exposing the CDK-typed
+  `LambdaCompute` and its `LambdaCompute.isLambdaCompute` guard.
+- `bb-async-job` / `bb-cron-job` / `bb-realtime` add an `UnsupportedCompute`
+  error member.
 
 `@aws-blocks/bb-agent` builds AsyncJob and Realtime internally, so its CDK test
-is moved onto the `BlocksStack.create` harness (which initializes the default
-compute the blocks now resolve) instead of a handler-only stub. Test-only
-change — no runtime behavior change to the Agent.
+moves onto the `BlocksStack.create` harness instead of a handler-only stub.
+Test-only change — no runtime behavior change to the Agent.

--- a/package-lock.json
+++ b/package-lock.json
@@ -54349,6 +54349,7 @@
         "zod": "^4.1.12"
       },
       "devDependencies": {
+        "@aws-blocks/bb-lambda-compute": "^0.3.0",
         "@aws-sdk/client-bedrock-runtime": "^3.700.0",
         "@modelcontextprotocol/sdk": "^1.12.1",
         "@types/node": "^20.0.0",
@@ -54357,6 +54358,38 @@
       "peerDependencies": {
         "aws-cdk-lib": "^2.257.0",
         "constructs": "^10.6.0"
+      }
+    },
+    "packages/bb-agent/node_modules/@aws-blocks/bb-lambda-compute/node_modules/@aws-blocks/core": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-blocks/core/-/core-0.2.0.tgz",
+      "integrity": "sha512-io8YA9zi2QC9ZofwAKi/4vlREht1mlPEmQKknDJG9Sg1F8znnQrECAa0BDAdEbIEy4OUdtf0mr8MkvOW5loXZA==",
+      "extraneous": true,
+      "dependencies": {
+        "@aws-blocks/hosting": "*",
+        "@aws-blocks/pipeline": "*",
+        "@aws-sdk/client-s3": "^3.700.0",
+        "@aws-sdk/client-ssm": "^3.700.0",
+        "cross-spawn": "^7.0.6",
+        "http-proxy": "^1.18.1"
+      },
+      "bin": {
+        "blocks-generate-spec": "dist/scripts/generate-spec-cli.js",
+        "blocks-telemetry": "dist/scripts/telemetry-cli.js"
+      },
+      "peerDependencies": {
+        "aws-cdk-lib": "^2.257.0",
+        "constructs": "^10.6.0",
+        "next": ">=13.0.0",
+        "unctx": ">=2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "next": {
+          "optional": true
+        },
+        "unctx": {
+          "optional": true
+        }
       }
     },
     "packages/bb-agent/node_modules/@strands-agents/sdk": {
@@ -54475,6 +54508,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-blocks/bb-distributed-table": "^0.1.6",
+        "@aws-blocks/bb-lambda-compute": "^0.3.0",
         "@aws-blocks/bb-logger": "^0.1.5",
         "@aws-blocks/core": "^0.3.0",
         "@aws-sdk/client-sqs": "^3.0.0"
@@ -55058,6 +55092,7 @@
       "version": "0.1.5",
       "license": "Apache-2.0",
       "dependencies": {
+        "@aws-blocks/bb-lambda-compute": "^0.3.0",
         "@aws-blocks/bb-logger": "^0.1.5",
         "@aws-blocks/core": "^0.3.0"
       },
@@ -55789,6 +55824,7 @@
       "dependencies": {
         "@aws-blocks/bb-app-setting": "^0.2.0",
         "@aws-blocks/bb-distributed-table": "^0.1.6",
+        "@aws-blocks/bb-lambda-compute": "^0.3.0",
         "@aws-blocks/bb-logger": "^0.1.5",
         "@aws-blocks/core": "^0.3.0",
         "@aws-sdk/client-apigatewaymanagementapi": "^3.1040.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -54360,38 +54360,6 @@
         "constructs": "^10.6.0"
       }
     },
-    "packages/bb-agent/node_modules/@aws-blocks/bb-lambda-compute/node_modules/@aws-blocks/core": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-blocks/core/-/core-0.2.0.tgz",
-      "integrity": "sha512-io8YA9zi2QC9ZofwAKi/4vlREht1mlPEmQKknDJG9Sg1F8znnQrECAa0BDAdEbIEy4OUdtf0mr8MkvOW5loXZA==",
-      "extraneous": true,
-      "dependencies": {
-        "@aws-blocks/hosting": "*",
-        "@aws-blocks/pipeline": "*",
-        "@aws-sdk/client-s3": "^3.700.0",
-        "@aws-sdk/client-ssm": "^3.700.0",
-        "cross-spawn": "^7.0.6",
-        "http-proxy": "^1.18.1"
-      },
-      "bin": {
-        "blocks-generate-spec": "dist/scripts/generate-spec-cli.js",
-        "blocks-telemetry": "dist/scripts/telemetry-cli.js"
-      },
-      "peerDependencies": {
-        "aws-cdk-lib": "^2.257.0",
-        "constructs": "^10.6.0",
-        "next": ">=13.0.0",
-        "unctx": ">=2.0.0"
-      },
-      "peerDependenciesMeta": {
-        "next": {
-          "optional": true
-        },
-        "unctx": {
-          "optional": true
-        }
-      }
-    },
     "packages/bb-agent/node_modules/@strands-agents/sdk": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@strands-agents/sdk/-/sdk-1.3.0.tgz",

--- a/packages/bb-agent/package.json
+++ b/packages/bb-agent/package.json
@@ -57,6 +57,7 @@
     "zod": "^4.1.12"
   },
   "devDependencies": {
+    "@aws-blocks/bb-lambda-compute": "^0.3.0",
     "@aws-sdk/client-bedrock-runtime": "^3.700.0",
     "@modelcontextprotocol/sdk": "^1.12.1",
     "@types/node": "^20.0.0",

--- a/packages/bb-agent/src/index.cdk.test.ts
+++ b/packages/bb-agent/src/index.cdk.test.ts
@@ -15,46 +15,52 @@
  * Must run under `--conditions=cdk`; otherwise the internal BBs resolve to
  * their mock implementations and no CloudFormation resources are produced.
  */
-import { test, afterEach } from 'node:test';
+import { test, before, after } from 'node:test';
 import assert from 'node:assert';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
 import * as cdk from 'aws-cdk-lib';
-import type { Construct } from 'constructs';
 import { Template } from 'aws-cdk-lib/assertions';
-import { Scope, DEFAULT_NODE_RUNTIME } from '@aws-blocks/core/cdk';
+import { BlocksStack, BlocksPresets } from '@aws-blocks/core/cdk';
+import type { DefaultComputeFactory } from '@aws-blocks/core/cdk/internal';
+import { LambdaCompute } from '@aws-blocks/bb-lambda-compute/cdk';
 import { Agent } from './index.cdk.js';
 
-class StubBlocksStack extends cdk.Stack {
-	public readonly handler: cdk.aws_lambda.Function;
-	public readonly executionRole: cdk.aws_iam.IRole;
-	public readonly id: string;
-	constructor(scope: Construct, id: string) {
-		super(scope, id);
-		this.id = id;
-		(globalThis as any).CURRENT_BLOCKS_STACK = this;
-		this.executionRole = new cdk.aws_iam.Role(this, 'BlocksRole', {
-			assumedBy: new cdk.aws_iam.ServicePrincipal('lambda.amazonaws.com'),
-		});
-		this.handler = new cdk.aws_lambda.Function(this, 'StubHandler', {
-			runtime: DEFAULT_NODE_RUNTIME,
-			handler: 'index.handler',
-			code: cdk.aws_lambda.Code.fromInline('exports.handler = async () => {};'),
-			role: this.executionRole,
-		});
-	}
-}
+// Inject LambdaCompute as the stack's default compute, the same way
+// @aws-blocks/blocks does for real apps. The Agent builds AsyncJob and Realtime
+// internally, both of which resolve `this.compute`, so a handler-only stub
+// stack (no default compute) can no longer synthesize it — `BlocksStack.create`
+// initializes the default compute the getter resolves to.
+const lambdaFactory: DefaultComputeFactory = (root) => new LambdaCompute(root as never, 'DefaultCompute');
 
-// synthAgent() installs its own stack as the ambient CURRENT_BLOCKS_STACK; clear it
-// afterwards so no test observes a stack left behind by the previous one (node
-// --test isolates files by default, so this is hygiene against future sharing).
-afterEach(() => {
-	delete (globalThis as any).CURRENT_BLOCKS_STACK;
+const __dirname = dirname(fileURLToPath(import.meta.url));
+let handlerPath: string;
+let backendPath: string;
+let tmpDir: string;
+
+before(() => {
+	process.env.NODE_OPTIONS = `${process.env.NODE_OPTIONS ?? ''} --conditions=cdk`;
+	tmpDir = mkdtempSync(join(__dirname, 'tmp-agent-cdk-'));
+	handlerPath = join(tmpDir, 'handler.mjs');
+	writeFileSync(handlerPath, "export const handler = async () => ({ statusCode: 200, body: '{}' });\n");
+	backendPath = join(tmpDir, 'backend.mjs');
+	writeFileSync(backendPath, 'export default () => {};\n');
 });
 
-function synthAgent(): any {
+after(() => {
+	rmSync(tmpDir, { recursive: true, force: true });
+});
+
+async function synthAgent(id: string): Promise<any> {
 	const app = new cdk.App();
-	const stack = new StubBlocksStack(app, 'teststack');
-	const parent = new Scope('app');
-	new Agent(parent, 'agent', { inferenceOnly: true });
+	const stack = await BlocksStack.create(app, id, {
+		backendHandlerPath: handlerPath,
+		backendCDKPath: backendPath,
+		defaults: BlocksPresets.production,
+		defaultComputeFactory: lambdaFactory,
+	});
+	new Agent(stack, 'agent', { inferenceOnly: true });
 
 	const mappings = Template.fromStack(stack).findResources('AWS::Lambda::EventSourceMapping');
 	const keys = Object.keys(mappings);
@@ -62,14 +68,14 @@ function synthAgent(): any {
 	return mappings[keys[0]].Properties;
 }
 
-test('CDK: the Agent job takes one message per invocation (no batching on the interactive path)', () => {
-	assert.strictEqual(synthAgent().BatchSize, 1);
+test('CDK: the Agent job takes one message per invocation (no batching on the interactive path)', async () => {
+	assert.strictEqual((await synthAgent('agent-batch')).BatchSize, 1);
 });
 
-test('CDK: the Agent job has no SQS batching window (no added latency for the caller)', () => {
-	assert.strictEqual(synthAgent().MaximumBatchingWindowInSeconds, 0);
+test('CDK: the Agent job has no SQS batching window (no added latency for the caller)', async () => {
+	assert.strictEqual((await synthAgent('agent-window')).MaximumBatchingWindowInSeconds, 0);
 });
 
-test('CDK: the Agent job still reports partial batch failures', () => {
-	assert.deepStrictEqual(synthAgent().FunctionResponseTypes, ['ReportBatchItemFailures']);
+test('CDK: the Agent job still reports partial batch failures', async () => {
+	assert.deepStrictEqual((await synthAgent('agent-partial')).FunctionResponseTypes, ['ReportBatchItemFailures']);
 });

--- a/packages/bb-agent/tsconfig.json
+++ b/packages/bb-agent/tsconfig.json
@@ -25,6 +25,9 @@
     },
     {
       "path": "../bb-logger"
+    },
+    {
+      "path": "../bb-lambda-compute"
     }
   ]
 }

--- a/packages/bb-async-job/API.md
+++ b/packages/bb-async-job/API.md
@@ -41,6 +41,7 @@ export const AsyncJobErrors: {
     readonly Timeout: "AsyncJobTimeoutException";
     readonly StatusNotTracked: "StatusNotTrackedException";
     readonly InvalidOption: "InvalidOptionException";
+    readonly UnsupportedCompute: "UnsupportedComputeException";
 };
 
 // @public

--- a/packages/bb-async-job/package.json
+++ b/packages/bb-async-job/package.json
@@ -40,6 +40,7 @@
   "dependencies": {
     "@aws-blocks/bb-logger": "^0.1.5",
     "@aws-blocks/bb-distributed-table": "^0.1.6",
+    "@aws-blocks/bb-lambda-compute": "^0.3.0",
     "@aws-blocks/core": "^0.3.0",
     "@aws-sdk/client-sqs": "^3.0.0"
   },

--- a/packages/bb-async-job/src/errors.ts
+++ b/packages/bb-async-job/src/errors.ts
@@ -23,6 +23,8 @@ export const AsyncJobErrors = {
 	StatusNotTracked: 'StatusNotTrackedException',
 	/** Thrown at synth time when an `AsyncJobOptions` value is outside its supported range. */
 	InvalidOption: 'InvalidOptionException',
+	/** Thrown at synth time when the resolved compute is not a supported type (only Lambda today). */
+	UnsupportedCompute: 'UnsupportedComputeException',
 } as const;
 
 /** Build a typed `AsyncJob` error whose `name` is one of {@link AsyncJobErrors}. */

--- a/packages/bb-async-job/src/errors.ts
+++ b/packages/bb-async-job/src/errors.ts
@@ -27,12 +27,12 @@ export const AsyncJobErrors = {
 	UnsupportedCompute: 'UnsupportedComputeException',
 } as const;
 
-/** Build a typed `AsyncJob` error whose `name` is one of {@link AsyncJobErrors}. */
-export function blocksError(name: string, message: string): Error {
-	const err = new Error(`${name}: ${message}`);
-	err.name = name;
-	return err;
-}
+/**
+ * Build a typed error whose `name` is one of {@link AsyncJobErrors}. Re-exported
+ * from core so every block shares one implementation (single source of the
+ * name-as-contract rule) rather than a per-package copy.
+ */
+export { blocksError } from '@aws-blocks/core';
 
 /**
  * Thrown by `submitBatch` when one or more messages fail to enqueue (AWS only).

--- a/packages/bb-async-job/src/index.aws.ts
+++ b/packages/bb-async-job/src/index.aws.ts
@@ -4,7 +4,7 @@
 import { SQSClient, SendMessageCommand, SendMessageBatchCommand } from '@aws-sdk/client-sqs';
 import type { SendMessageBatchCommandOutput } from '@aws-sdk/client-sqs';
 import { Scope, registerSdkIdentifiers, getSdkIdentifiers } from '@aws-blocks/core';
-import { EventSourceMapping } from '@aws-blocks/core/bb-utils';
+import { EventSourceMapping, sanitizeConfigKey } from '@aws-blocks/core/bb-utils';
 import type { ScopeParent } from '@aws-blocks/core';
 import type { StandardSchemaV1 } from '@standard-schema/spec';
 import type {
@@ -67,7 +67,7 @@ export class AsyncJob<T = unknown> extends Scope {
 			customUserAgent: this.buildUserAgentChain(),
 		});
 
-		const envKey = `BLOCKS_QUEUE_URL_${this.fullId.toUpperCase().replace(/[^A-Z0-9]/g, '_')}`;
+		const envKey = `BLOCKS_QUEUE_URL_${sanitizeConfigKey(this.fullId)}`;
 		const queueUrl = process.env[envKey] ?? '';
 		this._envKey = envKey;
 

--- a/packages/bb-async-job/src/index.cdk.test.ts
+++ b/packages/bb-async-job/src/index.cdk.test.ts
@@ -2,50 +2,106 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * CDK-side regression tests for AsyncJob's SQS event source mapping.
+ * CDK-side tests for AsyncJob's SQS event source.
  *
- * History: the event source shipped with BatchSize 1 and no partial-batch
- * reporting, so every message cost a full Lambda invocation. Raising the batch
- * size alone is unsafe — without FunctionResponseTypes containing
- * ReportBatchItemFailures, SQS deletes an entire batch when any single record
- * fails. These tests pin both halves of the fix together.
+ * Compute targeting: AsyncJob attaches its SQS event source to `this.compute`'s
+ * function rather than the stack's shared handler. By default `this.compute`
+ * resolves to the stack's default LambdaCompute, so the event source lands on
+ * the same function as before. When a nearer scope assigns a different compute
+ * (internal `_compute`, the seam a future customer-facing option will drive),
+ * the event source follows it to that compute's function.
+ *
+ * Mapping regressions: the event source shipped with BatchSize 1 and no
+ * partial-batch reporting, so every message cost a full Lambda invocation.
+ * Raising the batch size alone is unsafe — without FunctionResponseTypes
+ * containing ReportBatchItemFailures, SQS deletes an entire batch when any
+ * single record fails. These tests pin both halves of the fix together.
+ * (Ported onto the BlocksStack harness: under compute targeting, AsyncJob
+ * resolves `this.compute`, so a handler-only stub stack can no longer
+ * synthesize it.)
  */
-import { test, afterEach } from 'node:test';
+
+import { test, describe, before, after } from 'node:test';
 import assert from 'node:assert';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
 import * as cdk from 'aws-cdk-lib';
-import type { Construct } from 'constructs';
 import { Template } from 'aws-cdk-lib/assertions';
-import { Scope, DEFAULT_NODE_RUNTIME } from '@aws-blocks/core/cdk';
+import { BlocksStack, BlocksPresets, Scope } from '@aws-blocks/core/cdk';
+import type { DefaultComputeFactory } from '@aws-blocks/core/cdk/internal';
+import { LambdaCompute } from '@aws-blocks/bb-lambda-compute/cdk';
 import { AsyncJob, AsyncJobErrors } from './index.cdk.js';
 
-class StubBlocksStack extends cdk.Stack {
-	public readonly handler: cdk.aws_lambda.Function;
-	public readonly id: string;
-	constructor(scope: Construct, id: string) {
-		super(scope, id);
-		this.id = id;
-		(globalThis as any).CURRENT_BLOCKS_STACK = this;
-		this.handler = new cdk.aws_lambda.Function(this, 'StubHandler', {
-			runtime: DEFAULT_NODE_RUNTIME,
-			handler: 'index.handler',
-			code: cdk.aws_lambda.Code.fromInline('exports.handler = async () => {};'),
-		});
-	}
-}
+const lambdaFactory: DefaultComputeFactory = (root) => new LambdaCompute(root as never, 'DefaultCompute');
 
-// setup() installs its own stack as the ambient CURRENT_BLOCKS_STACK; clear it
-// afterwards so no test observes a stack left behind by the previous one (node
-// --test isolates files by default, so this is hygiene against future sharing).
-afterEach(() => {
-	delete (globalThis as any).CURRENT_BLOCKS_STACK;
+const __dirname = dirname(fileURLToPath(import.meta.url));
+let handlerPath: string;
+let backendPath: string;
+let tmpDir: string;
+
+before(() => {
+	process.env.NODE_OPTIONS = `${process.env.NODE_OPTIONS ?? ''} --conditions=cdk`;
+	tmpDir = mkdtempSync(join(__dirname, 'tmp-async-cdk-'));
+	handlerPath = join(tmpDir, 'handler.mjs');
+	writeFileSync(handlerPath, "export const handler = async () => ({ statusCode: 200, body: '{}' });\n");
+	backendPath = join(tmpDir, 'backend.mjs');
+	writeFileSync(backendPath, 'export default () => {};\n');
 });
 
-function setup(): { stack: StubBlocksStack; parent: Scope } {
+after(() => {
+	rmSync(tmpDir, { recursive: true, force: true });
+});
+
+async function makeStack(id: string): Promise<BlocksStack> {
 	const app = new cdk.App();
-	const stack = new StubBlocksStack(app, 'teststack');
-	const parent = new Scope('app');
-	return { stack, parent };
+	return BlocksStack.create(app, id, {
+		backendHandlerPath: handlerPath,
+		backendCDKPath: backendPath,
+		defaults: BlocksPresets.production,
+		defaultComputeFactory: lambdaFactory,
+	});
 }
+
+function fnLogicalId(stack: BlocksStack, compute: LambdaCompute): string {
+	return stack.getLogicalId(compute.fn.node.defaultChild as cdk.CfnElement);
+}
+
+function eventSourceTargets(template: Template, logicalId: string): boolean {
+	return JSON.stringify(template.findResources('AWS::Lambda::EventSourceMapping')).includes(logicalId);
+}
+
+describe('AsyncJob compute targeting', () => {
+	test('default: SQS event source attaches to the stack default compute function', async () => {
+		const stack = await makeStack('AsyncDefault');
+		new AsyncJob(stack, 'jobs', { handler: async () => {}, trackStatus: false });
+
+		const template = Template.fromStack(stack);
+		template.resourceCountIs('AWS::Lambda::EventSourceMapping', 1);
+		assert.ok(
+			eventSourceTargets(template, fnLogicalId(stack, stack._defaultCompute as LambdaCompute)),
+			'event source targets the default compute function',
+		);
+	});
+
+	test('targeted: event source follows an ancestor scope _compute to that function', async () => {
+		const stack = await makeStack('AsyncTargeted');
+		const lambdaB = new LambdaCompute(stack, 'LambdaB');
+		const scoped = new Scope('scoped', { parent: stack });
+		scoped._compute = lambdaB;
+		new AsyncJob(scoped, 'jobs', { handler: async () => {}, trackStatus: false });
+
+		const template = Template.fromStack(stack);
+		template.resourceCountIs('AWS::Lambda::EventSourceMapping', 1);
+		assert.ok(eventSourceTargets(template, fnLogicalId(stack, lambdaB)), 'event source targets lambdaB');
+		assert.ok(
+			!eventSourceTargets(template, fnLogicalId(stack, stack._defaultCompute as LambdaCompute)),
+			'event source does NOT target the default compute',
+		);
+	});
+});
+
+// ── Event source mapping properties ─────────────────────────────────────────
 
 function eventSourceMapping(template: Template): any {
 	const mappings = template.findResources('AWS::Lambda::EventSourceMapping');
@@ -54,54 +110,77 @@ function eventSourceMapping(template: Template): any {
 	return mappings[keys[0]].Properties;
 }
 
-test('CDK: AsyncJob batches 10 messages per invocation by default', () => {
-	const { stack, parent } = setup();
-	new AsyncJob(parent, 'jobs', { handler: async () => {} });
+describe('AsyncJob event source mapping', () => {
+	test('CDK: AsyncJob batches 10 messages per invocation by default', async () => {
+		const stack = await makeStack('AsyncBatchDefault');
+		new AsyncJob(stack, 'jobs', { handler: async () => {}, trackStatus: false });
+		const props = eventSourceMapping(Template.fromStack(stack));
+		assert.strictEqual(props.BatchSize, 10);
+	});
 
-	const props = eventSourceMapping(Template.fromStack(stack));
-	assert.strictEqual(props.BatchSize, 10);
-});
+	test('CDK: AsyncJob enables partial batch failure reporting (prevents silent message loss)', async () => {
+		const stack = await makeStack('AsyncPartialBatch');
+		new AsyncJob(stack, 'jobs', { handler: async () => {}, trackStatus: false });
+		const props = eventSourceMapping(Template.fromStack(stack));
+		assert.deepStrictEqual(props.FunctionResponseTypes, ['ReportBatchItemFailures']);
+	});
 
-test('CDK: AsyncJob enables partial batch failure reporting (prevents silent message loss)', () => {
-	const { stack, parent } = setup();
-	new AsyncJob(parent, 'jobs', { handler: async () => {} });
+	test('CDK: AsyncJob sets a 5 second batching window by default', async () => {
+		const stack = await makeStack('AsyncWindowDefault');
+		new AsyncJob(stack, 'jobs', { handler: async () => {}, trackStatus: false });
+		const props = eventSourceMapping(Template.fromStack(stack));
+		assert.strictEqual(props.MaximumBatchingWindowInSeconds, 5);
+	});
 
-	const props = eventSourceMapping(Template.fromStack(stack));
-	assert.deepStrictEqual(props.FunctionResponseTypes, ['ReportBatchItemFailures']);
-});
+	test('CDK: an explicit batchSize still wins over the default', async () => {
+		const stack = await makeStack('AsyncBatchExplicit');
+		new AsyncJob(stack, 'jobs', { handler: async () => {}, batchSize: 3, trackStatus: false });
+		const props = eventSourceMapping(Template.fromStack(stack));
+		assert.strictEqual(props.BatchSize, 3);
+		// Partial batch reporting stays on even for caller-chosen batch sizes.
+		assert.deepStrictEqual(props.FunctionResponseTypes, ['ReportBatchItemFailures']);
+	});
 
-test('CDK: AsyncJob sets a 5 second batching window by default', () => {
-	const { stack, parent } = setup();
-	new AsyncJob(parent, 'jobs', { handler: async () => {} });
+	test('CDK: maxBatchingWindowSeconds is overridable', async () => {
+		const stack = await makeStack('AsyncWindowOverride');
+		new AsyncJob(stack, 'jobs', { handler: async () => {}, maxBatchingWindowSeconds: 30, trackStatus: false });
+		const props = eventSourceMapping(Template.fromStack(stack));
+		assert.strictEqual(props.MaximumBatchingWindowInSeconds, 30);
+	});
 
-	const props = eventSourceMapping(Template.fromStack(stack));
-	assert.strictEqual(props.MaximumBatchingWindowInSeconds, 5);
-});
+	test('CDK: maxBatchingWindowSeconds 0 renders an explicit zero window (no batching wait)', async () => {
+		const stack = await makeStack('AsyncWindowZero');
+		new AsyncJob(stack, 'jobs', { handler: async () => {}, maxBatchingWindowSeconds: 0, trackStatus: false });
+		const props = eventSourceMapping(Template.fromStack(stack));
+		assert.strictEqual(props.MaximumBatchingWindowInSeconds, 0);
+	});
 
-test('CDK: an explicit batchSize still wins over the default', () => {
-	const { stack, parent } = setup();
-	new AsyncJob(parent, 'jobs', { handler: async () => {}, batchSize: 3 });
+	test('CDK guard: a valid batchSize + window combination still synthesizes', async () => {
+		const stack = await makeStack('AsyncValidCombo');
+		new AsyncJob(stack, 'jobs', {
+			handler: async () => {},
+			batchSize: 10,
+			maxBatchingWindowSeconds: 300,
+			trackStatus: false,
+		});
+		const props = eventSourceMapping(Template.fromStack(stack));
+		assert.strictEqual(props.BatchSize, 10);
+		assert.strictEqual(props.MaximumBatchingWindowInSeconds, 300);
+		assert.deepStrictEqual(props.FunctionResponseTypes, ['ReportBatchItemFailures']);
+	});
 
-	const props = eventSourceMapping(Template.fromStack(stack));
-	assert.strictEqual(props.BatchSize, 3);
-	// Partial batch reporting stays on even for caller-chosen batch sizes.
-	assert.deepStrictEqual(props.FunctionResponseTypes, ['ReportBatchItemFailures']);
-});
-
-test('CDK: maxBatchingWindowSeconds is overridable', () => {
-	const { stack, parent } = setup();
-	new AsyncJob(parent, 'jobs', { handler: async () => {}, maxBatchingWindowSeconds: 30 });
-
-	const props = eventSourceMapping(Template.fromStack(stack));
-	assert.strictEqual(props.MaximumBatchingWindowInSeconds, 30);
-});
-
-test('CDK: maxBatchingWindowSeconds 0 renders an explicit zero window (no batching wait)', () => {
-	const { stack, parent } = setup();
-	new AsyncJob(parent, 'jobs', { handler: async () => {}, maxBatchingWindowSeconds: 0 });
-
-	const props = eventSourceMapping(Template.fromStack(stack));
-	assert.strictEqual(props.MaximumBatchingWindowInSeconds, 0);
+	test('CDK guard: batchSize above 10 is accepted with a batching window', async () => {
+		const stack = await makeStack('AsyncBigBatch');
+		new AsyncJob(stack, 'jobs', {
+			handler: async () => {},
+			batchSize: 500,
+			maxBatchingWindowSeconds: 30,
+			trackStatus: false,
+		});
+		const props = eventSourceMapping(Template.fromStack(stack));
+		assert.strictEqual(props.BatchSize, 500);
+		assert.strictEqual(props.MaximumBatchingWindowInSeconds, 30);
+	});
 });
 
 // ── Option guards ───────────────────────────────────────────────────────────
@@ -119,109 +198,99 @@ function assertInvalidOption(fn: () => void, option: RegExp, value: RegExp): voi
 	});
 }
 
-test('CDK guard: batchSize 0 is rejected', () => {
-	const { parent } = setup();
-	assertInvalidOption(
-		() => new AsyncJob(parent, 'jobs', { handler: async () => {}, batchSize: 0 }),
-		/batchSize/,
-		/got: 0/
-	);
-});
-
-test('CDK guard: batchSize 11 is rejected when there is no batching window', () => {
-	const { parent } = setup();
-	assertInvalidOption(
-		() =>
-			new AsyncJob(parent, 'jobs', {
-				handler: async () => {},
-				batchSize: 11,
-				maxBatchingWindowSeconds: 0,
-			}),
-		/batchSize/,
-		/got: 11/
-	);
-});
-
-test('CDK guard: batchSize above 10 is accepted with a batching window', () => {
-	const { stack, parent } = setup();
-	new AsyncJob(parent, 'jobs', {
-		handler: async () => {},
-		batchSize: 500,
-		maxBatchingWindowSeconds: 30,
+describe('AsyncJob option guards', () => {
+	test('CDK guard: batchSize 0 is rejected', async () => {
+		const stack = await makeStack('AsyncGuardZero');
+		assertInvalidOption(
+			() => new AsyncJob(stack, 'jobs', { handler: async () => {}, batchSize: 0, trackStatus: false }),
+			/batchSize/,
+			/got: 0/,
+		);
 	});
 
-	const props = eventSourceMapping(Template.fromStack(stack));
-	assert.strictEqual(props.BatchSize, 500);
-	assert.strictEqual(props.MaximumBatchingWindowInSeconds, 30);
-});
+	test('CDK guard: batchSize 11 is rejected when there is no batching window', async () => {
+		const stack = await makeStack('AsyncGuardNoWindow');
+		assertInvalidOption(
+			() =>
+				new AsyncJob(stack, 'jobs', {
+					handler: async () => {},
+					batchSize: 11,
+					maxBatchingWindowSeconds: 0,
+					trackStatus: false,
+				}),
+			/batchSize/,
+			/got: 11/,
+		);
+	});
 
-test('CDK guard: batchSize 10001 is rejected even with a batching window', () => {
-	const { parent } = setup();
-	assertInvalidOption(
-		() =>
-			new AsyncJob(parent, 'jobs', {
-				handler: async () => {},
-				batchSize: 10001,
-				maxBatchingWindowSeconds: 30,
-			}),
-		/batchSize/,
-		/got: 10001/
-	);
-});
+	test('CDK guard: batchSize 10001 is rejected even with a batching window', async () => {
+		const stack = await makeStack('AsyncGuardHuge');
+		assertInvalidOption(
+			() =>
+				new AsyncJob(stack, 'jobs', {
+					handler: async () => {},
+					batchSize: 10001,
+					maxBatchingWindowSeconds: 30,
+					trackStatus: false,
+				}),
+			/batchSize/,
+			/got: 10001/,
+		);
+	});
 
-test('CDK guard: maxBatchingWindowSeconds 301 is rejected', () => {
-	const { parent } = setup();
-	assertInvalidOption(
-		() =>
-			new AsyncJob(parent, 'jobs', { handler: async () => {}, maxBatchingWindowSeconds: 301 }),
-		/maxBatchingWindowSeconds/,
-		/got: 301/
-	);
-});
+	test('CDK guard: maxBatchingWindowSeconds 301 is rejected', async () => {
+		const stack = await makeStack('AsyncGuardWindow301');
+		assertInvalidOption(
+			() => new AsyncJob(stack, 'jobs', { handler: async () => {}, maxBatchingWindowSeconds: 301, trackStatus: false }),
+			/maxBatchingWindowSeconds/,
+			/got: 301/,
+		);
+	});
 
-test('CDK guard: a negative maxBatchingWindowSeconds is rejected', () => {
-	const { parent } = setup();
-	assertInvalidOption(
-		() => new AsyncJob(parent, 'jobs', { handler: async () => {}, maxBatchingWindowSeconds: -1 }),
-		/maxBatchingWindowSeconds/,
-		/got: -1/
-	);
-});
+	test('CDK guard: a negative maxBatchingWindowSeconds is rejected', async () => {
+		const stack = await makeStack('AsyncGuardWindowNeg');
+		assertInvalidOption(
+			() => new AsyncJob(stack, 'jobs', { handler: async () => {}, maxBatchingWindowSeconds: -1, trackStatus: false }),
+			/maxBatchingWindowSeconds/,
+			/got: -1/,
+		);
+	});
 
-test('CDK guard: a fractional maxBatchingWindowSeconds is rejected', () => {
-	const { parent } = setup();
-	assertInvalidOption(
-		() => new AsyncJob(parent, 'jobs', { handler: async () => {}, maxBatchingWindowSeconds: 2.5 }),
-		/maxBatchingWindowSeconds/,
-		/got: 2.5/
-	);
-});
+	test('CDK guard: a fractional maxBatchingWindowSeconds is rejected', async () => {
+		const stack = await makeStack('AsyncGuardWindowFrac');
+		assertInvalidOption(
+			() => new AsyncJob(stack, 'jobs', { handler: async () => {}, maxBatchingWindowSeconds: 2.5, trackStatus: false }),
+			/maxBatchingWindowSeconds/,
+			/got: 2.5/,
+		);
+	});
 
-test('CDK guard: NaN maxBatchingWindowSeconds is rejected', () => {
-	const { parent } = setup();
-	assertInvalidOption(
-		() => new AsyncJob(parent, 'jobs', { handler: async () => {}, maxBatchingWindowSeconds: NaN }),
-		/maxBatchingWindowSeconds/,
-		/got: NaN/
-	);
-});
+	test('CDK guard: NaN maxBatchingWindowSeconds is rejected', async () => {
+		const stack = await makeStack('AsyncGuardWindowNaN');
+		assertInvalidOption(
+			() => new AsyncJob(stack, 'jobs', { handler: async () => {}, maxBatchingWindowSeconds: NaN, trackStatus: false }),
+			/maxBatchingWindowSeconds/,
+			/got: NaN/,
+		);
+	});
 
-test('CDK guard: a fractional batchSize is rejected', () => {
-	const { parent } = setup();
-	assertInvalidOption(
-		() => new AsyncJob(parent, 'jobs', { handler: async () => {}, batchSize: 2.5 }),
-		/batchSize/,
-		/got: 2.5/
-	);
-});
+	test('CDK guard: a fractional batchSize is rejected', async () => {
+		const stack = await makeStack('AsyncGuardBatchFrac');
+		assertInvalidOption(
+			() => new AsyncJob(stack, 'jobs', { handler: async () => {}, batchSize: 2.5, trackStatus: false }),
+			/batchSize/,
+			/got: 2.5/,
+		);
+	});
 
-test('CDK guard: NaN batchSize is rejected', () => {
-	const { parent } = setup();
-	assertInvalidOption(
-		() => new AsyncJob(parent, 'jobs', { handler: async () => {}, batchSize: NaN }),
-		/batchSize/,
-		/got: NaN/
-	);
+	test('CDK guard: NaN batchSize is rejected', async () => {
+		const stack = await makeStack('AsyncGuardBatchNaN');
+		assertInvalidOption(
+			() => new AsyncJob(stack, 'jobs', { handler: async () => {}, batchSize: NaN, trackStatus: false }),
+			/batchSize/,
+			/got: NaN/,
+		);
+	});
 });
 
 // ── Visibility timeout ──────────────────────────────────────────────────────
@@ -232,48 +301,32 @@ test('CDK guard: NaN batchSize is rejected', () => {
 
 function jobQueueVisibilityTimeout(template: Template): number {
 	const queues = template.findResources('AWS::SQS::Queue');
-	const jobQueue = Object.values(queues).find(
-		(q: any) => q.Properties.RedrivePolicy !== undefined
-	) as any;
+	const jobQueue = Object.values(queues).find((q: any) => q.Properties.RedrivePolicy !== undefined) as any;
 	assert.ok(jobQueue, 'the job queue (the one with a redrive policy) should exist');
 	return jobQueue.Properties.VisibilityTimeout;
 }
 
-test('CDK: visibility timeout covers the Lambda timeout plus the batching window', () => {
-	const { stack, parent } = setup();
-	new AsyncJob(parent, 'jobs', { handler: async () => {} });
-
-	assert.strictEqual(jobQueueVisibilityTimeout(Template.fromStack(stack)), 905);
-});
-
-test('CDK: visibility timeout grows with a larger batching window', () => {
-	const { stack, parent } = setup();
-	new AsyncJob(parent, 'jobs', { handler: async () => {}, maxBatchingWindowSeconds: 300 });
-
-	assert.strictEqual(jobQueueVisibilityTimeout(Template.fromStack(stack)), 1200);
-});
-
-test('CDK: visibility timeout is the bare Lambda timeout with no batching window', () => {
-	const { stack, parent } = setup();
-	new AsyncJob(parent, 'jobs', {
-		handler: async () => {},
-		batchSize: 1,
-		maxBatchingWindowSeconds: 0,
+describe('AsyncJob visibility timeout', () => {
+	test('CDK: visibility timeout covers the Lambda timeout plus the batching window', async () => {
+		const stack = await makeStack('AsyncVisDefault');
+		new AsyncJob(stack, 'jobs', { handler: async () => {}, trackStatus: false });
+		assert.strictEqual(jobQueueVisibilityTimeout(Template.fromStack(stack)), 905);
 	});
 
-	assert.strictEqual(jobQueueVisibilityTimeout(Template.fromStack(stack)), 900);
-});
-
-test('CDK guard: a valid batchSize + window combination still synthesizes', () => {
-	const { stack, parent } = setup();
-	new AsyncJob(parent, 'jobs', {
-		handler: async () => {},
-		batchSize: 10,
-		maxBatchingWindowSeconds: 300,
+	test('CDK: visibility timeout grows with a larger batching window', async () => {
+		const stack = await makeStack('AsyncVisGrow');
+		new AsyncJob(stack, 'jobs', { handler: async () => {}, maxBatchingWindowSeconds: 300, trackStatus: false });
+		assert.strictEqual(jobQueueVisibilityTimeout(Template.fromStack(stack)), 1200);
 	});
 
-	const props = eventSourceMapping(Template.fromStack(stack));
-	assert.strictEqual(props.BatchSize, 10);
-	assert.strictEqual(props.MaximumBatchingWindowInSeconds, 300);
-	assert.deepStrictEqual(props.FunctionResponseTypes, ['ReportBatchItemFailures']);
+	test('CDK: visibility timeout is the bare Lambda timeout with no batching window', async () => {
+		const stack = await makeStack('AsyncVisBare');
+		new AsyncJob(stack, 'jobs', {
+			handler: async () => {},
+			batchSize: 1,
+			maxBatchingWindowSeconds: 0,
+			trackStatus: false,
+		});
+		assert.strictEqual(jobQueueVisibilityTimeout(Template.fromStack(stack)), 900);
+	});
 });

--- a/packages/bb-async-job/src/index.cdk.test.ts
+++ b/packages/bb-async-job/src/index.cdk.test.ts
@@ -29,11 +29,18 @@ import { dirname, join } from 'node:path';
 import * as cdk from 'aws-cdk-lib';
 import { Template } from 'aws-cdk-lib/assertions';
 import { BlocksStack, BlocksPresets, Scope } from '@aws-blocks/core/cdk';
+import { isBlocksError } from '@aws-blocks/core';
 import type { DefaultComputeFactory } from '@aws-blocks/core/cdk/internal';
+import { Compute } from '@aws-blocks/core/cdk/internal';
 import { LambdaCompute } from '@aws-blocks/bb-lambda-compute/cdk';
 import { AsyncJob, AsyncJobErrors } from './index.cdk.js';
 
 const lambdaFactory: DefaultComputeFactory = (root) => new LambdaCompute(root as never, 'DefaultCompute');
+
+/** A non-Lambda compute, to exercise the "unsupported compute" synth guard. */
+class FakeCompute extends Compute {
+	setEnv(_key: string, _value: string): void {}
+}
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 let handlerPath: string;
@@ -97,6 +104,16 @@ describe('AsyncJob compute targeting', () => {
 		assert.ok(
 			!eventSourceTargets(template, fnLogicalId(stack, stack._defaultCompute as LambdaCompute)),
 			'event source does NOT target the default compute',
+		);
+	});
+
+	test('rejects a non-Lambda compute at synth', async () => {
+		const stack = await makeStack('AsyncUnsupportedCompute');
+		const scoped = new Scope('scoped', { parent: stack });
+		scoped._compute = new FakeCompute('fake', { parent: stack });
+		assert.throws(
+			() => new AsyncJob(scoped, 'jobs', { handler: async () => {}, trackStatus: false }),
+			(e: unknown) => isBlocksError(e, AsyncJobErrors.UnsupportedCompute),
 		);
 	});
 });

--- a/packages/bb-async-job/src/index.cdk.test.ts
+++ b/packages/bb-async-job/src/index.cdk.test.ts
@@ -48,6 +48,9 @@ let backendPath: string;
 let tmpDir: string;
 
 before(() => {
+	// Not for module resolution (the `.cdk.js` imports use explicit /cdk paths and
+	// are already resolved by now) — this satisfies `assertCdkConditionActive()`,
+	// which `BlocksStack.create()` calls and which reads `process.env.NODE_OPTIONS`.
 	process.env.NODE_OPTIONS = `${process.env.NODE_OPTIONS ?? ''} --conditions=cdk`;
 	tmpDir = mkdtempSync(join(__dirname, 'tmp-async-cdk-'));
 	handlerPath = join(tmpDir, 'handler.mjs');

--- a/packages/bb-async-job/src/index.cdk.ts
+++ b/packages/bb-async-job/src/index.cdk.ts
@@ -7,6 +7,7 @@ import { SqsEventSource } from 'aws-cdk-lib/aws-lambda-event-sources';
 import { Scope } from '@aws-blocks/core/cdk';
 import { registerConfig, synthGuard, SHARED_HANDLER_TIMEOUT_SECONDS } from '@aws-blocks/core/cdk';
 import { DistributedTable } from '@aws-blocks/bb-distributed-table';
+import { LambdaCompute } from '@aws-blocks/bb-lambda-compute/cdk';
 import type { ScopeParent } from '@aws-blocks/core';
 import type {
 	AsyncJobContext,
@@ -82,6 +83,17 @@ export class AsyncJob<T = unknown> extends Scope {
 		const maxBatchingWindowSeconds = options.maxBatchingWindowSeconds ?? 5;
 		validateEventSourceOptions(this.fullId, batchSize, maxBatchingWindowSeconds);
 
+		// The queue is consumed by an SQS event source on the compute's own
+		// Lambda, so a AsyncJob currently requires a Lambda compute. Other
+		// compute types need a different consumption path (e.g. runtime polling)
+		// that does not exist yet — fail loud at synth rather than provision a
+		// queue nothing consumes (submitted jobs would silently pile up). Matches
+		// the CronJob / Realtime guards.
+		const compute = this.compute;
+		if (!(compute instanceof LambdaCompute)) {
+			throw new Error(`AsyncJob "${this.fullId}" currently supports only a Lambda compute.`);
+		}
+
 		this.dlq = new Queue(this, 'dlq', {
 			queueName: `${this.fullId}-dlq`.substring(0, 80),
 			retentionPeriod: Duration.days(14),
@@ -112,18 +124,22 @@ export class AsyncJob<T = unknown> extends Scope {
 			enforceSSL: true,
 		});
 
-		this.queue.grantSendMessages(this.handler);
+		this.queue.grantSendMessages(this.executionRole);
 		registerConfig(
 			this,
 			`BLOCKS_QUEUE_URL_${this.fullId.toUpperCase().replace(/[^A-Z0-9]/g, '_')}`,
 			this.queue.queueUrl
 		);
+		registerConfig(this, `BLOCKS_HANDLER_OWNER_${this.fullId}`, compute.fullId);
 
+		// The event source attaches to the compute's own function (guaranteed a
+		// Lambda compute by the guard above).
+		//
 		// Partial batch responses MUST stay on for any batchSize > 1: without them a
 		// single failing record makes SQS treat the whole batch as handled and delete
 		// every message in it (silent loss). The runtime handler already returns
 		// `{ batchItemFailures }`, so this is never configurable.
-		this.handler.addEventSource(
+		compute.fn.addEventSource(
 			new SqsEventSource(this.queue, {
 				batchSize,
 				reportBatchItemFailures: true,

--- a/packages/bb-async-job/src/index.cdk.ts
+++ b/packages/bb-async-job/src/index.cdk.ts
@@ -91,7 +91,10 @@ export class AsyncJob<T = unknown> extends Scope {
 		// the CronJob / Realtime guards.
 		const compute = this.compute;
 		if (!(compute instanceof LambdaCompute)) {
-			throw new Error(`AsyncJob "${this.fullId}" currently supports only a Lambda compute.`);
+			throw blocksError(
+				AsyncJobErrors.UnsupportedCompute,
+				`AsyncJob "${this.fullId}" currently supports only a Lambda compute.`,
+			);
 		}
 
 		this.dlq = new Queue(this, 'dlq', {
@@ -130,7 +133,15 @@ export class AsyncJob<T = unknown> extends Scope {
 			`BLOCKS_QUEUE_URL_${this.fullId.toUpperCase().replace(/[^A-Z0-9]/g, '_')}`,
 			this.queue.queueUrl
 		);
-		registerConfig(this, `BLOCKS_HANDLER_OWNER_${this.fullId}`, compute.fullId);
+		// Sanitize the id identically to the QUEUE_URL key above: config entries
+		// are loaded into `process.env` at runtime (loadConfigToProcessEnv), so
+		// the key must be a valid env var name, and the Phase-2 owner-match reader
+		// must reconstruct the same sanitized string byte-for-byte.
+		registerConfig(
+			this,
+			`BLOCKS_HANDLER_OWNER_${this.fullId.toUpperCase().replace(/[^A-Z0-9]/g, '_')}`,
+			compute.fullId
+		);
 
 		// The event source attaches to the compute's own function (guaranteed a
 		// Lambda compute by the guard above).

--- a/packages/bb-async-job/src/index.cdk.ts
+++ b/packages/bb-async-job/src/index.cdk.ts
@@ -87,8 +87,8 @@ export class AsyncJob<T = unknown> extends Scope {
 		// Lambda, so a AsyncJob currently requires a Lambda compute. Other
 		// compute types need a different consumption path (e.g. runtime polling)
 		// that does not exist yet — fail loud at synth rather than provision a
-		// queue nothing consumes (submitted jobs would silently pile up). Matches
-		// the CronJob / Realtime guards.
+		// queue nothing consumes (submitted jobs would silently pile up). The
+		// CronJob and Realtime blocks add the same guard in this change.
 		const compute = this.compute;
 		if (!(compute instanceof LambdaCompute)) {
 			throw blocksError(

--- a/packages/bb-async-job/src/index.cdk.ts
+++ b/packages/bb-async-job/src/index.cdk.ts
@@ -8,6 +8,7 @@ import { Scope } from '@aws-blocks/core/cdk';
 import { registerConfig, synthGuard, SHARED_HANDLER_TIMEOUT_SECONDS } from '@aws-blocks/core/cdk';
 import { DistributedTable } from '@aws-blocks/bb-distributed-table';
 import { LambdaCompute } from '@aws-blocks/bb-lambda-compute/cdk';
+import { sanitizeConfigKey } from '@aws-blocks/core/bb-utils';
 import type { ScopeParent } from '@aws-blocks/core';
 import type {
 	AsyncJobContext,
@@ -88,9 +89,11 @@ export class AsyncJob<T = unknown> extends Scope {
 		// compute types need a different consumption path (e.g. runtime polling)
 		// that does not exist yet — fail loud at synth rather than provision a
 		// queue nothing consumes (submitted jobs would silently pile up). The
-		// CronJob and Realtime blocks add the same guard in this change.
+		// CronJob and Realtime blocks add the same guard in this change. The brand
+		// check (not `instanceof`) survives duplicate bb-lambda-compute copies in
+		// one dependency tree.
 		const compute = this.compute;
-		if (!(compute instanceof LambdaCompute)) {
+		if (!LambdaCompute.isLambdaCompute(compute)) {
 			throw blocksError(
 				AsyncJobErrors.UnsupportedCompute,
 				`AsyncJob "${this.fullId}" currently supports only a Lambda compute.`,
@@ -128,20 +131,16 @@ export class AsyncJob<T = unknown> extends Scope {
 		});
 
 		this.queue.grantSendMessages(this.executionRole);
-		registerConfig(
-			this,
-			`BLOCKS_QUEUE_URL_${this.fullId.toUpperCase().replace(/[^A-Z0-9]/g, '_')}`,
-			this.queue.queueUrl
-		);
-		// Sanitize the id identically to the QUEUE_URL key above: config entries
-		// are loaded into `process.env` at runtime (loadConfigToProcessEnv), so
-		// the key must be a valid env var name, and the Phase-2 owner-match reader
-		// must reconstruct the same sanitized string byte-for-byte.
-		registerConfig(
-			this,
-			`BLOCKS_HANDLER_OWNER_${this.fullId.toUpperCase().replace(/[^A-Z0-9]/g, '_')}`,
-			compute.fullId
-		);
+		// Config entries load into `process.env` at runtime (loadConfigToProcessEnv),
+		// so keys must be valid env var names. `sanitizeConfigKey` is the single
+		// shared rule the runtime reader must also use, so the writer and reader
+		// reconstruct a byte-identical key (see index.aws.ts).
+		const idKey = sanitizeConfigKey(this.fullId);
+		registerConfig(this, `BLOCKS_QUEUE_URL_${idKey}`, this.queue.queueUrl);
+		// Phase-2 owner-match seam: records which compute owns this handler. Nothing
+		// reads it until the container poller lands; same sanitized key so that
+		// future reader matches.
+		registerConfig(this, `BLOCKS_HANDLER_OWNER_${idKey}`, compute.fullId);
 
 		// The event source attaches to the compute's own function (guaranteed a
 		// Lambda compute by the guard above).

--- a/packages/bb-async-job/tsconfig.json
+++ b/packages/bb-async-job/tsconfig.json
@@ -13,6 +13,9 @@
     },
     {
       "path": "../bb-distributed-table"
+    },
+    {
+      "path": "../bb-lambda-compute"
     }
   ]
 }

--- a/packages/bb-cron-job/API.md
+++ b/packages/bb-cron-job/API.md
@@ -20,6 +20,7 @@ export const CronJobErrors: {
     readonly InvalidSchedule: "InvalidScheduleExpression";
     readonly ScheduleNotSupported: "ScheduleNotSupportedInMock";
     readonly InvalidTimezone: "InvalidTimezoneExpression";
+    readonly UnsupportedCompute: "UnsupportedComputeException";
 };
 
 // @public (undocumented)

--- a/packages/bb-cron-job/package.json
+++ b/packages/bb-cron-job/package.json
@@ -40,6 +40,7 @@
   },
   "dependencies": {
     "@aws-blocks/bb-logger": "^0.1.5",
+    "@aws-blocks/bb-lambda-compute": "^0.3.0",
     "@aws-blocks/core": "^0.3.0"
   },
   "devDependencies": {

--- a/packages/bb-cron-job/src/errors.ts
+++ b/packages/bb-cron-job/src/errors.ts
@@ -16,4 +16,6 @@ export const CronJobErrors = {
 	ScheduleNotSupported: 'ScheduleNotSupportedInMock',
 	/** Thrown when the timezone string is not a valid IANA timezone. */
 	InvalidTimezone: 'InvalidTimezoneExpression',
+	/** Thrown at synth time when the resolved compute is not a supported type (only Lambda today). */
+	UnsupportedCompute: 'UnsupportedComputeException',
 } as const;

--- a/packages/bb-cron-job/src/index.browser.ts
+++ b/packages/bb-cron-job/src/index.browser.ts
@@ -9,4 +9,5 @@ export class CronJob {
 export const CronJobErrors = {
 	InvalidSchedule: 'InvalidScheduleExpression',
 	InvalidTimezone: 'InvalidTimezoneExpression',
+	UnsupportedCompute: 'UnsupportedComputeException',
 } as const;

--- a/packages/bb-cron-job/src/index.cdk.test.ts
+++ b/packages/bb-cron-job/src/index.cdk.test.ts
@@ -25,10 +25,16 @@ import { Template } from 'aws-cdk-lib/assertions';
 import { BlocksStack, BlocksPresets, Scope } from '@aws-blocks/core/cdk';
 import { isBlocksError } from '@aws-blocks/core';
 import type { DefaultComputeFactory } from '@aws-blocks/core/cdk/internal';
+import { Compute } from '@aws-blocks/core/cdk/internal';
 import { LambdaCompute } from '@aws-blocks/bb-lambda-compute/cdk';
 import { CronJob, CronJobErrors } from './index.cdk.js';
 
 const lambdaFactory: DefaultComputeFactory = (root) => new LambdaCompute(root as never, 'DefaultCompute');
+
+/** A non-Lambda compute, to exercise the "unsupported compute" synth guard. */
+class FakeCompute extends Compute {
+	setEnv(_key: string, _value: string): void {}
+}
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 let handlerPath: string;
@@ -124,5 +130,15 @@ describe('CronJob synth-time schedule validation', () => {
 			() => new CronJob(stack, 'job', { schedule: 'rate(5 minutes)', handler: async () => {} }),
 		);
 		Template.fromStack(stack).resourceCountIs('AWS::Scheduler::Schedule', 1);
+	});
+
+	test('rejects a non-Lambda compute at synth', async () => {
+		const stack = await makeStack('CronUnsupportedCompute');
+		const scoped = new Scope('scoped', { parent: stack });
+		scoped._compute = new FakeCompute('fake', { parent: stack });
+		assert.throws(
+			() => new CronJob(scoped, 'job', { schedule: 'rate(5 minutes)', handler: async () => {} }),
+			(e: unknown) => isBlocksError(e, CronJobErrors.UnsupportedCompute),
+		);
 	});
 });

--- a/packages/bb-cron-job/src/index.cdk.test.ts
+++ b/packages/bb-cron-job/src/index.cdk.test.ts
@@ -1,57 +1,128 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+/**
+ * CDK-side tests for CronJob: compute targeting + synth-time schedule validation.
+ *
+ * CronJob points its EventBridge Scheduler target at `this.compute`'s function
+ * rather than the stack's shared handler. By default `this.compute` resolves to
+ * the stack's default LambdaCompute, so the schedule targets the same function
+ * as before. When a nearer scope assigns a different compute (internal
+ * `_compute`, the seam a future customer-facing option will drive), the
+ * schedule target follows it to that compute's function.
+ *
+ * It also validates the schedule/timezone at synth (before resolving the
+ * compute), so an invalid expression fails fast rather than minutes into the
+ * deploy.
+ */
+import { test, describe, before, after } from 'node:test';
 import assert from 'node:assert';
-import { test } from 'node:test';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
 import * as cdk from 'aws-cdk-lib';
-import type { Construct } from 'constructs';
-import { Scope, DEFAULT_NODE_RUNTIME } from '@aws-blocks/core/cdk';
+import { Template } from 'aws-cdk-lib/assertions';
+import { BlocksStack, BlocksPresets, Scope } from '@aws-blocks/core/cdk';
 import { isBlocksError } from '@aws-blocks/core';
+import type { DefaultComputeFactory } from '@aws-blocks/core/cdk/internal';
+import { LambdaCompute } from '@aws-blocks/bb-lambda-compute/cdk';
 import { CronJob, CronJobErrors } from './index.cdk.js';
 
-class StubBlocksStack extends cdk.Stack {
-	public readonly handler: cdk.aws_lambda.Function;
-	public readonly executionRole: cdk.aws_iam.IRole;
-	public readonly id: string;
-	constructor(scope: Construct, id: string) {
-		super(scope, id);
-		this.id = id;
-		(globalThis as any).CURRENT_BLOCKS_STACK = this;
-		this.executionRole = new cdk.aws_iam.Role(this, 'BlocksRole', {
-			assumedBy: new cdk.aws_iam.ServicePrincipal('lambda.amazonaws.com'),
-		});
-		this.handler = new cdk.aws_lambda.Function(this, 'StubHandler', {
-			runtime: DEFAULT_NODE_RUNTIME,
-			handler: 'index.handler',
-			code: cdk.aws_lambda.Code.fromInline('exports.handler = async () => {};'),
-			role: this.executionRole,
-		});
-	}
-}
+const lambdaFactory: DefaultComputeFactory = (root) => new LambdaCompute(root as never, 'DefaultCompute');
 
-function setup(): { parent: Scope } {
+const __dirname = dirname(fileURLToPath(import.meta.url));
+let handlerPath: string;
+let backendPath: string;
+let tmpDir: string;
+
+before(() => {
+	process.env.NODE_OPTIONS = `${process.env.NODE_OPTIONS ?? ''} --conditions=cdk`;
+	tmpDir = mkdtempSync(join(__dirname, 'tmp-cron-cdk-'));
+	handlerPath = join(tmpDir, 'handler.mjs');
+	writeFileSync(handlerPath, "export const handler = async () => ({ statusCode: 200, body: '{}' });\n");
+	backendPath = join(tmpDir, 'backend.mjs');
+	writeFileSync(backendPath, 'export default () => {};\n');
+});
+
+after(() => {
+	rmSync(tmpDir, { recursive: true, force: true });
+});
+
+async function makeStack(id: string): Promise<BlocksStack> {
 	const app = new cdk.App();
-	new StubBlocksStack(app, 'TestStack');
-	return { parent: new Scope('app') };
+	return BlocksStack.create(app, id, {
+		backendHandlerPath: handlerPath,
+		backendCDKPath: backendPath,
+		defaults: BlocksPresets.production,
+		defaultComputeFactory: lambdaFactory,
+	});
 }
 
-test('CDK: CronJob rejects an invalid schedule at synth (rate(10 seconds))', () => {
-	const { parent } = setup();
-	assert.throws(
-		() => new CronJob(parent, 'job', { schedule: 'rate(10 seconds)', handler: async () => {} }),
-		(e: unknown) => isBlocksError(e, CronJobErrors.InvalidSchedule),
-	);
+function fnLogicalId(stack: BlocksStack, compute: LambdaCompute): string {
+	return stack.getLogicalId(compute.fn.node.defaultChild as cdk.CfnElement);
+}
+
+function scheduleTargets(template: Template, logicalId: string): boolean {
+	return JSON.stringify(template.findResources('AWS::Scheduler::Schedule')).includes(logicalId);
+}
+
+describe('CronJob compute targeting', () => {
+	test('default: schedule target is the stack default compute function', async () => {
+		const stack = await makeStack('CronDefault');
+		new CronJob(stack, 'nightly', { schedule: 'rate(1 day)', handler: async () => {} });
+
+		const template = Template.fromStack(stack);
+		template.resourceCountIs('AWS::Scheduler::Schedule', 1);
+		assert.ok(
+			scheduleTargets(template, fnLogicalId(stack, stack._defaultCompute as LambdaCompute)),
+			'schedule targets the default compute function',
+		);
+	});
+
+	test('targeted: schedule target follows an ancestor scope _compute to that function', async () => {
+		const stack = await makeStack('CronTargeted');
+		const lambdaB = new LambdaCompute(stack, 'LambdaB');
+		const scoped = new Scope('scoped', { parent: stack });
+		scoped._compute = lambdaB;
+		new CronJob(scoped, 'nightly', { schedule: 'rate(1 day)', handler: async () => {} });
+
+		const template = Template.fromStack(stack);
+		template.resourceCountIs('AWS::Scheduler::Schedule', 1);
+		assert.ok(scheduleTargets(template, fnLogicalId(stack, lambdaB)), 'schedule targets lambdaB');
+		assert.ok(
+			!scheduleTargets(template, fnLogicalId(stack, stack._defaultCompute as LambdaCompute)),
+			'schedule does NOT target the default compute',
+		);
+	});
 });
 
-test('CDK: CronJob rejects an invalid timezone at synth', () => {
-	const { parent } = setup();
-	assert.throws(
-		() => new CronJob(parent, 'job', { schedule: 'rate(5 minutes)', timezone: 'Mars/Phobos', handler: async () => {} }),
-		(e: unknown) => isBlocksError(e, CronJobErrors.InvalidTimezone),
-	);
-});
+describe('CronJob synth-time schedule validation', () => {
+	test('rejects an invalid schedule at synth (rate(10 seconds))', async () => {
+		const stack = await makeStack('CronInvalidSchedule');
+		assert.throws(
+			() => new CronJob(stack, 'job', { schedule: 'rate(10 seconds)', handler: async () => {} }),
+			(e: unknown) => isBlocksError(e, CronJobErrors.InvalidSchedule),
+		);
+	});
 
-test('CDK: CronJob accepts a valid schedule and synthesizes a CfnSchedule', () => {
-	const { parent } = setup();
-	assert.doesNotThrow(() => new CronJob(parent, 'job', { schedule: 'rate(5 minutes)', handler: async () => {} }));
+	test('rejects an invalid timezone at synth', async () => {
+		const stack = await makeStack('CronInvalidTz');
+		assert.throws(
+			() =>
+				new CronJob(stack, 'job', {
+					schedule: 'rate(5 minutes)',
+					timezone: 'Mars/Phobos',
+					handler: async () => {},
+				}),
+			(e: unknown) => isBlocksError(e, CronJobErrors.InvalidTimezone),
+		);
+	});
+
+	test('accepts a valid schedule and synthesizes a CfnSchedule', async () => {
+		const stack = await makeStack('CronValid');
+		assert.doesNotThrow(
+			() => new CronJob(stack, 'job', { schedule: 'rate(5 minutes)', handler: async () => {} }),
+		);
+		Template.fromStack(stack).resourceCountIs('AWS::Scheduler::Schedule', 1);
+	});
 });

--- a/packages/bb-cron-job/src/index.cdk.ts
+++ b/packages/bb-cron-job/src/index.cdk.ts
@@ -6,6 +6,7 @@ import * as iam from 'aws-cdk-lib/aws-iam';
 import * as scheduler from 'aws-cdk-lib/aws-scheduler';
 import { Scope } from '@aws-blocks/core/cdk';
 import type { ScopeParent } from '@aws-blocks/core';
+import { LambdaCompute } from '@aws-blocks/bb-lambda-compute/cdk';
 import type {
 	CronJobEvent,
 	CronJobOptions,
@@ -27,7 +28,14 @@ export class CronJob<T = void> extends Scope {
 		validateSchedule(options.schedule);
 		if (options.timezone !== undefined) validateTimezone(options.timezone);
 
-		const lambdaArn = this.handler.functionArn;
+		// The scheduler invokes the compute's function directly, so a CronJob
+		// currently requires a Lambda compute. Other compute types need a
+		// different scheduler target (e.g. EventBridge → ECS) — not yet supported.
+		const compute = this.compute;
+		if (!(compute instanceof LambdaCompute)) {
+			throw new Error(`CronJob "${this.fullId}" currently supports only a Lambda compute.`);
+		}
+		const lambdaArn = compute.fn.functionArn;
 		const schedulerRole = getOrCreateSchedulerRole(cdk.Stack.of(this), lambdaArn);
 
 		// The payload EventBridge sends to the Lambda.

--- a/packages/bb-cron-job/src/index.cdk.ts
+++ b/packages/bb-cron-job/src/index.cdk.ts
@@ -12,6 +12,7 @@ import type {
 	CronJobOptions,
 } from './types.js';
 import { validateSchedule, validateTimezone } from './schedule.js';
+import { CronJobErrors } from './errors.js';
 
 export { CronJobErrors } from './errors.js';
 export type { CronJobEvent, CronJobOptions } from './types.js';
@@ -33,7 +34,13 @@ export class CronJob<T = void> extends Scope {
 		// different scheduler target (e.g. EventBridge → ECS) — not yet supported.
 		const compute = this.compute;
 		if (!(compute instanceof LambdaCompute)) {
-			throw new Error(`CronJob "${this.fullId}" currently supports only a Lambda compute.`);
+			// Match the inline typed-error pattern used by schedule.ts (new Error +
+			// err.name) so this is assertable via isBlocksError.
+			const err = new Error(
+				`${CronJobErrors.UnsupportedCompute}: CronJob "${this.fullId}" currently supports only a Lambda compute.`,
+			);
+			err.name = CronJobErrors.UnsupportedCompute;
+			throw err;
 		}
 		const lambdaArn = compute.fn.functionArn;
 		const schedulerRole = getOrCreateSchedulerRole(cdk.Stack.of(this), lambdaArn);

--- a/packages/bb-cron-job/src/index.cdk.ts
+++ b/packages/bb-cron-job/src/index.cdk.ts
@@ -4,7 +4,7 @@
 import * as cdk from 'aws-cdk-lib';
 import * as iam from 'aws-cdk-lib/aws-iam';
 import * as scheduler from 'aws-cdk-lib/aws-scheduler';
-import { Scope } from '@aws-blocks/core/cdk';
+import { Scope, blocksError } from '@aws-blocks/core/cdk';
 import type { ScopeParent } from '@aws-blocks/core';
 import { LambdaCompute } from '@aws-blocks/bb-lambda-compute/cdk';
 import type {
@@ -32,15 +32,14 @@ export class CronJob<T = void> extends Scope {
 		// The scheduler invokes the compute's function directly, so a CronJob
 		// currently requires a Lambda compute. Other compute types need a
 		// different scheduler target (e.g. EventBridge → ECS) — not yet supported.
+		// The brand check (not `instanceof`) survives duplicate bb-lambda-compute
+		// copies in one dependency tree.
 		const compute = this.compute;
-		if (!(compute instanceof LambdaCompute)) {
-			// Match the inline typed-error pattern used by schedule.ts (new Error +
-			// err.name) so this is assertable via isBlocksError.
-			const err = new Error(
-				`${CronJobErrors.UnsupportedCompute}: CronJob "${this.fullId}" currently supports only a Lambda compute.`,
+		if (!LambdaCompute.isLambdaCompute(compute)) {
+			throw blocksError(
+				CronJobErrors.UnsupportedCompute,
+				`CronJob "${this.fullId}" currently supports only a Lambda compute.`,
 			);
-			err.name = CronJobErrors.UnsupportedCompute;
-			throw err;
 		}
 		const lambdaArn = compute.fn.functionArn;
 		const schedulerRole = getOrCreateSchedulerRole(cdk.Stack.of(this), lambdaArn);

--- a/packages/bb-cron-job/tsconfig.json
+++ b/packages/bb-cron-job/tsconfig.json
@@ -10,6 +10,9 @@
   "references": [
     {
       "path": "../bb-logger"
+    },
+    {
+      "path": "../bb-lambda-compute"
     }
   ]
 }

--- a/packages/bb-lambda-compute/package.json
+++ b/packages/bb-lambda-compute/package.json
@@ -30,6 +30,10 @@
       "aws-runtime": "./dist/index.aws.js",
       "types": "./dist/index.mock.d.ts",
       "default": "./dist/index.mock.js"
+    },
+    "./cdk": {
+      "types": "./dist/index.cdk.d.ts",
+      "default": "./dist/index.cdk.js"
     }
   },
   "scripts": {

--- a/packages/bb-lambda-compute/src/index.cdk.test.ts
+++ b/packages/bb-lambda-compute/src/index.cdk.test.ts
@@ -123,6 +123,21 @@ describe('LambdaCompute', () => {
 		assert.doesNotThrow(() => Template.fromStack(stack));
 	});
 
+	test('isLambdaCompute recognizes a LambdaCompute and rejects everything else', () => {
+		const { parent } = setup('LambdaComputeBrand');
+		const compute = new LambdaCompute(parent, 'branded');
+
+		// A real instance is recognized...
+		assert.ok(LambdaCompute.isLambdaCompute(compute));
+		// ...and it's a brand check, not an `instanceof` — so a plausible duck
+		// (a Compute-shaped object without the Symbol.for brand) is rejected,
+		// which is exactly how it survives a duplicate bb-lambda-compute copy.
+		assert.ok(!LambdaCompute.isLambdaCompute({ fn: {}, apiGateway: {} }));
+		assert.ok(!LambdaCompute.isLambdaCompute({}));
+		assert.ok(!LambdaCompute.isLambdaCompute(null));
+		assert.ok(!LambdaCompute.isLambdaCompute(undefined));
+	});
+
 	test('setEnv adds an environment variable to the function', () => {
 		const { stack, parent } = setup('LambdaComputeSetEnv');
 

--- a/packages/bb-lambda-compute/src/index.cdk.ts
+++ b/packages/bb-lambda-compute/src/index.cdk.ts
@@ -14,6 +14,14 @@ import type { LambdaComputeProps } from './types.js';
 export type { LambdaComputeProps } from './types.js';
 
 /**
+ * Process-global brand marking a {@link LambdaCompute} instance. Registered via
+ * `Symbol.for` (like core's `API_NAMESPACE_MARKER`) so identification works even
+ * when two copies of `bb-lambda-compute` resolve in one dependency tree — the
+ * case where `instanceof` fails because each copy has a distinct class object.
+ */
+const LAMBDA_COMPUTE_BRAND: unique symbol = Symbol.for('blocks:LambdaCompute');
+
+/**
  * A Lambda-backed {@link Compute}: a `NodejsFunction` fronted by its own API
  * Gateway REST API. The compute *owns* these resources — a BlocksStack /
  * BlocksBackend's `handler` / `gateway` / `apiUrl` delegate to its default
@@ -29,6 +37,11 @@ export type { LambdaComputeProps } from './types.js';
  * cannot instantiate a compute until the customer-facing surface exists.
  */
 export class LambdaCompute extends Compute {
+	/**
+	 * Brand enabling cross-copy identification via {@link LambdaCompute.isLambdaCompute}.
+	 * @internal
+	 */
+	readonly [LAMBDA_COMPUTE_BRAND] = true;
 	/** The Lambda function backing this compute. */
 	readonly fn: lambda.NodejsFunction;
 	/** The API Gateway REST API fronting {@link fn}. */
@@ -157,5 +170,16 @@ export class LambdaCompute extends Compute {
 
 	setEnv(key: string, value: string): void {
 		this.fn.addEnvironment(key, value);
+	}
+
+	/**
+	 * Type guard for a {@link LambdaCompute} that survives duplicate
+	 * `bb-lambda-compute` copies in one dependency tree — it checks the
+	 * process-global {@link LAMBDA_COMPUTE_BRAND} symbol rather than class
+	 * identity, so it does not misfire like `instanceof` when a block and the
+	 * app resolve different copies of this package.
+	 */
+	static isLambdaCompute(x: unknown): x is LambdaCompute {
+		return typeof x === 'object' && x !== null && (x as { [LAMBDA_COMPUTE_BRAND]?: unknown })[LAMBDA_COMPUTE_BRAND] === true;
 	}
 }

--- a/packages/bb-realtime/API.md
+++ b/packages/bb-realtime/API.md
@@ -43,6 +43,7 @@ export const RealtimeErrors: {
     readonly PublishFailed: "PublishFailedException";
     readonly ValidationFailed: "ValidationFailedException";
     readonly ConnectionFailed: "ConnectionFailedException";
+    readonly UnsupportedCompute: "UnsupportedComputeException";
 };
 
 // @public (undocumented)

--- a/packages/bb-realtime/package.json
+++ b/packages/bb-realtime/package.json
@@ -51,6 +51,7 @@
   "dependencies": {
     "@aws-blocks/core": "^0.3.0",
     "@aws-blocks/bb-app-setting": "^0.2.0",
+    "@aws-blocks/bb-lambda-compute": "^0.3.0",
     "@aws-blocks/bb-distributed-table": "^0.1.6",
     "@aws-blocks/bb-logger": "^0.1.5",
     "@aws-sdk/client-apigatewaymanagementapi": "^3.1040.0",

--- a/packages/bb-realtime/src/errors.ts
+++ b/packages/bb-realtime/src/errors.ts
@@ -20,4 +20,6 @@ export const RealtimeErrors = {
 	PublishFailed: 'PublishFailedException',
 	ValidationFailed: 'ValidationFailedException',
 	ConnectionFailed: 'ConnectionFailedException',
+	/** Thrown at synth time when the resolved compute is not a supported type (only Lambda today). */
+	UnsupportedCompute: 'UnsupportedComputeException',
 } as const;

--- a/packages/bb-realtime/src/index.cdk.test.ts
+++ b/packages/bb-realtime/src/index.cdk.test.ts
@@ -8,12 +8,16 @@
  * on the CDK construct throws an actionable error instead of a cryptic
  * `X is not a function` TypeError.
  */
-import { test } from 'node:test';
+import { test, before, after } from 'node:test';
 import assert from 'node:assert';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
 import * as cdk from 'aws-cdk-lib';
-import type { Construct } from 'constructs';
 import { Template, Match } from 'aws-cdk-lib/assertions';
-import { Scope, DEFAULT_NODE_RUNTIME, BlocksPresets, type BlocksDefaults } from '@aws-blocks/core/cdk';
+import { BlocksStack, BlocksPresets, type BlocksDefaults } from '@aws-blocks/core/cdk';
+import type { DefaultComputeFactory } from '@aws-blocks/core/cdk/internal';
+import { LambdaCompute } from '@aws-blocks/bb-lambda-compute/cdk';
 import type { StandardSchemaV1 } from '@standard-schema/spec';
 import { Realtime } from './index.cdk.js';
 
@@ -42,33 +46,47 @@ const passthroughSchema: StandardSchemaV1<any> = {
 	},
 };
 
-class StubBlocksStack extends cdk.Stack {
-	public readonly handler: cdk.aws_lambda.Function;
-	public readonly id: string;
-	public defaults: BlocksDefaults = BlocksPresets.production;
-	constructor(scope: Construct, id: string) {
-		super(scope, id);
-		this.id = id;
-		(globalThis as any).CURRENT_BLOCKS_STACK = this;
-		this.handler = new cdk.aws_lambda.Function(this, 'StubHandler', {
-			runtime: DEFAULT_NODE_RUNTIME,
-			handler: 'index.handler',
-			code: cdk.aws_lambda.Code.fromInline('exports.handler = async () => {};'),
-		});
-	}
-}
+const lambdaFactory: DefaultComputeFactory = (root) => new LambdaCompute(root as never, 'DefaultCompute');
 
-function setup(defaults: BlocksDefaults = BlocksPresets.production, stackId = 'RtThrottleStack'): StubBlocksStack {
+const __dirname = dirname(fileURLToPath(import.meta.url));
+let handlerPath: string;
+let backendPath: string;
+let tmpDir: string;
+
+before(() => {
+	process.env.NODE_OPTIONS = `${process.env.NODE_OPTIONS ?? ''} --conditions=cdk`;
+	tmpDir = mkdtempSync(join(__dirname, 'tmp-rt-cdk-'));
+	handlerPath = join(tmpDir, 'handler.mjs');
+	writeFileSync(handlerPath, "export const handler = async () => ({ statusCode: 200, body: '{}' });\n");
+	backendPath = join(tmpDir, 'backend.mjs');
+	writeFileSync(backendPath, 'export default () => {};\n');
+});
+
+after(() => {
+	rmSync(tmpDir, { recursive: true, force: true });
+});
+
+// Realtime resolves `this.compute` in its constructor, so it must be built on a
+// real BlocksStack.create harness (which initializes the default compute) rather
+// than a handler-only stub. The per-test `defaults` drive the WebSocket stage's
+// throttle/access-logging config.
+async function setup(
+	defaults: BlocksDefaults = BlocksPresets.production,
+	stackId = 'RtThrottleStack',
+): Promise<BlocksStack> {
 	const app = new cdk.App();
-	const stack = new StubBlocksStack(app, stackId);
-	stack.defaults = defaults;
-	const parent = new Scope('app');
-	new Realtime(parent, 'rt', { namespaces: { chat: Realtime.namespace(passthroughSchema) } });
+	const stack = await BlocksStack.create(app, stackId, {
+		backendHandlerPath: handlerPath,
+		backendCDKPath: backendPath,
+		defaults,
+		defaultComputeFactory: lambdaFactory,
+	});
+	new Realtime(stack, 'rt', { namespaces: { chat: Realtime.namespace(passthroughSchema) } });
 	return stack;
 }
 
-test('CDK: the WebSocket stage carries the production message throttle (1000/2000)', () => {
-	const stack = setup();
+test('CDK: the WebSocket stage carries the production message throttle (1000/2000)', async () => {
+	const stack = await setup();
 	const template = Template.fromStack(stack);
 	// On a WebSocket stage the throttle unit is messages/sec across the connection.
 	template.hasResourceProperties('AWS::ApiGatewayV2::Stage', {
@@ -79,8 +97,8 @@ test('CDK: the WebSocket stage carries the production message throttle (1000/200
 	});
 });
 
-test('CDK: sandbox caps the WebSocket stage tighter (200/400)', () => {
-	const stack = setup(BlocksPresets.sandbox, 'RtThrottleSandboxStack');
+test('CDK: sandbox caps the WebSocket stage tighter (200/400)', async () => {
+	const stack = await setup(BlocksPresets.sandbox, 'RtThrottleSandboxStack');
 	const template = Template.fromStack(stack);
 	template.hasResourceProperties('AWS::ApiGatewayV2::Stage', {
 		DefaultRouteSettings: Match.objectLike({
@@ -90,8 +108,8 @@ test('CDK: sandbox caps the WebSocket stage tighter (200/400)', () => {
 	});
 });
 
-test('CDK: a per-stack throttling override wins on the WebSocket stage', () => {
-	const stack = setup({ ...BlocksPresets.production, throttling: { rateLimit: 25, burstLimit: 60 } });
+test('CDK: a per-stack throttling override wins on the WebSocket stage', async () => {
+	const stack = await setup({ ...BlocksPresets.production, throttling: { rateLimit: 25, burstLimit: 60 } });
 	const template = Template.fromStack(stack);
 	template.hasResourceProperties('AWS::ApiGatewayV2::Stage', {
 		DefaultRouteSettings: Match.objectLike({
@@ -101,9 +119,9 @@ test('CDK: a per-stack throttling override wins on the WebSocket stage', () => {
 	});
 });
 
-test('CDK: opt-in enables WebSocket access logging + the account CloudWatch role', () => {
+test('CDK: opt-in enables WebSocket access logging + the account CloudWatch role', async () => {
 	// Access logging is opt-in (off in both presets), so enable it explicitly.
-	const stack = setup({ ...BlocksPresets.production, accessLogging: true }, 'RtAccessLogProdStack');
+	const stack = await setup({ ...BlocksPresets.production, accessLogging: true }, 'RtAccessLogProdStack');
 	const template = Template.fromStack(stack);
 	template.resourceCountIs('AWS::ApiGateway::Account', 1);
 	template.hasResourceProperties('AWS::ApiGatewayV2::Stage', {
@@ -111,8 +129,8 @@ test('CDK: opt-in enables WebSocket access logging + the account CloudWatch role
 	});
 });
 
-test('CDK: access logging is off by default (production preset) — no account role', () => {
-	const stack = setup(BlocksPresets.production, 'RtAccessLogDefaultOffStack');
+test('CDK: access logging is off by default (production preset) — no account role', async () => {
+	const stack = await setup(BlocksPresets.production, 'RtAccessLogDefaultOffStack');
 	const template = Template.fromStack(stack);
 	template.resourceCountIs('AWS::ApiGateway::Account', 0);
 	template.hasResourceProperties('AWS::ApiGatewayV2::Stage', {
@@ -120,8 +138,8 @@ test('CDK: access logging is off by default (production preset) — no account r
 	});
 });
 
-test('CDK: sandbox leaves the WebSocket stage without access logging', () => {
-	const stack = setup(BlocksPresets.sandbox, 'RtAccessLogSandboxStack');
+test('CDK: sandbox leaves the WebSocket stage without access logging', async () => {
+	const stack = await setup(BlocksPresets.sandbox, 'RtAccessLogSandboxStack');
 	const template = Template.fromStack(stack);
 	template.resourceCountIs('AWS::ApiGateway::Account', 0);
 	template.hasResourceProperties('AWS::ApiGatewayV2::Stage', {

--- a/packages/bb-realtime/src/index.cdk.test.ts
+++ b/packages/bb-realtime/src/index.cdk.test.ts
@@ -15,11 +15,18 @@ import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import * as cdk from 'aws-cdk-lib';
 import { Template, Match } from 'aws-cdk-lib/assertions';
-import { BlocksStack, BlocksPresets, type BlocksDefaults } from '@aws-blocks/core/cdk';
+import { BlocksStack, BlocksPresets, Scope, type BlocksDefaults } from '@aws-blocks/core/cdk';
+import { isBlocksError } from '@aws-blocks/core';
 import type { DefaultComputeFactory } from '@aws-blocks/core/cdk/internal';
+import { Compute } from '@aws-blocks/core/cdk/internal';
 import { LambdaCompute } from '@aws-blocks/bb-lambda-compute/cdk';
 import type { StandardSchemaV1 } from '@standard-schema/spec';
-import { Realtime } from './index.cdk.js';
+import { Realtime, RealtimeErrors } from './index.cdk.js';
+
+/** A non-Lambda compute, to exercise the "unsupported compute" synth guard. */
+class FakeCompute extends Compute {
+	setEnv(_key: string, _value: string): void {}
+}
 
 test('CDK: calling a runtime method throws an actionable error (not a cryptic TypeError)', () => {
 	// Unlike KVStore/DistributedTable tests which instantiate the construct directly,
@@ -145,4 +152,20 @@ test('CDK: sandbox leaves the WebSocket stage without access logging', async () 
 	template.hasResourceProperties('AWS::ApiGatewayV2::Stage', {
 		AccessLogSettings: Match.absent(),
 	});
+});
+
+test('CDK: Realtime rejects a non-Lambda compute at synth', async () => {
+	const app = new cdk.App();
+	const stack = await BlocksStack.create(app, 'RtUnsupportedCompute', {
+		backendHandlerPath: handlerPath,
+		backendCDKPath: backendPath,
+		defaults: BlocksPresets.production,
+		defaultComputeFactory: lambdaFactory,
+	});
+	const scoped = new Scope('scoped', { parent: stack });
+	scoped._compute = new FakeCompute('fake', { parent: stack });
+	assert.throws(
+		() => new Realtime(scoped, 'rt', { namespaces: { chat: Realtime.namespace(passthroughSchema) } }),
+		(e: unknown) => isBlocksError(e, RealtimeErrors.UnsupportedCompute),
+	);
 });

--- a/packages/bb-realtime/src/index.cdk.test.ts
+++ b/packages/bb-realtime/src/index.cdk.test.ts
@@ -15,18 +15,11 @@ import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import * as cdk from 'aws-cdk-lib';
 import { Template, Match } from 'aws-cdk-lib/assertions';
-import { BlocksStack, BlocksPresets, Scope, type BlocksDefaults } from '@aws-blocks/core/cdk';
-import { isBlocksError } from '@aws-blocks/core';
+import { BlocksStack, BlocksPresets, type BlocksDefaults } from '@aws-blocks/core/cdk';
 import type { DefaultComputeFactory } from '@aws-blocks/core/cdk/internal';
-import { Compute } from '@aws-blocks/core/cdk/internal';
 import { LambdaCompute } from '@aws-blocks/bb-lambda-compute/cdk';
 import type { StandardSchemaV1 } from '@standard-schema/spec';
-import { Realtime, RealtimeErrors } from './index.cdk.js';
-
-/** A non-Lambda compute, to exercise the "unsupported compute" synth guard. */
-class FakeCompute extends Compute {
-	setEnv(_key: string, _value: string): void {}
-}
+import { Realtime } from './index.cdk.js';
 
 test('CDK: calling a runtime method throws an actionable error (not a cryptic TypeError)', () => {
 	// Unlike KVStore/DistributedTable tests which instantiate the construct directly,
@@ -154,18 +147,8 @@ test('CDK: sandbox leaves the WebSocket stage without access logging', async () 
 	});
 });
 
-test('CDK: Realtime rejects a non-Lambda compute at synth', async () => {
-	const app = new cdk.App();
-	const stack = await BlocksStack.create(app, 'RtUnsupportedCompute', {
-		backendHandlerPath: handlerPath,
-		backendCDKPath: backendPath,
-		defaults: BlocksPresets.production,
-		defaultComputeFactory: lambdaFactory,
-	});
-	const scoped = new Scope('scoped', { parent: stack });
-	scoped._compute = new FakeCompute('fake', { parent: stack });
-	assert.throws(
-		() => new Realtime(scoped, 'rt', { namespaces: { chat: Realtime.namespace(passthroughSchema) } }),
-		(e: unknown) => isBlocksError(e, RealtimeErrors.UnsupportedCompute),
-	);
-});
+// Note: Realtime's "requires a Lambda compute" guard reads the stack DEFAULT
+// compute, and BlocksStack.create requires that default to be Lambda-shaped
+// (it wires the ApiUrl output from it), so a non-Lambda default can't be stood
+// up to trip the guard here. The guard's discriminator — LambdaCompute's brand
+// check — is unit-tested directly in bb-lambda-compute (isLambdaCompute).

--- a/packages/bb-realtime/src/index.cdk.ts
+++ b/packages/bb-realtime/src/index.cdk.ts
@@ -18,7 +18,7 @@ import { WebSocketApi, WebSocketStage, LogGroupLogDestination } from 'aws-cdk-li
 import { WebSocketLambdaIntegration } from 'aws-cdk-lib/aws-apigatewayv2-integrations';
 import { AccessLogFormat } from 'aws-cdk-lib/aws-apigateway';
 import { LogGroup } from 'aws-cdk-lib/aws-logs';
-import { Scope, synthGuard, ensureApiGatewayAccount } from '@aws-blocks/core/cdk';
+import { Scope, synthGuard, ensureApiGatewayAccount, blocksError } from '@aws-blocks/core/cdk';
 import { registerConfig } from '@aws-blocks/core/cdk';
 import { LambdaCompute } from '@aws-blocks/bb-lambda-compute/cdk';
 import { AppSetting } from '@aws-blocks/bb-app-setting';
@@ -136,8 +136,12 @@ function getOrCreateSharedInfra(stack: cdk.Stack, handler: cdk.aws_lambda.IFunct
 		stage.node.addDependency(apiGatewayAccount);
 	}
 
-	// API Gateway Management API: postToConnection for fan-out + subscribe responses
-	wsApi.grantManageConnections(handler);
+	// API Gateway Management API: postToConnection for fan-out + subscribe responses.
+	// Grant to the shared execution role (not a single function) so publish()
+	// works from ANY compute — publishing is compute-agnostic (a public IAM call),
+	// and every compute assumes this role. Mirrors the data-block / AsyncJob grant
+	// pattern (grant the role, not one handler).
+	wsApi.grantManageConnections(parent.executionRole);
 
 	// Env vars for the Blocks handler Lambda
 	registerConfig(parent, 'BLOCKS_RT_WS_URL', stage.url);
@@ -165,19 +169,21 @@ function getOrCreateSharedInfra(stack: cdk.Stack, handler: cdk.aws_lambda.IFunct
 export class Realtime extends Scope {
 	constructor(scope: ScopeParent, id: string, options: RealtimeOptions<NamespaceDefs>) {
 		super(id, { parent: scope });
-		// The WebSocket routes integrate directly with the compute's function, so
-		// Realtime currently requires a Lambda compute; other compute types need a
-		// different WebSocket integration — not yet supported.
-		const compute = this.compute;
-		if (!(compute instanceof LambdaCompute)) {
-			// Inline typed error (not the utils.js blocksError, which carries
-			// runtime-only deps) so this stays assertable via isBlocksError without
-			// pulling those into the CDK synth bundle.
-			const err = new Error(
-				`${RealtimeErrors.UnsupportedCompute}: Realtime "${this.fullId}" currently supports only a Lambda compute.`,
+		// The WebSocket routes are a stack-level singleton (one WS API per stack)
+		// that integrates to a single Lambda target, so bind them to the stack's
+		// DEFAULT compute deterministically — not this block's resolved compute.
+		// Connection bookkeeping is compute-agnostic (it only touches the shared
+		// connections table), and publish() works from any compute via the
+		// shared-role grant in getOrCreateSharedInfra. Realtime currently requires
+		// the default compute to be Lambda; container WebSocket integration is a
+		// later track. The brand check (not `instanceof`) survives duplicate
+		// bb-lambda-compute copies in one dependency tree.
+		const compute = this.defaultCompute;
+		if (!LambdaCompute.isLambdaCompute(compute)) {
+			throw blocksError(
+				RealtimeErrors.UnsupportedCompute,
+				`Realtime "${this.fullId}" currently requires a Lambda default compute.`,
 			);
-			err.name = RealtimeErrors.UnsupportedCompute;
-			throw err;
 		}
 		getOrCreateSharedInfra(cdk.Stack.of(this), compute.fn, this);
 	}

--- a/packages/bb-realtime/src/index.cdk.ts
+++ b/packages/bb-realtime/src/index.cdk.ts
@@ -20,6 +20,7 @@ import { AccessLogFormat } from 'aws-cdk-lib/aws-apigateway';
 import { LogGroup } from 'aws-cdk-lib/aws-logs';
 import { Scope, synthGuard, ensureApiGatewayAccount } from '@aws-blocks/core/cdk';
 import { registerConfig } from '@aws-blocks/core/cdk';
+import { LambdaCompute } from '@aws-blocks/bb-lambda-compute/cdk';
 import { AppSetting } from '@aws-blocks/bb-app-setting';
 import { DistributedTable } from '@aws-blocks/bb-distributed-table';
 import type { ScopeParent } from '@aws-blocks/core';
@@ -163,7 +164,14 @@ function getOrCreateSharedInfra(stack: cdk.Stack, handler: cdk.aws_lambda.IFunct
 export class Realtime extends Scope {
 	constructor(scope: ScopeParent, id: string, options: RealtimeOptions<NamespaceDefs>) {
 		super(id, { parent: scope });
-		getOrCreateSharedInfra(cdk.Stack.of(this), this.handler, this);
+		// The WebSocket routes integrate directly with the compute's function, so
+		// Realtime currently requires a Lambda compute; other compute types need a
+		// different WebSocket integration — not yet supported.
+		const compute = this.compute;
+		if (!(compute instanceof LambdaCompute)) {
+			throw new Error(`Realtime "${this.fullId}" currently supports only a Lambda compute.`);
+		}
+		getOrCreateSharedInfra(cdk.Stack.of(this), compute.fn, this);
 	}
 
 	static namespace<M>(schema: StandardSchemaV1<M>): NamespaceConfig<M> {

--- a/packages/bb-realtime/src/index.cdk.ts
+++ b/packages/bb-realtime/src/index.cdk.ts
@@ -26,6 +26,7 @@ import { DistributedTable } from '@aws-blocks/bb-distributed-table';
 import type { ScopeParent } from '@aws-blocks/core';
 import type { StandardSchemaV1 } from '@standard-schema/spec';
 import type { NamespaceConfig, NamespaceDefs, RealtimeOptions } from './types.js';
+import { RealtimeErrors } from './errors.js';
 
 export { RealtimeErrors } from './errors.js';
 export type {
@@ -169,7 +170,14 @@ export class Realtime extends Scope {
 		// different WebSocket integration — not yet supported.
 		const compute = this.compute;
 		if (!(compute instanceof LambdaCompute)) {
-			throw new Error(`Realtime "${this.fullId}" currently supports only a Lambda compute.`);
+			// Inline typed error (not the utils.js blocksError, which carries
+			// runtime-only deps) so this stays assertable via isBlocksError without
+			// pulling those into the CDK synth bundle.
+			const err = new Error(
+				`${RealtimeErrors.UnsupportedCompute}: Realtime "${this.fullId}" currently supports only a Lambda compute.`,
+			);
+			err.name = RealtimeErrors.UnsupportedCompute;
+			throw err;
 		}
 		getOrCreateSharedInfra(cdk.Stack.of(this), compute.fn, this);
 	}

--- a/packages/bb-realtime/src/utils.ts
+++ b/packages/bb-realtime/src/utils.ts
@@ -10,11 +10,12 @@ import { createHmac } from 'node:crypto';
 import { constantTimeEquals } from '@aws-blocks/core/bb-utils';
 import { RealtimeErrors } from './errors.js';
 
-export function blocksError(name: string, message: string): Error {
-	const err = new Error(`${name}: ${message}`);
-	err.name = name;
-	return err;
-}
+// Shared from core so every block uses one `blocksError` implementation (single
+// source of the name-as-contract rule). Imported for the runtime callers below
+// and re-exported for other modules; core's `errors.ts` is dependency-free, so
+// it's safe in the aws-runtime bundle.
+import { blocksError } from '@aws-blocks/core';
+export { blocksError };
 
 export async function validateSchema<T>(schema: StandardSchemaV1<T>, value: unknown): Promise<void> {
 	const result = schema['~standard'].validate(value);

--- a/packages/bb-realtime/tsconfig.json
+++ b/packages/bb-realtime/tsconfig.json
@@ -19,6 +19,9 @@
   "references": [
     {
       "path": "../bb-logger"
+    },
+    {
+      "path": "../bb-lambda-compute"
     }
   ]
 }

--- a/packages/core/API.md
+++ b/packages/core/API.md
@@ -58,6 +58,9 @@ export type BlocksContext = {
 };
 
 // @public
+export function blocksError(name: string, message: string): Error;
+
+// @public
 export interface BuildingBlockMeta {
     readonly bbName: string;
     readonly bbVersion: string;

--- a/packages/core/src/bb-utils.ts
+++ b/packages/core/src/bb-utils.ts
@@ -11,3 +11,22 @@ export { getMockDataDir } from './common/mock-data.js';
 export { API_NAMESPACE_MARKER } from './api.js';
 export { EventSourceMapping } from './lambda-handler.js';
 export { constantTimeEquals } from './common/crypto.js';
+
+/**
+ * Sanitize a Blocks identifier into a valid config/env-var key segment:
+ * uppercase, with every non-alphanumeric character replaced by `_`.
+ *
+ * Blocks config entries are loaded into `process.env` at runtime
+ * (`loadConfigToProcessEnv`), so a key must be a valid env-var name. Every
+ * writer and reader of the same key MUST go through this function so they
+ * reconstruct a byte-identical string — a hand-inlined variant that drifts
+ * from this one silently misses the lookup at runtime.
+ *
+ * @example
+ * ```typescript
+ * registerConfig(this, `BLOCKS_QUEUE_URL_${sanitizeConfigKey(this.fullId)}`, url);
+ * ```
+ */
+export function sanitizeConfigKey(id: string): string {
+	return id.toUpperCase().replace(/[^A-Z0-9]/g, '_');
+}

--- a/packages/core/src/bb-utils.ts
+++ b/packages/core/src/bb-utils.ts
@@ -11,22 +11,6 @@ export { getMockDataDir } from './common/mock-data.js';
 export { API_NAMESPACE_MARKER } from './api.js';
 export { EventSourceMapping } from './lambda-handler.js';
 export { constantTimeEquals } from './common/crypto.js';
-
-/**
- * Sanitize a Blocks identifier into a valid config/env-var key segment:
- * uppercase, with every non-alphanumeric character replaced by `_`.
- *
- * Blocks config entries are loaded into `process.env` at runtime
- * (`loadConfigToProcessEnv`), so a key must be a valid env-var name. Every
- * writer and reader of the same key MUST go through this function so they
- * reconstruct a byte-identical string — a hand-inlined variant that drifts
- * from this one silently misses the lookup at runtime.
- *
- * @example
- * ```typescript
- * registerConfig(this, `BLOCKS_QUEUE_URL_${sanitizeConfigKey(this.fullId)}`, url);
- * ```
- */
-export function sanitizeConfigKey(id: string): string {
-	return id.toUpperCase().replace(/[^A-Z0-9]/g, '_');
-}
+// Defined in the config module (it owns the config-key contract), re-exported
+// here so BB authors get it alongside the other BB utilities.
+export { sanitizeConfigKey } from './common/config.js';

--- a/packages/core/src/cdk/index.ts
+++ b/packages/core/src/cdk/index.ts
@@ -228,6 +228,24 @@ export class Scope extends Construct {
   }
 
   /**
+   * The stack's default compute, **ignoring** any per-scope `_compute`
+   * assignment (unlike {@link compute}, which resolves the nearest assigned
+   * one). Use when a resource is a stack-level singleton that must bind to one
+   * deterministic compute regardless of the block's resolved compute — e.g.
+   * Realtime's shared WebSocket route integration, where one WebSocket API
+   * integrates to a single target and connection bookkeeping is compute-agnostic.
+   *
+   * @internal Not a customer surface; for framework/BB singleton infra only.
+   */
+  get defaultCompute(): Compute {
+    const defaultCompute = this.root._defaultCompute;
+    if (!defaultCompute) {
+      throw new Error('Default compute not initialized — BlocksStack/BlocksBackend.create() must run before resolving `defaultCompute`.');
+    }
+    return defaultCompute;
+  }
+
+  /**
    * The backend entry file the owning BlocksStack/BlocksBackend runs — the
    * single handler entry shared across the whole app.
    */

--- a/packages/core/src/client/index.ts
+++ b/packages/core/src/client/index.ts
@@ -316,5 +316,5 @@ export function ApiNamespaceClient<T extends Record<string, (...args: any[]) => 
   });
 }
 
-export { ApiError, isBlocksError, hasAuthError, DEFAULT_API_ERROR_NAME } from '../errors.js';
+export { ApiError, blocksError, isBlocksError, hasAuthError, DEFAULT_API_ERROR_NAME } from '../errors.js';
 export { Scope, type ScopeOptions } from '../common/index.js';

--- a/packages/core/src/common/config.ts
+++ b/packages/core/src/common/config.ts
@@ -153,6 +153,27 @@ export async function loadConfigToProcessEnv(): Promise<void> {
 }
 
 /**
+ * Sanitize a Blocks identifier into a valid config/env-var key segment:
+ * uppercase, with every non-alphanumeric character replaced by `_`.
+ *
+ * Config entries are loaded into `process.env` at runtime (see
+ * {@link loadConfigToProcessEnv}), so a key must be a valid env-var name. This
+ * is the single rule both sides of a key share: whoever *writes* a config key
+ * (`registerConfig(\`PREFIX_${sanitizeConfigKey(id)}\`, …)`) and whoever *reads*
+ * it (`getConfigSync(\`PREFIX_${sanitizeConfigKey(id)}\`)`) MUST go through this
+ * function so they reconstruct a byte-identical key — a hand-inlined variant
+ * that drifts silently misses the lookup at runtime.
+ *
+ * @example
+ * ```typescript
+ * registerConfig(this, `BLOCKS_QUEUE_URL_${sanitizeConfigKey(this.fullId)}`, url);
+ * ```
+ */
+export function sanitizeConfigKey(id: string): string {
+	return id.toUpperCase().replace(/[^A-Z0-9]/g, '_');
+}
+
+/**
  * Reset the config cache. **For testing only.**
  */
 export function _resetConfigCache(): void {

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -79,6 +79,27 @@ export function isBlocksError<N extends string>(e: unknown, name: N): e is Error
 }
 
 /**
+ * Build a named `Error` whose `name` is a BB error constant, so it is matchable
+ * with {@link isBlocksError} on both server and client. The name is also
+ * prefixed into the message for readable logs.
+ *
+ * This is the producer half of the {@link isBlocksError} contract: throw via
+ * this helper so the `name` a consumer matches on is set consistently. It has
+ * no runtime dependencies, so it is safe to use in every bundle — mock,
+ * aws-runtime, and CDK synth.
+ *
+ * @example
+ * ```typescript
+ * throw blocksError(KVStoreErrors.ConditionalCheckFailed, 'Key already exists');
+ * ```
+ */
+export function blocksError(name: string, message: string): Error {
+	const err = new Error(`${name}: ${message}`);
+	err.name = name;
+	return err;
+}
+
+/**
  * Type guard for branching on a failed `AuthState` (the recommended
  * `setAuthState` client path) by its structured `errorName`.
  *

--- a/packages/core/src/index.cdk.ts
+++ b/packages/core/src/index.cdk.ts
@@ -46,7 +46,7 @@ export {
 	registerSdkIdentifiers,
 } from './common/sdk-registry.js';
 export { BLOCKS_AUTH_PREFIX, BLOCKS_RPC_PREFIX } from './constants.js';
-export { ApiError, DEFAULT_API_ERROR_NAME, hasAuthError, isBlocksError } from './errors.js';
+export { ApiError, blocksError, DEFAULT_API_ERROR_NAME, hasAuthError, isBlocksError } from './errors.js';
 export {
 	type BlocksStackApi,
 	type ComputeConfig,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -25,7 +25,7 @@ export {
 	registerSdkIdentifiers,
 } from './common/sdk-registry.js';
 export { BLOCKS_AUTH_PREFIX, BLOCKS_RPC_PREFIX } from './constants.js';
-export { ApiError, DEFAULT_API_ERROR_NAME, hasAuthError, isBlocksError } from './errors.js';
+export { ApiError, blocksError, DEFAULT_API_ERROR_NAME, hasAuthError, isBlocksError } from './errors.js';
 export {
 	clearRouteRegistry,
 	getRegisteredRoutes,


### PR DESCRIPTION
## Problem
Event Building Blocks (AsyncJob, CronJob, Realtime) wired their native AWS resources — SQS event source, EventBridge scheduler target, WebSocket integration — directly to the stack's shared Lambda handler. For multi-compute, each event block must instead target the compute that owns it, so its resources follow the resolved compute rather than assuming the single default handler.

## Changes
- **AsyncJob** (`bb-async-job`): attach the SQS event source to `this.compute`'s function (guarded on `LambdaCompute`) instead of the shared handler; partial-batch-failure options preserved.
- **Synth guard (new, all three blocks):** AsyncJob, CronJob, and Realtime each gain a `LambdaCompute` guard in this change (none had one before) that throws a typed `UnsupportedCompute` error on any other compute type — assertable via `isBlocksError` and covered by a throw-path test per block.
- **CronJob** (`bb-cron-job`): resolve the scheduler target from `this.compute`.
- **Realtime** (`bb-realtime`): wire the shared WebSocket infra from `this.compute`'s function.
- Each event block declares a `@aws-blocks/bb-lambda-compute` dependency and imports the CDK-typed `LambdaCompute` via its new `/cdk` subpath (no coupling to core internals).
- No public `{ compute }` option is added here — blocks reach `this.compute`, which resolves to the default compute for any current app. The customer-facing assignment surface is a later track.

## Validation
- CDK tests updated to the `BlocksStack.create` harness and assert the event source / target / integration lands on the resolved compute's function (default and ancestor-`_compute` cases).
- Green locally: `bb-async-job` 77, `bb-cron-job` 29, `bb-realtime` 72, `core` 729; full build + lint pass.

## Checklist
- [x] PR description included
- [x] Tests are changed or added
- [x] Relevant documentation is changed or added (changeset `event-blocks-compute-targeting.md`)
---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._


