### PR TITLE
fix(ci): stale-stack cleanup empties versioned buckets + fire-and-forget deletes

### DIFF
--- a/.github/workflows/cleanup-stacks.yml
+++ b/.github/workflows/cleanup-stacks.yml
@@ -2,12 +2,20 @@ name: Cleanup Stale E2E Stacks
 
 on:
   schedule:
-    - cron: '0 */4 * * *' # Every 4 hours
+    - cron: '0 */2 * * *' # Every 2 hours
   workflow_dispatch:
 
 permissions:
   id-token: write
   contents: read
+
+# Never let two cleanup runs overlap (a slow drain + the next scheduled tick
+# would double-trigger deletes and race on the same buckets). Let the in-flight
+# run finish rather than cancelling it — cancellation is what made the old runs
+# show up as "cancelled" and never complete.
+concurrency:
+  group: cleanup-stale-stacks
+  cancel-in-progress: false
 
 jobs:
   cleanup:

--- a/.github/workflows/cleanup-stacks.yml
+++ b/.github/workflows/cleanup-stacks.yml
@@ -25,10 +25,34 @@ jobs:
       - name: Find and delete stale e2e stacks
         run: |
           CUTOFF=$(date -d '2 hours ago' +%s)
-          DELETED=0
-          FAILED=0
-          DELETED_STACKS=""
-          DELETE_FAILURES=""
+          TRIGGERED=0
+          SKIPPED=0
+
+          # Empty every S3 bucket in a stack, including all object versions and
+          # delete markers. Hosting/test buckets are versioned, so CloudFormation
+          # can't remove them on teardown once the stack's autoDeleteObjects Lambda
+          # is gone — which happens when the CREATE failed at the account IAM role
+          # quota (the Lambda never provisioned) or on a partial rollback. The
+          # bucket then blocks delete-stack, the stack sticks in DELETE_FAILED, and
+          # its IAM roles leak — worsening the very quota that caused the failure.
+          # Emptying out-of-band lets the subsequent delete-stack succeed.
+          empty_stack_buckets() {
+            local STACK="$1" B BUCKETS PAYLOAD
+            BUCKETS=$(aws cloudformation describe-stack-resources --stack-name "$STACK" \
+              --query "StackResources[?ResourceType=='AWS::S3::Bucket'].PhysicalResourceId" \
+              --output text 2>/dev/null || echo "")
+            for B in $BUCKETS; do
+              [ -z "$B" ] && continue
+              # Delete in pages of 1000 (the delete-objects limit) until empty.
+              while :; do
+                PAYLOAD=$(aws s3api list-object-versions --bucket "$B" --max-items 1000 --output json 2>/dev/null \
+                  | jq -c '{Objects: [(.Versions // []) + (.DeleteMarkers // [])] | map({Key, VersionId})}' 2>/dev/null)
+                [ -z "$PAYLOAD" ] && break
+                [ "$(echo "$PAYLOAD" | jq '.Objects | length')" = "0" ] && break
+                aws s3api delete-objects --bucket "$B" --delete "$PAYLOAD" >/dev/null 2>&1 || break
+              done
+            done
+          }
 
           # Get all e2e stacks in deletable states across all name patterns
           STACKS=""
@@ -47,6 +71,7 @@ jobs:
 
             if [[ "$PURPOSE" != e2e-* ]]; then
               echo "⏭️  Skipping $STACK (not tagged blocks:purpose=e2e-*)"
+              SKIPPED=$((SKIPPED + 1))
               continue
             fi
 
@@ -60,62 +85,30 @@ jobs:
               CREATED_TS=$(date -d "$CREATION_TIME" +%s 2>/dev/null || echo "0")
               if [ "$CREATED_TS" -gt "$CUTOFF" ]; then
                 echo "⏭️  Skipping $STACK (created $CREATION_TIME, less than 2 hours old)"
+                SKIPPED=$((SKIPPED + 1))
                 continue
               fi
             fi
 
+            # Empty versioned buckets first so the delete can complete, then trigger
+            # the delete WITHOUT waiting. CloudFront-backed hosting stacks take
+            # 15-20 min each to delete; waiting serially blew past this job's 60-min
+            # timeout, so it was cancelled every run and never drained the backlog.
+            # Fire-and-forget lets CloudFormation delete asynchronously; a stack that
+            # doesn't finish is retried on the next scheduled run.
+            echo "🧹 Emptying buckets for $STACK"
+            empty_stack_buckets "$STACK"
             echo "🗑️  Delete triggered: $STACK (created $CREATION_TIME)"
