### PR TITLE
fix(bb-cron-job): grant scheduler role access to all computes

### DIFF
--- a/.changeset/quiet-methods-adjust.md
+++ b/.changeset/quiet-methods-adjust.md
@@ -1,0 +1,5 @@
+---
+'@aws-blocks/bb-cron-job': patch
+---
+
+Grant the shared scheduler role permission to invoke every CronJob target compute.

--- a/packages/bb-cron-job/src/index.cdk.test.ts
+++ b/packages/bb-cron-job/src/index.cdk.test.ts
@@ -100,6 +100,31 @@ describe('CronJob compute targeting', () => {
 			'schedule does NOT target the default compute',
 		);
 	});
+
+	test('shared scheduler role can invoke every targeted compute', async () => {
+		const stack = await makeStack('CronMultipleComputes');
+		new CronJob(stack, 'defaultJob', { schedule: 'rate(1 day)', handler: async () => {} });
+
+		const lambdaB = new LambdaCompute(stack, 'LambdaB');
+		const scoped = new Scope('scoped', { parent: stack });
+		scoped._compute = lambdaB;
+		new CronJob(scoped, 'targetedJob', { schedule: 'rate(1 day)', handler: async () => {} });
+
+		const policies = Template.fromStack(stack).findResources('AWS::IAM::Policy');
+		const schedulerPolicy = Object.values(policies).find((policy) =>
+			JSON.stringify(policy).includes('BlocksSchedulerRole'),
+		);
+		assert.ok(schedulerPolicy, 'shared scheduler role has an IAM policy');
+		const policyDocument = JSON.stringify(schedulerPolicy);
+		assert.ok(
+			policyDocument.includes(fnLogicalId(stack, stack._defaultCompute as LambdaCompute)),
+			'scheduler role can invoke the default compute',
+		);
+		assert.ok(
+			policyDocument.includes(fnLogicalId(stack, lambdaB)),
+			'scheduler role can invoke the scoped compute',
+		);
+	});
 });
 
 describe('CronJob synth-time schedule validation', () => {

--- a/packages/bb-cron-job/src/index.cdk.ts
+++ b/packages/bb-cron-job/src/index.cdk.ts
@@ -73,18 +73,33 @@ export class CronJob<T = void> extends Scope {
 
 const SCHEDULER_ROLE_KEY = Symbol.for('BLOCKS_SCHEDULER_ROLE');
 
+interface SchedulerRoleState {
+	role: iam.Role;
+	handlerArns: Set<string>;
+}
+
 function getOrCreateSchedulerRole(stack: cdk.Stack, handlerArn: string): iam.Role {
-	const existing = (stack as any)[SCHEDULER_ROLE_KEY] as iam.Role | undefined;
-	if (existing) return existing;
+	const existing = (stack as any)[SCHEDULER_ROLE_KEY] as SchedulerRoleState | undefined;
+	if (existing) {
+		if (!existing.handlerArns.has(handlerArn)) {
+			grantSchedulerInvocation(existing.role, handlerArn);
+			existing.handlerArns.add(handlerArn);
+		}
+		return existing.role;
+	}
 
 	const role = new iam.Role(stack, 'BlocksSchedulerRole', {
 		assumedBy: new iam.ServicePrincipal('scheduler.amazonaws.com'),
 	});
+	grantSchedulerInvocation(role, handlerArn);
+
+	(stack as any)[SCHEDULER_ROLE_KEY] = { role, handlerArns: new Set([handlerArn]) } satisfies SchedulerRoleState;
+	return role;
+}
+
+function grantSchedulerInvocation(role: iam.Role, handlerArn: string): void {
 	role.addToPolicy(new iam.PolicyStatement({
 		actions: ['lambda:InvokeFunction'],
 		resources: [handlerArn],
 	}));
-
-	(stack as any)[SCHEDULER_ROLE_KEY] = role;
-	return role;
 }


### PR DESCRIPTION
## Problem

After #459, CronJob correctly targets its resolved Lambda compute. The Scheduler IAM role remains shared per stack, however, and only receives `lambda:InvokeFunction` for the first CronJob target. A later CronJob targeting a different resolved Lambda synthesizes a correct schedule target but lacks permission for EventBridge Scheduler to invoke it.

**Issue #:** N/A

## Changes

- Track the Lambda ARNs already granted to the shared Scheduler role.
- Add one `lambda:InvokeFunction` grant for each distinct CronJob target compute while preserving the existing single shared role per stack.
- Add a synth regression test with default and scoped Lambda computes that verifies the shared Scheduler role policy includes both targets.
- Add a patch changeset for `@aws-blocks/bb-cron-job`.

## Validation

- `npm run build --workspace @aws-blocks/bb-cron-job`
- `npm test --workspace @aws-blocks/bb-cron-job` (65 passing)
- `npm run lint`
- `npm run lint:deps`
- `npx changeset status --since=origin/main`
- `git diff --check`

## Checklist

- [x] PR description included
- [x] Tests are changed or added
- [ ] Relevant documentation is changed or added (not applicable: this fixes internal IAM synthesis behavior without changing the public API)

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._