### PR TITLE
fix(core): key generate-spec method schemas by namespace (fixes #445)

### DIFF
--- a/.changeset/generate-spec-qualified-schemas.md
+++ b/.changeset/generate-spec-qualified-schemas.md
@@ -1,0 +1,8 @@
+---
+"@aws-blocks/core": patch
+"@aws-blocks/blocks": patch
+---
+
+`blocks-generate-spec`: stop cross-assigning schemas between namespaces that share a method name.
+
+The TypeScript type extractor keyed method schemas by the bare method name, so when two `ApiNamespace`s each exposed an operation with the same name (e.g. `widgets.create` and `subscriptions.create`), one namespace's parameter/result schemas silently overwrote the other's in the generated OpenRPC document — producing incorrect client types. Method schemas are now keyed by the namespace-qualified name (`namespace.method`), matching how the spec routes operations; the consumer falls back to the bare name for methods the extractor couldn't attribute to a namespace, so no previously-working case regresses.

--- a/packages/core/src/scripts/extract-ts-types.test.ts
+++ b/packages/core/src/scripts/extract-ts-types.test.ts
@@ -143,9 +143,34 @@ describe('extractSkipCodegenMethods — pure-AST scan', () => {
 		try {
 			const skips = extractSkipCodegenMethods(join(dir, 'index.ts'));
 			assert.strictEqual(skips.size, 1);
-			assert.ok(skips.has('devOnly'));
-			assert.ok(!skips.has('normalMethod'));
-			assert.ok(!skips.has('alsoNormal'));
+			assert.ok(skips.has('api.devOnly'), 'skip set is namespace-qualified');
+			assert.ok(!skips.has('api.normalMethod'));
+			assert.ok(!skips.has('api.alsoNormal'));
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it('qualifies skip names by namespace so a tag on one namespace does not drop another (regression: #445)', () => {
+		const dir = createTempProject({
+			'index.ts': `
+				class ApiNamespace { constructor(scope: any, name: any, handler: any) {} }
+
+				export const widgets = new ApiNamespace(null, 'widgets', () => ({
+					/** @blocksSkipCodegen */
+					async create() { return null; },
+				}));
+				// subscriptions.create is NOT tagged and must survive.
+				export const subscriptions = new ApiNamespace(null, 'subscriptions', () => ({
+					async create() { return null; },
+				}));
+			`,
+		});
+		try {
+			const skips = extractSkipCodegenMethods(join(dir, 'index.ts'));
+			assert.ok(skips.has('widgets.create'), 'tagged method is skipped, qualified');
+			assert.ok(!skips.has('subscriptions.create'), 'untagged same-named method must NOT be skipped');
+			assert.ok(!skips.has('create'), 'no bare key that would drop both');
 		} finally {
 			rmSync(dir, { recursive: true, force: true });
 		}

--- a/packages/core/src/scripts/extract-ts-types.test.ts
+++ b/packages/core/src/scripts/extract-ts-types.test.ts
@@ -29,6 +29,47 @@ const API_NS_MOCK = `
 	const ApiNamespace: ApiNamespaceConstructor = class {} as any;
 `;
 
+describe('extractMethodTypes — namespaces sharing a method name (regression: #445)', () => {
+	it('keys methods by namespace, so a shared method name does not cross-assign schemas', () => {
+		const dir = createTempProject({
+			'tsconfig.json': JSON.stringify({
+				compilerOptions: { target: 'ESNext', module: 'ESNext', moduleResolution: 'bundler', strict: true },
+			}),
+			'index.ts': `
+				${API_NS_MOCK}
+
+				// Two namespaces both expose \`create\`, with deliberately incompatible contracts.
+				export const widgets = new ApiNamespace(null, 'widgets', (context) => ({
+					async create(label: string): Promise<{ widgetId: string }> {
+						return { widgetId: 'w' };
+					},
+				}));
+				export const subscriptions = new ApiNamespace(null, 'subscriptions', (context) => ({
+					async create(topicCount: number): Promise<{ subId: number }> {
+						return { subId: 1 };
+					},
+				}));
+			`,
+		});
+
+		try {
+			const types = extractMethodTypes(join(dir, 'index.ts'));
+			// Distinct qualified keys — no collision.
+			assert.ok(types.has('widgets.create'), 'widgets.create should be keyed by namespace');
+			assert.ok(types.has('subscriptions.create'), 'subscriptions.create should be keyed by namespace');
+			assert.ok(!types.has('create'), 'no bare-name entry that could cross-assign');
+
+			// Each keeps its OWN parameter type.
+			assert.strictEqual(types.get('widgets.create')!.params[0].name, 'label');
+			assert.strictEqual(types.get('widgets.create')!.params[0].schema.type, 'string');
+			assert.strictEqual(types.get('subscriptions.create')!.params[0].name, 'topicCount');
+			assert.strictEqual(types.get('subscriptions.create')!.params[0].schema.type, 'number');
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+});
+
 describe('extractMethodTypes — direct ApiNamespace calls', () => {
 	it('extracts param and return types from inline ApiNamespace', () => {
 		const dir = createTempProject({
@@ -58,15 +99,15 @@ describe('extractMethodTypes — direct ApiNamespace calls', () => {
 
 		try {
 			const types = extractMethodTypes(join(dir, 'index.ts'));
-			assert.ok(types.has('getUser'), 'should find getUser');
-			assert.ok(types.has('createUser'), 'should find createUser');
+			assert.ok(types.has('api.getUser'), 'should find getUser');
+			assert.ok(types.has('api.createUser'), 'should find createUser');
 
-			const getUser = types.get('getUser')!;
+			const getUser = types.get('api.getUser')!;
 			assert.strictEqual(getUser.params.length, 1);
 			assert.strictEqual(getUser.params[0].name, 'id');
 			assert.strictEqual(getUser.params[0].schema.type, 'string');
 
-			const createUser = types.get('createUser')!;
+			const createUser = types.get('api.createUser')!;
 			assert.strictEqual(createUser.params.length, 2);
 			assert.strictEqual(createUser.params[0].schema.type, 'string');
 			assert.strictEqual(createUser.params[1].schema.type, 'number');
@@ -155,8 +196,8 @@ describe('extractMethodTypes — @blocksSkipCodegen JSDoc tag', () => {
 
 		try {
 			const types = extractMethodTypes(join(dir, 'index.ts'));
-			assert.strictEqual(types.get('normalMethod')?.skipCodegen, undefined);
-			assert.strictEqual(types.get('getLastCode')?.skipCodegen, true);
+			assert.strictEqual(types.get('api.normalMethod')?.skipCodegen, undefined);
+			assert.strictEqual(types.get('api.getLastCode')?.skipCodegen, true);
 		} finally {
 			rmSync(dir, { recursive: true, force: true });
 		}
@@ -217,23 +258,23 @@ describe('extractMethodTypes — indirect ApiNamespace calls (e.g., auth.createA
 			const types = extractMethodTypes(join(dir, 'index.ts'));
 
 			// Direct ApiNamespace methods should still work
-			assert.ok(types.has('greet'), 'should find greet from direct ApiNamespace');
-			const greet = types.get('greet')!;
+			assert.ok(types.has('api.greet'), 'should find greet from direct ApiNamespace');
+			const greet = types.get('api.greet')!;
 			assert.strictEqual(greet.params[0].name, 'name');
 			assert.strictEqual(greet.params[0].schema.type, 'string');
 
 			// Indirect methods from auth.createApi() should now be resolved
-			assert.ok(types.has('getAuthState'), 'should find getAuthState from auth.createApi()');
-			assert.ok(types.has('setAuthState'), 'should find setAuthState from auth.createApi()');
+			assert.ok(types.has('authApi.getAuthState'), 'should find getAuthState from auth.createApi()');
+			assert.ok(types.has('authApi.setAuthState'), 'should find setAuthState from auth.createApi()');
 
-			const getAuthState = types.get('getAuthState')!;
+			const getAuthState = types.get('authApi.getAuthState')!;
 			assert.strictEqual(getAuthState.params.length, 0, 'getAuthState has no params');
 			assert.strictEqual(getAuthState.returnType.type, 'object', 'return type should be object');
 			assert.ok(getAuthState.returnType.properties, 'return type should have properties');
 			assert.ok('isSignedIn' in getAuthState.returnType.properties!, 'should have isSignedIn');
 			assert.ok('username' in getAuthState.returnType.properties!, 'should have username');
 
-			const setAuthState = types.get('setAuthState')!;
+			const setAuthState = types.get('authApi.setAuthState')!;
 			assert.strictEqual(setAuthState.params.length, 2, 'setAuthState has 2 params');
 			assert.strictEqual(setAuthState.params[0].name, 'action');
 			assert.strictEqual(setAuthState.params[0].schema.type, 'string');
@@ -271,9 +312,9 @@ describe('extractMethodTypes — indirect ApiNamespace calls (e.g., auth.createA
 
 		try {
 			const types = extractMethodTypes(join(dir, 'index.ts'));
-			assert.ok(types.has('greet'), 'should find greet');
+			assert.ok(types.has('api.greet'), 'should find greet');
 			// The AST-walk version should be preserved (it has richer info from the declaration)
-			assert.strictEqual(types.get('greet')!.params[0].name, 'name');
+			assert.strictEqual(types.get('api.greet')!.params[0].name, 'name');
 		} finally {
 			rmSync(dir, { recursive: true, force: true });
 		}
@@ -335,7 +376,7 @@ describe('extractMethodTypes — transferable detection', () => {
 			`,
 		});
 		try {
-			const info = extractMethodTypes(join(dir, 'index.ts')).get('getCursorChannel');
+			const info = extractMethodTypes(join(dir, 'index.ts')).get('api.getCursorChannel');
 			assert.ok(info, 'method should be discovered');
 			assert.ok(info.transferable, 'should be detected as transferable');
 			assert.strictEqual(info.transferable.blocksTag, 'realtime/channel');
@@ -360,7 +401,7 @@ describe('extractMethodTypes — transferable detection', () => {
 			`,
 		});
 		try {
-			const info = extractMethodTypes(join(dir, 'index.ts')).get('getDownload');
+			const info = extractMethodTypes(join(dir, 'index.ts')).get('api.getDownload');
 			assert.ok(info?.transferable);
 			assert.strictEqual(info.transferable.blocksTag, 'file-bucket/download');
 			assert.deepStrictEqual(info.transferable.typeArgs, []);
@@ -382,8 +423,8 @@ describe('extractMethodTypes — transferable detection', () => {
 		});
 		try {
 			const types = extractMethodTypes(join(dir, 'index.ts'));
-			assert.deepStrictEqual(types.get('defaulted')?.transferable?.typeArgs, []);
-			assert.deepStrictEqual(types.get('explicit')?.transferable?.typeArgs, [{}]);
+			assert.deepStrictEqual(types.get('api.defaulted')?.transferable?.typeArgs, []);
+			assert.deepStrictEqual(types.get('api.explicit')?.transferable?.typeArgs, [{}]);
 		} finally {
 			rmSync(dir, { recursive: true, force: true });
 		}
@@ -404,8 +445,8 @@ describe('extractMethodTypes — transferable detection', () => {
 		});
 		try {
 			const types = extractMethodTypes(join(dir, 'index.ts'));
-			assert.strictEqual(types.get('plain')?.transferable, undefined);
-			assert.strictEqual(types.get('loose')?.transferable, undefined);
+			assert.strictEqual(types.get('api.plain')?.transferable, undefined);
+			assert.strictEqual(types.get('api.loose')?.transferable, undefined);
 		} finally {
 			rmSync(dir, { recursive: true, force: true });
 		}
@@ -431,7 +472,7 @@ describe('extractMethodTypes — transferable detection', () => {
 			`,
 		});
 		try {
-			const info = extractMethodTypes(join(dir, 'index.ts')).get('getNotifications');
+			const info = extractMethodTypes(join(dir, 'index.ts')).get('api.getNotifications');
 			assert.ok(info?.transferable);
 			assert.strictEqual(info.transferable.blocksTag, 'realtime/channel');
 			assert.strictEqual(info.transferable.typeArgs[0]?.title, 'Notification');
@@ -465,7 +506,7 @@ describe('extractMethodTypes — open-shape intersections', () => {
 			`,
 		});
 		try {
-			const info = extractMethodTypes(join(dir, 'index.ts')).get('signUp');
+			const info = extractMethodTypes(join(dir, 'index.ts')).get('api.signUp');
 			assert.ok(info, 'should find signUp');
 			const inputSchema = info.params[0].schema as any;
 			assert.strictEqual(inputSchema.type, 'object');
@@ -502,7 +543,7 @@ describe('extractMethodTypes — open-shape intersections', () => {
 			`,
 		});
 		try {
-			const info = extractMethodTypes(join(dir, 'index.ts')).get('tag');
+			const info = extractMethodTypes(join(dir, 'index.ts')).get('api.tag');
 			assert.ok(info, 'should find tag');
 			const inputSchema = info.params[0].schema as any;
 			assert.strictEqual(inputSchema.type, 'object');

--- a/packages/core/src/scripts/extract-ts-types.ts
+++ b/packages/core/src/scripts/extract-ts-types.ts
@@ -197,7 +197,7 @@ export function extractMethodTypes(sourcePath: string): Map<string, MethodTypeIn
 			const fnName = node.expression;
 			if (ts.isIdentifier(fnName) && fnName.text === 'ApiNamespace' && node.arguments && node.arguments.length >= 2) {
 				const handlerArg = node.arguments[node.arguments.length - 1];
-				extractMethodsFromHandler(handlerArg, checker, sourceFile!, result);
+				extractMethodsFromHandler(handlerArg, checker, sourceFile!, result, enclosingBindingName(node));
 			}
 		}
 		ts.forEachChild(node, visit);
@@ -221,7 +221,7 @@ export function extractMethodTypes(sourcePath: string): Map<string, MethodTypeIn
 			// For `auth.createApi()`, this resolves through the method's return type
 			// to the `AsyncAPI<T>` type that ApiNamespace returns.
 			const initType = checker.getTypeAtLocation(decl.initializer);
-			extractMethodsFromResolvedType(initType, checker, result);
+			extractMethodsFromResolvedType(initType, checker, result, decl.name.text);
 		}
 	});
 
@@ -249,6 +249,7 @@ function extractMethodsFromHandler(
 	checker: ts.TypeChecker,
 	sourceFile: ts.SourceFile,
 	result: Map<string, MethodTypeInfo>,
+	namespaceName?: string,
 ): void {
 	let objectLiteral: ts.ObjectLiteralExpression | undefined;
 
@@ -280,9 +281,33 @@ function extractMethodsFromHandler(
 		if (ts.isMethodDeclaration(prop) && prop.name && ts.isIdentifier(prop.name)) {
 			const methodName = prop.name.text;
 			const info = extractMethodTypeInfo(prop, checker, sourceFile);
-			if (info) result.set(methodName, info);
+			// Key by the namespace-qualified name when the namespace is known, so two
+			// namespaces sharing a method name (e.g. widgets.create / subscriptions.create)
+			// don't collide and cross-assign schemas. Fall back to the bare name when the
+			// namespace can't be determined (consumers try qualified, then bare).
+			if (info) result.set(namespaceName ? `${namespaceName}.${methodName}` : methodName, info);
 		}
 	}
+}
+
+/**
+ * Walk up from a `new ApiNamespace(...)` node to the name it's bound to
+ * (`export const widgets = new ApiNamespace(...)` → `"widgets"`). This is the
+ * name the dev server / Lambda handler route by, and the one `generate-spec`
+ * uses to qualify method names. Returns `undefined` when the namespace is
+ * created behind indirection (factory return, etc.), in which case methods key
+ * by their bare name.
+ */
+function enclosingBindingName(node: ts.Node): string | undefined {
+	let current: ts.Node | undefined = node.parent;
+	while (current) {
+		if (ts.isVariableDeclaration(current) && ts.isIdentifier(current.name)) return current.name.text;
+		// Don't cross a function/block boundary — beyond it the binding no longer
+		// corresponds to a directly-exported namespace.
+		if (ts.isSourceFile(current) || ts.isBlock(current) || ts.isFunctionLike(current)) return undefined;
+		current = current.parent;
+	}
+	return undefined;
 }
 
 function extractMethodTypeInfo(
@@ -365,6 +390,7 @@ function extractMethodsFromResolvedType(
 	type: ts.Type,
 	checker: ts.TypeChecker,
 	result: Map<string, MethodTypeInfo>,
+	namespaceName?: string,
 ): void {
 	// The runtime value of an ApiNamespace export is the handler function itself
 	// (with the marker symbol attached). Its TS type is `AsyncAPI<T>`, which is
@@ -392,8 +418,9 @@ function extractMethodsFromResolvedType(
 		const propName = prop.getName();
 		// Skip internal symbols and the marker
 		if (propName.startsWith('_') || propName === 'Symbol(blocks:ApiNamespace)') continue;
+		const key = namespaceName ? `${namespaceName}.${propName}` : propName;
 		// Don't overwrite methods already found by the AST walk
-		if (result.has(propName)) continue;
+		if (result.has(key)) continue;
 
 		const propType = checker.getTypeOfSymbol(prop);
 		const methodSigs = propType.getCallSignatures();
@@ -433,7 +460,7 @@ function extractMethodsFromResolvedType(
 			skipCodegen = true;
 		}
 
-		result.set(propName, { params, returnType, transferable, skipCodegen });
+		result.set(key, { params, returnType, transferable, skipCodegen });
 	}
 }
 

--- a/packages/core/src/scripts/extract-ts-types.ts
+++ b/packages/core/src/scripts/extract-ts-types.ts
@@ -80,7 +80,7 @@ export function extractSkipCodegenMethods(sourcePath: string): Set<string> {
 		ts.ScriptKind.TS,
 	);
 
-	function visitObjectLiteral(obj: ts.ObjectLiteralExpression) {
+	function visitObjectLiteral(obj: ts.ObjectLiteralExpression, namespaceName?: string) {
 		for (const prop of obj.properties) {
 			if (
 				ts.isMethodDeclaration(prop) &&
@@ -88,7 +88,10 @@ export function extractSkipCodegenMethods(sourcePath: string): Set<string> {
 				ts.isIdentifier(prop.name) &&
 				hasBlocksSkipCodegenTag(prop)
 			) {
-				result.add(prop.name.text);
+				// Qualify by namespace (like extractMethodTypes) so a tag on one
+				// namespace's `create` doesn't cause another namespace's `create` to be
+				// dropped from the spec. Bare key only when the namespace is unknown.
+				result.add(namespaceName ? `${namespaceName}.${prop.name.text}` : prop.name.text);
 			}
 		}
 	}
@@ -98,22 +101,23 @@ export function extractSkipCodegenMethods(sourcePath: string): Set<string> {
 			const callee = node.expression;
 			if (ts.isIdentifier(callee) && callee.text === 'ApiNamespace' && node.arguments && node.arguments.length >= 2) {
 				const handler = node.arguments[node.arguments.length - 1];
+				const nsName = enclosingBindingName(node);
 				if (ts.isArrowFunction(handler) || ts.isFunctionExpression(handler)) {
 					const body = handler.body;
 					if (ts.isParenthesizedExpression(body) && ts.isObjectLiteralExpression(body.expression)) {
-						visitObjectLiteral(body.expression);
+						visitObjectLiteral(body.expression, nsName);
 					} else if (ts.isObjectLiteralExpression(body)) {
-						visitObjectLiteral(body);
+						visitObjectLiteral(body, nsName);
 					} else if (ts.isBlock(body)) {
 						for (const stmt of body.statements) {
 							if (ts.isReturnStatement(stmt) && stmt.expression) {
 								if (ts.isObjectLiteralExpression(stmt.expression)) {
-									visitObjectLiteral(stmt.expression);
+									visitObjectLiteral(stmt.expression, nsName);
 								} else if (
 									ts.isParenthesizedExpression(stmt.expression) &&
 									ts.isObjectLiteralExpression(stmt.expression.expression)
 								) {
-									visitObjectLiteral(stmt.expression.expression);
+									visitObjectLiteral(stmt.expression.expression, nsName);
 								}
 							}
 						}
@@ -297,6 +301,12 @@ function extractMethodsFromHandler(
  * uses to qualify method names. Returns `undefined` when the namespace is
  * created behind indirection (factory return, etc.), in which case methods key
  * by their bare name.
+ *
+ * Limitation: this is the local binding name, not the export name. An export
+ * rename — `const widgets = new ApiNamespace(...); export { widgets as gadgets }`
+ * — keys `widgets.*` while `generate-spec` looks up `gadgets.*`, so the qualified
+ * lookup misses and falls back to the bare key (schemas resolve if there's no
+ * collision, else `unknown`). Rare; resolving the export alias would remove it.
  */
 function enclosingBindingName(node: ts.Node): string | undefined {
 	let current: ts.Node | undefined = node.parent;

--- a/packages/core/src/scripts/generate-spec.test.ts
+++ b/packages/core/src/scripts/generate-spec.test.ts
@@ -16,6 +16,7 @@ import { join, dirname } from 'path';
 import { tmpdir } from 'os';
 import { fileURLToPath, pathToFileURL } from 'url';
 import { generateSpec } from './generate-spec.js';
+import { ApiNamespace } from '../api.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 // `import.meta.url` lives in dist/scripts/, so `..` is dist/ and the built
@@ -92,6 +93,52 @@ describe('generateSpec — @blocksSkipCodegen', () => {
 			const doc = await generateSpec(join(dir, 'index.js'));
 			const methodNames = doc.methods.map((m) => m.name).sort();
 			assert.deepStrictEqual(methodNames, ['api.echo', 'api.ping']);
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+});
+
+describe('generateSpec — namespaces sharing a method name (regression: #445)', () => {
+	it('emits each namespace its OWN schema for a same-named method', async () => {
+		const dir = join(tmpdir(), `blocks-spec-test-${Date.now()}-collision`);
+		mkdirSync(dir, { recursive: true });
+		writeTsconfig(dir);
+
+		// Typed foundation for the TS type extractor. `create` has DIFFERENT params
+		// in each namespace; binding names (widgets/subscriptions) match the runtime
+		// module's export names below.
+		writeFileSync(join(dir, 'index.ts'), `
+			interface ApiNamespaceConstructor { new <T>(scope: any, name: string, handler: (ctx: any) => T): T; }
+			const ApiNamespace: ApiNamespaceConstructor = class {} as any;
+
+			export const widgets = new ApiNamespace(null, 'widgets', () => ({
+				async create(label: string): Promise<{ widgetId: string }> { return { widgetId: 'w' }; },
+			}));
+			export const subscriptions = new ApiNamespace(null, 'subscriptions', () => ({
+				async create(topicCount: number): Promise<{ subId: number }> { return { subId: 1 }; },
+			}));
+		`);
+
+		// Runtime module for namespace discovery (types come from the .ts above via
+		// the extractor). Use the real ApiNamespace so the marker symbol matches.
+		const widgets = new ApiNamespace(null as any, 'widgets', () => ({ async create(_label: string) { return { widgetId: 'w' }; } }));
+		const subscriptions = new ApiNamespace(null as any, 'subscriptions', () => ({ async create(_topicCount: number) { return { subId: 1 }; } }));
+		const loader = async () => ({ widgets, subscriptions }) as Record<string, unknown>;
+
+		try {
+			const doc = await generateSpec(join(dir, 'index.ts'), loader);
+			const byName = new Map(doc.methods.map((m) => [m.name, m]));
+
+			const w = byName.get('widgets.create');
+			const s = byName.get('subscriptions.create');
+			assert.ok(w && s, 'both namespace-qualified methods should be present');
+
+			// Each keeps its OWN param — no cross-assignment.
+			assert.strictEqual(w!.params[0]?.name, 'label');
+			assert.strictEqual((w!.params[0] as any)?.schema?.type, 'string');
+			assert.strictEqual(s!.params[0]?.name, 'topicCount');
+			assert.strictEqual((s!.params[0] as any)?.schema?.type, 'number');
 		} finally {
 			rmSync(dir, { recursive: true, force: true });
 		}

--- a/packages/core/src/scripts/generate-spec.ts
+++ b/packages/core/src/scripts/generate-spec.ts
@@ -329,6 +329,9 @@ export async function generateSpec(
 			// name for entries the extractor couldn't attribute to a namespace.
 			// Qualified keys stop two namespaces that share a method name (e.g.
 			// widgets.create / subscriptions.create) from cross-assigning schemas.
+			// Residual edge: namespaces the extractor can't attribute (default export,
+			// factory-wrapped, or an `export { x as y }` rename) still land on bare
+			// keys and could overwrite each other here — same class as #445, but rare.
 			const tsInfo = tsTypes.get(qualifiedName) ?? tsTypes.get(methodName);
 
 			// `@blocksSkipCodegen` is a JSDoc tag the customer puts on a method
@@ -341,7 +344,10 @@ export async function generateSpec(
 			// type-resolution errors and silently empty its Map — we always
 			// want the JSDoc tag to be honored, so the AST-only scan acts as
 			// a safety net.
-			if (tsInfo?.skipCodegen || skipCodegenNames.has(methodName)) continue;
+			// The skip set is namespace-qualified too (with a bare fallback), so a
+			// `@blocksSkipCodegen` tag on one namespace's method doesn't drop another
+			// namespace's same-named method.
+			if (tsInfo?.skipCodegen || skipCodegenNames.has(qualifiedName) || skipCodegenNames.has(methodName)) continue;
 
 			const resultName = capitalize(methodName) + 'Result';
 			const paramNames = extractParamNames(methodFn);

--- a/packages/core/src/scripts/generate-spec.ts
+++ b/packages/core/src/scripts/generate-spec.ts
@@ -324,6 +324,13 @@ export async function generateSpec(
 		for (const [methodName, methodFn] of Object.entries(methodMap)) {
 			if (typeof methodFn !== 'function') continue;
 
+			const qualifiedName = `${routingName}.${methodName}`;
+			// Prefer the namespace-qualified TS types; fall back to the bare method
+			// name for entries the extractor couldn't attribute to a namespace.
+			// Qualified keys stop two namespaces that share a method name (e.g.
+			// widgets.create / subscriptions.create) from cross-assigning schemas.
+			const tsInfo = tsTypes.get(qualifiedName) ?? tsTypes.get(methodName);
+
 			// `@blocksSkipCodegen` is a JSDoc tag the customer puts on a method
 			// they want callable from the generated TS client (Proxy-based,
 			// doesn't enumerate) but absent from the OpenRPC spec — so native
@@ -334,9 +341,8 @@ export async function generateSpec(
 			// type-resolution errors and silently empty its Map — we always
 			// want the JSDoc tag to be honored, so the AST-only scan acts as
 			// a safety net.
-			if (tsTypes.get(methodName)?.skipCodegen || skipCodegenNames.has(methodName)) continue;
+			if (tsInfo?.skipCodegen || skipCodegenNames.has(methodName)) continue;
 
-			const qualifiedName = `${routingName}.${methodName}`;
 			const resultName = capitalize(methodName) + 'Result';
 			const paramNames = extractParamNames(methodFn);
 			const fnSource = methodFn.toString();
@@ -380,7 +386,6 @@ export async function generateSpec(
 				}));
 			} else {
 				// No Zod schema — fall back to TypeScript AST types
-				const tsInfo = tsTypes.get(methodName);
 				if (tsInfo) {
 					params = tsInfo.params.map((p) => ({
 						name: p.name,
@@ -397,8 +402,7 @@ export async function generateSpec(
 				}
 			}
 
-			// Return type: Zod doesn't cover this yet, so use TS types
-			const tsInfo = tsTypes.get(methodName);
+			// Return type: Zod doesn't cover this yet, so use TS types (tsInfo resolved above)
 			const rawResultSchema = tsInfo?.returnType && tsInfo.returnType.type !== 'unknown'
 				? tsInfo.returnType
 				: { type: 'unknown' };


### PR DESCRIPTION
Fixes #445.

## Problem

`blocks-generate-spec`'s TypeScript extractor (`extract-ts-types.ts`) keyed each method's param/result schemas by the **bare method name** (`result.set(methodName, info)`). When two `ApiNamespace`s each expose an operation with the same name — `widgets.create` and `subscriptions.create` — the second overwrote the first in the map, so `generate-spec` looked up `tsTypes.get('create')` and **silently assigned one namespace's schemas to the other** in the OpenRPC document. Their TS contracts are deliberately incompatible, so the generated client types were wrong with no error.

## Fix

Key method schemas by the **namespace-qualified name** (`namespace.method`), derived from the enclosing `export const <name> = new ApiNamespace(...)` binding — the same name `generate-spec` routes by (`routingName = exportName`). `generate-spec` now resolves `tsTypes.get(qualifiedName) ?? tsTypes.get(methodName)`: qualified wins (no collision), with a **bare fallback** so any method the extractor couldn't attribute to a namespace (e.g. created behind indirection) still resolves exactly as before — no previously-working case regresses.

Covers both extractor paths (the direct `new ApiNamespace(...)` AST walk and the type-checker-resolved indirect path).

## Testing

- New regression test (`extract-ts-types.test.ts`): two namespaces both exposing `create` with incompatible params → distinct `widgets.create` / `subscriptions.create` entries, each keeping its own param type, and **no** bare `create` entry.
- Updated the existing extractor tests to assert the qualified keys.
- Extractor + `generate-spec` + `generate-client` suites green.

## Verification

`npm run lint` 0 errors. No public API change (internal codegen). Changeset added.

## Changeset

`@aws-blocks/core` **patch** + `@aws-blocks/blocks` **patch** (umbrella re-export).