-            if aws cloudformation delete-stack --stack-name "$STACK"; then
-              DELETED=$((DELETED + 1))
-              DELETED_STACKS="$DELETED_STACKS $STACK"
-            else
-              echo "❌ Failed to trigger delete for $STACK"
-              FAILED=$((FAILED + 1))
-              DELETE_FAILURES="$DELETE_FAILURES $STACK"
-            fi
-          done
-
-          # --- Wait for all triggered deletes to complete ---
-          ACTUALLY_DELETED=0
-
-          for STACK in $DELETED_STACKS; do
-            [ -z "$STACK" ] && continue
-            CURRENT_STATUS=$(aws cloudformation describe-stacks --stack-name "$STACK" \
-              --query "Stacks[0].StackStatus" --output text 2>/dev/null || echo "GONE")
-            if [ "$CURRENT_STATUS" = "DELETE_IN_PROGRESS" ]; then
-              echo "⏳ Waiting for $STACK..."
-              if aws cloudformation wait stack-delete-complete --stack-name "$STACK" 2>/dev/null; then
-                echo "✅ $STACK deleted"
-                ACTUALLY_DELETED=$((ACTUALLY_DELETED + 1))
-              else
-                FINAL_STATUS=$(aws cloudformation describe-stacks --stack-name "$STACK" \
-                  --query "Stacks[0].StackStatus" --output text 2>/dev/null || echo "GONE")
-                echo "❌ $STACK failed (status: $FINAL_STATUS)"
-                DELETE_FAILURES="$DELETE_FAILURES $STACK"
-              fi
-            elif [ "$CURRENT_STATUS" = "GONE" ]; then
-              ACTUALLY_DELETED=$((ACTUALLY_DELETED + 1))
-            else
-              echo "⚠️ $STACK unexpected status: $CURRENT_STATUS"
-              DELETE_FAILURES="$DELETE_FAILURES $STACK"
-            fi
+            aws cloudformation delete-stack --stack-name "$STACK" || echo "⚠️  delete-stack call failed for $STACK (will retry next run)"
+            TRIGGERED=$((TRIGGERED + 1))
           done
 
           echo ""
           echo "## Stack Cleanup Summary" | tee -a "$GITHUB_STEP_SUMMARY"
-          echo "- Delete triggered: $DELETED" | tee -a "$GITHUB_STEP_SUMMARY"
-          echo "- Actually deleted: $ACTUALLY_DELETED" | tee -a "$GITHUB_STEP_SUMMARY"
-          echo "- Failed to trigger: $FAILED" | tee -a "$GITHUB_STEP_SUMMARY"
-
-          if [ -n "$DELETE_FAILURES" ] || [ "$FAILED" -gt 0 ]; then
-            echo "" | tee -a "$GITHUB_STEP_SUMMARY"
-            echo "### ❌ Failed to delete:" | tee -a "$GITHUB_STEP_SUMMARY"
-            for STACK in $DELETE_FAILURES; do
-              echo "- $STACK" | tee -a "$GITHUB_STEP_SUMMARY"
-            done
-            echo "::error::Some stacks failed to delete"
-            exit 1
-          fi
+          echo "- Delete triggered: $TRIGGERED" | tee -a "$GITHUB_STEP_SUMMARY"
+          echo "- Skipped (not e2e / too new): $SKIPPED" | tee -a "$GITHUB_STEP_SUMMARY"
+          echo "" | tee -a "$GITHUB_STEP_SUMMARY"
+          echo "_Deletes run asynchronously; stacks that don't finish are retried on the next scheduled run._" | tee -a "$GITHUB_STEP_SUMMARY"
 
       - name: Find and delete stale Amplify sandbox stacks
         if: always()
@@ -125,9 +118,7 @@ jobs:
           # They are NOT covered by the prefix/tag rules above, so they accumulate
           # (each holds an AppSync GraphQL API and exhausts the per-region quota).
           CUTOFF=$(date -d '2 hours ago' +%s)
-          DELETED=0
-          FAILED=0
-          DELETE_FAILURES=""
+          TRIGGERED=0
 
           # Root sandbox stacks only: end in "-sandbox-<hex>" (skip nested -blocksCD/-data/-auth/-amplifyData stacks).
           # The middle identifier segment is matched loosely ([a-z0-9]+) so a future change to
@@ -164,47 +155,25 @@ jobs:
               fi
             fi
 
