### PR TITLE
fix(telemetry): raise send-worker delivery timeout 500ms->5000ms to fix tail-latency flake

### DIFF
--- a/.changeset/telemetry-worker-timeout.md
+++ b/.changeset/telemetry-worker-timeout.md
@@ -1,0 +1,30 @@
+---
+"@aws-blocks/core": patch
+"@aws-blocks/create-blocks-app": patch
+---
+
+fix(telemetry): stop the send worker aborting in-flight events at 500ms
+
+The telemetry send worker gave the whole HTTPS POST — DNS, TCP connect, TLS
+handshake, request body, and the wait for response headers — a single 500ms
+socket budget with no retry. Whenever a cold round trip to
+`blocks-telemetry.us-east-1.api.aws` ran past that, the worker destroyed a
+request that was otherwise on its way to a `200`, logged
+`BLOCKS-TELEMETRY: timed out`, and exited non-zero. The event was silently lost
+in production, and in CI the `Telemetry E2E` suite — which asserts
+`BLOCKS-TELEMETRY: sent (status=200)` at 15 call sites — failed on whichever
+event happened to land in the latency tail, turning an unrelated PR red.
+
+The 500ms value was carried over from the pre-#48 design, when the POST ran
+in-process and the budget genuinely gated how long telemetry could keep the
+CLI's event loop alive. Since #48 the send happens in a `detached` + `unref()`ed
+subprocess, so the parent CLI has already returned before the request is in
+flight and the budget no longer protects user-perceived latency — it only
+decides whether the background process gives up before the endpoint answers.
+
+The budget is now 5s in both workers (`@aws-blocks/core` and
+`@aws-blocks/create-blocks-app`, which are kept byte-compatible by design). It
+still bounds the background process so a hung endpoint can't leave it
+lingering, but it no longer discards events that just needed a normal cold
+connection. Nothing about the request itself changed, telemetry remains
+fire-and-forget, and command latency and exit codes are unaffected.

--- a/.changeset/telemetry-worker-timeout.md
+++ b/.changeset/telemetry-worker-timeout.md
@@ -1,6 +1,7 @@
 ---
 "@aws-blocks/core": patch
 "@aws-blocks/create-blocks-app": patch
+"@aws-blocks/blocks": patch
 ---
 
 fix(telemetry): stop the send worker aborting in-flight events at 500ms

--- a/packages/core/src/telemetry/telemetry-send-worker.ts
+++ b/packages/core/src/telemetry/telemetry-send-worker.ts
@@ -17,7 +17,12 @@
 import { request as httpsRequest } from 'node:https';
 import { request as httpRequest } from 'node:http';
 
-const TIMEOUT_MS = 500;
+// This worker is spawned detached and unref'd, so the parent CLI has already
+// returned by the time the POST is in flight — this budget bounds only the
+// background process, never user-perceived command latency. 500ms (carried over
+// from the pre-#48 in-process send, where it did gate the CLI) aborted otherwise
+// successful requests whenever a cold DNS+TCP+TLS+origin round trip ran long.
+const TIMEOUT_MS = 5_000;
 const debug = (process.env.NODE_DEBUG || '').includes('blocks-telemetry');
 
 const endpoint = process.argv[2];

--- a/packages/core/src/telemetry/trackCommand.ts
+++ b/packages/core/src/telemetry/trackCommand.ts
@@ -51,8 +51,9 @@ export function classifyError(error: unknown): { code: string; phase: string } {
  * Wrap a CLI command function with telemetry tracking.
  *
  * Measures wall-clock duration, classifies errors, and sends a single telemetry event
- * after the command completes (success or failure). The telemetry send is fire-and-forget
- * and bounded by a 500ms timeout — it will never delay the command or affect its exit code.
+ * after the command completes (success or failure). The telemetry send is fire-and-forget,
+ * handed to a detached background subprocess — it will never delay the command or affect
+ * its exit code.
  *
  * If telemetry is disabled (via env var or config), the function is executed directly
  * with zero overhead.

--- a/packages/create-blocks-app/src/telemetry-send-worker.ts
+++ b/packages/create-blocks-app/src/telemetry-send-worker.ts
@@ -18,7 +18,9 @@ import { request as httpsRequest } from 'node:https';
 import { request as httpRequest } from 'node:http';
 
 // Matches the timeout in packages/core/src/telemetry/telemetry-send-worker.ts — keep in sync.
-const TIMEOUT_MS = 500;
+// Spawned detached and unref'd, so this bounds only the background process, never
+// user-perceived command latency.
+const TIMEOUT_MS = 5_000;
 const debug = (process.env.NODE_DEBUG || '').includes('blocks-telemetry');
 
 const endpoint = process.argv[2];

--- a/packages/create-blocks-app/src/telemetry.ts
+++ b/packages/create-blocks-app/src/telemetry.ts
@@ -218,8 +218,8 @@ export interface TrackCommandOptions {
  * persisted, no first-run notice).
  *
  * The file sink writes regardless of opt-out status (inspired by CDK CLI's --telemetry-file).
- * The HTTP sink is fire-and-forget with a 500ms timeout and respects consent —
- * it will never delay the command.
+ * The HTTP sink is fire-and-forget, handed to a detached background subprocess,
+ * and respects consent — it will never delay the command.
  */
 export async function trackCommand(
   commandName: string,


### PR DESCRIPTION
## Problem
Telemetry delivery intermittently fails under tail latency: the send worker gives up before the request completes, dropping the telemetry event. Signature: process `exit=0` plus a NODE_DEBUG delivery-failure log line (distinct from the E2E harness failure). This was the root cause of the earlier PR #341 CI flake.

## Root cause
`TIMEOUT_MS=500` in the telemetry send worker is too short for CI/tail-latency conditions, so slow-but-successful deliveries are aborted.

## Fix
Raise `TIMEOUT_MS` `500 -> 5000` in `packages/core/src/telemetry/telemetry-send-worker.ts` and `packages/create-blocks-app/src/telemetry-send-worker.ts` (plus docs + changeset).

## Relationship to the E2E harness fix
Independent of `fix/telemetry-e2e-destroy-timeout`. That PR fixes the E2E `destroy` timeout (`exit=null`, killed before emit); this PR fixes a genuine delivery flake (`exit=0`, slow emit). Neither is redundant with the other.