### PR TITLE
[core + 3 more] Route logging retention and tracing through the compute

### DIFF
--- a/.changeset/compute-logging-tracing.md
+++ b/.changeset/compute-logging-tracing.md
@@ -1,0 +1,26 @@
+---
+"@aws-blocks/core": patch
+"@aws-blocks/bb-lambda-compute": patch
+"@aws-blocks/bb-logger": patch
+"@aws-blocks/bb-tracer": patch
+---
+
+feat: route logging retention and tracing through the compute
+
+The `Compute` abstraction gains the observability seam so the Logger and Tracer
+Building Blocks target the resolved compute instead of poking a specific
+function:
+
+- `enableLogging(retentionDays?)` — when a `retentionDays` is given, sets it on
+  the compute's single log group (created with the stack-wide
+  `defaults.logRetention`); the compute owns the last-wins + synth
+  conflict-warning policy across multiple Loggers. A bare call leaves retention
+  untouched.
+- `enableTracing()` — turns on the compute's active X-Ray tracing and grants the
+  shared execution role trace-publish permission.
+
+The infra hooks (`applyLogRetention` / `applyTracing`) are `protected` abstracts
+implemented by the concrete compute, so the shared policy always runs. `bb-logger`
+now calls `this.compute.enableLogging(options?.retention)` and `bb-tracer` calls
+`this.compute.enableTracing()` — neither reaches into the shared handler's
+resources directly anymore.

--- a/packages/bb-async-job/src/index.cdk.test.ts
+++ b/packages/bb-async-job/src/index.cdk.test.ts
@@ -21,18 +21,18 @@
  * synthesize it.)
  */
 
-import { test, describe, before, after } from 'node:test';
 import assert from 'node:assert';
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
-import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
-import * as cdk from 'aws-cdk-lib';
-import { Template } from 'aws-cdk-lib/assertions';
-import { BlocksStack, BlocksPresets, Scope } from '@aws-blocks/core/cdk';
+import { after, before, describe, test } from 'node:test';
+import { fileURLToPath } from 'node:url';
+import { LambdaCompute } from '@aws-blocks/bb-lambda-compute/cdk';
 import { isBlocksError } from '@aws-blocks/core';
+import { BlocksPresets, BlocksStack, Scope } from '@aws-blocks/core/cdk';
 import type { DefaultComputeFactory } from '@aws-blocks/core/cdk/internal';
 import { Compute } from '@aws-blocks/core/cdk/internal';
-import { LambdaCompute } from '@aws-blocks/bb-lambda-compute/cdk';
+import * as cdk from 'aws-cdk-lib';
+import { Template } from 'aws-cdk-lib/assertions';
 import { AsyncJob, AsyncJobErrors } from './index.cdk.js';
 
 const lambdaFactory: DefaultComputeFactory = (root) => new LambdaCompute(root as never, 'DefaultCompute');