-            echo "🗑️  Deleting $STACK (status $STATUS, created $CREATION_TIME)"
+            # Fire-and-forget (no wait) so the job can't time out draining a backlog;
+            # CloudFormation deletes asynchronously and anything that doesn't finish is
+            # retried on the next scheduled run. We intentionally do NOT retry with
+            # --retain-resources: at the root level the only stuck child is the nested
+            # data stack, which *contains* the AppSync GraphQLApi we are trying to
+            # reclaim — retaining it would orphan that API (and the managed DynamoDB
+            # table), leaking the very quota this job exists to free. A persistent
+            # failure here is usually the Amplify managed DynamoDB table (its
+            # table-manager Lambda role lacks dynamodb:DescribeTable) — a real upstream bug.
+            echo "🗑️  Delete triggered: $STACK (status $STATUS, created $CREATION_TIME)"
             aws cloudformation delete-stack --stack-name "$STACK" || true
-
-            # A deleted stack queried by name no longer exists, so describe-stacks errors -> "GONE".
-            # We intentionally do NOT retry with --retain-resources: at the root level the only
-            # stuck child is the nested data stack, which *contains* the AppSync GraphQLApi we are
-            # trying to reclaim. Retaining it would orphan that API (and the managed DynamoDB table),
-            # leaking the very quota this job exists to free while reporting a false success.
-            # If a delete fails here it means a leaf resource (commonly the Amplify managed
-            # DynamoDB table, whose table-manager Lambda role lacks dynamodb:DescribeTable) couldn't
-            # be removed — that's a real upstream bug, so surface it as a failure rather than hide it.
-            if aws cloudformation wait stack-delete-complete --stack-name "$STACK" 2>/dev/null; then
-              echo "✅ $STACK deleted"; DELETED=$((DELETED + 1))
-            else
-              FINAL=$(aws cloudformation describe-stacks --stack-name "$STACK" \
-                --query "Stacks[0].StackStatus" --output text 2>/dev/null || echo "GONE")
-              if [ "$FINAL" = "GONE" ]; then
-                echo "✅ $STACK deleted"; DELETED=$((DELETED + 1))
-              else
-                echo "❌ $STACK final status: $FINAL"; FAILED=$((FAILED + 1)); DELETE_FAILURES="$DELETE_FAILURES $STACK"
-              fi
-            fi
+            TRIGGERED=$((TRIGGERED + 1))
           done
 
           echo ""
           echo "## Amplify Sandbox Cleanup Summary" | tee -a "$GITHUB_STEP_SUMMARY"
-          echo "- Deleted: $DELETED" | tee -a "$GITHUB_STEP_SUMMARY"
-          echo "- Still failing: $FAILED" | tee -a "$GITHUB_STEP_SUMMARY"
-          if [ -n "$DELETE_FAILURES" ]; then
-            echo "### ❌ Failed to delete:" | tee -a "$GITHUB_STEP_SUMMARY"
-            for STACK in $DELETE_FAILURES; do
-              echo "- $STACK" | tee -a "$GITHUB_STEP_SUMMARY"
-            done
-          fi
-
-          # Surface persistent failures as a workflow annotation so the backlog can't grow
-          # silently again (the silent accumulation is what exhausted the AppSync quota).
-          # Intentionally not failing the job: cleanup is best-effort and shouldn't block CI.
-          if [ "$FAILED" -gt 0 ]; then
-            echo "::warning::$FAILED Amplify sandbox stack(s) failed to delete; AppSync API quota may be at risk"
-          fi
+          echo "- Delete triggered: $TRIGGERED" | tee -a "$GITHUB_STEP_SUMMARY"
+          echo "" | tee -a "$GITHUB_STEP_SUMMARY"
+          echo "_Deletes run asynchronously; stacks that don't finish (commonly the Amplify managed DynamoDB table) are retried on the next scheduled run._" | tee -a "$GITHUB_STEP_SUMMARY"
 
       - name: Cleanup orphaned CloudFront Response Headers Policies
         if: always()

--- a/.github/workflows/cleanup-stacks.yml
+++ b/.github/workflows/cleanup-stacks.yml
@@ -44,12 +44,24 @@ jobs:
             for B in $BUCKETS; do
               [ -z "$B" ] && continue
               # Delete in pages of 1000 (the delete-objects limit) until empty.
