### PR TITLE
[core] Record each API namespace on its resolved compute

### DIFF
--- a/.changeset/core-namespace-compute-recording.md
+++ b/.changeset/core-namespace-compute-recording.md
@@ -1,0 +1,15 @@
+---
+"@aws-blocks/core": patch
+---
+
+feat(core): record each API namespace on its resolved compute (internal)
+
+`ApiNamespace` now records its name on the namespace's resolved compute
+(`compute.namespaces`) so later request routing can map a namespace to the
+compute that hosts it. This is a CDK-synth-only internal side effect — in the
+mock/runtime bundles there is no compute and it is a silent no-op.
+
+The public `ApiNamespace(scope, name, handler)` signature is unchanged and the
+returned handler is byte-identical. On the default single-compute app every
+namespace is recorded on the stack's default compute. No `{ compute }` overload
+is added here (that is the later customer-facing surface).

--- a/packages/core/src/api.test.ts
+++ b/packages/core/src/api.test.ts
@@ -38,3 +38,13 @@ test('ApiNamespace is a no-op recorder when the scope has no compute', () => {
   const handler = new ApiNamespace(new Scope('no-compute'), 'plainapi', () => ({ x: () => 1 }));
   assert.strictEqual((handler as any)[API_NAMESPACE_MARKER], 'plainapi');
 });
+
+test('ApiNamespace records a namespace at most once per compute', () => {
+  // `namespaces` is a set of names: recording the same name twice (e.g. a
+  // re-imported module during synth) must not append a duplicate.
+  const compute = { namespaces: [] as string[] };
+  const scopeLike = { id: 'app', compute } as never;
+  new ApiNamespace(scopeLike, 'dup', () => ({ ping: () => 'ok' }));
+  new ApiNamespace(scopeLike, 'dup', () => ({ ping: () => 'ok' }));
+  assert.deepStrictEqual(compute.namespaces, ['dup']);
+});

--- a/packages/core/src/api.test.ts
+++ b/packages/core/src/api.test.ts
@@ -23,3 +23,18 @@ test('Different ApiNamespace names should not collide', () => {
   assert.strictEqual((api1 as any)[API_NAMESPACE_MARKER], 'api1');
   assert.strictEqual((api2 as any)[API_NAMESPACE_MARKER], 'api2');
 });
+
+// ApiNamespace records its name on the scope's resolved compute (CDK
+// synth), while staying a silent no-op where no compute is resolvable.
+test('ApiNamespace records its name on a resolvable compute', () => {
+  const compute = { namespaces: [] as string[] };
+  new ApiNamespace({ id: 'app', compute } as never, 'myapi', () => ({ ping: () => 'ok' }));
+  assert.deepStrictEqual(compute.namespaces, ['myapi']);
+});
+
+test('ApiNamespace is a no-op recorder when the scope has no compute', () => {
+  // The common Scope (mock/runtime) has no `compute`; recording must not throw
+  // and the handler is still tagged and returned unchanged.
+  const handler = new ApiNamespace(new Scope('no-compute'), 'plainapi', () => ({ x: () => 1 }));
+  assert.strictEqual((handler as any)[API_NAMESPACE_MARKER], 'plainapi');
+});

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -72,23 +72,26 @@ type ComputeResolvingScope = { compute?: { namespaces?: string[] } };
  *
  * CDK-synth concern only: in the CDK bundle `scope.compute` resolves to the
  * namespace's compute (the stack default today), and we append the name to its
