### PR TITLE
docs: clarify event block compute compatibility

### DIFF
--- a/packages/bb-async-job/README.md
+++ b/packages/bb-async-job/README.md
@@ -79,7 +79,7 @@ latency-sensitive work — a batching window makes SQS wait up to
 a user-facing path starts up to that many seconds late. `maxBatchingWindowSeconds: 0`
 opts out of the wait while keeping batching.
 
-The queue's visibility timeout is set to the shared Lambda's timeout plus
+The queue's visibility timeout is set to the Lambda timeout plus
 `maxBatchingWindowSeconds`, because a message's visibility clock starts when the
 poller receives it — before the batching window elapses and before the handler runs.
 
@@ -107,7 +107,14 @@ AsyncJobErrors.ValidationFailed   // schema validation failed
 AsyncJobErrors.BatchSubmitFailed  // one or more messages failed to enqueue
 AsyncJobErrors.Timeout            // waitUntilComplete() gave up before the job settled
 AsyncJobErrors.StatusNotTracked   // status method called without trackStatus: true
+AsyncJobErrors.UnsupportedCompute // resolved compute is not Lambda (thrown at synth time)
 ```
+
+## Compute Compatibility
+
+AsyncJob attaches its SQS event source to its resolved compute. It currently
+supports Lambda compute only; constructing an AsyncJob under another compute
+fails at synth time with `UnsupportedComputeException`.
 
 ## Local Development
 
@@ -115,7 +122,9 @@ In local dev mode, AsyncJob uses an in-process queue. Jobs process via `setTimeo
 
 ## AWS Deployment
 
-Automatically provisions an SQS queue, dead-letter queue, and connects to the shared API Lambda. Failed jobs become visible for retry after 900 seconds (matching the Lambda timeout).
+Automatically provisions an SQS queue, dead-letter queue, and attaches the event
+source to the resolved Lambda compute. Failed jobs become visible for retry after
+900 seconds (matching the Lambda timeout).
 
 ## How Do I Know My Job Ran?
 
@@ -198,5 +207,4 @@ handler: async (payload, ctx) => {
 ```
 
 **Check the dead-letter queue:** Jobs that fail after `maxRetries` attempts land in the DLQ. In AWS, check the `{scope}-{id}-dlq` queue in the SQS console. In local dev, failed jobs are logged to the console with their full payload.
-
 

--- a/packages/bb-cron-job/README.md
+++ b/packages/bb-cron-job/README.md
@@ -105,9 +105,14 @@ import { CronJobErrors } from '@aws-blocks/bb-cron-job';
 
 CronJobErrors.InvalidSchedule  // schedule expression is not a valid cron or rate format
 CronJobErrors.InvalidTimezone  // timezone string is not a valid IANA timezone
+CronJobErrors.UnsupportedCompute // resolved compute is not Lambda (thrown at synth time)
 ```
 
-Both errors are thrown at construction time (fail-fast validation).
+## Compute Compatibility
+
+CronJob targets its resolved compute. It currently supports Lambda compute only;
+constructing a CronJob under another compute fails at synth time with
+`UnsupportedComputeException`.
 
 ## Examples
 
@@ -212,7 +217,7 @@ In local dev mode, CronJob runs schedules in-process:
 Automatically provisions:
 
 - **EventBridge Schedule:** One `AWS::Scheduler::Schedule` per CronJob instance
-- **Shared Lambda:** Targets the shared Lambda (same as API handlers and AsyncJob). No dedicated Lambda per job.
+- **Lambda compute:** Each schedule targets its resolved Lambda compute. No dedicated Lambda is created per job.
 - **IAM role:** Per-stack EventBridge Scheduler role with `lambda:InvokeFunction` permission
 - **Schedule name:** Derived from the CronJob's `fullId` (truncated to 64 chars)
 

--- a/packages/bb-realtime/README.md
+++ b/packages/bb-realtime/README.md
@@ -198,6 +198,7 @@ import { RealtimeErrors } from '@aws-blocks/bb-realtime';
 RealtimeErrors.ValidationFailed  // data failed schema validation on publish
 RealtimeErrors.PublishFailed     // Publish fan-out failed (AWS only)
 RealtimeErrors.ConnectionFailed  // WebSocket connection or subscribe rejected
+RealtimeErrors.UnsupportedCompute // default compute is not Lambda (thrown at synth time)
 ```
 
 ## Best Practices

--- a/packages/bb-realtime/src/errors.ts
+++ b/packages/bb-realtime/src/errors.ts
@@ -20,6 +20,6 @@ export const RealtimeErrors = {
 	PublishFailed: 'PublishFailedException',
 	ValidationFailed: 'ValidationFailedException',
 	ConnectionFailed: 'ConnectionFailedException',
-	/** Thrown at synth time when the resolved compute is not a supported type (only Lambda today). */
+	/** Thrown at synth time when the default compute is not a supported type (only Lambda today). */
 	UnsupportedCompute: 'UnsupportedComputeException',
 } as const;


### PR DESCRIPTION
## Problem

**Issue #:** N/A

The event-block compute targeting change in #459 exposes UnsupportedComputeException and routes AsyncJob and CronJob to their resolved Lambda compute. Their public READMEs still describe a shared Lambda and omit the new error. Realtime's public API comment also describes the wrong compute selection.

## Changes

- Document the Lambda-only compute constraint and UnsupportedComputeException for AsyncJob and CronJob.
- Update AsyncJob and CronJob deployment descriptions to refer to the resolved Lambda compute.
- Document Realtime's default-compute requirement and correct its API comment.

## Validation

- Ran npm run sync-docs:check.
- Ran git diff --check.
- No automated tests were added because this changes documentation and an API comment only.

## Checklist

- [x] PR description included
- [ ] Tests are changed or added
- [x] Relevant documentation is changed or added (and PR referenced)

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._