### PR TITLE
fix(hosting): drop CloudFront invalidation from BlocksConfigDeployment (aws-cdk#15891 CREATE timeout)

### DIFF
--- a/.changeset/hosting-cloudfront-invalidation-timeout.md
+++ b/.changeset/hosting-cloudfront-invalidation-timeout.md
@@ -1,0 +1,12 @@
+---
+"@aws-blocks/core": patch
+"@aws-blocks/blocks": patch
+---
+
+fix(hosting): drop CloudFront invalidation from BlocksConfigDeployment to avoid CDK #15891 CREATE timeout
+
+The BlocksConfigDeployment BucketDeployment passed a CloudFront distribution/distributionPaths, whose
+invalidation-confirmation step times out on fresh stack CREATE (aws-cdk#15891), causing CREATE_FAILED,
+a ~30-minute rollback, a retry, and ultimately E2E Hosting job cancellations at the 63-minute CI timeout.
+The deployed config.json already sets Cache-Control: public, max-age=60, must-revalidate, so the
+invalidation was defense-in-depth only; removing it eliminates the failure with negligible cache impact.

--- a/packages/core/src/hosting.test.ts
+++ b/packages/core/src/hosting.test.ts
@@ -1775,24 +1775,34 @@ describe('Hosting', () => {
       );
     });
 
-    it('invalidates the post-rewrite cache key (/builds/<id>/.blocks-sandbox/*)', () => {
-      // The viewer-request skew-protection function rewrites the URI to
-      // `/builds/<buildId>/.blocks-sandbox/config.json` BEFORE the cache
-      // lookup, so the real edge cache key lives under `/builds/<id>/`.
-      // Invalidating only `/.blocks-sandbox/*` never matches it.
+    it('does NOT emit a CloudFront invalidation on any BucketDeployment', () => {
+      // A BucketDeployment given a `distribution` waits for the CloudFront
+      // invalidation to be CONFIRMED, which hangs on a fresh stack CREATE
+      // (aws-cdk#15891): CREATE_FAILED → ~30-minute rollback → cancelled E2E
+      // jobs. config.json is served with `max-age=60, must-revalidate` and the
+      // placeholder is registered no-cache, so the invalidation was
+      // defense-in-depth only. The CDK BucketDeployment renders
+      // DistributionId / DistributionPaths only when `distribution` is set, so
+      // their absence proves no invalidation is wired.
       createSpaBuildOutput(tmpDir);
       const app = new App();
       const stack = new Stack(app, 'InvalidationPathStack');
       new Hosting(stack, 'Hosting', { root: tmpDir, api: MOCK_API });
 
-      // Assert via Template + Match so a CDK property rename fails loudly here
-      // rather than silently skipping a structural-heuristic lookup.
-      Template.fromStack(stack).hasResourceProperties(
-        'Custom::CDKBucketDeployment',
-        Match.objectLike({
-          DistributionPaths: Match.arrayWith([Match.stringLikeRegexp('^/builds/.+/\\.blocks-sandbox/\\*$')]),
-        }),
-      );
+      const tpl = Template.fromStack(stack).toJSON();
+      const deployments = Object.entries(
+        tpl.Resources as Record<string, { Type: string; Properties?: object }>,
+      ).filter(([, r]) => r.Type === 'Custom::CDKBucketDeployment');
+      assert.ok(deployments.length > 0, 'expected BucketDeployments in the template, else this assertion is vacuous');
+
+      const offenders = deployments
+        .filter(([, r]) => {
+          const props = r.Properties ?? {};
+          return 'DistributionId' in props || 'DistributionPaths' in props;
+        })
+        .map(([id]) => id);
+
+      assert.deepStrictEqual(offenders, [], 'no BucketDeployment may invalidate CloudFront (aws-cdk#15891)');
     });
   });
 });

