### PR TITLE
docs: align KVStore/Setting examples with real put()/get() API

### DIFF
--- a/packages/foundations/README.md
+++ b/packages/foundations/README.md
@@ -2,6 +2,8 @@
 
 Standard Building Blocks for common AWS services in the AWS Blocks.
 
+> **Note:** This README describes an *aspirational* consolidated API for the foundation blocks. It is **not yet implemented** — this package is currently a stub. For the API that actually ships today, see [`packages/bb-kv-store/README.md`](../bb-kv-store/README.md) and [`packages/bb-app-setting/README.md`](../bb-app-setting/README.md), which are the authoritative reference for the shipped blocks.
+
 ## Overview
 
 `foundations` provides production-ready Building Blocks for the most common AWS services. Each block includes CDK infrastructure, runtime SDK integration, and local mocking for development without an AWS account.
@@ -73,8 +75,8 @@ Simple key-value storage for user-scoped data.
 import { KeyValueStore } from '@aws-blocks/blocks';
 
 const store = new KeyValueStore('app', 'settings');
-await store.set(userId, 'theme', 'dark');
-const theme = await store.get(userId, 'theme');
+await store.put(`user:${userId}:theme`, 'dark');
+const theme = await store.get(`user:${userId}:theme`);
 ```
 
 ### SQLTable
@@ -111,7 +113,8 @@ Application configuration values using AWS Systems Manager Parameter Store.
 import { Setting } from '@aws-blocks/blocks';
 
 const config = new Setting('app', 'feature-flags');
-await config.set('newUI', 'enabled');
+await config.put('enabled');
+const newUI = await config.get();
 ```
 
 ### CronJob


### PR DESCRIPTION
## Summary

`packages/foundations/README.md` documented a `.set()` method on `KeyValueStore` and `Setting` that no shipped block exposes. The real API is `get` / `put` / `delete` / `scan` (see `packages/bb-kv-store/README.md`, `packages/bb-kv-store/src/index.mock.ts`, and design rule **G14** in `docs/design/API-DESIGN.md`).

This PR rewrites the stale examples to the real signatures:

- `KVStore`: `put(key, value, options?)` / `get(key)` — the multi-arg `store.set(userId, 'theme', 'dark')` became `store.put(\`user:${userId}:theme\`, 'dark')` / `store.get(...)`.
- `Setting`: `put(value)` / `get()` — `config.set('newUI', 'enabled')` became `config.put('enabled')` / `config.get()`.

It also adds a note at the top of the README stating that this document describes an **aspirational consolidated API that is not yet implemented** (this package is a stub: `src/index.ts` is `export default {}` and it is not in the root `package.json` `workspaces`), and pointing readers to `packages/bb-kv-store/README.md` and `packages/bb-app-setting/README.md` as the authoritative reference for the shipped API.

A repo-wide grep confirms no `.set(` calls remain on stores / notes / settings in docs or examples. The only remaining `.set(` matches are the genuine `Headers` API (`ctx.response.headers.set(...)`) and `Map` / cookie / `URLSearchParams` usage in tests — intentionally left alone.

## Related issue

Addresses aws-amplify/private-amplify-backend-staging#1107 (cross-repo, so it will not auto-link):
https://github.com/aws-amplify/private-amplify-backend-staging/issues/1107

## Files changed

- `packages/foundations/README.md` (docs only — no code changed)

## Alternative considered

The other option was to **delete `packages/foundations/` entirely**, since it is an unbuilt stub and its README duplicates/diverges from the shipped per-block READMEs. This PR deliberately chose the **reversible rewrite** instead: there is an open question about whether maintainers want to revive `foundations` as a real consolidated API surface. If the answer is no, deleting the package is a clean follow-up and this change costs nothing. Maintainer input on `foundations`' future is welcome.
