### PR TITLE
fix(bb-distributed-table): deterministic GSI sort-key tie ordering in the mock

### DIFF
--- a/.changeset/dt-index-tie-ordering.md
+++ b/.changeset/dt-index-tie-ordering.md
@@ -5,4 +5,4 @@
 
 `DistributedTable` mock: order GSI sort-key ties deterministically to match DynamoDB.
 
-When a GSI sort key was shared by multiple items, the mock's `query` fell back to Map insertion order for the tied rows — so results depended on write order / disk-reload order and diverged from deployed behavior. The mock now tie-breaks on the base-table primary key (partition key, then sort key), matching how DynamoDB orders index rows with equal sort keys, and reverses the whole order (ties included) under `order: 'desc'`. No change for unique sort keys.
+When a GSI sort key was shared by multiple items, the mock's `query` fell back to Map insertion order for the tied rows — so results depended on write order / disk-reload order and diverged from deployed behavior. The mock now tie-breaks on the base-table primary key (partition key, then sort key), matching DynamoDB's observed ordering for index rows with equal sort keys, and reverses the whole order (ties included) under `order: 'desc'`. AWS doesn't document a contractual guarantee for the tie order, so the mock is intentionally deterministic even where DynamoDB's contract is unspecified. No change for unique sort keys.

--- a/.changeset/dt-index-tie-ordering.md
+++ b/.changeset/dt-index-tie-ordering.md
@@ -1,0 +1,8 @@
+---
+"@aws-blocks/bb-distributed-table": patch
+"@aws-blocks/blocks": patch
+---
+
+`DistributedTable` mock: order GSI sort-key ties deterministically to match DynamoDB.
+
+When a GSI sort key was shared by multiple items, the mock's `query` fell back to Map insertion order for the tied rows — so results depended on write order / disk-reload order and diverged from deployed behavior. The mock now tie-breaks on the base-table primary key (partition key, then sort key), matching how DynamoDB orders index rows with equal sort keys, and reverses the whole order (ties included) under `order: 'desc'`. No change for unique sort keys.