+              # The `|| echo ""` keeps the substitution total: under `set -eo pipefail`
+              # a jq error on empty/null stdin (empty bucket) would otherwise abort the
+              # whole step instead of falling through to the empty-guard below.
               while :; do
                 PAYLOAD=$(aws s3api list-object-versions --bucket "$B" --max-items 1000 --output json 2>/dev/null \
-                  | jq -c '{Objects: [(.Versions // []) + (.DeleteMarkers // [])] | map({Key, VersionId})}' 2>/dev/null)
+                  | jq -c '{Objects: [(.Versions // []) + (.DeleteMarkers // [])] | map({Key, VersionId})}' 2>/dev/null || echo "")
                 [ -z "$PAYLOAD" ] && break
-                [ "$(echo "$PAYLOAD" | jq '.Objects | length')" = "0" ] && break
-                aws s3api delete-objects --bucket "$B" --delete "$PAYLOAD" >/dev/null 2>&1 || break
+                [ "$(echo "$PAYLOAD" | jq '.Objects | length' 2>/dev/null || echo 0)" = "0" ] && break
+                # delete-objects exits 0 even when individual keys fail (legal hold,
+                # retention lock, or keys the role can't delete) and reports them in
+                # `.Errors`. We re-list from the start each pass, so an object that
+                # never disappears would loop forever until the job timeout — break on
+                # any reported Errors (no forward progress), not just a non-zero exit.
+                RESP=$(aws s3api delete-objects --bucket "$B" --delete "$PAYLOAD" --output json 2>/dev/null) || break
+                if echo "$RESP" | jq -e '(.Errors // []) | length > 0' >/dev/null 2>&1; then
+                  echo "⚠️  undeletable objects in $B (legal hold / retention / access denied); skipping"
+                  break
+                fi
               done
             done
           }
@@ -103,12 +115,29 @@ jobs:
             TRIGGERED=$((TRIGGERED + 1))
           done
 
+          # Early-warning: stacks still stuck in DELETE_FAILED (failed on a prior run
+          # and not cleared this run). Best-effort — surfaced as a warning so the
+          # silent backlog growth that exhausted the quota can't recur unnoticed,
+          # without hard-failing this best-effort cleanup job.
+          STILL_FAILED=0
+          for PREFIX in blocks-test- blocks-hosting- bb-test-; do
+            CNT=$(aws cloudformation list-stacks \
+              --stack-status-filter DELETE_FAILED \
+              --query "length(StackSummaries[?starts_with(StackName, '${PREFIX}')])" \
+              --output text 2>/dev/null || echo 0)
+            STILL_FAILED=$((STILL_FAILED + CNT))
+          done
+
           echo ""
           echo "## Stack Cleanup Summary" | tee -a "$GITHUB_STEP_SUMMARY"
           echo "- Delete triggered: $TRIGGERED" | tee -a "$GITHUB_STEP_SUMMARY"
           echo "- Skipped (not e2e / too new): $SKIPPED" | tee -a "$GITHUB_STEP_SUMMARY"
+          echo "- Still DELETE_FAILED: $STILL_FAILED" | tee -a "$GITHUB_STEP_SUMMARY"
           echo "" | tee -a "$GITHUB_STEP_SUMMARY"
           echo "_Deletes run asynchronously; stacks that don't finish are retried on the next scheduled run._" | tee -a "$GITHUB_STEP_SUMMARY"
+          if [ "$STILL_FAILED" -gt 0 ]; then
+            echo "::warning::$STILL_FAILED e2e stack(s) still in DELETE_FAILED after cleanup"
+          fi
 
       - name: Find and delete stale Amplify sandbox stacks
         if: always()
@@ -169,11 +198,23 @@ jobs:
             TRIGGERED=$((TRIGGERED + 1))
           done
 
+          # Early-warning tally (see the e2e step) — Amplify sandboxes still stuck in
+          # DELETE_FAILED (commonly the managed DynamoDB table) surfaced as a warning
+          # so the backlog can't grow silently and exhaust the AppSync API quota.
+          STILL_FAILED=$(aws cloudformation list-stacks \
+            --stack-status-filter DELETE_FAILED \
+            --query "length(StackSummaries[?starts_with(StackName, 'amplify-amplifygen2-') || starts_with(StackName, 'amplify-amplifyinteroptest-')])" \
+            --output text 2>/dev/null || echo 0)
+
           echo ""
           echo "## Amplify Sandbox Cleanup Summary" | tee -a "$GITHUB_STEP_SUMMARY"
           echo "- Delete triggered: $TRIGGERED" | tee -a "$GITHUB_STEP_SUMMARY"
