### PR TITLE
fix(bb-agent): widen UseChatOptions.api sendMessage/resume return types to Promise<unknown>

### DIFF
--- a/.changeset/usechat-api-return-types.md
+++ b/.changeset/usechat-api-return-types.md
@@ -1,0 +1,8 @@
+---
+"@aws-blocks/bb-agent": patch
+"@aws-blocks/blocks": patch
+---
+
+`useChat`: widen `UseChatOptions.api.sendMessage` and `resume` return types from `Promise<void>` to `Promise<unknown>`.
+
+The natural backend methods return objects (`agent.stream()` → `{ channelId }`, `resume` wrappers → `{ ok: true }`), but `Promise<{ channelId }>` is not assignable to `Promise<void>` (TS2322), which forced customers into an await-and-discard wrapper. `useChat` awaits both calls only for completion and discards the resolved value, so `Promise<unknown>` — assignable-from both object results and `void` — lets natural-shape backends wire up directly while existing `void`-returning backends keep compiling. Type-only change; no runtime behavior change.

--- a/packages/bb-agent/README.md
+++ b/packages/bb-agent/README.md
@@ -763,7 +763,8 @@ export const api = new ApiNamespace(scope, 'api', (context) => ({
     return { conversationId: await agent.createConversationId(userId) };
   },
   async sendMessage(conversationId: string, message: string, channelId: string, userId: string) {
-    await agent.stream(message, { conversationId, channelId, userId });
+    const result = await agent.stream(message, { conversationId, channelId, userId });
+    return { channelId: result.channelId };
   },
   async getConversation(conversationId: string) {
     const messages = await agent.getConversation(conversationId);

--- a/packages/bb-agent/src/index.hooks.ts
+++ b/packages/bb-agent/src/index.hooks.ts
@@ -29,10 +29,10 @@ export interface ChatMessage {
 /** Options for creating a chat instance. */
 export interface UseChatOptions {
 	api: {
-		sendMessage(conversationId: string, message: string, channelId: string): Promise<void>;
+		sendMessage(conversationId: string, message: string, channelId: string): Promise<unknown>;
 		createConversation(): Promise<{ conversationId: string }>;
 		getConversation(id: string): Promise<{ messages: { role: string; content: string; metadata?: Record<string, any> }[] }>;
-		resume?(channelId: string, responses: Array<{ interruptId: string; approved: boolean; trust?: boolean; toolName?: string; input?: any }>, conversationId?: string): Promise<void>;
+		resume?(channelId: string, responses: Array<{ interruptId: string; approved: boolean; trust?: boolean; toolName?: string; input?: any }>, conversationId?: string): Promise<unknown>;
 		getPendingInterrupts?(conversationId: string): Promise<{ interrupts: Array<{ id: string; name: string; reason?: any }> }>;
 	};
 	/**

--- a/packages/bb-agent/src/index.test.ts
+++ b/packages/bb-agent/src/index.test.ts
@@ -1185,8 +1185,32 @@ describe('model-factory', () => {
 // ── useChat ──────────────────────────────────────────────────────────────────
 
 import { useChat } from './index.hooks.js';
+import type { UseChatOptions } from './index.hooks.js';
 
 describe('useChat', () => {
+	// Type-only regression guard for the api return-type contract (PR that widened
+	// sendMessage/resume from Promise<void> to Promise<unknown>). This is compiled by
+	// `tsc --build` before the runtime tests execute, so narrowing either member back
+	// to Promise<void> fails CI here — the durable proof the manual PR check could not
+	// commit. `unknown` must accept BOTH a natural object-returning backend and a
+	// void-returning one; both assignments below must type-check.
+	test('api sendMessage/resume accept object- and void-returning backends (type-only)', () => {
+		const objectBackend: UseChatOptions['api'] = {
+			sendMessage: async () => ({ channelId: 'c' }),
+			createConversation: async () => ({ conversationId: 'c' }),
+			getConversation: async () => ({ messages: [] }),
+			resume: async () => ({ ok: true }),
+		};
+		const voidBackend: UseChatOptions['api'] = {
+			sendMessage: async () => {},
+			createConversation: async () => ({ conversationId: 'c' }),
+			getConversation: async () => ({ messages: [] }),
+			resume: async () => {},
+		};
+		assert.ok(objectBackend.sendMessage);
+		assert.ok(voidBackend.sendMessage);
+	});
+
 	test('onError is called when error chunk arrives', async () => {
 		let chunkHandler: (chunk: any) => void;
 		let errorReceived: string | undefined;


### PR DESCRIPTION
## Problem

`useChat`'s `UseChatOptions.api` types `sendMessage` and `resume` as `Promise<void>`, but the natural backend methods return objects — `agent.stream()` resolves to `{ channelId }` and the `resume` wrappers to `{ ok: true }`. `Promise<{ channelId }>` is not assignable to `Promise<void>` (TS2322: `'{ channelId: string; }' is not assignable to 'void'`), so a customer with a natural backend is forced into an await-and-discard wrapper:

```ts
// forced today:
sendMessage: async (convId, msg, chId) => { await api.sendMessage(convId, msg, chId); },
// wanted:
sendMessage: (convId, msg, chId) => api.sendMessage(convId, msg, chId),
```

`useChat` awaits both calls purely for completion and **discards the resolved value** (`index.hooks.ts` — `await options.api.sendMessage(...)` and `await options.api.resume(...)`), so the strict `Promise<void>` is unnecessarily narrow and buys nothing.

The README backend example currently dodges this by having `sendMessage` return `void` (it awaits `agent.stream()` without returning `{ channelId }`) — the very workaround this change removes. The comprehensive test-app's `agentStream` returns `{ channelId }` and `agentResume` returns `{ ok: true }`, the natural shapes that hit the friction.

**Issue #, if available:**
no linked issue: reported via bug bash, no issue was filed.

## Changes

- `packages/bb-agent/src/index.hooks.ts`: widen `UseChatOptions.api.sendMessage` and `resume?` return types from `Promise<void>` to `Promise<unknown>`. `unknown` is assignable-from both `{ ... }` results and `void`, and since the hook discards the value this only widens what callers may return — no runtime behavior change, and existing `void`-returning backends keep compiling (backward compatible).
- `packages/bb-agent/README.md`: simplify the backend `sendMessage` example to `return { channelId }`, showing the natural, more useful shape now that the clean frontend wiring compiles.

The public `ChatInstance.sendMessage` / `respondToInterrupt` stay `Promise<void>` — those genuinely surface no value to the UI consumer. The change is scoped to the boundary where customer backends plug in.

## Validation

- Verified the original friction reproduces the exact `TS2322` (`Promise<{ channelId: string; }>` not assignable to `Promise<void>`) and that `Promise<unknown>` accepts both a natural `{ channelId }` / `{ ok }` backend and an existing `void` backend, confirming the fix works and is backward compatible.
- Typechecked the edited `index.hooks.ts` in isolation (it only imports `./types.js`) — clean.
- No API report drift: `API.md` is generated by API Extractor from `dist/index.aws.d.ts` (the CDK/server entry point); `UseChatOptions` lives in the client entry point `index.hooks.ts` and does not appear in `API.md`, so no regeneration is needed.

## Manual verification

N/A — type-only change plus a doc example; unit-level type assertions cover the behavior.

## Checklist

- [x] PR description included
- [ ] Tests are changed or added — N/A, this is a type-signature widening; no runtime code path changes and no new test hook exists for the client entry-point type surface
- [x] Relevant documentation is changed or added (README backend example updated)