--- a/packages/core/src/hosting.ts
+++ b/packages/core/src/hosting.ts
@@ -730,21 +730,18 @@ export class Hosting extends Construct {
     // ── 8. Deploy config.json with resolved CDK tokens ───────────
     const buildId = manifest.buildId;
     if (buildId) {
+      // Deliberately NO `distribution` / `distributionPaths`: a BucketDeployment
+      // that invalidates CloudFront waits for the invalidation to be CONFIRMED,
+      // which hangs on a fresh stack CREATE (aws-cdk#15891) → CREATE_FAILED, a
+      // ~30-minute rollback, and cancelled E2E jobs. It is safe to drop because
+      // the config.json written below carries `max-age=60, must-revalidate`, so
+      // any edge entry self-expires within a minute; staleness is already
+      // guarded by step 5a's no-cache placeholder.
       const configDeployment = new s3deploy.BucketDeployment(this, 'BlocksConfigDeployment', {
         sources: [s3deploy.Source.jsonData('config.json', this.buildConfigJson(props))],
         destinationBucket: hosting.bucket,
         destinationKeyPrefix: `builds/${buildId}/.blocks-sandbox`,
         prune: false,
-        distribution: hosting.distribution,
-        // The skew-protection viewer-request CloudFront function rewrites the
-        // URI to `/builds/<buildId>/.blocks-sandbox/config.json` BEFORE the
-        // cache lookup, so the real edge cache key lives under `/builds/<id>/`.
-        // Invalidating only `/.blocks-sandbox/*` never matches that key and is
-        // a no-op for config.json. Invalidate the post-rewrite key too. (The
-        // primary guard against staleness is step 5a's no-cache placeholder;
-        // this is defense-in-depth so a post-deploy invalidation actually
-        // clears any edge entry at its real key.)
-        distributionPaths: [`/builds/${buildId}/.blocks-sandbox/*`, '/.blocks-sandbox/*'],
         cacheControl: [s3deploy.CacheControl.fromString('public, max-age=60, must-revalidate')],
       });
 


### PR DESCRIPTION
## Problem

All three of #391, #460 and #459 are failing on the **same** shared E2E Hosting jobs, and it is not their code — it is a latent bug in `packages/core/src/hosting.ts`.

The `Hosting/BlocksConfigDeployment` `BucketDeployment` was given a CloudFront `distribution:` + `distributionPaths:`. A `BucketDeployment` that is asked to invalidate waits for the **invalidation to be CONFIRMED**, and that confirmation step hangs on a *fresh stack CREATE* — [aws-cdk#15891](https://github.com/aws/aws-cdk/issues/15891). The result is a cascade:

`CREATE_FAILED` → ~30-minute rollback → retry → the 63-minute job timeout trips → **all E2E Hosting jobs cancelled**.

The code is latent from #115 / `9d4ccea8`; it only started firing after #465/#466 made CI perform fresh stack CREATEs rather than updates, which is why three unrelated PRs suddenly went red together.

## Fix

Remove `distribution` and `distributionPaths` from **only** the `BlocksConfigDeployment` `BucketDeployment`. Nothing else changes: `sources`, `destinationBucket`, `destinationKeyPrefix`, `prune`, `cacheControl` and the `addDependency` ordering over the asset deployments are all untouched.

The invalidation was **defense-in-depth only**, so dropping it is safe:

- the deployed `config.json` already carries `Cache-Control: public, max-age=60, must-revalidate`, so any edge entry self-expires within 60s;
- the primary staleness guard is the step-5a no-cache placeholder registration, which is unchanged.

Cache impact is therefore negligible — a worst-case 60-second window that already existed by design.

This also matches existing repo precedent: the asset deployments in `packages/hosting/src/constructs/hosting_construct.ts` deliberately carry **no** `distribution`/`distributionPaths`, and `hosting_construct.atomic_deploy.test.ts` already asserts that no `BucketDeployment` emits an invalidation.

## Tests

The one test that asserted the removed wiring — `invalidates the post-rewrite cache key (/builds/<id>/.blocks-sandbox/*)` — has been **inverted** into a regression guard, `does NOT emit a CloudFront invalidation on any BucketDeployment`, mirroring the `atomic_deploy` precedent. It scans every `Custom::CDKBucketDeployment` in the synthesized template and fails if any renders `DistributionId`/`DistributionPaths`, plus a vacuity guard so it cannot pass by finding zero deployments.

Verified locally (Node 22, per `.nvmrc`):

- `npm run build` (root) → exit 0
- `npm test -w @aws-blocks/core` → **729 pass / 0 fail**
- `npm test -w @aws-blocks/hosting` → **845 pass / 0 fail**
- `changeset-guard.ts` `validate-structure` / `verify-coverage` / `block-major` / `verify-umbrella` → all exit 0
- **Negative control:** re-adding `distribution`/`distributionPaths` makes the new test fail (exit 1), proving the guard is real and not vacuous.

The changeset bumps both `@aws-blocks/core` and the `@aws-blocks/blocks` umbrella, as `verify-umbrella` requires (#273).

Fixes the shared E2E Hosting failure blocking #391, #460 and #459.