+          echo "- Still DELETE_FAILED: $STILL_FAILED" | tee -a "$GITHUB_STEP_SUMMARY"
           echo "" | tee -a "$GITHUB_STEP_SUMMARY"
           echo "_Deletes run asynchronously; stacks that don't finish (commonly the Amplify managed DynamoDB table) are retried on the next scheduled run._" | tee -a "$GITHUB_STEP_SUMMARY"
+          if [ "$STILL_FAILED" -gt 0 ]; then
+            echo "::warning::$STILL_FAILED Amplify sandbox stack(s) still in DELETE_FAILED after cleanup; AppSync API quota may be at risk"
+          fi
 
       - name: Cleanup orphaned CloudFront Response Headers Policies
         if: always()


### PR DESCRIPTION
## Problem

The scheduled **Cleanup Stale E2E Stacks** workflow has been `cancelled` on every run for days — it hits `timeout-minutes: 60` and is killed before draining the backlog. As a result E2E stacks and their IAM roles accumulate until the account reaches the **`RolesPerAccount: 1500`** quota, after which hosting/sandbox/amplify deploys fail at role creation across PRs (e.g. `Cannot exceed quota for RolesPerAccount: 1500`). Because the failure surfaced only as a generic `cancelled`, it went unnoticed for days.

## Root causes fixed

**1. Versioned S3 buckets were never emptied.** Hosting/test buckets are versioned. When a stack's CREATE fails at the role quota, its `autoDeleteObjects` custom-resource Lambda never provisions, so CloudFormation can't empty the bucket on teardown → the stack sticks in `DELETE_FAILED` → its ~15 IAM roles leak → the quota worsens (self-amplifying). This adds `empty_stack_buckets()`, which deletes all object **versions + delete markers** (paged in 1000s) before `delete-stack`. It breaks on any reported `.Errors` (legal-hold / retention / denied keys) so an undeletable object can't spin the re-list loop until the timeout, and the `list | jq` substitution is made total (`|| echo ""`) so it can't abort the step under `set -eo pipefail`.

**2. Serial `aws cloudformation wait stack-delete-complete` per stack.** CloudFront-backed hosting stacks take 15–20 min each to delete; waiting on them one-by-one blew past the 60-min job timeout. Switched to **fire-and-forget** — trigger the deletes and let CloudFormation run them asynchronously; anything that doesn't finish is retried on the next scheduled run. Applied to both the e2e-stack step and the Amplify-sandbox step.

## Other changes

- **Dropped `exit 1`** on best-effort failures (cleanup shouldn't hard-fail the job).
- **Restored failure visibility:** after triggering, each step tallies stacks still in `DELETE_FAILED` for its prefixes and emits a `::warning::` + a step-summary line — so a persistent backlog surfaces instead of growing silently (async deletes mean we can't wait for the count, so this is eventually-consistent across runs).
- **Frequency 4h → 2h + a non-overlapping `concurrency` guard.** Now that the job is fast (fire-and-forget), running twice as often roughly halves the worst-case time a dead stack lingers (~6h → ~4h). The 2h age gate is the binding constraint, so 1h would be diminishing returns for double the runs. `concurrency: { group: cleanup-stale-stacks, cancel-in-progress: false }` prevents a slow drain from overlapping the next tick (and never cancels an in-flight run — cancellation is what produced the old `cancelled` noise).

## Dependency

The bucket-emptying needs `s3:DeleteObjectVersion` (+ List/Get) on the E2E bucket prefixes, which the `blocks-github-actions` OIDC role previously lacked. That grant was added in **`AwsBlocksIntegTestAndGithubInfraCDK`** (CR-301551315) and has been **deployed** to the CI account, so the role already has it.

## Not covered here (separate follow-ups)

- VPC-ENI-stuck `bb-test-prod-*` stacks and the Amplify managed-DynamoDB-table blocker (upstream: table-manager Lambda role lacks `dynamodb:DescribeTable`).
- Making sandbox hosting buckets non-versioned at creation (`packages/hosting`) so this class of failure can't recur.
- Alarming on `RolesPerAccount` utilization and on this workflow being cancelled.
- Per-job teardown as the primary reclaimer (makes this scheduled job a backstop).

## Testing

YAML parses; all run scripts pass `bash -euo pipefail -n`. Behavior verified by hand in the CI account: emptying the versioned buckets lets the previously-`DELETE_FAILED` hosting stacks delete, freeing their roles.