### PR TITLE
chore: add npm keywords to published packages for discoverability (#491)

### DIFF
--- a/.changeset/npm-keywords-discoverability.md
+++ b/.changeset/npm-keywords-discoverability.md
@@ -30,8 +30,8 @@
 
 Add npm keywords for discoverability via `npm search keywords:aws-blocks`
 
-Every published package now carries an npm `keywords` array: the umbrella keywords
-`aws-blocks`, `aws`, `cdk` on all of them, plus 2–5 functional keywords describing
-the package's domain (e.g. `realtime`, `websocket`, `pubsub` for `bb-realtime`;
+Every published package now carries an npm `keywords` array: the shared `aws-blocks`
+discovery tag plus 2–5 functional keywords describing the package's domain and the
+AWS services it uses (e.g. `realtime`, `websocket`, `pubsub` for `bb-realtime`;
 `ci-cd`, `pipelines`, `deployment` for `pipeline`). Metadata only — no runtime,
 API, or behavior change.

--- a/.changeset/npm-keywords-discoverability.md
+++ b/.changeset/npm-keywords-discoverability.md
@@ -1,0 +1,37 @@
+---
+"@aws-blocks/auth-common": patch
+"@aws-blocks/bb-agent": patch
+"@aws-blocks/bb-app-setting": patch
+"@aws-blocks/bb-async-job": patch
+"@aws-blocks/bb-auth-basic": patch
+"@aws-blocks/bb-auth-cognito": patch
+"@aws-blocks/bb-auth-oidc": patch
+"@aws-blocks/bb-cron-job": patch
+"@aws-blocks/bb-dashboard": patch
+"@aws-blocks/bb-data": patch
+"@aws-blocks/bb-distributed-data": patch
+"@aws-blocks/bb-distributed-table": patch
+"@aws-blocks/bb-email-client": patch
+"@aws-blocks/bb-file-bucket": patch
+"@aws-blocks/bb-knowledge-base": patch
+"@aws-blocks/bb-kv-store": patch
+"@aws-blocks/bb-lambda-compute": patch
+"@aws-blocks/bb-logger": patch
+"@aws-blocks/bb-metrics": patch
+"@aws-blocks/bb-realtime": patch
+"@aws-blocks/bb-tracer": patch
+"@aws-blocks/blocks": patch
+"@aws-blocks/core": patch
+"@aws-blocks/create-blocks-app": patch
+"@aws-blocks/data-common": patch
+"@aws-blocks/hosting": patch
+"@aws-blocks/pipeline": patch
+---
+
+Add npm keywords for discoverability via `npm search keywords:aws-blocks`
+
+Every published package now carries an npm `keywords` array: the umbrella keywords
+`aws-blocks`, `aws`, `cdk` on all of them, plus 2–5 functional keywords describing
+the package's domain (e.g. `realtime`, `websocket`, `pubsub` for `bb-realtime`;
+`ci-cd`, `pipelines`, `deployment` for `pipeline`). Metadata only — no runtime,
+API, or behavior change.

--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -29,6 +29,8 @@ jobs:
       # here instead of as a wrong verdict in the steps below.
       - name: Test the changeset guards
         run: node --test scripts/changeset-guard.test.mjs
+      - name: Test the keyword guard
+        run: node --test scripts/keywords-guard.test.mjs
       # Catches malformed changesets (broken frontmatter, unknown package,
       # invalid bump type) that the regex parser silently ignores and would
       # otherwise fail post-merge at `changeset version`. Validates only the
@@ -49,3 +51,10 @@ jobs:
       # treat removing an existing one as the same failure.
       - name: Verify the umbrella is bumped with its siblings
         run: node --experimental-strip-types scripts/changeset-guard.ts verify-umbrella
+      # `npm search keywords:aws-blocks` is the discovery path the publishing
+      # guide documents, and a package missing the tag still builds, tests and
+      # publishes cleanly — it just never shows up in that search. #491 was
+      # exactly that, across every published package, so assert the tag here
+      # instead of relying on review to spot its absence.
+      - name: Verify every published package carries the aws-blocks keyword
+        run: node --experimental-strip-types scripts/keywords-guard.ts verify-discovery-tag

--- a/docs/guides/extending-with-existing-aws-resources.md
+++ b/docs/guides/extending-with-existing-aws-resources.md
@@ -483,7 +483,7 @@ Blocks BB ships. Once your BB is generally useful, you can publish it.
 {
   "name": "@your-org/bb-queue",
   "version": "0.1.0",
-  "keywords": ["aws-blocks"],   // <-- TODO: confirm final tag with the Blocks team
+  "keywords": ["aws-blocks", "queue"],
   "exports": { /* ... cdk / aws-runtime / default conditions ... */ }
 }
 ```
@@ -495,9 +495,11 @@ BBs by searching npm:
 npm search keywords:aws-blocks
 ```
 
-> **TODO** — the official discovery tag is pending finalization with the
-> Blocks team. `aws-blocks` is the proposed value; this guide will be
-> updated when the tag is confirmed.
+`aws-blocks` is the confirmed discovery tag — every first-party Blocks package
+carries it, so tagging your BB with it makes it discoverable alongside them.
+You can optionally add functional keywords describing what your BB does (e.g.
+`queue`), but `aws-blocks` is the one that matters for discovery. Keep keywords
+accurate to what your BB actually implements rather than aspirational.
 
 **A few things to get right before publishing:**
 

