### PR TITLE
fix: harden GitHub Actions workflow against script injection

### DIFF
--- a/.github/workflows/revert-release.yml
+++ b/.github/workflows/revert-release.yml
@@ -31,8 +31,10 @@ jobs:
     steps:
       - name: Enforce main branch
         if: github.ref_name != 'main'
+        env:
+          REF_NAME: ${{ github.ref_name }}
         run: |
-          echo "::error::This workflow can only run from main (got '${{ github.ref_name }}')."
+          echo "::error::This workflow can only run from main (got '$REF_NAME')."
           exit 1
 
       - uses: actions/checkout@v7


### PR DESCRIPTION
## Summary

Hardens a GitHub Actions workflow against **script injection** from untrusted context expressions.

The `Enforce main branch` step in `.github/workflows/revert-release.yml` interpolated `${{ github.ref_name }}` directly into a `run:` shell script:

```yaml
run: |
  echo "::error::This workflow can only run from main (got '${{ github.ref_name }}')."
  exit 1
```

A ref name containing shell metacharacters could break out of the surrounding quotes and execute arbitrary commands on the runner. Because this workflow is `workflow_dispatch` and the guard fires specifically when the dispatch ref is **not** `main`, the injected value is exactly the attacker-influenced branch/tag name.

## Fix

Pass the untrusted context through a step-level `env:` variable and reference it as a quoted shell variable, so it is never evaluated as part of the shell command:

```yaml
env:
  REF_NAME: ${{ github.ref_name }}
run: |
  echo "::error::This workflow can only run from main (got '$REF_NAME')."
  exit 1
```

This is the pattern already used by the rest of the workflows in this repo (untrusted input assigned to `env:`, referenced as a quoted `$VAR`). No workflow logic is changed.

## Scope

- Single file changed: `.github/workflows/revert-release.yml` (3 insertions, 1 deletion).
- The remaining workflows were reviewed and already route untrusted context (`issue.title`, `comment.body`, `pull_request.head.ref`, `inputs.*`, etc.) through `env:` vars, so no further changes were needed.

## Testing

- `python3 -c "import yaml; yaml.safe_load(...)"` confirms the file is still valid YAML.
- No behavioral change: the same error message and exit code are produced.