@@ -40,6 +40,9 @@ const lambdaFactory: DefaultComputeFactory = (root) => new LambdaCompute(root as
 /** A non-Lambda compute, to exercise the "unsupported compute" synth guard. */
 class FakeCompute extends Compute {
 	setEnv(_key: string, _value: string): void {}
+	// Observability hooks are irrelevant here — stub them to satisfy Compute.
+	protected applyLogRetention(): void {}
+	protected applyTracing(): void {}
 }
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -261,7 +264,12 @@ describe('AsyncJob option guards', () => {
 	test('CDK guard: maxBatchingWindowSeconds 301 is rejected', async () => {
 		const stack = await makeStack('AsyncGuardWindow301');
 		assertInvalidOption(
-			() => new AsyncJob(stack, 'jobs', { handler: async () => {}, maxBatchingWindowSeconds: 301, trackStatus: false }),
+			() =>
+				new AsyncJob(stack, 'jobs', {
+					handler: async () => {},
+					maxBatchingWindowSeconds: 301,
+					trackStatus: false,
+				}),
 			/maxBatchingWindowSeconds/,
 			/got: 301/,
 		);
@@ -270,7 +278,12 @@ describe('AsyncJob option guards', () => {
 	test('CDK guard: a negative maxBatchingWindowSeconds is rejected', async () => {
 		const stack = await makeStack('AsyncGuardWindowNeg');
 		assertInvalidOption(
-			() => new AsyncJob(stack, 'jobs', { handler: async () => {}, maxBatchingWindowSeconds: -1, trackStatus: false }),
+			() =>
+				new AsyncJob(stack, 'jobs', {
+					handler: async () => {},
+					maxBatchingWindowSeconds: -1,
+					trackStatus: false,
+				}),
 			/maxBatchingWindowSeconds/,
 			/got: -1/,
 		);
@@ -279,7 +292,12 @@ describe('AsyncJob option guards', () => {
 	test('CDK guard: a fractional maxBatchingWindowSeconds is rejected', async () => {
 		const stack = await makeStack('AsyncGuardWindowFrac');
 		assertInvalidOption(
-			() => new AsyncJob(stack, 'jobs', { handler: async () => {}, maxBatchingWindowSeconds: 2.5, trackStatus: false }),
+			() =>
+				new AsyncJob(stack, 'jobs', {
+					handler: async () => {},
+					maxBatchingWindowSeconds: 2.5,
+					trackStatus: false,
+				}),
 			/maxBatchingWindowSeconds/,
 			/got: 2.5/,
 		);
@@ -288,7 +306,12 @@ describe('AsyncJob option guards', () => {
 	test('CDK guard: NaN maxBatchingWindowSeconds is rejected', async () => {
 		const stack = await makeStack('AsyncGuardWindowNaN');
 		assertInvalidOption(
-			() => new AsyncJob(stack, 'jobs', { handler: async () => {}, maxBatchingWindowSeconds: NaN, trackStatus: false }),
+			() =>
+				new AsyncJob(stack, 'jobs', {
+					handler: async () => {},
+					maxBatchingWindowSeconds: NaN,
+					trackStatus: false,
+				}),
 			/maxBatchingWindowSeconds/,
 			/got: NaN/,
 		);

--- a/packages/bb-cron-job/src/index.cdk.test.ts
+++ b/packages/bb-cron-job/src/index.cdk.test.ts
@@ -1,6 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import assert from 'node:assert';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
 /**
  * CDK-side tests for CronJob: compute targeting + synth-time schedule validation.
  *
@@ -15,18 +18,15 @@
  * compute), so an invalid expression fails fast rather than minutes into the
  * deploy.
  */
-import { test, describe, before, after } from 'node:test';
-import assert from 'node:assert';
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { after, before, describe, test } from 'node:test';
 import { fileURLToPath } from 'node:url';
-import { dirname, join } from 'node:path';
-import * as cdk from 'aws-cdk-lib';
-import { Template } from 'aws-cdk-lib/assertions';
-import { BlocksStack, BlocksPresets, Scope } from '@aws-blocks/core/cdk';
+import { LambdaCompute } from '@aws-blocks/bb-lambda-compute/cdk';
 import { isBlocksError } from '@aws-blocks/core';
+import { BlocksPresets, BlocksStack, Scope } from '@aws-blocks/core/cdk';
 import type { DefaultComputeFactory } from '@aws-blocks/core/cdk/internal';
 import { Compute } from '@aws-blocks/core/cdk/internal';
-import { LambdaCompute } from '@aws-blocks/bb-lambda-compute/cdk';
+import * as cdk from 'aws-cdk-lib';
+import { Template } from 'aws-cdk-lib/assertions';
 import { CronJob, CronJobErrors } from './index.cdk.js';
 
 const lambdaFactory: DefaultComputeFactory = (root) => new LambdaCompute(root as never, 'DefaultCompute');
@@ -34,6 +34,9 @@ const lambdaFactory: DefaultComputeFactory = (root) => new LambdaCompute(root as
 /** A non-Lambda compute, to exercise the "unsupported compute" synth guard. */
 class FakeCompute extends Compute {
 	setEnv(_key: string, _value: string): void {}
+	// Observability hooks are irrelevant here — stub them to satisfy Compute.
+	protected applyLogRetention(): void {}
+	protected applyTracing(): void {}
 }
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -126,9 +129,7 @@ describe('CronJob synth-time schedule validation', () => {
 
 	test('accepts a valid schedule and synthesizes a CfnSchedule', async () => {
 		const stack = await makeStack('CronValid');
-		assert.doesNotThrow(
-			() => new CronJob(stack, 'job', { schedule: 'rate(5 minutes)', handler: async () => {} }),
-		);
+		assert.doesNotThrow(() => new CronJob(stack, 'job', { schedule: 'rate(5 minutes)', handler: async () => {} }));
 		Template.fromStack(stack).resourceCountIs('AWS::Scheduler::Schedule', 1);
 	});
 

--- a/packages/bb-lambda-compute/src/index.cdk.test.ts
+++ b/packages/bb-lambda-compute/src/index.cdk.test.ts
@@ -17,7 +17,7 @@ import { fileURLToPath } from 'node:url';
 import { type BlocksDefaults, BlocksPresets, Scope } from '@aws-blocks/core/cdk';
 import { Compute } from '@aws-blocks/core/cdk/internal';
 import * as cdk from 'aws-cdk-lib';
-import { Match, Template } from 'aws-cdk-lib/assertions';
+import { Annotations, Match, Template } from 'aws-cdk-lib/assertions';
 import { Architecture } from 'aws-cdk-lib/aws-lambda';
 import type { Construct } from 'constructs';
 import { LambdaCompute } from './index.cdk.js';
@@ -251,13 +251,66 @@ describe('LambdaCompute handler log-group retention (defaults.logRetention)', ()
 	});
 });
 
+// enableLogging(retention) reconfigures the compute's OWN single log group (the
+// one the function writes to), enforcing last-wins + a synth warning on
+// conflict. This is the seam bb-logger drives when a Logger passes an explicit
+// retention; the compute owns whether a group already exists and the policy.
+describe('LambdaCompute enableLogging(retention)', () => {
+	test('overrides the handler group retention without spawning a second group', () => {
+		const { stack, parent } = setup('LambdaComputeSetRetention', BlocksPresets.production);
+		const compute = new LambdaCompute(parent, 'extra');
+		compute.enableLogging(30);
+		const template = Template.fromStack(stack);
+		template.hasResourceProperties('AWS::Logs::LogGroup', { RetentionInDays: 30 });
+		// Still exactly one group — the override mutates the owned group.
+		template.resourceCountIs('AWS::Logs::LogGroup', 1);
+	});
+
+	test('last explicit retention wins across multiple calls', () => {
+		const { stack, parent } = setup('LambdaComputeRetentionLastWins', BlocksPresets.production);
+		const compute = new LambdaCompute(parent, 'extra');
+		compute.enableLogging(14);
+		compute.enableLogging(30);
+		Template.fromStack(stack).hasResourceProperties('AWS::Logs::LogGroup', { RetentionInDays: 30 });
+	});
+
+	test('conflicting retentions emit a synth warning (last wins, not silent)', () => {
+		const { stack, parent } = setup('LambdaComputeRetentionConflict', BlocksPresets.production);
+		const compute = new LambdaCompute(parent, 'extra');
+		compute.enableLogging(14);
+		compute.enableLogging(30);
+		Annotations.fromStack(stack).hasWarning('*', Match.stringLikeRegexp('log retention set to 30'));
+	});
+
+	test('the same retention twice emits no conflict warning', () => {
+		const { stack, parent } = setup('LambdaComputeRetentionSame', BlocksPresets.production);
+		const compute = new LambdaCompute(parent, 'extra');
+		compute.enableLogging(30);
+		compute.enableLogging(30);
+		Annotations.fromStack(stack).hasNoWarning('*', Match.stringLikeRegexp('log-retention-conflict|overriding'));
+	});
+
+	test('a bare enableLogging() leaves the stack-wide default retention untouched', () => {
+		const { stack, parent } = setup('LambdaComputeRetentionDefault', BlocksPresets.production);
+		const compute = new LambdaCompute(parent, 'extra');
+		compute.enableLogging();
+		// No explicit retention → the group keeps the production default (365).
+		Template.fromStack(stack).hasResourceProperties('AWS::Logs::LogGroup', { RetentionInDays: 365 });
+	});
+});
+
 describe('LambdaCompute stage throttling (defaults.throttling)', () => {
 	test('production carries the 1000/2000 rate + burst default', () => {
 		const { stack, parent } = setup('LambdaComputeThrottleProd', BlocksPresets.production);
 		new LambdaCompute(parent, 'extra');
 		Template.fromStack(stack).hasResourceProperties('AWS::ApiGateway::Stage', {
 			MethodSettings: Match.arrayWith([
-				Match.objectLike({ HttpMethod: '*', ResourcePath: '/*', ThrottlingRateLimit: 1000, ThrottlingBurstLimit: 2000 }),
+				Match.objectLike({
+					HttpMethod: '*',
+					ResourcePath: '/*',
+					ThrottlingRateLimit: 1000,
+					ThrottlingBurstLimit: 2000,
+				}),
 			]),
 		});
 	});
@@ -279,9 +332,7 @@ describe('LambdaCompute stage throttling (defaults.throttling)', () => {
 		});
 		new LambdaCompute(parent, 'extra');
 		Template.fromStack(stack).hasResourceProperties('AWS::ApiGateway::Stage', {
-			MethodSettings: Match.arrayWith([
-				Match.objectLike({ ThrottlingRateLimit: 50, ThrottlingBurstLimit: 75 }),
-			]),
+			MethodSettings: Match.arrayWith([Match.objectLike({ ThrottlingRateLimit: 50, ThrottlingBurstLimit: 75 })]),
 		});
 	});
 });
@@ -343,5 +394,33 @@ describe('LambdaCompute stage access logging (defaults.accessLogging)', () => {
 		template.resourceCountIs('AWS::ApiGateway::Account', 1);
 		// Both stages still get access logging.
 		template.resourceCountIs('AWS::ApiGateway::Stage', 2);
+	});
+});
+
+// enableTracing routes tracing onto the resolved compute (X-Ray on its function
+// + trace-publish permission on the shared role) instead of poking a specific
+// function. (Dashboard rendering of the traces section lands with the Dashboard
+// change that builds on this.)
+describe('LambdaCompute observability', () => {
+	test('enableTracing turns on Active tracing and grants X-Ray publish on the shared role', () => {
+		const { stack, parent } = setup('LambdaComputeTracing');
+
+		const compute = new LambdaCompute(parent, 'extra');
+		compute.enableTracing();
+
+		const template = Template.fromStack(stack);
+		template.hasResourceProperties('AWS::Lambda::Function', {
+			TracingConfig: { Mode: 'Active' },
+		});
+		template.hasResourceProperties('AWS::IAM::Policy', {
+			PolicyDocument: {
+				Statement: Match.arrayWith([
+					Match.objectLike({
+						Action: ['xray:PutTraceSegments', 'xray:PutTelemetryRecords'],
+						Effect: 'Allow',
+					}),
+				]),
+			},
+		});
 	});
 });

--- a/packages/bb-lambda-compute/src/index.cdk.ts
+++ b/packages/bb-lambda-compute/src/index.cdk.ts
@@ -2,13 +2,20 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { ScopeParent } from '@aws-blocks/core';
-import { BLOCKS_RPC_PREFIX, DEFAULT_NODE_RUNTIME, blocksNodejsBundling, ensureApiGatewayAccount } from '@aws-blocks/core/cdk';
+import {
+	BLOCKS_RPC_PREFIX,
+	blocksNodejsBundling,
+	DEFAULT_NODE_RUNTIME,
+	ensureApiGatewayAccount,
+} from '@aws-blocks/core/cdk';
 import { BLOCKS_NAMESPACE, Compute } from '@aws-blocks/core/cdk/internal';
 import * as cdk from 'aws-cdk-lib';
 import * as apigateway from 'aws-cdk-lib/aws-apigateway';
+import { PolicyStatement } from 'aws-cdk-lib/aws-iam';
+import type { CfnFunction } from 'aws-cdk-lib/aws-lambda';
 import { Architecture } from 'aws-cdk-lib/aws-lambda';
 import * as lambda from 'aws-cdk-lib/aws-lambda-nodejs';
-import { LogGroup } from 'aws-cdk-lib/aws-logs';
+import { type CfnLogGroup, LogGroup } from 'aws-cdk-lib/aws-logs';
 import type { LambdaComputeProps } from './types.js';
 
 export type { LambdaComputeProps } from './types.js';
@@ -180,6 +187,28 @@ export class LambdaCompute extends Compute {
 	 * app resolve different copies of this package.
 	 */
 	static isLambdaCompute(x: unknown): x is LambdaCompute {
-		return typeof x === 'object' && x !== null && (x as { [LAMBDA_COMPUTE_BRAND]?: unknown })[LAMBDA_COMPUTE_BRAND] === true;
+		return (
+			typeof x === 'object' &&
+			x !== null &&
+			(x as { [LAMBDA_COMPUTE_BRAND]?: unknown })[LAMBDA_COMPUTE_BRAND] === true
+		);
+	}
+
+	protected applyLogRetention(retentionDays: number): void {
+		// `this.logGroup` is a concrete L2 LogGroup this compute created, so its
+		// defaultChild is always the CfnLogGroup — reconfigure retention on the
+		// one group the function already writes to rather than spawning a
+		// competing `/aws/lambda/<fn>` group.
+		(this.logGroup.node.defaultChild as CfnLogGroup).retentionInDays = retentionDays;
+	}
+
+	protected applyTracing(): void {
+		(this.fn.node.defaultChild as CfnFunction).tracingConfig = { mode: 'Active' };
+		this.executionRole.addToPrincipalPolicy(
+			new PolicyStatement({
+				actions: ['xray:PutTraceSegments', 'xray:PutTelemetryRecords'],
+				resources: ['*'],
+			}),
+		);
 	}
 }

--- a/packages/bb-logger/DESIGN.md
+++ b/packages/bb-logger/DESIGN.md
@@ -8,20 +8,26 @@ Design document for Logger. For usage, see [README.md](./README.md).
 
 ## Infrastructure (CDK)
 
-The framework owns a single CloudWatch Logs LogGroup for the shared handler
-Lambda (created by the `BlocksStack`/`BlocksBackend` with retention from the
-stack-wide `defaults.logRetention`). The Logger construct **reconfigures that
-group's retention** rather than creating its own:
+Every compute owns a single CloudWatch Logs LogGroup for its handler (created by
+the compute with retention from the stack-wide `defaults.logRetention`). Logger
+owns **no** infrastructure — it targets the compute it resolves to and calls one
+seam, `compute.enableLogging(options?.retention)`:
 
-- **Retention:** Resolved as `options.retention ?? scope.defaults.logRetention`
-  and applied to the shared handler log group via the L1 escape hatch
-  (`CfnLogGroup.retentionInDays`). An explicit per-Logger `retention` wins over
-  the stack-wide default; both target the one group.
+- **Presence + retention (one call):** `enableLogging` always marks the compute
+  as having a Logger (so the per-compute Dashboard renders its logs section), and
+  when a `retention` is passed, the compute reconfigures **its own** log group
+  (via the L1 `CfnLogGroup.retentionInDays` escape hatch). The compute owns the
+  policy: because several Loggers can target one compute and all describe the
+  same group, the last explicit value wins and a synth warning is emitted on a
+  conflicting value. Targeting the resolved compute means a Logger attached to a
+  non-default compute reconfigures *that* compute's group, not always the
+  default one.
 - **When `retention` is omitted:** The group keeps the stack-wide
-  `defaults.logRetention` already applied by the BlocksStack/BlocksBackend.
+  `defaults.logRetention` the compute already applied — a bare Logger never
+  clobbers a retention another Logger set.
 - **No second LogGroup:** Logger deliberately does not create a
   `/aws/lambda/${handler.functionName}` group of its own — that would collide
-  with the framework-owned group on the log-group name.
+  with the compute-owned group on the log-group name.
 - **Log level env var:** Sets `LOG_LEVEL` on the shared Lambda handler when
   `options.level` is configured. Multiple Logger BBs can coexist with different
   levels via constructor options.

--- a/packages/bb-logger/src/index.cdk.test.ts
+++ b/packages/bb-logger/src/index.cdk.test.ts
@@ -4,101 +4,74 @@
 /**
  * CDK-side tests for Logger.
  *
- * Logger no longer creates its own `/aws/lambda/<fn>` LogGroup (which would
- * collide with the framework-owned handler log group). Instead it reconfigures
- * retention on the single shared group — but ONLY when an explicit
- * `options.retention` is given, so a bare Logger can't clobber a retention set
- * by another Logger or the stack default.
+ * Logger owns no infrastructure. It targets the compute it resolves to: it
+ * always calls `enableLogging()` (presence, so the per-compute Dashboard renders
+ * the logs section) and, only when an explicit `retention` is given, forwards it
+ * via `setLogRetention()`. The compute owns the actual log group and the
+ * last-wins + conflict-warning policy (covered in `@aws-blocks/bb-lambda-compute`
+ * tests), so here we assert only that Logger delegates correctly.
  */
-import { test, describe } from 'node:test';
+import assert from 'node:assert';
+import { describe, test } from 'node:test';
+import { type BlocksDefaults, BlocksPresets, Scope } from '@aws-blocks/core/cdk';
 import * as cdk from 'aws-cdk-lib';
 import type { Construct } from 'constructs';
-import { Annotations, Match, Template } from 'aws-cdk-lib/assertions';
-import { Scope, DEFAULT_NODE_RUNTIME, BlocksPresets, type BlocksDefaults } from '@aws-blocks/core/cdk';
 import { Logger } from './index.cdk.js';
 
+/** Records the observability-seam calls bb-logger makes on its resolved compute. */
+class SpyCompute {
+	/** One entry per `enableLogging` call — the retention arg it was passed. */
+	enableLoggingArgs: Array<number | undefined> = [];
+	enableLogging(retentionDays?: number): void {
+		this.enableLoggingArgs.push(retentionDays);
+	}
+}
+
+// Minimal owner. Logger resolves `this.compute` to the root's `_defaultCompute`
+// and reads `defaults`/`id` off the ambient stack; a spy compute is enough to
+// observe the delegation without provisioning a real log group.
 class StubBlocksStack extends cdk.Stack {
-	public readonly handler: cdk.aws_lambda.Function;
-	public readonly handlerLogGroup: cdk.aws_logs.ILogGroup;
 	public readonly id: string;
 	public readonly defaults: BlocksDefaults;
+	public readonly _defaultCompute = new SpyCompute();
 	constructor(scope: Construct, id: string, defaults: BlocksDefaults) {
 		super(scope, id);
 		this.id = id;
 		this.defaults = defaults;
 		(globalThis as any).CURRENT_BLOCKS_STACK = this;
-		// The framework-owned handler log group carries defaults.logRetention,
-		// exactly as setupBlocksInfra creates it.
-		this.handlerLogGroup = new cdk.aws_logs.LogGroup(this, 'HandlerLogGroup', {
-			retention: defaults.logRetention,
-			removalPolicy: cdk.RemovalPolicy.DESTROY,
-		});
-		this.handler = new cdk.aws_lambda.Function(this, 'StubHandler', {
-			runtime: DEFAULT_NODE_RUNTIME,
-			handler: 'index.handler',
-			code: cdk.aws_lambda.Code.fromInline('exports.handler = async () => {};'),
-			logGroup: this.handlerLogGroup,
-		});
 	}
 }
 
-function setup(defaults: BlocksDefaults = BlocksPresets.production): { stack: StubBlocksStack; parent: Scope } {
+function setup(defaults: BlocksDefaults = BlocksPresets.production): { parent: Scope; compute: SpyCompute } {
 	const app = new cdk.App();
 	const stack = new StubBlocksStack(app, 'LoggerStack', defaults);
 	const parent = new Scope('app');
-	return { stack, parent };
+	return { parent, compute: stack._defaultCompute };
 }
 
-describe('Logger CDK retention', () => {
-	test('does not create a second (colliding) log group', () => {
-		const { stack, parent } = setup();
+describe('Logger CDK (delegates observability to the compute)', () => {
+	test('marks logging on the resolved compute with no retention when none is given', () => {
+		const { parent, compute } = setup();
 		new Logger(parent, 'log', { level: 'info' });
-		const template = Template.fromStack(stack);
-		// Only the framework-owned handler log group exists.
-		template.resourceCountIs('AWS::Logs::LogGroup', 1);
+		assert.deepStrictEqual(compute.enableLoggingArgs, [undefined], 'enableLogging() called once, no retention');
 	});
 
-	test('a bare Logger leaves the stack-wide default retention untouched (no clobber)', () => {
-		const { stack, parent } = setup(BlocksPresets.production);
+	test('a bare Logger enables logging with no retention (no clobber of the stack default)', () => {
+		const { parent, compute } = setup();
 		new Logger(parent, 'log');
-		const template = Template.fromStack(stack);
-		// Retention is whatever setupBlocksInfra set (production → 365); Logger
-		// must not rewrite it.
-		template.hasResourceProperties('AWS::Logs::LogGroup', { RetentionInDays: 365 });
+		assert.deepStrictEqual(compute.enableLoggingArgs, [undefined]);
 	});
 
-	test('an explicit per-Logger retention overrides the shared group retention', () => {
-		const { stack, parent } = setup(BlocksPresets.production);
+	test('forwards an explicit retention to the compute', () => {
+		const { parent, compute } = setup();
 		new Logger(parent, 'log', { retention: 30 });
-		const template = Template.fromStack(stack);
-		template.hasResourceProperties('AWS::Logs::LogGroup', { RetentionInDays: 30 });
-		// Still one group — the override mutates the shared group, not a new one.
-		template.resourceCountIs('AWS::Logs::LogGroup', 1);
+		assert.deepStrictEqual(compute.enableLoggingArgs, [30]);
 	});
 
-	test('the last explicit retention wins; a later bare Logger does not reset it', () => {
-		const { stack, parent } = setup(BlocksPresets.production);
-		new Logger(parent, 'explicit', { retention: 14 });
-		new Logger(parent, 'bare'); // must NOT clobber the 14 above
-		const template = Template.fromStack(stack);
-		template.hasResourceProperties('AWS::Logs::LogGroup', { RetentionInDays: 14 });
-	});
-
-	test('two Loggers with conflicting explicit retention: last wins, with a synth warning', () => {
-		const { stack, parent } = setup(BlocksPresets.production);
+	test('two Loggers each forward their own value (compute enforces last-wins/conflict policy)', () => {
+		const { parent, compute } = setup();
 		new Logger(parent, 'first', { retention: 14 });
 		new Logger(parent, 'second', { retention: 30 });
-		const template = Template.fromStack(stack);
-		// Last explicit value wins on the shared group.
-		template.hasResourceProperties('AWS::Logs::LogGroup', { RetentionInDays: 30 });
-		// …but the clobber is surfaced as a synth warning, not silent.
-		Annotations.fromStack(stack).hasWarning('*', Match.stringLikeRegexp('retention'));
-	});
-
-	test('two Loggers with the SAME explicit retention: no conflict warning', () => {
-		const { stack, parent } = setup(BlocksPresets.production);
-		new Logger(parent, 'first', { retention: 30 });
-		new Logger(parent, 'second', { retention: 30 });
-		Annotations.fromStack(stack).hasNoWarning('*', Match.stringLikeRegexp('retention-conflict|overriding'));
+		assert.deepStrictEqual(compute.enableLoggingArgs, [14, 30]);
 	});
 });

--- a/packages/bb-logger/src/index.cdk.ts
+++ b/packages/bb-logger/src/index.cdk.ts
@@ -1,40 +1,27 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Annotations } from 'aws-cdk-lib';
-import type { CfnLogGroup } from 'aws-cdk-lib/aws-logs';
-import { Scope, registerConfig } from '@aws-blocks/core/cdk';
 import type { ScopeParent } from '@aws-blocks/core';
+import { registerConfig, Scope } from '@aws-blocks/core/cdk';
 import type { LoggingOptions } from './types.js';
-
-/**
- * Marks the explicit retention a `Logger` last wrote to the shared handler log
- * group, so a second `Logger` setting a *different* explicit value can warn
- * about the silent last-wins (both target the one group).
- */
-const EXPLICIT_RETENTION = Symbol.for('BLOCKS_LOGGER_EXPLICIT_RETENTION');
 
 // Re-export public types and errors (no runtime dependencies)
 export { LoggingErrors } from './errors.js';
-export type { LogLevel, LoggingOptions, LogEntry, ChildLogger, RetentionDays } from './types.js';
+export type { ChildLogger, LogEntry, LoggingOptions, LogLevel, RetentionDays } from './types.js';
 
 /**
- * CDK construct for Logger. Sets the retention on the shared handler Lambda's
- * CloudWatch log group and the `LOG_LEVEL` environment variable when configured.
+ * CDK construct for Logger. Sets the `LOG_LEVEL` environment variable when
+ * configured, and reconfigures the resolved compute's log group retention when
+ * an explicit `retention` is given.
  *
- * The framework owns a single log group for the shared handler (created by the
- * BlocksStack/BlocksBackend, already carrying `defaults.logRetention`). Logger
- * reconfigures **that** group's retention rather than creating a second
- * `/aws/lambda/<fn>` group, which would collide on the log-group name.
- *
- * Logger writes the group's retention **only when `options.retention` is
- * explicitly set** — an explicit per-Logger value wins over the stack-wide
- * default. A bare `new Logger(scope, id)` leaves the group's retention
- * untouched: because every Logger targets the same shared group, writing the
- * default back would let the last-constructed Logger silently clobber a
- * `retention` an earlier Logger set (order-dependent). If two Loggers set
- * *different* explicit `retention` values, the last one still wins, but a synth
- * warning is emitted so the ambiguity isn't silent.
+ * Logger owns no infrastructure. It targets the compute it resolves to and
+ * calls `enableLogging(options?.retention)` — the only observability seam it
+ * knows about. That marks the compute as having a Logger (so the per-compute
+ * Dashboard renders its logs section) and, when a `retention` is given, has the
+ * compute reconfigure its **own** single log group (created with the stack-wide
+ * `defaults.logRetention`) rather than spawning a second, competing group. The
+ * compute owns everything else — whether a group already exists, the last-wins
+ * behavior, and the synth conflict warning across multiple Loggers.
  */
 export class Logger extends Scope {
 	constructor(scope: ScopeParent, id: string, options?: LoggingOptions) {
@@ -45,36 +32,9 @@ export class Logger extends Scope {
 			registerConfig(this, 'LOG_LEVEL', options.level);
 		}
 
-		// Override retention on the shared handler log group ONLY when this
-		// Logger explicitly asks for one. Applied via the L1 escape hatch because
-		// a per-block option must reconfigure the framework-owned group, not spawn
-		// a competing one.
-		if (options?.retention) {
-			const cfnLogGroup = this.handlerLogGroup.node.defaultChild as CfnLogGroup | undefined;
-			if (!cfnLogGroup) {
-				// The shared group is always a concrete LogGroup today; guard so an
-				// imported ILogGroup can't silently drop the requested retention.
-				throw new Error(
-					'Logger: cannot apply `retention` — the shared handler log group is not a concrete ' +
-						'LogGroup (it may have been imported). Set retention via the stack-wide ' +
-						'`defaults.logRetention` instead.',
-				);
-			}
-			// All Loggers reconfigure the one shared handler group, so the last
-			// explicit `retention` wins. Warn at synth if a different Logger already
-			// pinned a conflicting value — silent last-wins is otherwise invisible.
-			const prior = (cfnLogGroup as unknown as Record<symbol, number | undefined>)[EXPLICIT_RETENTION];
-			if (prior !== undefined && prior !== options.retention) {
-				Annotations.of(this).addWarningV2(
-					'@aws-blocks/bb-logger:retention-conflict',
-					`Logger "${id}" sets handler log retention to ${options.retention} day(s), overriding an ` +
-						`earlier Logger's explicit ${prior} day(s) — all Loggers share the one handler log group, ` +
-						'so the last-constructed value wins. Set a single explicit `retention` (or rely on the ' +
-						'stack-wide `defaults.logRetention`) to avoid the ambiguity.',
-				);
-			}
-			cfnLogGroup.retentionInDays = options.retention;
-			(cfnLogGroup as unknown as Record<symbol, number | undefined>)[EXPLICIT_RETENTION] = options.retention;
-		}
+		// Signal to the resolved compute that a Logger is attached (so the
+		// Dashboard renders its logs section) and, when set, forward the desired
+		// retention. The compute owns whether/how to apply it.
+		this.compute.enableLogging(options?.retention);
 	}
 }

--- a/packages/bb-tracer/DESIGN.md
+++ b/packages/bb-tracer/DESIGN.md
@@ -35,13 +35,16 @@ Beyond `addAnnotation` and `addMetadata`, `Segment` exposes two additional metho
 
 ## Infrastructure (CDK)
 
-Tracer is a **composite Building Block** — it creates no new AWS resources. It configures tracing on the parent scope's Lambda function:
+Tracer is a **composite Building Block** — it creates no new AWS resources. It
+**delegates to its resolved compute** by calling `this.compute.enableTracing()`,
+so tracing targets whichever compute backs the block. For a Lambda compute that
+turns on:
 
-- **Tracing mode:** Sets `TracingConfig.Mode = 'Active'` on the Lambda `CfnFunction` (L1 construct).
-- **IAM permissions:** Adds `xray:PutTraceSegments` and `xray:PutTelemetryRecords` on resource `'*'` to the Lambda execution role.
+- **Tracing mode:** `TracingConfig.Mode = 'Active'` on the Lambda `CfnFunction` (L1 construct).
+- **IAM permissions:** `xray:PutTraceSegments` and `xray:PutTelemetryRecords` on resource `'*'`, added to the shared execution role.
 - **No sampling rules:** X-Ray sampling rules are not managed by this BB. The default sampling rule (1 req/sec + 5% of additional requests) applies unless configured externally.
 
-When `enabled: false` is passed, no CDK mutations occur — the Lambda runs without active tracing.
+When `enabled: false` is passed, `enableTracing()` is not called — no CDK mutations occur and the compute runs without active tracing.
 
 ## Mock Implementation
 

--- a/packages/bb-tracer/src/index.cdk.ts
+++ b/packages/bb-tracer/src/index.cdk.ts
@@ -1,26 +1,20 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import type { CfnFunction } from 'aws-cdk-lib/aws-lambda';
-import { PolicyStatement } from 'aws-cdk-lib/aws-iam';
-import { Scope } from '@aws-blocks/core/cdk';
 import type { ScopeParent } from '@aws-blocks/core';
-import type { TracerOptions, Segment, AnnotationValue } from './types.js';
+import { Scope } from '@aws-blocks/core/cdk';
+import type { TracerOptions } from './types.js';
 
-export type { TracerOptions, Segment, AnnotationValue } from './types.js';
+export type { AnnotationValue, Segment, TracerOptions } from './types.js';
 
 export class Tracer extends Scope {
 	constructor(scope: ScopeParent, id: string, options?: TracerOptions) {
 		super(id, { parent: scope });
 
 		if (options?.enabled !== false) {
-			const cfnFunction = this.handler.node.defaultChild as CfnFunction;
-			cfnFunction.tracingConfig = { mode: 'Active' };
-
-			this.handler.addToRolePolicy(new PolicyStatement({
-				actions: ['xray:PutTraceSegments', 'xray:PutTelemetryRecords'],
-				resources: ['*'],
-			}));
+			// The compute owns marking itself traced + turning on active tracing;
+			// the Tracer only signals intent by calling enableTracing().
+			this.compute.enableTracing();
 		}
 	}
 }

--- a/packages/core/src/cdk/blocks-backend.test.ts
+++ b/packages/core/src/cdk/blocks-backend.test.ts
@@ -57,6 +57,9 @@ class StubLambdaCompute extends Compute {
 	setEnv(key: string, value: string): void {
 		this.fn.addEnvironment(key, value);
 	}
+
+	protected applyLogRetention(_retentionDays: number): void {}
+	protected applyTracing(): void {}
 }
 
 const stubComputeFactory: DefaultComputeFactory = (root) => new StubLambdaCompute(root as never, 'DefaultCompute');
@@ -77,7 +80,12 @@ const importMetaHandlerPath = join(__dirname, '__fixtures__', 'import-meta-handl
 // Wraps BlocksBackend.create, injecting the stub default-compute factory the way
 // @aws-blocks/blocks injects LambdaCompute — so tests don't repeat it 15 times.
 const makeBackend = (scope: Construct, id: string, backendCDKPath: string) =>
-	BlocksBackend.create(scope, id, { backendHandlerPath: handlerPath, backendCDKPath, defaults: BlocksPresets.production, defaultComputeFactory: stubComputeFactory });
+	BlocksBackend.create(scope, id, {
+		backendHandlerPath: handlerPath,
+		backendCDKPath,
+		defaults: BlocksPresets.production,
+		defaultComputeFactory: stubComputeFactory,
+	});
 
 describe('ESM cache-busting (multi-stage)', () => {
 	test('BlocksBackend.create() with same backendCDKPath but different IDs produces constructs in each', async () => {
@@ -230,25 +238,25 @@ describe('shared execution role', () => {
 });
 
 describe('CJS bundle: import.meta.url in the handler is shimmed (no Lambda-load crash)', () => {
-  test('a handler that uses import.meta.url bundles successfully instead of throwing at load', async () => {
-    // The handler is bundled to CJS, where `import.meta` is empty. Left unshimmed,
-    // `fileURLToPath(import.meta.url)` compiles to `fileURLToPath(undefined)` and
-    // throws at Lambda load (esbuild only warns, so the broken bundle would deploy).
-    // blocksNodejsBundling shims import.meta.* to CommonJS equivalents, so bundling
-    // (which runs synchronously during construction) succeeds. The runtime behaviour
-    // of the emitted shim is verified directly in bundling.test.ts.
-    const app = new cdk.App();
-    const stack = new cdk.Stack(app, 'ImportMetaStack');
+	test('a handler that uses import.meta.url bundles successfully instead of throwing at load', async () => {
+		// The handler is bundled to CJS, where `import.meta` is empty. Left unshimmed,
+		// `fileURLToPath(import.meta.url)` compiles to `fileURLToPath(undefined)` and
+		// throws at Lambda load (esbuild only warns, so the broken bundle would deploy).
+		// blocksNodejsBundling shims import.meta.* to CommonJS equivalents, so bundling
+		// (which runs synchronously during construction) succeeds. The runtime behaviour
+		// of the emitted shim is verified directly in bundling.test.ts.
+		const app = new cdk.App();
+		const stack = new cdk.Stack(app, 'ImportMetaStack');
 
-    await assert.doesNotReject(() =>
-      BlocksBackend.create(stack, 'blocks', {
-        backendHandlerPath: importMetaHandlerPath,
-        backendCDKPath: sideEffectBackendPath,
-        defaults: BlocksPresets.production,
-        defaultComputeFactory: stubComputeFactory,
-      }),
-    );
-  });
+		await assert.doesNotReject(() =>
+			BlocksBackend.create(stack, 'blocks', {
+				backendHandlerPath: importMetaHandlerPath,
+				backendCDKPath: sideEffectBackendPath,
+				defaults: BlocksPresets.production,
+				defaultComputeFactory: stubComputeFactory,
+			}),
+		);
+	});
 });
 
 describe('factory function support', () => {
@@ -348,44 +356,44 @@ describe('fullId is token-free (construct IDs / env-var keys)', () => {
 });
 
 describe('infrastructure defaults (backend-anchored)', () => {
-  test('each backend exposes its own defaults', async () => {
-    const app = new cdk.App();
-    const stack = new cdk.Stack(app, 'TwoBackendsStack');
+	test('each backend exposes its own defaults', async () => {
+		const app = new cdk.App();
+		const stack = new cdk.Stack(app, 'TwoBackendsStack');
 
-    const a = await BlocksBackend.create(stack, 'A', {
-      backendHandlerPath: handlerPath,
-      backendCDKPath: sideEffectBackendPath,
-      defaults: BlocksPresets.production,
-      defaultComputeFactory: stubComputeFactory,
-    });
-    const b = await BlocksBackend.create(stack, 'B', {
-      backendHandlerPath: handlerPath,
-      backendCDKPath: sideEffectBackendPath,
-      defaults: BlocksPresets.sandbox,
-      defaultComputeFactory: stubComputeFactory,
-    });
+		const a = await BlocksBackend.create(stack, 'A', {
+			backendHandlerPath: handlerPath,
+			backendCDKPath: sideEffectBackendPath,
+			defaults: BlocksPresets.production,
+			defaultComputeFactory: stubComputeFactory,
+		});
+		const b = await BlocksBackend.create(stack, 'B', {
+			backendHandlerPath: handlerPath,
+			backendCDKPath: sideEffectBackendPath,
+			defaults: BlocksPresets.sandbox,
+			defaultComputeFactory: stubComputeFactory,
+		});
 
-    // Two backends in one stack must NOT clobber each other — defaults are
-    // anchored on the backend, not the shared stack.
-    assert.strictEqual(a.defaults, BlocksPresets.production);
-    assert.strictEqual(b.defaults, BlocksPresets.sandbox);
-  });
+		// Two backends in one stack must NOT clobber each other — defaults are
+		// anchored on the backend, not the shared stack.
+		assert.strictEqual(a.defaults, BlocksPresets.production);
+		assert.strictEqual(b.defaults, BlocksPresets.sandbox);
+	});
 
-  test('a nested block resolves its owning backend defaults via the tree-walk', async () => {
-    const app = new cdk.App();
-    const stack = new cdk.Stack(app, 'ResolveDefaultsStack');
+	test('a nested block resolves its owning backend defaults via the tree-walk', async () => {
+		const app = new cdk.App();
+		const stack = new cdk.Stack(app, 'ResolveDefaultsStack');
 
-    const backend = await BlocksBackend.create(stack, 'Blocks', {
-      backendHandlerPath: handlerPath,
-      backendCDKPath: sideEffectBackendPath,
-      defaults: BlocksPresets.sandbox,
-      defaultComputeFactory: stubComputeFactory,
-    });
+		const backend = await BlocksBackend.create(stack, 'Blocks', {
+			backendHandlerPath: handlerPath,
+			backendCDKPath: sideEffectBackendPath,
+			defaults: BlocksPresets.sandbox,
+			defaultComputeFactory: stubComputeFactory,
+		});
 
-    // A Scope under the backend resolves scope.defaults by walking up to it.
-    const outer = new Scope('outer');
-    const inner = new Scope('inner', { parent: outer });
-    assert.strictEqual(inner.defaults, backend.defaults);
-    assert.strictEqual(inner.defaults, BlocksPresets.sandbox);
-  });
+		// A Scope under the backend resolves scope.defaults by walking up to it.
+		const outer = new Scope('outer');
+		const inner = new Scope('inner', { parent: outer });
+		assert.strictEqual(inner.defaults, backend.defaults);
+		assert.strictEqual(inner.defaults, BlocksPresets.sandbox);
+	});
 });

--- a/packages/core/src/cdk/blocks-stack.test.ts
+++ b/packages/core/src/cdk/blocks-stack.test.ts
@@ -15,7 +15,7 @@ import { BlocksBackend } from './blocks-backend.js';
 import { Compute } from './compute/compute.js';
 import { getComputes } from './compute/compute-registry.js';
 import type { DefaultComputeFactory } from './compute/default-compute-factory.js';
-import { BlocksStack, BlocksPresets, Scope } from './index.js';
+import { BlocksPresets, BlocksStack, Scope } from './index.js';
 
 // A real app gets its default compute from @aws-blocks/bb-lambda-compute (via
 // @aws-blocks/blocks), which core's own tests can't depend on. Use an
@@ -55,6 +55,9 @@ class StubLambdaCompute extends Compute {
 	setEnv(key: string, value: string): void {
 		this.fn.addEnvironment(key, value);
 	}
+
+	protected applyLogRetention(_retentionDays: number): void {}
+	protected applyTracing(): void {}
 }
 
 const stubComputeFactory: DefaultComputeFactory = (root) => new StubLambdaCompute(root as never, 'DefaultCompute');
@@ -72,9 +75,19 @@ const factoryBackendPath = join(__dirname, '__fixtures__', 'factory-backend.js')
 // Wrap create(), injecting the stub default-compute factory the way
 // @aws-blocks/blocks injects LambdaCompute — so tests don't repeat it.
 const makeStack = (scope: Construct, id: string, backendCDKPath: string) =>
-	BlocksStack.create(scope, id, { backendHandlerPath: handlerPath, backendCDKPath, defaults: BlocksPresets.production, defaultComputeFactory: stubComputeFactory });
+	BlocksStack.create(scope, id, {
+		backendHandlerPath: handlerPath,
+		backendCDKPath,
+		defaults: BlocksPresets.production,
+		defaultComputeFactory: stubComputeFactory,
+	});
 const makeBackend = (scope: Construct, id: string, backendCDKPath: string) =>
-	BlocksBackend.create(scope, id, { backendHandlerPath: handlerPath, backendCDKPath, defaults: BlocksPresets.production, defaultComputeFactory: stubComputeFactory });
+	BlocksBackend.create(scope, id, {
+		backendHandlerPath: handlerPath,
+		backendCDKPath,
+		defaults: BlocksPresets.production,
+		defaultComputeFactory: stubComputeFactory,
+	});
 
 describe('ESM cache-busting (multi-stage)', () => {
 	test('BlocksStack.create() with same backendCDKPath but different IDs produces constructs in each', async () => {
@@ -203,16 +216,13 @@ describe('assertCdkConditionActive', () => {
 		try {
 			const app = new cdk.App();
 
-			await assert.rejects(
-				makeStack(app, 'MissingConditionStack', sideEffectBackendPath),
-				(err: Error) => {
-					assert.ok(
-						err.message.includes('Missing --conditions=cdk'),
-						`Expected condition error, got: ${err.message}`,
-					);
-					return true;
-				},
-			);
+			await assert.rejects(makeStack(app, 'MissingConditionStack', sideEffectBackendPath), (err: Error) => {
+				assert.ok(
+					err.message.includes('Missing --conditions=cdk'),
+					`Expected condition error, got: ${err.message}`,
+				);
+				return true;
+			});
 		} finally {
 			process.env.NODE_OPTIONS = origNodeOptions;
 			process.execArgv = origExecArgv;

--- a/packages/core/src/cdk/compute/compute.ts
+++ b/packages/core/src/cdk/compute/compute.ts
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { Annotations } from 'aws-cdk-lib';
 import type { ScopeOptions } from '../../common/index.js';
 import { Scope } from '../index.js';
 import { registerCompute } from './compute-registry.js';
@@ -30,6 +31,14 @@ export abstract class Compute extends Scope {
 	 */
 	readonly namespaces: string[] = [];
 
+	/**
+	 * The last explicit log retention (in days) written via {@link enableLogging}.
+	 * Tracked so a later, conflicting explicit value can warn about the silent
+	 * last-wins (several Loggers can target one compute and all describe its one
+	 * log group). Private — only {@link enableLogging} sets it.
+	 */
+	private explicitLogRetentionDays?: number;
+
 	constructor(id: string, options?: ScopeOptions) {
 		super(id, options);
 		// Self-register on the owning stack so finalize steps (config, routing,
@@ -44,4 +53,62 @@ export abstract class Compute extends Scope {
 	 * directly so config targets the right compute.
 	 */
 	abstract setEnv(key: string, value: string): void;
+
+	/**
+	 * Attach a Logger to this compute. When an explicit `retentionDays` is given,
+	 * sets the retention on the compute's single log group. The Logger Building
+	 * Block calls this so logging targets the right compute without touching a
+	 * specific function's log group.
+	 *
+	 * The Logger only knows about `enableLogging`; the compute owns the rest. A
+	 * compute already owns one log group (created with the stack-wide
+	 * `defaults.logRetention`), so no second group is spawned. The compute also
+	 * owns the shared policy for `retentionDays`: because several Loggers can
+	 * target one compute and all describe the same group, the **last** explicit
+	 * value wins and a synth warning is emitted if a later call disagrees with an
+	 * earlier one (so the clobber isn't silent). A bare `enableLogging()` (no
+	 * `retentionDays`) leaves the group's retention untouched.
+	 *
+	 * @param retentionDays - Optional CloudWatch Logs retention, in days. When
+	 *   omitted, the group keeps the stack-wide `defaults.logRetention`.
+	 */
+	enableLogging(retentionDays?: number): void {
+		if (retentionDays === undefined) return;
+
+		if (this.explicitLogRetentionDays !== undefined && this.explicitLogRetentionDays !== retentionDays) {
+			Annotations.of(this).addWarningV2(
+				'@aws-blocks/core:log-retention-conflict',
+				`Compute "${this.id}": log retention set to ${retentionDays} day(s), overriding an earlier ` +
+					`explicit ${this.explicitLogRetentionDays} day(s) — all Loggers on a compute share its one ` +
+					'log group, so the last value wins. Set a single explicit retention (or rely on the ' +
+					'stack-wide `defaults.logRetention`) to avoid the ambiguity.',
+			);
+		}
+		this.explicitLogRetentionDays = retentionDays;
+		this.applyLogRetention(retentionDays);
+	}
+
+	/**
+	 * Reconfigure this compute's log group retention to `retentionDays`.
+	 * Implemented by the concrete compute (which owns the group); invoked only
+	 * via {@link enableLogging} so the last-wins + conflict-warning policy always
+	 * runs. `protected` so retention can't be changed without that policy.
+	 */
+	protected abstract applyLogRetention(retentionDays: number): void;
+
+	/**
+	 * Enable distributed tracing on this compute: turn on the compute's active
+	 * tracing via {@link applyTracing}. The Tracer Building Block calls this
+	 * instead of poking a specific function so tracing targets the right compute.
+	 */
+	enableTracing(): void {
+		this.applyTracing();
+	}
+
+	/**
+	 * Turn on this compute's active tracing (e.g. X-Ray) and grant its role the
+	 * permission to publish trace segments. Called by {@link enableTracing};
+	 * `protected` so tracing can't be turned on without going through it.
+	 */
+	protected abstract applyTracing(): void;
 }

--- a/packages/core/src/cdk/config-registry.test.ts
+++ b/packages/core/src/cdk/config-registry.test.ts
@@ -42,6 +42,11 @@ class TestCompute extends Compute {
 	setEnv(key: string, value: string): void {
 		this.fn.addEnvironment(key, value);
 	}
+
+	// Observability hooks are irrelevant to config-registry tests — stub them so
+	// this test double satisfies Compute's abstract contract.
+	protected applyLogRetention(): void {}
+	protected applyTracing(): void {}
 }
 
 function stackWithCompute(id: string): {


### PR DESCRIPTION
Part 1 of 2 (stacked) — the compute observability seam, split out of #462.

## What
Move logging-retention and tracing ownership from the observability Building Blocks into the `Compute` abstraction:
- `Compute.enableLogging(retentionDays?)` — sets retention on the compute's single log group when a value is given; owns the last-wins + synth conflict-warning policy across multiple Loggers.
- `Compute.enableTracing()` — turns on active X-Ray tracing + trace-publish permission on the shared role.
- `applyLogRetention` / `applyTracing` are `protected` abstract hooks implemented by `LambdaCompute`, so the policy always runs.
- `bb-logger` and `bb-tracer` now delegate to the resolved compute instead of reaching into the shared handler's log group / function directly.

No dashboard changes here — those are in the stacked PR on top.

## Stack
- **#504 (this) — base `main`**
- #505 — per-compute Dashboard, base this branch

## Test
`build`, `biome check`, `lint:deps`, and unit tests (bb-lambda-compute, bb-logger, bb-tracer, bb-async-job, bb-cron-job, core targeted) pass on Node 22.