--- a/packages/auth-common/package.json
+++ b/packages/auth-common/package.json
@@ -1,6 +1,14 @@
 {
   "name": "@aws-blocks/auth-common",
   "version": "0.1.7",
+  "keywords": [
+    "aws-blocks",
+    "aws",
+    "cdk",
+    "authentication",
+    "auth-ui",
+    "typescript"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/aws-devtools-labs/aws-blocks.git",

--- a/packages/auth-common/package.json
+++ b/packages/auth-common/package.json
@@ -6,8 +6,7 @@
     "aws",
     "cdk",
     "authentication",
-    "auth-ui",
-    "typescript"
+    "auth-ui"
   ],
   "repository": {
     "type": "git",

--- a/packages/auth-common/package.json
+++ b/packages/auth-common/package.json
@@ -3,8 +3,6 @@
   "version": "0.1.7",
   "keywords": [
     "aws-blocks",
-    "aws",
-    "cdk",
     "authentication",
     "auth-ui"
   ],

--- a/packages/bb-agent/package.json
+++ b/packages/bb-agent/package.json
@@ -1,6 +1,16 @@
 {
   "name": "@aws-blocks/bb-agent",
   "version": "0.4.0",
+  "keywords": [
+    "aws-blocks",
+    "aws",
+    "cdk",
+    "ai",
+    "agent",
+    "llm",
+    "bedrock",
+    "chatbot"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/aws-devtools-labs/aws-blocks.git",

--- a/packages/bb-agent/package.json
+++ b/packages/bb-agent/package.json
@@ -3,8 +3,6 @@
   "version": "0.4.0",
   "keywords": [
     "aws-blocks",
-    "aws",
-    "cdk",
     "ai",
     "agent",
     "llm",

--- a/packages/bb-app-setting/package.json
+++ b/packages/bb-app-setting/package.json
@@ -3,8 +3,6 @@
   "version": "0.2.1",
   "keywords": [
     "aws-blocks",
-    "aws",
-    "cdk",
     "configuration",
     "ssm",
     "parameter-store",

--- a/packages/bb-app-setting/package.json
+++ b/packages/bb-app-setting/package.json
@@ -8,7 +8,7 @@
     "configuration",
     "ssm",
     "parameter-store",
-    "feature-flags"
+    "secrets"
   ],
   "repository": {
     "type": "git",

--- a/packages/bb-app-setting/package.json
+++ b/packages/bb-app-setting/package.json
@@ -1,6 +1,15 @@
 {
   "name": "@aws-blocks/bb-app-setting",
   "version": "0.2.1",
+  "keywords": [
+    "aws-blocks",
+    "aws",
+    "cdk",
+    "configuration",
+    "ssm",
+    "parameter-store",
+    "feature-flags"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/aws-devtools-labs/aws-blocks.git",

--- a/packages/bb-async-job/package.json
+++ b/packages/bb-async-job/package.json
@@ -3,8 +3,6 @@
   "version": "0.2.0",
   "keywords": [
     "aws-blocks",
-    "aws",
-    "cdk",
     "background-jobs",
     "queue",
     "sqs",

--- a/packages/bb-async-job/package.json
+++ b/packages/bb-async-job/package.json
@@ -1,6 +1,15 @@
 {
   "name": "@aws-blocks/bb-async-job",
   "version": "0.2.0",
+  "keywords": [
+    "aws-blocks",
+    "aws",
+    "cdk",
+    "background-jobs",
+    "queue",
+    "sqs",
+    "lambda"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/aws-devtools-labs/aws-blocks.git",

--- a/packages/bb-auth-basic/package.json
+++ b/packages/bb-auth-basic/package.json
@@ -3,8 +3,6 @@
   "version": "0.1.8",
   "keywords": [
     "aws-blocks",
-    "aws",
-    "cdk",
     "authentication",
     "jwt",
     "password-auth"

--- a/packages/bb-auth-basic/package.json
+++ b/packages/bb-auth-basic/package.json
@@ -1,6 +1,14 @@
 {
   "name": "@aws-blocks/bb-auth-basic",
   "version": "0.1.8",
+  "keywords": [
+    "aws-blocks",
+    "aws",
+    "cdk",
+    "authentication",
+    "jwt",
+    "password-auth"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/aws-devtools-labs/aws-blocks.git",

--- a/packages/bb-auth-cognito/package.json
+++ b/packages/bb-auth-cognito/package.json
@@ -3,8 +3,6 @@
   "version": "0.1.9",
   "keywords": [
     "aws-blocks",
-    "aws",
-    "cdk",
     "authentication",
     "cognito",
     "mfa",

--- a/packages/bb-auth-cognito/package.json
+++ b/packages/bb-auth-cognito/package.json
@@ -1,6 +1,15 @@
 {
   "name": "@aws-blocks/bb-auth-cognito",
   "version": "0.1.9",
+  "keywords": [
+    "aws-blocks",
+    "aws",
+    "cdk",
+    "authentication",
+    "cognito",
+    "mfa",
+    "user-pool"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/aws-devtools-labs/aws-blocks.git",

--- a/packages/bb-auth-oidc/package.json
+++ b/packages/bb-auth-oidc/package.json
@@ -3,8 +3,6 @@
   "version": "0.1.10",
   "keywords": [
     "aws-blocks",
-    "aws",
-    "cdk",
     "authentication",
     "oidc",
     "oauth2"

--- a/packages/bb-auth-oidc/package.json
+++ b/packages/bb-auth-oidc/package.json
@@ -7,8 +7,7 @@
     "cdk",
     "authentication",
     "oidc",
-    "oauth2",
-    "sso"
+    "oauth2"
   ],
   "repository": {
     "type": "git",

--- a/packages/bb-auth-oidc/package.json
+++ b/packages/bb-auth-oidc/package.json
@@ -1,6 +1,15 @@
 {
   "name": "@aws-blocks/bb-auth-oidc",
   "version": "0.1.10",
+  "keywords": [
+    "aws-blocks",
+    "aws",
+    "cdk",
+    "authentication",
+    "oidc",
+    "oauth2",
+    "sso"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/aws-devtools-labs/aws-blocks.git",

--- a/packages/bb-cron-job/package.json
+++ b/packages/bb-cron-job/package.json
@@ -1,6 +1,15 @@
 {
   "name": "@aws-blocks/bb-cron-job",
   "version": "0.2.0",
+  "keywords": [
+    "aws-blocks",
+    "aws",
+    "cdk",
+    "cron",
+    "scheduler",
+    "eventbridge",
+    "lambda"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/aws-devtools-labs/aws-blocks.git",

--- a/packages/bb-cron-job/package.json
+++ b/packages/bb-cron-job/package.json
@@ -3,8 +3,6 @@
   "version": "0.2.0",
   "keywords": [
     "aws-blocks",
-    "aws",
-    "cdk",
     "cron",
     "scheduler",
     "eventbridge",

--- a/packages/bb-dashboard/package.json
+++ b/packages/bb-dashboard/package.json
@@ -7,8 +7,7 @@
     "cdk",
     "cloudwatch",
     "dashboard",
-    "observability",
-    "monitoring"
+    "observability"
   ],
   "repository": {
     "type": "git",

--- a/packages/bb-dashboard/package.json
+++ b/packages/bb-dashboard/package.json
@@ -1,6 +1,15 @@
 {
   "name": "@aws-blocks/bb-dashboard",
   "version": "0.1.5",
+  "keywords": [
+    "aws-blocks",
+    "aws",
+    "cdk",
+    "cloudwatch",
+    "dashboard",
+    "observability",
+    "monitoring"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/aws-devtools-labs/aws-blocks.git",

--- a/packages/bb-dashboard/package.json
+++ b/packages/bb-dashboard/package.json
@@ -3,8 +3,6 @@
   "version": "0.1.5",
   "keywords": [
     "aws-blocks",
-    "aws",
-    "cdk",
     "cloudwatch",
     "dashboard",
     "observability"

--- a/packages/bb-data/package.json
+++ b/packages/bb-data/package.json
@@ -3,8 +3,6 @@
   "version": "0.2.7",
   "keywords": [
     "aws-blocks",
-    "aws",
-    "cdk",
     "database",
     "postgresql",
     "aurora",

--- a/packages/bb-data/package.json
+++ b/packages/bb-data/package.json
@@ -1,6 +1,15 @@
 {
   "name": "@aws-blocks/bb-data",
   "version": "0.2.7",
+  "keywords": [
+    "aws-blocks",
+    "aws",
+    "cdk",
+    "database",
+    "postgresql",
+    "aurora",
+    "sql"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/aws-devtools-labs/aws-blocks.git",

--- a/packages/bb-distributed-data/package.json
+++ b/packages/bb-distributed-data/package.json
@@ -3,8 +3,6 @@
   "version": "0.1.8",
   "keywords": [
     "aws-blocks",
-    "aws",
-    "cdk",
     "database",
     "sql",
     "dsql",

--- a/packages/bb-distributed-data/package.json
+++ b/packages/bb-distributed-data/package.json
@@ -1,6 +1,16 @@
 {
   "name": "@aws-blocks/bb-distributed-data",
   "version": "0.1.8",
+  "keywords": [
+    "aws-blocks",
+    "aws",
+    "cdk",
+    "database",
+    "sql",
+    "dsql",
+    "serverless",
+    "multi-region"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/aws-devtools-labs/aws-blocks.git",

--- a/packages/bb-distributed-data/package.json
+++ b/packages/bb-distributed-data/package.json
@@ -8,8 +8,7 @@
     "database",
     "sql",
     "dsql",
-    "serverless",
-    "multi-region"
+    "serverless"
   ],
   "repository": {
     "type": "git",

--- a/packages/bb-distributed-data/package.json
+++ b/packages/bb-distributed-data/package.json
@@ -8,7 +8,8 @@
     "database",
     "sql",
     "dsql",
-    "serverless"
+    "serverless",
+    "aurora-dsql"
   ],
   "repository": {
     "type": "git",

--- a/packages/bb-distributed-table/package.json
+++ b/packages/bb-distributed-table/package.json
@@ -7,8 +7,7 @@
     "cdk",
     "dynamodb",
     "nosql",
-    "database",
-    "table"
+    "database"
   ],
   "repository": {
     "type": "git",

--- a/packages/bb-distributed-table/package.json
+++ b/packages/bb-distributed-table/package.json
@@ -3,8 +3,6 @@
   "version": "0.1.7",
   "keywords": [
     "aws-blocks",
-    "aws",
-    "cdk",
     "dynamodb",
     "nosql",
     "database"

--- a/packages/bb-distributed-table/package.json
+++ b/packages/bb-distributed-table/package.json
@@ -1,6 +1,15 @@
 {
   "name": "@aws-blocks/bb-distributed-table",
   "version": "0.1.7",
+  "keywords": [
+    "aws-blocks",
+    "aws",
+    "cdk",
+    "dynamodb",
+    "nosql",
+    "database",
+    "table"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/aws-devtools-labs/aws-blocks.git",

--- a/packages/bb-email-client/package.json
+++ b/packages/bb-email-client/package.json
@@ -3,8 +3,6 @@
   "version": "0.1.6",
   "keywords": [
     "aws-blocks",
-    "aws",
-    "cdk",
     "email",
     "ses",
     "transactional-email"

--- a/packages/bb-email-client/package.json
+++ b/packages/bb-email-client/package.json
@@ -1,6 +1,14 @@
 {
   "name": "@aws-blocks/bb-email-client",
   "version": "0.1.6",
+  "keywords": [
+    "aws-blocks",
+    "aws",
+    "cdk",
+    "email",
+    "ses",
+    "transactional-email"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/aws-devtools-labs/aws-blocks.git",

--- a/packages/bb-file-bucket/package.json
+++ b/packages/bb-file-bucket/package.json
@@ -3,8 +3,6 @@
   "version": "0.2.0",
   "keywords": [
     "aws-blocks",
-    "aws",
-    "cdk",
     "storage",
     "s3",
     "file-upload"

--- a/packages/bb-file-bucket/package.json
+++ b/packages/bb-file-bucket/package.json
@@ -1,6 +1,14 @@
 {
   "name": "@aws-blocks/bb-file-bucket",
   "version": "0.2.0",
+  "keywords": [
+    "aws-blocks",
+    "aws",
+    "cdk",
+    "storage",
+    "s3",
+    "file-upload"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/aws-devtools-labs/aws-blocks.git",

--- a/packages/bb-knowledge-base/package.json
+++ b/packages/bb-knowledge-base/package.json
@@ -6,7 +6,6 @@
     "aws",
     "cdk",
     "knowledge-base",
-    "rag",
     "bedrock",
     "semantic-search"
   ],

--- a/packages/bb-knowledge-base/package.json
+++ b/packages/bb-knowledge-base/package.json
@@ -1,6 +1,15 @@
 {
   "name": "@aws-blocks/bb-knowledge-base",
   "version": "0.2.3",
+  "keywords": [
+    "aws-blocks",
+    "aws",
+    "cdk",
+    "knowledge-base",
+    "rag",
+    "bedrock",
+    "semantic-search"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/aws-devtools-labs/aws-blocks.git",

--- a/packages/bb-knowledge-base/package.json
+++ b/packages/bb-knowledge-base/package.json
@@ -3,8 +3,6 @@
   "version": "0.2.3",
   "keywords": [
     "aws-blocks",
-    "aws",
-    "cdk",
     "knowledge-base",
     "bedrock",
     "semantic-search"

--- a/packages/bb-kv-store/package.json
+++ b/packages/bb-kv-store/package.json
@@ -3,8 +3,6 @@
   "version": "0.1.8",
   "keywords": [
     "aws-blocks",
-    "aws",
-    "cdk",
     "key-value",
     "dynamodb",
     "storage"

--- a/packages/bb-kv-store/package.json
+++ b/packages/bb-kv-store/package.json
@@ -7,7 +7,6 @@
     "cdk",
     "key-value",
     "dynamodb",
-    "cache",
     "storage"
   ],
   "repository": {

--- a/packages/bb-kv-store/package.json
+++ b/packages/bb-kv-store/package.json
@@ -1,6 +1,15 @@
 {
   "name": "@aws-blocks/bb-kv-store",
   "version": "0.1.8",
+  "keywords": [
+    "aws-blocks",
+    "aws",
+    "cdk",
+    "key-value",
+    "dynamodb",
+    "cache",
+    "storage"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/aws-devtools-labs/aws-blocks.git",

--- a/packages/bb-lambda-compute/package.json
+++ b/packages/bb-lambda-compute/package.json
@@ -1,6 +1,15 @@
 {
   "name": "@aws-blocks/bb-lambda-compute",
   "version": "0.4.0",
+  "keywords": [
+    "aws-blocks",
+    "aws",
+    "cdk",
+    "lambda",
+    "serverless",
+    "api-gateway",
+    "compute"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/aws-devtools-labs/aws-blocks.git",

--- a/packages/bb-lambda-compute/package.json
+++ b/packages/bb-lambda-compute/package.json
@@ -3,8 +3,6 @@
   "version": "0.4.0",
   "keywords": [
     "aws-blocks",
-    "aws",
-    "cdk",
     "lambda",
     "serverless",
     "api-gateway",

--- a/packages/bb-logger/package.json
+++ b/packages/bb-logger/package.json
@@ -1,6 +1,14 @@
 {
   "name": "@aws-blocks/bb-logger",
   "version": "0.1.6",
+  "keywords": [
+    "aws-blocks",
+    "aws",
+    "cdk",
+    "logging",
+    "structured-logging",
+    "observability"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/aws-devtools-labs/aws-blocks.git",

--- a/packages/bb-logger/package.json
+++ b/packages/bb-logger/package.json
@@ -3,8 +3,6 @@
   "version": "0.1.6",
   "keywords": [
     "aws-blocks",
-    "aws",
-    "cdk",
     "logging",
     "structured-logging",
     "observability"

--- a/packages/bb-metrics/package.json
+++ b/packages/bb-metrics/package.json
@@ -1,6 +1,15 @@
 {
   "name": "@aws-blocks/bb-metrics",
   "version": "0.1.6",
+  "keywords": [
+    "aws-blocks",
+    "aws",
+    "cdk",
+    "metrics",
+    "cloudwatch",
+    "observability",
+    "monitoring"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/aws-devtools-labs/aws-blocks.git",

--- a/packages/bb-metrics/package.json
+++ b/packages/bb-metrics/package.json
@@ -8,7 +8,7 @@
     "metrics",
     "cloudwatch",
     "observability",
-    "monitoring"
+    "emf"
   ],
   "repository": {
     "type": "git",

--- a/packages/bb-metrics/package.json
+++ b/packages/bb-metrics/package.json
@@ -3,8 +3,6 @@
   "version": "0.1.6",
   "keywords": [
     "aws-blocks",
-    "aws",
-    "cdk",
     "metrics",
     "cloudwatch",
     "observability",

--- a/packages/bb-realtime/package.json
+++ b/packages/bb-realtime/package.json
@@ -1,6 +1,15 @@
 {
   "name": "@aws-blocks/bb-realtime",
   "version": "0.2.0",
+  "keywords": [
+    "aws-blocks",
+    "aws",
+    "cdk",
+    "realtime",
+    "websocket",
+    "pubsub",
+    "api-gateway"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/aws-devtools-labs/aws-blocks.git",

--- a/packages/bb-realtime/package.json
+++ b/packages/bb-realtime/package.json
@@ -3,8 +3,6 @@
   "version": "0.2.0",
   "keywords": [
     "aws-blocks",
-    "aws",
-    "cdk",
     "realtime",
     "websocket",
     "pubsub",

--- a/packages/bb-tracer/package.json
+++ b/packages/bb-tracer/package.json
@@ -3,8 +3,6 @@
   "version": "0.1.8",
   "keywords": [
     "aws-blocks",
-    "aws",
-    "cdk",
     "tracing",
     "distributed-tracing",
     "xray",

--- a/packages/bb-tracer/package.json
+++ b/packages/bb-tracer/package.json
@@ -1,6 +1,15 @@
 {
   "name": "@aws-blocks/bb-tracer",
   "version": "0.1.8",
+  "keywords": [
+    "aws-blocks",
+    "aws",
+    "cdk",
+    "tracing",
+    "distributed-tracing",
+    "xray",
+    "observability"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/aws-devtools-labs/aws-blocks.git",

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -1,6 +1,16 @@
 {
   "name": "@aws-blocks/blocks",
   "version": "0.5.0",
+  "keywords": [
+    "aws-blocks",
+    "aws",
+    "cdk",
+    "framework",
+    "fullstack",
+    "backend",
+    "typescript",
+    "serverless"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/aws-devtools-labs/aws-blocks.git",

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -3,8 +3,6 @@
   "version": "0.5.0",
   "keywords": [
     "aws-blocks",
-    "aws",
-    "cdk",
     "framework",
     "fullstack",
     "backend",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,8 +3,6 @@
   "version": "0.4.0",
   "keywords": [
     "aws-blocks",
-    "aws",
-    "cdk",
     "framework",
     "typescript",
     "backend",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,15 @@
 {
   "name": "@aws-blocks/core",
   "version": "0.4.0",
+  "keywords": [
+    "aws-blocks",
+    "aws",
+    "cdk",
+    "framework",
+    "typescript",
+    "backend",
+    "primitives"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/aws-devtools-labs/aws-blocks.git",

--- a/packages/create-blocks-app/package.json
+++ b/packages/create-blocks-app/package.json
@@ -3,8 +3,6 @@
   "version": "0.1.22",
   "keywords": [
     "aws-blocks",
-    "aws",
-    "cdk",
     "cli",
     "scaffolding",
     "starter",

--- a/packages/create-blocks-app/package.json
+++ b/packages/create-blocks-app/package.json
@@ -1,6 +1,15 @@
 {
   "name": "@aws-blocks/create-blocks-app",
   "version": "0.1.22",
+  "keywords": [
+    "aws-blocks",
+    "aws",
+    "cdk",
+    "cli",
+    "scaffolding",
+    "starter",
+    "template"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/aws-devtools-labs/aws-blocks.git",

--- a/packages/data-common/package.json
+++ b/packages/data-common/package.json
@@ -4,7 +4,6 @@
   "keywords": [
     "aws-blocks",
     "aws",
-    "cdk",
     "database",
     "sql",
     "abstractions"

--- a/packages/data-common/package.json
+++ b/packages/data-common/package.json
@@ -1,6 +1,14 @@
 {
   "name": "@aws-blocks/data-common",
   "version": "0.1.4",
+  "keywords": [
+    "aws-blocks",
+    "aws",
+    "cdk",
+    "database",
+    "sql",
+    "abstractions"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/aws-devtools-labs/aws-blocks.git",

--- a/packages/data-common/package.json
+++ b/packages/data-common/package.json
@@ -3,7 +3,6 @@
   "version": "0.1.4",
   "keywords": [
     "aws-blocks",
-    "aws",
     "database",
     "sql",
     "abstractions"

--- a/packages/hosting/package.json
+++ b/packages/hosting/package.json
@@ -1,6 +1,16 @@
 {
   "name": "@aws-blocks/hosting",
   "version": "0.3.0",
+  "keywords": [
+    "aws-blocks",
+    "aws",
+    "cdk",
+    "hosting",
+    "cloudfront",
+    "s3",
+    "static-site",
+    "ssr"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/aws-devtools-labs/aws-blocks.git",

--- a/packages/hosting/package.json
+++ b/packages/hosting/package.json
@@ -3,8 +3,6 @@
   "version": "0.3.0",
   "keywords": [
     "aws-blocks",
-    "aws",
-    "cdk",
     "hosting",
     "cloudfront",
     "s3",

--- a/packages/pipeline/package.json
+++ b/packages/pipeline/package.json
@@ -13,8 +13,6 @@
   "description": "CDK Pipelines-based CI/CD construct for AWS Blocks applications",
   "keywords": [
     "aws-blocks",
-    "aws",
-    "cdk",
     "ci-cd",
     "pipelines",
     "deployment",

--- a/packages/pipeline/package.json
+++ b/packages/pipeline/package.json
@@ -11,6 +11,15 @@
     "url": "https://github.com/aws-devtools-labs/aws-blocks/issues"
   },
   "description": "CDK Pipelines-based CI/CD construct for AWS Blocks applications",
+  "keywords": [
+    "aws-blocks",
+    "aws",
+    "cdk",
+    "ci-cd",
+    "pipelines",
+    "deployment",
+    "codepipeline"
+  ],
   "author": "Amazon Web Services",
   "license": "Apache-2.0",
   "type": "module",

--- a/scripts/keywords-guard.test.mjs
+++ b/scripts/keywords-guard.test.mjs
@@ -1,0 +1,215 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Unit tests for scripts/keywords-guard.ts. Every case builds a throwaway
+// workspace in a temp dir and copies the real guard into its scripts/ (the guard
+// roots itself at `import.meta.dirname/..`, so the copy sees the fixture as the
+// repo), then runs the guard for real: real fs, no stubs.
+//
+// Run: node --test scripts/keywords-guard.test.mjs
+
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { copyFileSync, existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const SCRIPTS_DIR = dirname(fileURLToPath(import.meta.url));
+const GUARD_SRC = join(SCRIPTS_DIR, "keywords-guard.ts");
+
+// CI runs the pinned Node (.nvmrc), which strips types natively. Older local
+// Node builds without --experimental-strip-types fall back to the repo's tsx, so
+// the suite is runnable on a laptop too.
+const TSX_BIN = join(SCRIPTS_DIR, "..", "node_modules", ".bin", "tsx");
+const STRIPS_TYPES = Number(process.versions.node.split(".")[0]) >= 22;
+function runner(guardPath, command) {
+	return STRIPS_TYPES || !existsSync(TSX_BIN)
+		? [process.execPath, ["--experimental-strip-types", guardPath, command]]
+		: [TSX_BIN, [guardPath, command]];
+}
+
+const DISCOVERY_KEYWORD = "aws-blocks";
+const UMBRELLA = "@aws-blocks/blocks";
+const SIBLING = "@aws-blocks/core";
+
+function write(dir, relPath, contents) {
+	const full = join(dir, relPath);
+	mkdirSync(dirname(full), { recursive: true });
+	writeFileSync(full, contents);
+}
+
+function pkgJson(name, extra = {}) {
+	return `${JSON.stringify({ name, version: "0.1.0", ...extra }, null, 2)}\n`;
+}
+
+/**
+ * A fixture workspace whose packages/ holds two tagged publishable packages.
+ * `files` is merged over that layout; `null` omits an entry.
+ */
+function baseRepo(t, files = {}) {
+	const dir = mkdtempSync(join(tmpdir(), "keywords-guard-"));
+	t.after(() => rmSync(dir, { recursive: true, force: true }));
+
+	mkdirSync(join(dir, "scripts"), { recursive: true });
+	copyFileSync(GUARD_SRC, join(dir, "scripts", "keywords-guard.ts"));
+
+	const layout = {
+		"package.json": `${JSON.stringify({ name: "fixture-root", private: true }, null, 2)}\n`,
+		"packages/blocks/package.json": pkgJson(UMBRELLA, {
+			keywords: [DISCOVERY_KEYWORD, "framework"],
+		}),
+		"packages/core/package.json": pkgJson(SIBLING, {
+			keywords: [DISCOVERY_KEYWORD, "primitives"],
+		}),
+		...files,
+	};
+
+	for (const [relPath, contents] of Object.entries(layout)) {
+		if (contents === null) continue;
+		write(dir, relPath, contents);
+	}
+	return dir;
+}
+
+/**
+ * Runs the guard in the fixture and returns its exit code plus combined
+ * stdout+stderr. A non-zero exit is the behaviour under test, so the throw
+ * execFileSync raises for it is unwrapped rather than propagated.
+ */
+function guard(dir, command) {
+	const [bin, args] = runner(join(dir, "scripts", "keywords-guard.ts"), command);
+	try {
+		const stdout = execFileSync(bin, args, {
+			cwd: dir,
+			encoding: "utf-8",
+			stdio: ["ignore", "pipe", "pipe"],
+		});
+		return { status: 0, output: stdout };
+	} catch (err) {
+		return { status: err.status ?? 1, output: `${err.stdout ?? ""}${err.stderr ?? ""}` };
+	}
+}
+
+describe("verify-discovery-tag: every published package carries the discovery keyword", () => {
+	it("passes when all publishable packages carry it", (t) => {
+		const dir = baseRepo(t);
+
+		const { status, output } = guard(dir, "verify-discovery-tag");
+		assert.equal(status, 0, output);
+		assert.match(output, /All 2 published package\(s\) carry the "aws-blocks" keyword/);
+	});
+
+	it("fails and names the package when one is missing it", (t) => {
+		const dir = baseRepo(t, {
+			"packages/bb-queue/package.json": pkgJson("@aws-blocks/bb-queue", {
+				keywords: ["queue", "sqs"],
+			}),
+		});
+
+		const { status, output } = guard(dir, "verify-discovery-tag");
+		assert.equal(status, 1, output);
+		assert.match(output, /missing the "aws-blocks" keyword/);
+		assert.match(output, /@aws-blocks\/bb-queue {2}\(packages\/bb-queue\/package\.json\)/);
+		// The compliant packages must not be reported.
+		assert.doesNotMatch(output, /@aws-blocks\/core/);
+	});
+
+	it("fails when a package declares no keywords at all", (t) => {
+		const dir = baseRepo(t, {
+			"packages/bb-queue/package.json": pkgJson("@aws-blocks/bb-queue"),
+		});
+
+		const { status, output } = guard(dir, "verify-discovery-tag");
+		assert.equal(status, 1, output);
+		assert.match(output, /@aws-blocks\/bb-queue/);
+	});
+
+	it("fails when keywords is present but not an array", (t) => {
+		const dir = baseRepo(t, {
+			"packages/bb-queue/package.json": pkgJson("@aws-blocks/bb-queue", {
+				keywords: DISCOVERY_KEYWORD,
+			}),
+		});
+
+		const { status, output } = guard(dir, "verify-discovery-tag");
+		assert.equal(status, 1, output);
+		assert.match(output, /@aws-blocks\/bb-queue/);
+	});
+
+	it("reports every offender, not just the first", (t) => {
+		const dir = baseRepo(t, {
+			"packages/bb-queue/package.json": pkgJson("@aws-blocks/bb-queue", { keywords: ["queue"] }),
+			"packages/bb-cache/package.json": pkgJson("@aws-blocks/bb-cache", { keywords: [] }),
+		});
+
+		const { status, output } = guard(dir, "verify-discovery-tag");
+		assert.equal(status, 1, output);
+		assert.match(output, /@aws-blocks\/bb-queue/);
+		assert.match(output, /@aws-blocks\/bb-cache/);
+	});
+
+	it("ignores private workspaces, which are never published", (t) => {
+		const dir = baseRepo(t, {
+			"packages/foundations/package.json": pkgJson("foundations", { private: true, keywords: [] }),
+			"packages/bb-internal/package.json": pkgJson("@aws-blocks/bb-internal", {
+				private: true,
+				keywords: [],
+			}),
+		});
+
+		const { status, output } = guard(dir, "verify-discovery-tag");
+		assert.equal(status, 0, output);
+	});
+
+	it("ignores packages outside the @aws-blocks scope", (t) => {
+		const dir = baseRepo(t, {
+			"packages/unscoped/package.json": pkgJson("some-other-package", { keywords: [] }),
+		});
+
+		const { status, output } = guard(dir, "verify-discovery-tag");
+		assert.equal(status, 0, output);
+	});
+
+	it("substring matches do not satisfy the tag", (t) => {
+		const dir = baseRepo(t, {
+			"packages/bb-queue/package.json": pkgJson("@aws-blocks/bb-queue", {
+				keywords: ["aws-blocks-queue", "aws"],
+			}),
+		});
+
+		const { status, output } = guard(dir, "verify-discovery-tag");
+		assert.equal(status, 1, output);
+		assert.match(output, /@aws-blocks\/bb-queue/);
+	});
+
+	it("fails loudly on a malformed package.json instead of skipping it", (t) => {
+		const dir = baseRepo(t, {
+			"packages/bb-queue/package.json": "{ not json",
+		});
+
+		const { status, output } = guard(dir, "verify-discovery-tag");
+		assert.equal(status, 1, output);
+		assert.match(output, /Cannot parse packages\/bb-queue\/package\.json/);
+	});
+
+	it("fails rather than passing vacuously when there are no publishable packages", (t) => {
+		const dir = baseRepo(t, {
+			"packages/blocks/package.json": pkgJson(UMBRELLA, { private: true }),
+			"packages/core/package.json": pkgJson(SIBLING, { private: true }),
+		});
+
+		const { status, output } = guard(dir, "verify-discovery-tag");
+		assert.equal(status, 1, output);
+		assert.match(output, /Found no publishable @aws-blocks\/\* packages/);
+	});
+
+	it("rejects an unknown subcommand", (t) => {
+		const dir = baseRepo(t);
+
+		const { status, output } = guard(dir, "not-a-command");
+		assert.equal(status, 2, output);
+		assert.match(output, /Unknown command: not-a-command/);
+	});
+});

--- a/scripts/keywords-guard.ts
+++ b/scripts/keywords-guard.ts
@@ -1,0 +1,163 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Keyword guard used in CI.
+ *
+ *   verify-discovery-tag  Exit non-zero if any publishable `@aws-blocks/*`
+ *                   package omits the `aws-blocks` keyword from its
+ *                   package.json. That keyword is the documented discovery
+ *                   path — `npm search keywords:aws-blocks`
+ *                   (docs/guides/extending-with-existing-aws-resources.md) —
+ *                   and it is invisible at review time: a new Building Block
+ *                   builds, tests and publishes perfectly well without it,
+ *                   and simply never shows up in the search the docs promise.
+ *                   That is exactly how #491 happened (every published package
+ *                   was missing the tag), so the invariant is asserted here
+ *                   rather than left to reviewers.
+ *
+ * A package counts as publishable when it lives in packages/, is not
+ * `private: true`, and its name is under the `@aws-blocks/` scope — the same
+ * rule the changeset coverage guard applies. Everything else (the private
+ * `foundations` workspace, test-apps, create-blocks-app templates, native
+ * clients, scripts) is never published to npm and so is not checked.
+ *
+ * The guard fails loudly. When it cannot read what it asserts against (a
+ * missing or malformed package.json, say) it exits non-zero with the reason
+ * instead of printing a green line it did not earn.
+ *
+ * Usage:
+ *   node --experimental-strip-types scripts/keywords-guard.ts verify-discovery-tag
+ */
+
+import { readFileSync, readdirSync, existsSync, statSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const PACKAGES_DIR = join(ROOT, "packages");
+const SCOPE = "@aws-blocks/";
+const DISCOVERY_KEYWORD = "aws-blocks";
+
+/**
+ * The guard could not evaluate what it was asked to assert. Reported as a normal
+ * failure (exit 1) with the reason, never swallowed.
+ */
+class GuardError extends Error {}
+
+/** Parse a JSON file, failing the guard loudly if it is unreadable or invalid. */
+function readJson(path: string, label: string): Record<string, unknown> {
+	let raw: string;
+	try {
+		raw = readFileSync(path, "utf-8");
+	} catch (err) {
+		throw new GuardError(`Cannot read ${label} (${path}): ${(err as Error).message}`);
+	}
+	try {
+		return JSON.parse(raw);
+	} catch (err) {
+		throw new GuardError(`Cannot parse ${label} (${path}) as JSON: ${(err as Error).message}`);
+	}
+}
+
+interface PublishablePackage {
+	name: string;
+	dir: string;
+	keywords: string[];
+}
+
+/**
+ * Every publishable `@aws-blocks/*` package under packages/, with its declared
+ * keywords. A `keywords` that is absent or not an array yields an empty list, so
+ * the package is reported as missing the tag rather than silently skipped.
+ *
+ * An empty result means the layout this guard assumes no longer holds (renamed
+ * or moved packages/), which would make the check pass vacuously — so that is a
+ * failure, not a green line.
+ */
+function getPublishablePackages(): PublishablePackage[] {
+	if (!existsSync(PACKAGES_DIR)) {
+		throw new GuardError(
+			`No packages/ directory at ${PACKAGES_DIR}, so publishable packages cannot be enumerated.`,
+		);
+	}
+
+	const packages: PublishablePackage[] = [];
+	for (const entry of readdirSync(PACKAGES_DIR).sort()) {
+		const pkgDir = join(PACKAGES_DIR, entry);
+		if (!statSync(pkgDir).isDirectory()) continue;
+
+		const pkgJsonPath = join(pkgDir, "package.json");
+		if (!existsSync(pkgJsonPath)) continue;
+
+		const pkgJson = readJson(pkgJsonPath, `packages/${entry}/package.json`);
+		if (typeof pkgJson.name !== "string" || !pkgJson.name.startsWith(SCOPE)) continue;
+		if (pkgJson.private === true) continue;
+
+		packages.push({
+			name: pkgJson.name,
+			dir: `packages/${entry}`,
+			keywords: Array.isArray(pkgJson.keywords)
+				? pkgJson.keywords.filter((k): k is string => typeof k === "string")
+				: [],
+		});
+	}
+
+	if (packages.length === 0) {
+		throw new GuardError(
+			`Found no publishable ${SCOPE}* packages under ${PACKAGES_DIR}. The guard asserts against\n` +
+			"that set, so an empty one means the layout changed and the check would pass vacuously.",
+		);
+	}
+	return packages;
+}
+
+function verifyDiscoveryTag(): number {
+	const packages = getPublishablePackages();
+	const missing = packages.filter((pkg) => !pkg.keywords.includes(DISCOVERY_KEYWORD));
+
+	if (missing.length > 0) {
+		console.error(
+			`\n❌ The following published package(s) are missing the "${DISCOVERY_KEYWORD}" keyword:\n`,
+		);
+		for (const pkg of missing) {
+			console.error(`   • ${pkg.name}  (${pkg.dir}/package.json)`);
+		}
+		console.error(
+			`\nAdd "${DISCOVERY_KEYWORD}" to each package.json "keywords" array, alongside the\n` +
+			"functional keywords describing what the package does. Without it the package never\n" +
+			`appears in \`npm search keywords:${DISCOVERY_KEYWORD}\`, the discovery path the\n` +
+			"publishing guide documents (#491).\n",
+		);
+		return 1;
+	}
+
+	console.log(
+		`✓ All ${packages.length} published package(s) carry the "${DISCOVERY_KEYWORD}" keyword.`,
+	);
+	return 0;
+}
+
+function main(): number {
+	const command = process.argv[2];
+
+	switch (command) {
+		case "verify-discovery-tag":
+			return verifyDiscoveryTag();
+		default:
+			console.error(
+				`Unknown command: ${command ?? "(none)"}\n` +
+				"Usage: node --experimental-strip-types scripts/keywords-guard.ts " +
+				"<verify-discovery-tag>",
+			);
+			return 2;
+	}
+}
+
+try {
+	process.exit(main());
+} catch (err) {
+	if (!(err instanceof GuardError)) throw err;
+	console.error(`\n❌ ${err.message}\n`);
+	process.exit(1);
+}


### PR DESCRIPTION
## Summary

Resolves the discovery gap reported in #491: the publishing guide recommends discovering Building Blocks via `npm search keywords:aws-blocks`, but no published package actually carried that keyword, so the documented path returned nothing.

This PR adds an npm `keywords` array to all **27 published `@aws-blocks/*` packages**, so `npm search keywords:aws-blocks` now surfaces first-party Building Blocks.

## Discovery mechanism

Went with **Option A (npm keyword)** from #491 — the mechanism the docs already promise; it unblocks discovery immediately.

## Keyword convention

Each published package carries:
- **`aws-blocks`** — the shared discovery tag (the point of #491)
- **2–5 functional keywords** naming the package's actual domain and the AWS services it uses

Generic tags (`aws`, `cdk`) were intentionally left out — high-competition, low-signal; the functional keywords do the targeted work. Keywords were audited against each package's source so they reflect what's **actually implemented, not aspirational** (e.g. no `rag` where only retrieval exists, no `sso` for single-IdP OIDC, no `multi-region` for a single-region cluster).

<details><summary>Final keywords per package (27)</summary>

| Package | keywords |
|---|---|
| `@aws-blocks/auth-common` | `aws-blocks`, `authentication`, `auth-ui` |
| `@aws-blocks/bb-agent` | `aws-blocks`, `ai`, `agent`, `llm`, `bedrock`, `chatbot` |
| `@aws-blocks/bb-app-setting` | `aws-blocks`, `configuration`, `ssm`, `parameter-store`, `secrets` |
| `@aws-blocks/bb-async-job` | `aws-blocks`, `background-jobs`, `queue`, `sqs`, `lambda` |
| `@aws-blocks/bb-auth-basic` | `aws-blocks`, `authentication`, `jwt`, `password-auth` |
| `@aws-blocks/bb-auth-cognito` | `aws-blocks`, `authentication`, `cognito`, `mfa`, `user-pool` |
| `@aws-blocks/bb-auth-oidc` | `aws-blocks`, `authentication`, `oidc`, `oauth2` |
| `@aws-blocks/bb-cron-job` | `aws-blocks`, `cron`, `scheduler`, `eventbridge`, `lambda` |
| `@aws-blocks/bb-dashboard` | `aws-blocks`, `cloudwatch`, `dashboard`, `observability` |
| `@aws-blocks/bb-data` | `aws-blocks`, `database`, `postgresql`, `aurora`, `sql` |
| `@aws-blocks/bb-distributed-data` | `aws-blocks`, `database`, `sql`, `dsql`, `serverless`, `aurora-dsql` |
| `@aws-blocks/bb-distributed-table` | `aws-blocks`, `dynamodb`, `nosql`, `database` |
| `@aws-blocks/bb-email-client` | `aws-blocks`, `email`, `ses`, `transactional-email` |
| `@aws-blocks/bb-file-bucket` | `aws-blocks`, `storage`, `s3`, `file-upload` |
| `@aws-blocks/bb-knowledge-base` | `aws-blocks`, `knowledge-base`, `bedrock`, `semantic-search` |
| `@aws-blocks/bb-kv-store` | `aws-blocks`, `key-value`, `dynamodb`, `storage` |
| `@aws-blocks/bb-lambda-compute` | `aws-blocks`, `lambda`, `serverless`, `api-gateway`, `compute` |
| `@aws-blocks/bb-logger` | `aws-blocks`, `logging`, `structured-logging`, `observability` |
| `@aws-blocks/bb-metrics` | `aws-blocks`, `metrics`, `cloudwatch`, `observability`, `emf` |
| `@aws-blocks/bb-realtime` | `aws-blocks`, `realtime`, `websocket`, `pubsub`, `api-gateway` |
| `@aws-blocks/bb-tracer` | `aws-blocks`, `tracing`, `distributed-tracing`, `xray`, `observability` |
| `@aws-blocks/blocks` | `aws-blocks`, `framework`, `fullstack`, `backend`, `typescript`, `serverless` |
| `@aws-blocks/core` | `aws-blocks`, `framework`, `typescript`, `backend`, `primitives` |
| `@aws-blocks/create-blocks-app` | `aws-blocks`, `cli`, `scaffolding`, `starter`, `template` |
| `@aws-blocks/data-common` | `aws-blocks`, `database`, `sql`, `abstractions` |
| `@aws-blocks/hosting` | `aws-blocks`, `hosting`, `cloudfront`, `s3`, `static-site`, `ssr` |
| `@aws-blocks/pipeline` | `aws-blocks`, `ci-cd`, `pipelines`, `deployment`, `codepipeline` |

</details>

## Also included
- **Changeset** (`patch` bump for all 27 published packages) per AGENTS.md core rule #10.
- **Docs**: `docs/guides/extending-with-existing-aws-resources.md` publishing guide updated — confirms `aws-blocks` as the discovery tag (removes the stale "pending finalization" TODOs) and recommends a minimal `aws-blocks` + functional-keyword convention for community BB authors.

## Scope
Only publishable packages. `private:true` packages (`foundations`, native clients, agent-bench) and test-apps/templates are untouched. **Metadata + docs only** — no code, behavior, or API changes.

Refs #491
