### PR TITLE
fix(hosting): DeleteOldBuilds no longer expires the live build (#480)

### DIFF
--- a/.changeset/fix-480-lifecycle-live-build.md
+++ b/.changeset/fix-480-lifecycle-live-build.md
@@ -1,0 +1,47 @@
+---
+"@aws-blocks/hosting": minor
+"@aws-blocks/core": minor
+"@aws-blocks/blocks": minor
+---
+
+fix(hosting): DeleteOldBuilds no longer expires the build that is currently served (#480)
+
+The `DeleteOldBuilds` S3 lifecycle rule expired every object under `builds/`
+after `buildRetentionDays` (default 30), including the build that CloudFront KVS
+`meta.b` currently points to. An app that did not deploy within the retention
+window had its live build's objects expired out from under an otherwise-healthy
+stack — the router kept rewriting to the now-empty prefix, so every static path
+returned 403 (hosting ≤ 0.1.4) or 404 (≥ 0.1.5) while the API path stayed 200.
+Recovery required a redeploy.
+
+**Fix.** The lifecycle rule now matches only objects tagged
+`aws-blocks:build-state=superseded`. At the KVS cutover, after the pointer flips
+to the new build, the cutover handler tags the *outgoing* build's objects
+superseded (best-effort; list + tag only — the handler is granted **no** S3
+delete permission). The live build is never tagged, so it is never expired,
+regardless of deploy cadence. Superseded builds are still cleaned up after
+`buildRetentionDays`. S3 lifecycle `TagFilters` are inclusion-only (there is no
+"NOT tagged" predicate), which is why the superseded build is tagged rather than
+the live build excluded.
+
+**`buildRetentionDays` is now configurable from `@aws-blocks/core`.** Previously
+`HostingProps` dropped it (only `retainOnDelete` was forwarded), so the only way
+to change retention was an L1 bucket override. It now flows through to the
+hosting bucket lifecycle rule. Must be at least `skewProtection.maxAge`
+(converted to days) or synth throws `InvalidSkewProtectionMaxAgeError`, as
+before.
+
+**New advisory guard.** An optional `storage.deployIntervalDays` hint emits a
+synth-time **warning** (never an error) when the deploy cadence is at or beyond
+`buildRetentionDays`, i.e. when superseded builds could age out before the next
+deploy and shrink the rollback window. The live build is unaffected, so this is
+a rollback-window note, not a correctness gate.
+
+Pre-1.0 `minor` per this repo's convention: the change alters the synthesized
+lifecycle rule and the `KvKeys` custom resource (a benign in-place bucket-config
++ Lambda-role update on the next deploy; no bucket replacement), and adds a new
+IAM grant (`s3:ListBucket` + `s3:PutObjectTagging`, scoped to `builds/*`) to the
+cutover handler. Build artifacts uploaded before the upgrade carry no
+`build-state` tag and are therefore never expired by the new rule — including
+the live build — so the upgrade cannot delete a running build; from the next
+deploy onward each superseded build is tagged and reclaimed normally.

--- a/.changeset/fix-480-lifecycle-live-build.md
+++ b/.changeset/fix-480-lifecycle-live-build.md
@@ -17,12 +17,19 @@ Recovery required a redeploy.
 **Fix.** The lifecycle rule now matches only objects tagged
 `aws-blocks:build-state=superseded`. At the KVS cutover, after the pointer flips
 to the new build, the cutover handler tags the *outgoing* build's objects
-superseded (best-effort; list + tag only — the handler is granted **no** S3
-delete permission). The live build is never tagged, so it is never expired,
+superseded (best-effort; list + tag/untag only — the handler is granted **no** S3
+delete-object permission). The live build is never tagged, so it is never expired,
 regardless of deploy cadence. Superseded builds are still cleaned up after
 `buildRetentionDays`. S3 lifecycle `TagFilters` are inclusion-only (there is no
 "NOT tagged" predicate), which is why the superseded build is tagged rather than
 the live build excluded.
+
+**Rollback-safety hardening.** The same cutover also *clears* the build-state tag
+on the *incoming* build's objects, symmetric to tagging the outgoing one. Without
+this, a rollback that re-points `meta.b` back to a retained build that was tagged
+superseded by an earlier cutover would hand the now-live build to
+`DeleteOldBuilds` — #480 again. Clearing is best-effort and uses
+`s3:DeleteObjectTagging` (tags only, never objects).
 
 **`buildRetentionDays` is now configurable from `@aws-blocks/core`.** Previously
 `HostingProps` dropped it (only `retainOnDelete` was forwarded), so the only way
@@ -40,7 +47,8 @@ a rollback-window note, not a correctness gate.
 Pre-1.0 `minor` per this repo's convention: the change alters the synthesized
 lifecycle rule and the `KvKeys` custom resource (a benign in-place bucket-config
 + Lambda-role update on the next deploy; no bucket replacement), and adds a new
-IAM grant (`s3:ListBucket` + `s3:PutObjectTagging`, scoped to `builds/*`) to the
+IAM grant (`s3:ListBucket` + `s3:PutObjectTagging` + `s3:DeleteObjectTagging`,
+scoped to `builds/*`) to the
 cutover handler. Build artifacts uploaded before the upgrade carry no
 `build-state` tag and are therefore never expired by the new rule — including
 the live build — so the upgrade cannot delete a running build; from the next

--- a/package-lock.json
+++ b/package-lock.json
@@ -55930,6 +55930,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-cloudfront-keyvaluestore": "^3.1075.0",
+        "@aws-sdk/client-s3": "^3.700.0",
         "@aws-sdk/client-secrets-manager": "^3.700.0",
         "@aws-sdk/client-ssm": "^3.700.0",
         "@aws-sdk/signature-v4a": "^3.1069.0",

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -313,6 +313,17 @@ new Hosting(stack, 'Web', {
 
 The `framework` option selects the frontend type: `'spa' | 'static' | 'nextjs'`. When omitted, the framework is auto-detected by reading your app's OWN `package.json` (not `node_modules`): a `next` dependency → `nextjs`; otherwise `spa`; and `static` when there is no `package.json`. Set `framework: 'spa'` explicitly to override auto-detection — e.g. when a stray `next` dependency would otherwise trigger an unwanted Next.js/OpenNext build. Full reference lives in the source JSDoc.
 
+Old builds are retained for rollback and expired by an S3 lifecycle rule after `buildRetentionDays` (default **30**). The build currently being served is never expired regardless of deploy cadence — only superseded builds are cleaned up. Raise the window with `buildRetentionDays` (it must be ≥ `skewProtection.maxAge` in days):
+
+```typescript
+new Hosting(stack, 'Web', {
+  root: join(__dirname, '..'),
+  api: blocksStack,
+  buildRetentionDays: 90,
+});
+```
+
+
 ## Building Blocks
 
 Import Building Blocks from their specific packages (or from the `@aws-blocks/blocks` umbrella):

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -313,7 +313,7 @@ new Hosting(stack, 'Web', {
 
 The `framework` option selects the frontend type: `'spa' | 'static' | 'nextjs'`. When omitted, the framework is auto-detected by reading your app's OWN `package.json` (not `node_modules`): a `next` dependency → `nextjs`; otherwise `spa`; and `static` when there is no `package.json`. Set `framework: 'spa'` explicitly to override auto-detection — e.g. when a stray `next` dependency would otherwise trigger an unwanted Next.js/OpenNext build. Full reference lives in the source JSDoc.
 
-Old builds are retained for rollback and expired by an S3 lifecycle rule after `buildRetentionDays` (default **30**). The build currently being served is never expired regardless of deploy cadence — only superseded builds are cleaned up. Raise the window with `buildRetentionDays` (it must be ≥ `skewProtection.maxAge` in days):
+Old builds are retained for rollback and expired by an S3 lifecycle rule after `buildRetentionDays` (default **30**). The build currently being served is never expired regardless of deploy cadence — only superseded builds are cleaned up. Only builds superseded by a normal `Update` cutover are auto-tagged (and thus auto-expired): pre-existing/orphaned builds and aborted or rolled-back deploys are never tagged and need manual cleanup (e.g. an S3 inventory / Batch Operations sweep). Raise the window with `buildRetentionDays` (it must be ≥ `skewProtection.maxAge` in days):
 
 ```typescript
 new Hosting(stack, 'Web', {
@@ -322,6 +322,8 @@ new Hosting(stack, 'Web', {
   buildRetentionDays: 90,
 });
 ```
+
+Core's top-level `buildRetentionDays` maps to the L3 construct's `storage.buildRetentionDays`.
 
 
 ## Building Blocks

--- a/packages/core/src/hosting.test.ts
+++ b/packages/core/src/hosting.test.ts
@@ -484,6 +484,34 @@ describe('Hosting', () => {
       }
       assert.ok(foundRetain, 'At least one bucket should have Retain deletion policy');
     });
+
+    it('forwards buildRetentionDays to the hosting bucket lifecycle rule (#480)', () => {
+      createSpaBuildOutput(tmpDir);
+
+      const app = new App();
+      const stack = new Stack(app, 'RetentionStack');
+
+      new Hosting(stack, 'Hosting', {
+        root: tmpDir,
+        api: MOCK_API,
+        buildRetentionDays: 90,
+      });
+
+      const template = Template.fromStack(stack);
+      // Before the fix, core dropped buildRetentionDays (only retainOnDelete was
+      // forwarded), so this asserted 30. It must now reach the DeleteOldBuilds
+      // rule as 90.
+      template.hasResourceProperties('AWS::S3::Bucket', {
+        LifecycleConfiguration: Match.objectLike({
+          Rules: Match.arrayWith([
+            Match.objectLike({
+              Id: 'DeleteOldBuilds',
+              ExpirationInDays: 90,
+            }),
+          ]),
+        }),
+      });
+    });
   });
 
   // ── API integration tests ────────────────────────────────────

--- a/packages/core/src/hosting.ts
+++ b/packages/core/src/hosting.ts
@@ -264,6 +264,16 @@ export interface HostingProps {
   /** Retain the S3 bucket when the stack is deleted. Default: false. */
   retainOnDelete?: boolean;
 
+  /**
+   * Days to retain SUPERSEDED build artifacts in S3 before they are expired.
+   * Default: 30. The build currently referenced by CloudFront KVS (`meta.b`)
+   * is NEVER expired regardless of this value — only builds that have been
+   * replaced by a newer deploy are cleaned up (issue #480). Raise this to keep
+   * a longer rollback window. Must be at least `skewProtection.maxAge`
+   * (converted to days), or synth throws `InvalidSkewProtectionMaxAgeError`.
+   */
+  buildRetentionDays?: number;
+
   /** Custom Content-Security-Policy header value. */
   contentSecurityPolicy?: string;
 
@@ -671,7 +681,17 @@ export class Hosting extends Construct {
       environment: Object.keys(plainEnv).length ? plainEnv : undefined,
       domain: resolvedDomain,
       waf: props.waf,
-      storage: props.retainOnDelete != null ? { retainOnDelete: props.retainOnDelete } : undefined,
+      storage:
+        props.retainOnDelete != null || props.buildRetentionDays != null
+          ? {
+              ...(props.retainOnDelete != null
+                ? { retainOnDelete: props.retainOnDelete }
+                : {}),
+              ...(props.buildRetentionDays != null
+                ? { buildRetentionDays: props.buildRetentionDays }
+                : {}),
+            }
+          : undefined,
       cdn:
         props.contentSecurityPolicy || props.priceClass || props.geoRestriction || props.quotas
           ? {

--- a/packages/hosting/README.md
+++ b/packages/hosting/README.md
@@ -254,6 +254,36 @@ immediate — SSM Parameter Store has no recovery window.)
 └──────────────────────────────────────────────┘
 ```
 
+## Build retention & rollback
+
+Each deploy uploads its assets under an immutable `builds/<buildId>/` prefix and
+flips a CloudFront KeyValueStore pointer (`meta.b`) to the new build. Old builds
+are retained for `storage.buildRetentionDays` (default **30**) so you can roll
+back, then expired by an S3 lifecycle rule.
+
+- **The build currently being served is never expired**, no matter how long ago
+  it was deployed. Only *superseded* builds (ones a later deploy replaced) are
+  eligible for cleanup — they are tagged `aws-blocks:build-state=superseded` at
+  the cutover, and the lifecycle rule matches only that tag.
+- Raise `storage.buildRetentionDays` for a longer rollback window. It must be at
+  least `skewProtection.maxAge` (converted to days), or synth throws
+  `InvalidSkewProtectionMaxAgeError` — a skew cookie must not outlive the build
+  it pins to.
+- Optional `storage.deployIntervalDays` is an advisory hint: if you set it and
+  it is ≥ `buildRetentionDays`, synth prints a warning that superseded builds
+  may expire before your next deploy (shrinking the rollback window). It never
+  blocks a deploy and never affects the live build.
+
+```ts
+new Hosting(stack, 'Hosting', {
+  root: './',
+  storage: {
+    buildRetentionDays: 90,   // keep 90 days of rollback targets
+    deployIntervalDays: 30,   // advisory only
+  },
+});
+```
+
 ## Custom domains
 
 Configure a custom domain through the `domain` prop on `HostingConstruct`

--- a/packages/hosting/README.md
+++ b/packages/hosting/README.md
@@ -274,6 +274,14 @@ back, then expired by an S3 lifecycle rule.
   may expire before your next deploy (shrinking the rollback window). It never
   blocks a deploy and never affects the live build.
 
+> **Cleanup caveat:** a build is tagged superseded only during a normal deploy
+> cutover (an `Update` that flips `meta.b`). Builds that become stale outside
+> that path — every build already present before upgrading to this version, or
+> builds left by an aborted/rolled-back deploy — are never tagged, so the
+> lifecycle rule never expires them and they accumulate until you remove them
+> manually. This is safe (nothing deletes the live build), just not
+> self-cleaning for pre-existing artifacts.
+
 ```ts
 new Hosting(stack, 'Hosting', {
   root: './',

--- a/packages/hosting/README.md
+++ b/packages/hosting/README.md
@@ -283,8 +283,8 @@ back, then expired by an S3 lifecycle rule.
 > self-cleaning for pre-existing artifacts.
 
 ```ts
-new Hosting(stack, 'Hosting', {
-  root: './',
+new HostingConstruct(stack, 'Hosting', {
+  manifest,
   storage: {
     buildRetentionDays: 90,   // keep 90 days of rollback targets
     deployIntervalDays: 30,   // advisory only

--- a/packages/hosting/package.json
+++ b/packages/hosting/package.json
@@ -56,6 +56,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-cloudfront-keyvaluestore": "^3.1075.0",
+    "@aws-sdk/client-s3": "^3.700.0",
     "@aws-sdk/client-secrets-manager": "^3.700.0",
     "@aws-sdk/client-ssm": "^3.700.0",
     "@aws-sdk/signature-v4a": "^3.1069.0",

--- a/packages/hosting/src/constructs/build_tags.ts
+++ b/packages/hosting/src/constructs/build_tags.ts
@@ -1,0 +1,25 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Shared build-artifact tag constants.
+//
+// This module is intentionally dependency-free (no `aws-cdk-lib`, no
+// `constructs`) so it can be imported by BOTH the CDK construct
+// (`storage_construct.ts`) and the esbuild-bundled Lambda handler
+// (`kv_keys_handler.ts`) without dragging the CDK library into the Lambda
+// bundle. Keep it free of any non-type imports.
+
+/**
+ * Object tag key that marks a build's objects as SUPERSEDED — i.e. no longer
+ * the build that KVS `meta.b` points to. The `DeleteOldBuilds` S3 lifecycle
+ * rule matches ONLY objects carrying this tag, so the in-service build (which
+ * is never tagged) is never expired, regardless of deploy cadence (issue #480).
+ *
+ * S3 lifecycle `TagFilters` are inclusion-only (there is no "NOT tagged"
+ * predicate), which is why we tag the superseded build rather than tagging the
+ * live build and excluding it.
+ */
+export const BUILD_STATE_TAG_KEY = 'aws-blocks:build-state';
+
+/** Tag value applied to a build once it is no longer the live build. */
+export const BUILD_STATE_SUPERSEDED = 'superseded';

--- a/packages/hosting/src/constructs/cdn_construct.ts
+++ b/packages/hosting/src/constructs/cdn_construct.ts
@@ -775,6 +775,7 @@ export class CdnConstruct extends Construct {
     // ---- KvKeys: live KVS update, gated on asset upload (atomic cutover) ----
     const kvKeys = new KvKeys(this, 'RouteStoreKeys', {
       store: routeStore,
+      bucket, // #480: handler tags the outgoing build superseded at cutover
       entries: kvsEntries,
     });
     // The KV write that flips buildId/routes to the new build must happen only

--- a/packages/hosting/src/constructs/hosting_construct.ts
+++ b/packages/hosting/src/constructs/hosting_construct.ts
@@ -246,6 +246,8 @@ export type HostingConstructProps = {
     encryptionKey?: IKey;
     retainOnDelete?: boolean;
     buildRetentionDays?: number;
+    /** Advisory hint used at synth to warn when deploy cadence ≥ retention (#480). */
+    deployIntervalDays?: number;
     /** 3.3 — opt-in daily S3 inventory of `builds/`. */
     inventory?: { enabled: boolean };
     /**
@@ -425,6 +427,26 @@ export class HostingConstruct extends Construct {
           resolution:
             'Lower skewProtection.maxAge to at most storage.buildRetentionDays (in seconds), or raise storage.buildRetentionDays. A cookie that outlives the build prefix pins returning viewers to a deleted build → 403.',
         });
+      }
+    }
+
+    // #480: advisory (NOT fatal) — a deploy cadence at or beyond the retention
+    // window means a superseded build can age out before the next deploy,
+    // shrinking the rollback window. The IN-SERVICE build is never expired
+    // (only superseded builds carry the lifecycle tag), so this is a
+    // rollback-window note, not a 403 risk — hence warn, not throw (mirrors the
+    // rewrite-proxy warning above: never block a deployable, working app).
+    const deployIntervalDays = props.storage?.deployIntervalDays;
+    if (deployIntervalDays != null) {
+      const retentionDays = props.storage?.buildRetentionDays ?? 30;
+      if (deployIntervalDays >= retentionDays) {
+        process.stderr.write(
+          `⚠️  Hosting: storage.deployIntervalDays (${deployIntervalDays}d) is >= ` +
+            `storage.buildRetentionDays (${retentionDays}d). Superseded builds may be ` +
+            `expired before your next deploy, shrinking the rollback window. The build ` +
+            `currently being served is unaffected. Raise storage.buildRetentionDays to ` +
+            `keep more rollback targets available.\n`,
+        );
       }
     }
 

--- a/packages/hosting/src/constructs/hosting_construct.ts
+++ b/packages/hosting/src/constructs/hosting_construct.ts
@@ -55,7 +55,7 @@ import { MonitoringConstruct } from './monitoring_construct.js';
 import { DEFAULT_NODE_RUNTIME } from './node_runtime.js';
 import type { QuotaOverrides } from './quota_budget.js';
 import { createSecurityHeadersPolicy } from './security_headers.js';
-import { StorageConstruct } from './storage_construct.js';
+import { StorageConstruct, DEFAULT_BUILD_RETENTION_DAYS } from './storage_construct.js';
 import { WafConstruct } from './waf_construct.js';
 
 // Re-export build ID helpers for public API + tests
@@ -419,7 +419,7 @@ export class HostingConstruct extends Construct {
     // viewer present a cookie for a build whose `builds/<id>/` prefix the
     // S3 lifecycle rule has already deleted → hard 403 on every asset.
     if (props.skewProtection?.enabled && props.skewProtection.maxAge) {
-      const retentionDays = props.storage?.buildRetentionDays ?? 30;
+      const retentionDays = props.storage?.buildRetentionDays ?? DEFAULT_BUILD_RETENTION_DAYS;
       const retentionSeconds = retentionDays * 24 * 60 * 60;
       if (props.skewProtection.maxAge > retentionSeconds) {
         throw new HostingError('InvalidSkewProtectionMaxAgeError', {
@@ -438,7 +438,7 @@ export class HostingConstruct extends Construct {
     // rewrite-proxy warning above: never block a deployable, working app).
     const deployIntervalDays = props.storage?.deployIntervalDays;
     if (deployIntervalDays != null) {
-      const retentionDays = props.storage?.buildRetentionDays ?? 30;
+      const retentionDays = props.storage?.buildRetentionDays ?? DEFAULT_BUILD_RETENTION_DAYS;
       if (deployIntervalDays >= retentionDays) {
         process.stderr.write(
           `⚠️  Hosting: storage.deployIntervalDays (${deployIntervalDays}d) is >= ` +

--- a/packages/hosting/src/constructs/kv_keys.ts
+++ b/packages/hosting/src/constructs/kv_keys.ts
@@ -6,6 +6,7 @@ import { Code, Function as LambdaFunction } from 'aws-cdk-lib/aws-lambda';
 import * as iam from 'aws-cdk-lib/aws-iam';
 import { Provider } from 'aws-cdk-lib/custom-resources';
 import type { IKeyValueStore } from 'aws-cdk-lib/aws-cloudfront';
+import type { IBucket } from 'aws-cdk-lib/aws-s3';
 import { DEFAULT_NODE_RUNTIME } from './node_runtime.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -28,6 +29,13 @@ const HANDLER_BUNDLE = join(__dirname, 'kv_keys_handler_bundle.mjs');
 export type KvKeysProps = {
   /** The CloudFront KeyValueStore to write into. */
   store: IKeyValueStore;
+  /**
+   * The hosting bucket that holds `builds/<id>/...`. At the KVS cutover the
+   * handler tags the OUTGOING build's objects as superseded so the
+   * `DeleteOldBuilds` S3 lifecycle rule can expire them without ever touching
+   * the live build (#480). The handler is granted list + tag (never delete).
+   */
+  bucket: IBucket;
   /**
    * Desired key→value map. The custom resource diffs this against the
    * previously deployed entries (empty on Create) and applies the minimal set
@@ -80,6 +88,25 @@ export class KvKeys extends Construct {
       }),
     );
 
+    // #480: supersede-tagging of the OUTGOING build at cutover. Least
+    // privilege: the handler may LIST and TAG objects under `builds/*` only —
+    // it is deliberately granted NO delete permission. Actual expiry is done
+    // by the S3 `DeleteOldBuilds` lifecycle rule, so a bug in the handler can
+    // never delete the live build; worst case an old build lingers untagged.
+    handler.addToRolePolicy(
+      new iam.PolicyStatement({
+        actions: ['s3:ListBucket'],
+        resources: [props.bucket.bucketArn],
+        conditions: { StringLike: { 's3:prefix': ['builds/*'] } },
+      }),
+    );
+    handler.addToRolePolicy(
+      new iam.PolicyStatement({
+        actions: ['s3:PutObjectTagging'],
+        resources: [`${props.bucket.bucketArn}/builds/*`],
+      }),
+    );
+
     const provider = new Provider(this, 'Provider', {
       onEventHandler: handler,
     });
@@ -88,6 +115,7 @@ export class KvKeys extends Construct {
       serviceToken: provider.serviceToken,
       properties: {
         KvsArn: props.store.keyValueStoreArn,
+        BucketName: props.bucket.bucketName,
         // Stringify so CloudFormation sees a single property that changes
         // whenever any entry changes (triggers Update → diff → UpdateKeys).
         Entries: JSON.stringify(props.entries),

--- a/packages/hosting/src/constructs/kv_keys.ts
+++ b/packages/hosting/src/constructs/kv_keys.ts
@@ -88,11 +88,13 @@ export class KvKeys extends Construct {
       }),
     );
 
-    // #480: supersede-tagging of the OUTGOING build at cutover. Least
-    // privilege: the handler may LIST and TAG objects under `builds/*` only —
-    // it is deliberately granted NO delete permission. Actual expiry is done
-    // by the S3 `DeleteOldBuilds` lifecycle rule, so a bug in the handler can
-    // never delete the live build; worst case an old build lingers untagged.
+    // #480: supersede-tagging of the OUTGOING build at cutover, plus clearing
+    // the build-state tag on the INCOMING build. Least privilege: the handler
+    // may LIST and TAG/UNTAG objects under `builds/*` only — it is deliberately
+    // granted NO delete-object permission (`DeleteObjectTagging` removes tags,
+    // never objects). Actual expiry is done by the S3 `DeleteOldBuilds`
+    // lifecycle rule, so a bug in the handler can never delete the live build;
+    // worst case an old build lingers untagged.
     handler.addToRolePolicy(
       new iam.PolicyStatement({
         actions: ['s3:ListBucket'],
@@ -102,7 +104,7 @@ export class KvKeys extends Construct {
     );
     handler.addToRolePolicy(
       new iam.PolicyStatement({
-        actions: ['s3:PutObjectTagging'],
+        actions: ['s3:PutObjectTagging', 's3:DeleteObjectTagging'],
         resources: [`${props.bucket.bucketArn}/builds/*`],
       }),
     );

--- a/packages/hosting/src/constructs/kv_keys_handler.test.ts
+++ b/packages/hosting/src/constructs/kv_keys_handler.test.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { batches, computeDiff, deleteDrainSet } from './kv_keys_handler.js';
+import { batches, computeDiff, deleteDrainSet, activeBuildId } from './kv_keys_handler.js';
 
 // Regression for the Delete-path drain bug: CloudFormation does not send
 // OldResourceProperties on Delete, so the keys to drain must come from
@@ -118,5 +118,44 @@ describe('kv_keys_handler — batches (50-key / 3 MB boundaries)', () => {
 
   it('yields nothing for an empty diff (no-op path)', () => {
     assert.equal(collect([], []).length, 0);
+  });
+});
+
+// #480: the supersede-tagging at cutover keys off `activeBuildId`, which
+// extracts the live buildId (`meta.b`) from the stringified entries map. The
+// handler tags the OLD build superseded only when old !== new — so correct
+// extraction is what guarantees the live build is never tagged (never expired).
+describe('kv_keys_handler — activeBuildId (#480)', () => {
+  const entriesJson = (b: string): string =>
+    JSON.stringify({ r0: '[]', meta: JSON.stringify({ b, bp: '/', v: 1 }) });
+
+  it('extracts meta.b from a stringified entries map', () => {
+    assert.equal(activeBuildId(entriesJson('ms2z0nnb-6eec9615')), 'ms2z0nnb-6eec9615');
+  });
+
+  it('returns undefined for undefined / empty input', () => {
+    assert.equal(activeBuildId(undefined), undefined);
+    assert.equal(activeBuildId(''), undefined);
+  });
+
+  it('returns undefined when there is no meta key', () => {
+    assert.equal(activeBuildId(JSON.stringify({ r0: '[]' })), undefined);
+  });
+
+  it('returns undefined when meta has no b', () => {
+    assert.equal(activeBuildId(JSON.stringify({ meta: JSON.stringify({ bp: '/' }) })), undefined);
+  });
+
+  it('returns undefined on malformed JSON (never throws)', () => {
+    assert.equal(activeBuildId('not json'), undefined);
+    assert.equal(activeBuildId(JSON.stringify({ meta: 'not json' })), undefined);
+  });
+
+  it('distinguishes old vs new build so only a real cutover triggers tagging', () => {
+    const oldB = activeBuildId(entriesJson('old-1111'));
+    const newB = activeBuildId(entriesJson('new-2222'));
+    assert.notEqual(oldB, newB);
+    // Same build on both sides → no cutover → handler must not tag.
+    assert.equal(activeBuildId(entriesJson('same-3333')), activeBuildId(entriesJson('same-3333')));
   });
 });

--- a/packages/hosting/src/constructs/kv_keys_handler.test.ts
+++ b/packages/hosting/src/constructs/kv_keys_handler.test.ts
@@ -1,8 +1,16 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { describe, it } from 'node:test';
+import { describe, it, mock, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
-import { batches, computeDiff, deleteDrainSet, activeBuildId } from './kv_keys_handler.js';
+import { S3Client, ListObjectsV2Command } from '@aws-sdk/client-s3';
+import { CloudFrontKeyValueStoreClient } from '@aws-sdk/client-cloudfront-keyvaluestore';
+import {
+  batches,
+  computeDiff,
+  deleteDrainSet,
+  activeBuildId,
+  handler,
+} from './kv_keys_handler.js';
 
 // Regression for the Delete-path drain bug: CloudFormation does not send
 // OldResourceProperties on Delete, so the keys to drain must come from
@@ -157,5 +165,116 @@ describe('kv_keys_handler — activeBuildId (#480)', () => {
     assert.notEqual(oldB, newB);
     // Same build on both sides → no cutover → handler must not tag.
     assert.equal(activeBuildId(entriesJson('same-3333')), activeBuildId(entriesJson('same-3333')));
+  });
+});
+
+// #480 F1: at cutover the handler must tag the OUTGOING build superseded AND
+// clear the build-state tag on the INCOMING build. Leaving the incoming build
+// tagged means a rollback that flips `meta.b` back to it hands the live build to
+// the `DeleteOldBuilds` lifecycle rule — the original #480 bug.
+describe('kv_keys_handler — cutover tagging (#480 F1)', () => {
+  const OLD = 'old-1111';
+  const NEW = 'new-2222';
+  const BUCKET = 'hosting-bucket';
+  const entriesJson = (b: string): string =>
+    JSON.stringify({ r0: '[]', meta: JSON.stringify({ b, bp: '/', v: 1 }) });
+
+  type Call = { name: string; Key?: string; Prefix?: string };
+
+  const install = (): Call[] => {
+    const calls: Call[] = [];
+    mock.method(
+      CloudFrontKeyValueStoreClient.prototype,
+      'send',
+      async (cmd: { constructor: { name: string } }) => {
+        const name = cmd.constructor.name;
+        calls.push({ name });
+        return name === 'DescribeKeyValueStoreCommand' ? { ETag: 'etag-1' } : {};
+      },
+    );
+    mock.method(
+      S3Client.prototype,
+      'send',
+      async (cmd: { constructor: { name: string }; input: Record<string, string> }) => {
+        const name = cmd.constructor.name;
+        calls.push({ name, Key: cmd.input.Key, Prefix: cmd.input.Prefix });
+        if (cmd instanceof ListObjectsV2Command) {
+          const prefix = cmd.input.Prefix ?? '';
+          return {
+            Contents: [{ Key: `${prefix}index.html` }, { Key: `${prefix}assets/app.js` }],
+            IsTruncated: false,
+          };
+        }
+        return {};
+      },
+    );
+    return calls;
+  };
+
+  const event = (
+    RequestType: 'Create' | 'Update' | 'Delete',
+    oldBuild: string | undefined,
+    newBuild: string,
+  ) => ({
+    RequestType,
+    ResourceProperties: {
+      KvsArn: 'arn:aws:cloudfront::1:key-value-store/store-1',
+      BucketName: BUCKET,
+      Entries: entriesJson(newBuild),
+    },
+    OldResourceProperties: oldBuild ? { Entries: entriesJson(oldBuild) } : undefined,
+  });
+
+  afterEach(() => mock.restoreAll());
+
+  const of = (calls: Call[], name: string): Call[] => calls.filter((c) => c.name === name);
+
+  it('tags ONLY the outgoing build superseded and clears tags ONLY on the incoming build', async () => {
+    const calls = install();
+    await handler(event('Update', OLD, NEW));
+
+    const puts = of(calls, 'PutObjectTaggingCommand');
+    const dels = of(calls, 'DeleteObjectTaggingCommand');
+
+    assert.ok(puts.length > 0, 'PutObjectTagging issued for the outgoing build');
+    assert.ok(
+      puts.every((c) => c.Key?.startsWith(`builds/${OLD}/`)),
+      'every PutObjectTagging key is under the outgoing build prefix',
+    );
+    assert.ok(
+      !puts.some((c) => c.Key?.startsWith(`builds/${NEW}/`)),
+      'the incoming (live) build is NEVER tagged superseded',
+    );
+
+    assert.ok(dels.length > 0, 'DeleteObjectTagging issued for the incoming build');
+    assert.ok(
+      dels.every((c) => c.Key?.startsWith(`builds/${NEW}/`)),
+      'every DeleteObjectTagging key is under the incoming build prefix',
+    );
+    assert.ok(
+      !dels.some((c) => c.Key?.startsWith(`builds/${OLD}/`)),
+      'the outgoing build never has its superseded tag cleared',
+    );
+  });
+
+  it('issues neither tagging call on Create', async () => {
+    const calls = install();
+    await handler(event('Create', undefined, NEW));
+    assert.equal(of(calls, 'PutObjectTaggingCommand').length, 0);
+    assert.equal(of(calls, 'DeleteObjectTaggingCommand').length, 0);
+  });
+
+  it('issues neither tagging call on Delete', async () => {
+    const calls = install();
+    await handler(event('Delete', OLD, NEW));
+    assert.equal(of(calls, 'PutObjectTaggingCommand').length, 0);
+    assert.equal(of(calls, 'DeleteObjectTaggingCommand').length, 0);
+  });
+
+  it('issues neither tagging call on an Update that does not change the build (no cutover)', async () => {
+    const calls = install();
+    await handler(event('Update', 'same-3333', 'same-3333'));
+    assert.equal(of(calls, 'PutObjectTaggingCommand').length, 0);
+    assert.equal(of(calls, 'DeleteObjectTaggingCommand').length, 0);
   });
 });

--- a/packages/hosting/src/constructs/kv_keys_handler.ts
+++ b/packages/hosting/src/constructs/kv_keys_handler.ts
@@ -95,17 +95,24 @@ export function activeBuildId(entriesJson?: string): string | undefined {
 /**
  * Tag every object under `builds/<buildId>/` as SUPERSEDED so the
  * `DeleteOldBuilds` S3 lifecycle rule (which matches that tag) can reclaim it
- * (#480). Paginates the listing and tags each object version's current tag set.
+ * (#480). Paginates the listing and tags each object with bounded concurrency
+ * (15 in flight) to keep the cutover fast without overwhelming S3.
  *
  * Best-effort by contract: a failure here only means the old build lingers
  * UNtagged, which is safe — an untagged build is simply never matched by the
  * lifecycle rule, so it is not expired (it just isn't cleaned up yet). The NEW
  * (live) build is never passed here, so it is never a lifecycle target.
+ *
+ * Bounded by the custom-resource Lambda timeout: on a very large build the run
+ * may not tag every object before timing out, leaving some objects untagged.
+ * That is safe by the same contract — untagged objects are never expired, and
+ * the live build is never tagged regardless.
  */
 export async function supersedeBuild(
   bucket: string,
   buildId: string,
 ): Promise<void> {
+  const CONCURRENCY = 15;
   let token: string | undefined;
   do {
     const page = await s3.send(
@@ -115,16 +122,23 @@ export async function supersedeBuild(
         ContinuationToken: token,
       }),
     );
-    for (const obj of page.Contents ?? []) {
-      if (!obj.Key) continue;
-      await s3.send(
-        new PutObjectTaggingCommand({
-          Bucket: bucket,
-          Key: obj.Key,
-          Tagging: {
-            TagSet: [{ Key: BUILD_STATE_TAG_KEY, Value: BUILD_STATE_SUPERSEDED }],
-          },
-        }),
+    const keys = (page.Contents ?? [])
+      .map((obj) => obj.Key)
+      .filter((key): key is string => typeof key === 'string');
+    for (let i = 0; i < keys.length; i += CONCURRENCY) {
+      const chunk = keys.slice(i, i + CONCURRENCY);
+      await Promise.all(
+        chunk.map((key) =>
+          s3.send(
+            new PutObjectTaggingCommand({
+              Bucket: bucket,
+              Key: key,
+              Tagging: {
+                TagSet: [{ Key: BUILD_STATE_TAG_KEY, Value: BUILD_STATE_SUPERSEDED }],
+              },
+            }),
+          ),
+        ),
       );
     }
     token = page.IsTruncated ? page.NextContinuationToken : undefined;

--- a/packages/hosting/src/constructs/kv_keys_handler.ts
+++ b/packages/hosting/src/constructs/kv_keys_handler.ts
@@ -34,6 +34,12 @@ import {
 // with "Neither CRT nor JS SigV4a implementation is available". Importing it
 // for side effects forces esbuild to bundle it and registers the JS signer.
 import '@aws-sdk/signature-v4a';
+import {
+  S3Client,
+  ListObjectsV2Command,
+  PutObjectTaggingCommand,
+} from '@aws-sdk/client-s3';
+import { BUILD_STATE_TAG_KEY, BUILD_STATE_SUPERSEDED } from './build_tags.js';
 
 type Entries = Record<string, string>;
 
@@ -41,6 +47,12 @@ type Event = {
   RequestType: 'Create' | 'Update' | 'Delete';
   ResourceProperties: {
     KvsArn: string;
+    /**
+     * Hosting bucket that holds `builds/<id>/...`. Enables supersede-tagging of
+     * the outgoing build at cutover (#480). Optional so older templates / unit
+     * tests that omit it simply skip tagging.
+     */
+    BucketName?: string;
     /** JSON string of the desired key→value map. */
     Entries: string;
   };
@@ -58,6 +70,66 @@ const MAX_BYTES_PER_REQUEST = 3 * 1024 * 1024;
 const client = new CloudFrontKeyValueStoreClient({
   sigv4aSigningRegionSet: ['*'],
 });
+
+const s3 = new S3Client({});
+
+/**
+ * Extract the active buildId (`meta.b`) from a stringified entries map. The
+ * KVS `meta` value is itself a JSON blob (`{"b":"<buildId>",...}`), so this
+ * double-parses: outer map → `meta` string → `.b`. Returns undefined on any
+ * malformed / missing input (callers treat undefined as "nothing to do").
+ * Exported for unit testing.
+ */
+export function activeBuildId(entriesJson?: string): string | undefined {
+  if (!entriesJson) return undefined;
+  try {
+    const entries = JSON.parse(entriesJson) as Entries;
+    if (typeof entries.meta !== 'string') return undefined;
+    const meta = JSON.parse(entries.meta) as { b?: unknown };
+    return typeof meta.b === 'string' ? meta.b : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Tag every object under `builds/<buildId>/` as SUPERSEDED so the
+ * `DeleteOldBuilds` S3 lifecycle rule (which matches that tag) can reclaim it
+ * (#480). Paginates the listing and tags each object version's current tag set.
+ *
+ * Best-effort by contract: a failure here only means the old build lingers
+ * UNtagged, which is safe — an untagged build is simply never matched by the
+ * lifecycle rule, so it is not expired (it just isn't cleaned up yet). The NEW
+ * (live) build is never passed here, so it is never a lifecycle target.
+ */
+export async function supersedeBuild(
+  bucket: string,
+  buildId: string,
+): Promise<void> {
+  let token: string | undefined;
+  do {
+    const page = await s3.send(
+      new ListObjectsV2Command({
+        Bucket: bucket,
+        Prefix: `builds/${buildId}/`,
+        ContinuationToken: token,
+      }),
+    );
+    for (const obj of page.Contents ?? []) {
+      if (!obj.Key) continue;
+      await s3.send(
+        new PutObjectTaggingCommand({
+          Bucket: bucket,
+          Key: obj.Key,
+          Tagging: {
+            TagSet: [{ Key: BUILD_STATE_TAG_KEY, Value: BUILD_STATE_SUPERSEDED }],
+          },
+        }),
+      );
+    }
+    token = page.IsTruncated ? page.NextContinuationToken : undefined;
+  } while (token);
+}
 
 const byteLen = (s: string): number => Buffer.byteLength(s, 'utf8');
 
@@ -193,5 +265,29 @@ export async function handler(event: Event): Promise<{ PhysicalResourceId: strin
       : {};
 
   await applyUpdate(KvsArn, desired, previous);
+
+  // #480: after the KVS pointer has flipped to the new build, tag the OUTGOING
+  // build's objects as superseded so the `DeleteOldBuilds` lifecycle rule can
+  // expire them. Order matters: we tag ONLY after applyUpdate() has committed
+  // the flip, so a failure here can never affect the build that is now live
+  // (the new build is never tagged). Best-effort — a failure leaves the old
+  // build untagged (not expired), which is safe; we log and continue so a
+  // transient S3 error never fails an otherwise-successful deploy.
+  if (event.RequestType === 'Update' && event.ResourceProperties.BucketName) {
+    const oldBuildId = activeBuildId(event.OldResourceProperties?.Entries);
+    const newBuildId = activeBuildId(entriesJson);
+    if (oldBuildId && oldBuildId !== newBuildId) {
+      try {
+        await supersedeBuild(event.ResourceProperties.BucketName, oldBuildId);
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          `Failed to tag superseded build ${oldBuildId}; it will not be expired by ` +
+            `the DeleteOldBuilds lifecycle rule until re-tagged. ${String(err)}`,
+        );
+      }
+    }
+  }
+
   return { PhysicalResourceId: physicalId };
 }

--- a/packages/hosting/src/constructs/kv_keys_handler.ts
+++ b/packages/hosting/src/constructs/kv_keys_handler.ts
@@ -38,6 +38,7 @@ import {
   S3Client,
   ListObjectsV2Command,
   PutObjectTaggingCommand,
+  DeleteObjectTaggingCommand,
 } from '@aws-sdk/client-s3';
 import { BUILD_STATE_TAG_KEY, BUILD_STATE_SUPERSEDED } from './build_tags.js';
 
@@ -138,6 +139,48 @@ export async function supersedeBuild(
               },
             }),
           ),
+        ),
+      );
+    }
+    token = page.IsTruncated ? page.NextContinuationToken : undefined;
+  } while (token);
+}
+
+/**
+ * Remove the build-state tag from every object under `builds/<buildId>/`, the
+ * symmetric counterpart of {@link supersedeBuild}. Called on the INCOMING build
+ * at cutover so a retained prefix is never left tagged `superseded`: a rollback
+ * that re-points the KVS `meta.b` pointer back at it would otherwise hand the
+ * now-live build to the `DeleteOldBuilds` lifecycle rule — #480 all over again.
+ *
+ * Same bounded concurrency (15 in flight) and best-effort contract as
+ * {@link supersedeBuild}: a failure only leaves a stale tag on a build that is
+ * live right now (the lifecycle rule cannot expire it while it is pointed at by
+ * a deploy that keeps re-clearing on each cutover), so we never fail a deploy
+ * for it.
+ */
+export async function clearBuildState(
+  bucket: string,
+  buildId: string,
+): Promise<void> {
+  const CONCURRENCY = 15;
+  let token: string | undefined;
+  do {
+    const page = await s3.send(
+      new ListObjectsV2Command({
+        Bucket: bucket,
+        Prefix: `builds/${buildId}/`,
+        ContinuationToken: token,
+      }),
+    );
+    const keys = (page.Contents ?? [])
+      .map((obj) => obj.Key)
+      .filter((key): key is string => typeof key === 'string');
+    for (let i = 0; i < keys.length; i += CONCURRENCY) {
+      const chunk = keys.slice(i, i + CONCURRENCY);
+      await Promise.all(
+        chunk.map((key) =>
+          s3.send(new DeleteObjectTaggingCommand({ Bucket: bucket, Key: key })),
         ),
       );
     }
@@ -299,6 +342,23 @@ export async function handler(event: Event): Promise<{ PhysicalResourceId: strin
           `Failed to tag superseded build ${oldBuildId}; it will not be expired by ` +
             `the DeleteOldBuilds lifecycle rule until re-tagged. ${String(err)}`,
         );
+      }
+      // Symmetric to the supersede tagging above: clear the build-state tag on
+      // the INCOMING build so a rollback that flips the pointer back to it can
+      // never hand a live build to `DeleteOldBuilds` (#480 F1). Best-effort for
+      // the same reason — a stale tag on the live build is not expired while
+      // deploys keep clearing it, so never fail the deploy over it.
+      if (newBuildId) {
+        try {
+          await clearBuildState(event.ResourceProperties.BucketName, newBuildId);
+        } catch (err) {
+          // eslint-disable-next-line no-console
+          console.warn(
+            `Failed to clear the build-state tag on incoming build ${newBuildId}; ` +
+              `a rollback to it could be expired by the DeleteOldBuilds lifecycle ` +
+              `rule until the tag is cleared. ${String(err)}`,
+          );
+        }
       }
     }
   }

--- a/packages/hosting/src/constructs/storage_construct.test.ts
+++ b/packages/hosting/src/constructs/storage_construct.test.ts
@@ -3,7 +3,11 @@ import assert from 'node:assert';
 import { App, Stack } from 'aws-cdk-lib';
 import { Match, Template } from 'aws-cdk-lib/assertions';
 import { Key } from 'aws-cdk-lib/aws-kms';
-import { StorageConstruct } from './storage_construct.js';
+import {
+  StorageConstruct,
+  BUILD_STATE_TAG_KEY,
+  BUILD_STATE_SUPERSEDED,
+} from './storage_construct.js';
 
 // ---- Test helpers ----
 
@@ -544,5 +548,36 @@ void describe('StorageConstruct', () => {
         'BucketOwnerPreferred',
       );
     });
+  });
+});
+
+// #480: DeleteOldBuilds must only expire builds tagged SUPERSEDED, so the
+// live build (KVS meta.b) — which is never tagged — is never expired,
+// regardless of deploy cadence. This is the core regression guard.
+void describe('DeleteOldBuilds excludes the live build (#480)', () => {
+  void it('scopes DeleteOldBuilds to the superseded tag filter', () => {
+    const stack = createStack();
+    new StorageConstruct(stack, 'Storage');
+    const template = Template.fromStack(stack);
+
+    template.hasResourceProperties('AWS::S3::Bucket', {
+      LifecycleConfiguration: Match.objectLike({
+        Rules: Match.arrayWith([
+          Match.objectLike({
+            Id: 'DeleteOldBuilds',
+            Prefix: 'builds/',
+            Status: 'Enabled',
+            TagFilters: Match.arrayWith([
+              { Key: BUILD_STATE_TAG_KEY, Value: BUILD_STATE_SUPERSEDED },
+            ]),
+          }),
+        ]),
+      }),
+    });
+  });
+
+  void it('exposes the superseded tag constants (shared with the cutover handler)', () => {
+    assert.strictEqual(BUILD_STATE_TAG_KEY, 'aws-blocks:build-state');
+    assert.strictEqual(BUILD_STATE_SUPERSEDED, 'superseded');
   });
 });

--- a/packages/hosting/src/constructs/storage_construct.ts
+++ b/packages/hosting/src/constructs/storage_construct.ts
@@ -9,6 +9,7 @@ import {
   ObjectOwnership,
 } from 'aws-cdk-lib/aws-s3';
 import { IKey } from 'aws-cdk-lib/aws-kms';
+import { BUILD_STATE_TAG_KEY, BUILD_STATE_SUPERSEDED } from './build_tags.js';
 
 // ---- Constants ----
 
@@ -24,6 +25,13 @@ import { IKey } from 'aws-cdk-lib/aws-kms';
  */
 const DEFAULT_BUILD_RETENTION_DAYS = 30;
 
+/**
+ * Build-state tag constants (issue #480). Defined in the dependency-free
+ * `build_tags` module so the esbuild-bundled KVS cutover handler can share
+ * them without pulling `aws-cdk-lib` into the Lambda bundle. Re-exported here
+ * for callers and tests that reason about the storage construct.
+ */
+export { BUILD_STATE_TAG_KEY, BUILD_STATE_SUPERSEDED } from './build_tags.js';
 /** Default retention for access logs */
 const DEFAULT_ACCESS_LOG_RETENTION_DAYS = 90;
 
@@ -155,6 +163,12 @@ export class StorageConstruct extends Construct {
         {
           id: 'DeleteOldBuilds',
           prefix: 'builds/',
+          // #480: only expire builds explicitly marked superseded at the KVS
+          // cutover. The live build (KVS meta.b) is never tagged, so it is
+          // never matched by this rule and never expired — regardless of how
+          // long it has been since the last deploy. TagFilters are
+          // inclusion-only, so we tag the superseded builds, not the live one.
+          tagFilters: { [BUILD_STATE_TAG_KEY]: BUILD_STATE_SUPERSEDED },
           expiration: Duration.days(buildRetentionDays),
           enabled: true,
         },

--- a/packages/hosting/src/constructs/storage_construct.ts
+++ b/packages/hosting/src/constructs/storage_construct.ts
@@ -23,7 +23,8 @@ import { BUILD_STATE_TAG_KEY, BUILD_STATE_SUPERSEDED } from './build_tags.js';
  * wouldn't even work end-to-end). Customers who genuinely need long
  * rollback windows can extend via `storage.buildRetentionDays`.
  */
-const DEFAULT_BUILD_RETENTION_DAYS = 30;
+export const DEFAULT_BUILD_RETENTION_DAYS = 30;
+
 
 /**
  * Build-state tag constants (issue #480). Defined in the dependency-free
@@ -49,7 +50,7 @@ export type StorageConstructProps = {
   encryption?: 'S3_MANAGED' | 'KMS';
   /** BYO KMS key for bucket encryption (requires encryption: 'KMS'). */
   encryptionKey?: IKey;
-  /** Days to retain build artifacts in S3. Default: 365. */
+  /** Days to retain build artifacts in S3. Default: 30. */
   buildRetentionDays?: number;
   /** Days to retain access logs. Default: 90. */
   logRetentionDays?: number;

--- a/packages/hosting/src/types.ts
+++ b/packages/hosting/src/types.ts
@@ -311,6 +311,14 @@ export type HostingProps = {
     /** Days to retain build artifacts in S3. Default: 30. */
     buildRetentionDays?: number;
     /**
+     * Optional advisory hint: how often you expect to deploy, in days. Used
+     * ONLY at synth to emit a warning when your rollback window
+     * (`buildRetentionDays`) is shorter than your deploy cadence, which would
+     * let superseded builds expire before your next deploy. The live build is
+     * never affected (#480), so this is a rollback-window note, not an error.
+     */
+    deployIntervalDays?: number;
+    /**
      * Opt-in S3 inventory of `builds/` (3.3). When enabled, a daily
      * CSV report of every object under `builds/` lands in a
      * dedicated inventory bucket. Useful for cost audits — find


### PR DESCRIPTION
Fixes #480. The DeleteOldBuilds S3 lifecycle rule was prefix-only (builds/, 30-day expiration) with no tag filter, so it expired the live build that CloudFront's KVS meta.b points at, breaking static asset paths (403/404) while the API stayed 200. This scopes the lifecycle rule to superseded-tagged builds only and tags the outgoing build at KVS cutover (list+PutObjectTagging, no delete). Also plumbs buildRetentionDays through core HostingProps and adds a deployIntervalDays advisory warn. Hosting tests 853/0; adds a core buildRetentionDays pass-through test (passing).