### PR TITLE
fix(ci): run E2E matrix when CI workflow definitions change

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -47,7 +47,15 @@ jobs:
           fetch-depth: 0
       - id: check
         run: |
-          if git diff --name-only origin/main...HEAD | grep -qE '^(packages|test-apps)/'; then
+          # CI-definition changes count as source changes for the E2E gate.
+          # A PR that only edits this workflow, the composite actions the E2E
+          # jobs `uses:`, or the stale-stack cleanup workflow alters E2E
+          # *behaviour* (e.g. stale-stack reuse vs a fresh CREATE) — so the E2E
+          # matrix must actually run to validate it. Listed explicitly rather
+          # than a blanket `.github/workflows/**` so unrelated workflow edits
+          # (issue triage, publishing, docs bots) don't pay for the full
+          # expensive E2E matrix.
+          if git diff --name-only origin/main...HEAD | grep -qE '^(packages/|test-apps/|\.github/workflows/pr-checks\.yml$|\.github/workflows/cleanup-stacks\.yml$|\.github/actions/)'; then
             echo "source-changed=true" >> "$GITHUB_OUTPUT"
           else
             echo "source-changed=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## The gap

`pr-checks.yml`'s `Detect Changes` job gates every expensive E2E job (`E2E Templates`, `E2E Sandbox`, `E2E Sandbox (VPC Smoke)`, `E2E Production`, `E2E Supabase`, `E2E Hosting (...)` matrix, `Telemetry E2E`) on `needs.detect-changes.outputs.source-changed == 'true'`. That output came from:

```sh
git diff --name-only origin/main...HEAD | grep -qE '^(packages|test-apps)/'
```

So a PR that only edits `.github/workflows/**` produced `source-changed=false` and the entire E2E matrix was skipped (and the `Build and Test` gate treats skipped E2E jobs as passing).

That is how PRs #465/#466 (commits 327f0619 / 7401d30e) changed CI *behaviour* — turning stale-stack reuse into fresh CREATEs in `cleanup-stacks.yml` — without a single E2E job ever running against the new behaviour. The resulting hosting regression (aws-cdk#15891 class) only surfaced later on #391/#460/#459.

## The fix

Treat CI-definition changes that actually affect the E2E jobs as source changes:

- `.github/workflows/pr-checks.yml` — the workflow defining the E2E jobs themselves
- `.github/workflows/cleanup-stacks.yml` — the stale-stack cleanup that determines whether E2E deploys reuse or freshly CREATE stacks
- `.github/actions/` — composite actions the E2E jobs `uses:` (e.g. `seed-telemetry-id`)

## Alternative considered

A blanket `.github/workflows/**` rule. Rejected: it would run the full, expensive E2E matrix (6-way hosting matrix + sandbox/production/supabase/telemetry AWS deploys) on every unrelated workflow edit — issue triage, publishing, docs bots, stale-issue lockers. The explicit list is the minimal set that actually influences E2E outcomes.

## Notes

- Diff touches only `.github/workflows/pr-checks.yml` — nothing under `packages/`, so no changeset is required (changeset-guard only tracks `^packages/([^/]+)/`).
- YAML parses cleanly; regex verified against sample paths (matches packages/, test-apps/, the two workflows, .github/actions/; does not match e.g. `lock.yml` or `README.md`).
- This PR itself edits `pr-checks.yml`, so it should now self-trigger the E2E matrix — a live demonstration of the fix.