- * `namespaces` list. In the mock/runtime bundles — or a scopeless test — there
- * is no `compute`, so this is a silent no-op. The `compute` getter can also
- * throw before the default compute is initialized (outside synth); that too is
- * treated as "nothing to record". The public `ApiNamespace` signature is
- * unchanged; this is a purely internal side effect.
+ * `namespaces` list. In the mock/runtime bundles — or a scopeless test — the
+ * property is absent, so `scope.compute` is `undefined` and this is a silent
+ * no-op. The public `ApiNamespace` signature is unchanged; this is a purely
+ * internal side effect.
+ *
+ * No `try/catch`: `BlocksBackend.create()` initializes the default compute
+ * before it imports the backend module that constructs any `ApiNamespace`, so
+ * the `compute` getter always resolves at this call site. If it ever threw
+ * here it would signal a genuine lifecycle violation (an `ApiNamespace` built
+ * before `create()` resolved), which should surface rather than be swallowed.
  */
 function recordNamespaceOnCompute(scope: ScopeParent | null | undefined, name: string): void {
   // An API created without a Scope stays unrecorded and routes to the
   // default compute.
   if (!scope || typeof scope !== 'object') return;
-  try {
-    const compute = (scope as ComputeResolvingScope).compute;
-    if (compute && Array.isArray(compute.namespaces)) {
-      compute.namespaces.push(name);
-    }
-  } catch {
-    // compute resolution isn't available in this context — nothing to record.
+  const compute = (scope as ComputeResolvingScope).compute;
+  // Guard against duplicates so `namespaces` stays a set of names: a namespace
+  // could otherwise be recorded twice (e.g. a re-imported module during synth).
+  if (compute && Array.isArray(compute.namespaces) && !compute.namespaces.includes(name)) {
+    compute.namespaces.push(name);
   }
 }
 

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -60,6 +60,39 @@ export const API_NAMESPACE_MARKER = Symbol.for('blocks:ApiNamespace');
 import type { ScopeParent } from './common/index.js';
 
 /**
+ * Structural view of a scope that resolves a compute carrying a recordable
+ * namespace list. Only the CDK `Scope` satisfies this at runtime (via its
+ * `compute` getter); in the mock/runtime bundles the property is absent.
+ */
+type ComputeResolvingScope = { compute?: { namespaces?: string[] } };
+
+/**
+ * Record this namespace on its resolved compute so request routing can later
+ * map a namespace to the compute that hosts it.
+ *
+ * CDK-synth concern only: in the CDK bundle `scope.compute` resolves to the
+ * namespace's compute (the stack default today), and we append the name to its
+ * `namespaces` list. In the mock/runtime bundles — or a scopeless test — there
+ * is no `compute`, so this is a silent no-op. The `compute` getter can also
+ * throw before the default compute is initialized (outside synth); that too is
+ * treated as "nothing to record". The public `ApiNamespace` signature is
+ * unchanged; this is a purely internal side effect.
+ */
+function recordNamespaceOnCompute(scope: ScopeParent | null | undefined, name: string): void {
+  // An API created without a Scope stays unrecorded and routes to the
+  // default compute.
+  if (!scope || typeof scope !== 'object') return;
+  try {
+    const compute = (scope as ComputeResolvingScope).compute;
+    if (compute && Array.isArray(compute.namespaces)) {
+      compute.namespaces.push(name);
+    }
+  } catch {
+    // compute resolution isn't available in this context — nothing to record.
+  }
+}
+
+/**
  * Define a type-safe API namespace that works seamlessly between frontend and backend.
  * 
  * ## Usage
@@ -157,6 +190,9 @@ export interface ApiNamespaceConstructor {
 export const ApiNamespace: ApiNamespaceConstructor = class ApiNamespace {
   constructor(scope: ScopeParent, name: string, handler: any) {
     handler[API_NAMESPACE_MARKER] = name;
+    // Record the namespace → compute association for per-compute routing.
+    // No-op outside CDK synth. Signature and returned handler are unchanged.
+    recordNamespaceOnCompute(scope, name);
     return handler;
   }
 } as any;


### PR DESCRIPTION
## Problem
Request routing (a later track) needs to know which compute hosts each API namespace. This records that mapping at synth time — without changing the public `ApiNamespace` signature.

> **Stacked on #391** (config registry / compute registry). Base is the #391 branch; it retargets to `main` automatically once #391 merges. Review only this PR's layer (3 files).

## Changes
- `ApiNamespace` constructor records its namespace on the resolved compute (`recordNamespaceOnCompute` → `compute.namespaces.push(name)`) during CDK synth. Public signature `(scope, name, handler)` is byte-identical; recording is an internal side effect.
- No-op outside CDK synth (mock/runtime bundles have no compute) and when a scope resolves no compute — an API created without a Scope stays unrecorded and routes to the default compute.

## Validation
- Unit tests for recording on a resolvable compute and the scopeless no-op.
- Green locally: `core` 702; full build + lint pass.

## Checklist
- [x] PR description included
- [x] Tests are changed or added
- [x] Relevant documentation is changed or added (changeset `core-namespace-compute-recording.md`)
---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._

