### PR TITLE
refactor(bb-agent): remove inert structuredOutput field from AgentConfig

### DIFF
--- a/.changeset/remove-inert-structured-output.md
+++ b/.changeset/remove-inert-structured-output.md
@@ -1,0 +1,26 @@
+---
+"@aws-blocks/bb-agent": minor
+"@aws-blocks/blocks": minor
+---
+
+refactor(bb-agent): remove inert `structuredOutput` field from `AgentConfig`
+
+`AgentConfig` declared `structuredOutput?: z.ZodType`, but the field was never
+implemented, read, or consumed anywhere — no JSDoc, no consumer, no docs, no
+tests. It advertised a capability that does not exist, so setting it was a silent
+no-op. The declaration is removed (along with its line in the generated
+`API.md` report); no runtime behavior changes, because nothing ever read it.
+
+Structured output remains a planned future LLM-BB feature, tracked separately.
+This change only deletes the dead placeholder surface — it does not add or design
+any real structured-output support.
+
+This is a `minor` bump. Removing a property from an exported interface is a
+breaking change to the public type surface, but every package here is pre-1.0,
+where this repo's convention is that `minor` — not `major` — is the signal for a
+breaking or behavior-altering change (see the `maxLlmCalls`/`maxToolIterations`
+caps, which shipped as `minor` for exactly that reason). Practically the blast
+radius is a compile error only: code that set `structuredOutput` was already
+getting no-op behavior, so the error points at configuration that never did
+anything and the fix is to delete it. The umbrella `@aws-blocks/blocks` gets the
+same bump because it re-exports `AgentConfig`.

--- a/packages/bb-agent/API.md
+++ b/packages/bb-agent/API.md
@@ -41,8 +41,6 @@ export interface AgentConfig<TContext = DefaultToolContext> {
     removalPolicy?: 'destroy' | 'retain';
     streamingMode?: 'token' | 'block';
     // (undocumented)
-    structuredOutput?: z.ZodType;
-    // (undocumented)
     systemPrompt: string;
     toolContextSchema?: z.ZodType<TContext>;
     tools?: ToolsConfig<TContext>;

--- a/packages/bb-agent/src/types.ts
+++ b/packages/bb-agent/src/types.ts
@@ -85,7 +85,6 @@ export interface AgentConfig<TContext = DefaultToolContext> {
 	 */
 	toolContextSchema?: z.ZodType<TContext>;
 	conversation?: ConversationManagerConfig;
-	structuredOutput?: z.ZodType;
 	/**
 	 * Safety cap on the number of **model (Bedrock) invocations per turn**.
 	 *


### PR DESCRIPTION
## Problem

`AgentConfig` declared `structuredOutput?: z.ZodType`, but the field was completely inert — never implemented, read, or consumed anywhere in the codebase. It had no JSDoc, no consumer, no documentation, and no tests. As part of the public `AgentConfig` surface it advertised a capability that does not exist, so anyone setting it would get silent no-op behaviour.

Structured output is a planned future LLM-BB feature and is tracked separately; this PR does not design or add any real structured-output support.

**Issue #, if available:** n/a

## Changes

Removes the dead placeholder API surface — 3 deletions across 2 files:

- `packages/bb-agent/src/types.ts` — removed `structuredOutput?: z.ZodType;` from `AgentConfig`.
- `packages/bb-agent/API.md` — removed the corresponding `structuredOutput?: z.ZodType;` line and its orphaned `// (undocumented)` marker, keeping the generated API report in sync.

Notes on scope:

- The `z`/zod import stays — zod is still used elsewhere in `types.ts` (e.g. `toolContextSchema?: z.ZodType<TContext>`).
- No behaviour change: since nothing read the field, there is no runtime code to remove.
- Other `structuredOutput` hits in the repo were deliberately left alone: `scripts/agent-bench/steps/4-judge.ts` uses Strands' genuine `structuredOutputSchema` / `result.structuredOutput`, which is unrelated to `AgentConfig`.

Potentially problematic part: this is a removal from a public exported interface, so it is technically a breaking type change for any consumer that set the property. Because the field never did anything, such a consumer's code was already a no-op, and the only effect is a compile error pointing at dead configuration.

## Validation

No tests were added or changed. The field had no implementation and no test coverage, so there is no behaviour to test — deleting it removes surface area rather than adding any. Validation was therefore done by proving the change is inert:

- **Typecheck:** ran `tsc --build` for `@aws-blocks/bb-agent` at the base commit and at this commit, and diffed the sorted error sets — **byte-identical**. The 5 remaining `error TS` lines are pre-existing failures in `packages/core` (`pipeline.test.ts`, `pipeline/index.ts` — `secretStore` / `configStore` / `ConfigValue`) that reproduce on `main` and are unrelated to this PR.
- **Tests:** `npm test` in `packages/bb-agent` gives `79 tests / 53 pass / 26 fail` — unchanged, with the identical counts verified by re-running on the base commit, confirming all 26 failures are pre-existing.
- **Reference sweep:** repo-wide search for `structuredOutput` confirms no remaining reference to the `AgentConfig` field.

## Checklist

- [x] PR description included
- [ ] Tests are changed or added
- [ ] Relevant documentation is changed or added (and PR referenced)

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