--- a/packages/bb-distributed-table/DESIGN.md
+++ b/packages/bb-distributed-table/DESIGN.md
@@ -81,7 +81,9 @@ orders.query({
 
 The `order` field maps to DynamoDB's `ScanIndexForward` parameter (`'desc'` → `ScanIndexForward: false`). It defaults to `'asc'`.
 
-**Ordering ties (GSI):** a GSI sort key need not be unique, so multiple items can share one sort-key value. DynamoDB orders such ties by the base-table primary key; the mock does the same (tie-break on partition key then sort key), rather than by Map insertion order — otherwise mock results would depend on write order / disk-reload order and diverge from deployed behavior. Under `order: 'desc'` the whole index order, ties included, reverses.
+**Ordering ties (GSI):** a GSI sort key need not be unique, so multiple items can share one sort-key value. The mock tie-breaks on the base-table primary key (partition key, then sort key) rather than on Map insertion order — otherwise results would depend on write order / disk-reload order. This **matches DynamoDB's observed ordering** for index rows with equal sort keys; AWS does not document a contractual guarantee for the tie order, so the mock is intentionally **deterministic even where DynamoDB's contract is unspecified** (a plus for reproducible tests — just don't rely on a specific tie order in production logic). Under `order: 'desc'` the whole index order, ties included, reverses.
+
+**String-ordering boundary:** the mock compares sort/base keys with JavaScript `<`/`>` (UTF-16 code-unit order), which can differ from DynamoDB's UTF-8 byte order for non-ASCII string keys. This applies to both the index sort-key comparison and the base-key tie-break, and is a pre-existing property of the mock — surfaced here so the parity discussion is complete.
 
 ### D-DT-7: TTL via options field
 

--- a/packages/bb-distributed-table/DESIGN.md
+++ b/packages/bb-distributed-table/DESIGN.md
@@ -81,6 +81,8 @@ orders.query({
 
 The `order` field maps to DynamoDB's `ScanIndexForward` parameter (`'desc'` → `ScanIndexForward: false`). It defaults to `'asc'`.
 
+**Ordering ties (GSI):** a GSI sort key need not be unique, so multiple items can share one sort-key value. DynamoDB orders such ties by the base-table primary key; the mock does the same (tie-break on partition key then sort key), rather than by Map insertion order — otherwise mock results would depend on write order / disk-reload order and diverge from deployed behavior. Under `order: 'desc'` the whole index order, ties included, reverses.
+
 ### D-DT-7: TTL via options field
 
 **Decision:** TTL is configured via `ttl: 'fieldName'` in the constructor options, not as a separate method or decorator.

--- a/packages/bb-distributed-table/src/index.mock.ts
+++ b/packages/bb-distributed-table/src/index.mock.ts
@@ -266,7 +266,14 @@ export class DistributedTable<
 			const dir = options.order === 'desc' ? -1 : 1;
 			items.sort((a, b) => {
 				const av = (a as any)[skField], bv = (b as any)[skField];
-				return (av < bv ? -1 : av > bv ? 1 : 0) * dir;
+				const primary = av < bv ? -1 : av > bv ? 1 : 0;
+				// Tie-break on the base-table primary key. On a GSI the sort key need
+				// not be unique, so equal sort-key values must NOT fall back to Map
+				// insertion order (which varies by write order / disk reload) — that's
+				// the mock-vs-DynamoDB divergence. DynamoDB orders index ties by the
+				// base-table key, and the whole index (ties included) reverses under
+				// `order: 'desc'`.
+				return (primary !== 0 ? primary : this.compareByBaseKey(a, b)) * dir;
 			});
 		}
 
@@ -357,6 +364,24 @@ export class DistributedTable<
 				throw blocksError(DistributedTableErrors.ConditionalCheckFailed, 'The conditional request failed');
 			}
 		}
+	}
+
+	/**
+	 * Deterministic tie-break for `query` ordering: compare two items by the
+	 * base-table primary key (partition key, then sort key). Used when an index
+	 * sort-key value is shared by multiple items, so results don't depend on Map
+	 * insertion order. Returns a stable -1/0/1.
+	 */
+	private compareByBaseKey(a: T, b: T): number {
+		const pk = this.keyConfig.partitionKey;
+		const ap = (a as any)[pk], bp = (b as any)[pk];
+		if (ap !== bp) return ap < bp ? -1 : 1;
+		const sk = this.keyConfig.sortKey;
+		if (sk) {
+			const as = (a as any)[sk], bs = (b as any)[sk];
+			if (as !== bs) return as < bs ? -1 : 1;
+		}
+		return 0;
 	}
 
 	private serializeKey(key: TableKey<T, K>): string {

--- a/packages/bb-distributed-table/src/index.mock.ts
+++ b/packages/bb-distributed-table/src/index.mock.ts
@@ -381,6 +381,9 @@ export class DistributedTable<
 			const as = (a as any)[sk], bs = (b as any)[sk];
 			if (as !== bs) return as < bs ? -1 : 1;
 		}
+		// Unreachable for distinct rows: every item is keyed by its serialized base
+		// primary key, so two different entries always differ in base PK or SK.
+		// (String comparisons above use JS UTF-16 order — see DESIGN.md D-DT-6.)
 		return 0;
 	}
 

--- a/packages/bb-distributed-table/src/index.test.ts
+++ b/packages/bb-distributed-table/src/index.test.ts
@@ -859,4 +859,49 @@ describe('DistributedTable', () => {
 			);
 		});
 	});
+
+	// ── Query: index sort-key ties are ordered deterministically ────────────
+	describe('query (index sort-key ties)', () => {
+		const cardSchema = z.object({ boardId: z.string(), cardId: z.string(), position: z.number() });
+		// Base key is (boardId, cardId); the GSI sorts by `position`, which is NOT
+		// unique — several cards can share a position. DynamoDB tie-breaks such
+		// index rows by the base-table key, so the mock must too (not by Map
+		// insertion order, which varies by write order / disk reload).
+		function cardTable() {
+			return new DistributedTable(testScope(), 'cards', {
+				schema: cardSchema,
+				key: { partitionKey: 'boardId', sortKey: 'cardId' },
+				indexes: { byPosition: { partitionKey: 'boardId', sortKey: 'position' } },
+			});
+		}
+		const q = (t: ReturnType<typeof cardTable>, order?: 'asc' | 'desc') =>
+			collect(t.query({ index: 'byPosition', where: { boardId: { equals: 'b1' } }, ...(order ? { order } : {}) }));
+
+		test('ties on the index sort key order by the base-table key, regardless of write order', async () => {
+			const t1 = cardTable();
+			// All position=1; insert cardIds out of order.
+			for (const cardId of ['c3', 'c1', 'c2']) await t1.put({ boardId: 'b1', cardId, position: 1 });
+			assert.deepEqual((await q(t1)).map((c) => c.cardId), ['c1', 'c2', 'c3']);
+
+			// A different write order must yield the SAME result (deterministic).
+			const t2 = cardTable();
+			for (const cardId of ['c2', 'c3', 'c1']) await t2.put({ boardId: 'b1', cardId, position: 1 });
+			assert.deepEqual((await q(t2)).map((c) => c.cardId), ['c1', 'c2', 'c3']);
+		});
+
+		test('desc reverses ties too (whole index order flips)', async () => {
+			const t = cardTable();
+			for (const cardId of ['c1', 'c3', 'c2']) await t.put({ boardId: 'b1', cardId, position: 1 });
+			assert.deepEqual((await q(t, 'desc')).map((c) => c.cardId), ['c3', 'c2', 'c1']);
+		});
+
+		test('primary order stays by index sort key; base key only breaks ties', async () => {
+			const t = cardTable();
+			await t.put({ boardId: 'b1', cardId: 'zzz', position: 1 });
+			await t.put({ boardId: 'b1', cardId: 'aaa', position: 2 });
+			await t.put({ boardId: 'b1', cardId: 'mmm', position: 1 });
+			// position asc first (1,1,2); within position=1, base key (cardId) breaks the tie.
+			assert.deepEqual((await q(t)).map((c) => [c.position, c.cardId]), [[1, 'mmm'], [1, 'zzz'], [2, 'aaa']]);
+		});
+	});
 });


### PR DESCRIPTION
## Card

Bug Bash board (Starter Kit, DX P3): **"bb-distributed-table: position-tie ordering nondeterministic (mock vs prod)"** — *Map insertion order vs DDB sort-key order; tied positions render differently.*
🔗 https://github.com/orgs/aws-amplify/projects/141/views/15?pane=issue&itemId=195534546

## Problem

A **GSI** sort key need not be unique, so several items can share one sort-key value (e.g. a `position` field). In `query`, the mock collects items from a `Map` and sorts by the index sort key, returning `0` for equal values — so tied rows keep **Map insertion order**. That order depends on write order and on disk-reload order (`.bb-data`), so mock results are **nondeterministic and can diverge from deployed behavior**. DynamoDB orders index rows with equal sort keys by the **base-table primary key**.

## Fix

Tie-break on the base-table primary key (partition key, then sort key) via a small `compareByBaseKey` helper, instead of falling back to insertion order. The whole index order — ties included — still reverses under `order: 'desc'`. No change when the sort key is unique (the common base-table case).

## Testing

New `query (index sort-key ties)` block (`index.test.ts`): a `byPosition` GSI with several cards sharing `position`:
- ties order by the base key (`cardId`), and **the same result holds regardless of write order** (deterministic);
- `order: 'desc'` reverses ties too;
- primary ordering stays by the index sort key — the base key only breaks ties.

`@aws-blocks/bb-distributed-table` suite **144 pass / 0 fail**.

## Verification

`npm run lint` 0 errors · umbrella-changeset guard ✅. Internal change (private comparator) — no public API change. Documented in DESIGN.md D-DT-6.

## Changeset

`@aws-blocks/bb-distributed-table` **patch** + `@aws-blocks/blocks` **patch** (umbrella re-export).

## Why no real-DynamoDB e2e for the tie order

The fix makes the **mock deterministic** by tie-breaking on the base-table key. It matches DynamoDB's *observed* ordering, but AWS doesn't document a **contractual** guarantee for how index rows with equal sort keys are ordered. An e2e that asserts a specific tie order against real DynamoDB would therefore be asserting unspecified behavior — brittle, and liable to flake if the service's internal ordering ever shifts. So the e2e is intentionally out of scope; the value here is reproducible local ordering (covered by the write-order-convergence unit tests), not pinning DynamoDB's contract. Documented in DESIGN.md D-DT-6.