### PR TITLE
fix: handle raw-socket errors during WebSocket upgrade to prevent ECONNRESET crash

### DIFF
--- a/.changeset/ws-upgrade-socket-error-handling.md
+++ b/.changeset/ws-upgrade-socket-error-handling.md
@@ -1,0 +1,8 @@
+---
+"@aws-blocks/bb-realtime": patch
+"@aws-blocks/blocks": patch
+---
+
+Local dev server: handle raw-socket errors during the WebSocket upgrade instead of crashing.
+
+The `upgrade` handlers routed the HTTP upgrade without attaching an `'error'` listener to the raw `net.Socket` first. A stale WebSocket client that reset its connection inside the upgrade window emitted ECONNRESET on a socket with no handler, so Node's default unhandled-`'error'` behaviour killed the dev server process right after port bind. Both upgrade paths now attach `socket.on('error', () => socket.destroy())` as their first statement, the HTTP server answers malformed/aborted requests via a `clientError` handler, and the `noServer` `WebSocketServer` logs server-level errors rather than throwing. The fix is scoped to the vulnerable socket — a genuine error anywhere else still crashes as before.

--- a/.changeset/ws-upgrade-socket-error-handling.md
+++ b/.changeset/ws-upgrade-socket-error-handling.md
@@ -1,4 +1,5 @@
 ---
+"@aws-blocks/core": patch
 "@aws-blocks/bb-realtime": patch
 "@aws-blocks/blocks": patch
 ---

--- a/packages/bb-realtime/src/ws-server.test.ts
+++ b/packages/bb-realtime/src/ws-server.test.ts
@@ -13,7 +13,8 @@
 import { describe, it, before, after } from 'node:test';
 import assert from 'node:assert';
 import { createServer, type Server } from 'node:http';
-import type { AddressInfo } from 'node:net';
+import { connect as netConnect, type AddressInfo } from 'node:net';
+import { PassThrough } from 'node:stream';
 import { WebSocket } from 'ws';
 import { attach, closeWebSocketServer, localRealtimeBus } from './ws-server.js';
 import { LOCAL_TOKEN_SECRET } from './local-dev.js';
@@ -139,6 +140,64 @@ describe('WebSocket server: subscribe authorization', () => {
 
 		publisher.close();
 		subscriber.close();
+	});
+});
+
+describe('WebSocket server: raw-socket errors during upgrade (issue #1108 regression)', () => {
+	it('survives a connection reset in the middle of a /realtime upgrade', async () => {
+		const unhandled: unknown[] = [];
+		const onUnhandled = (err: unknown) => unhandled.push(err);
+		process.on('uncaughtException', onUnhandled);
+
+		try {
+			for (let i = 0; i < 20; i++) {
+				const socket = netConnect({ host: '127.0.0.1', port });
+				await new Promise<void>((resolve, reject) => {
+					socket.once('connect', resolve);
+					socket.once('error', reject);
+				});
+				socket.on('error', () => {}); // client side of the reset — not under test
+
+				// Partial upgrade request: headers arrive, the handshake never completes.
+				socket.write(
+					'GET /realtime HTTP/1.1\r\n' +
+						`Host: localhost:${port}\r\n` +
+						'Upgrade: websocket\r\n' +
+						'Connection: Upgrade\r\n' +
+						'Sec-WebSocket-Version: 13\r\n' +
+						'Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n\r\n',
+				);
+
+				// Abort with RST (setNoDelay + destroy after linger 0) during the upgrade window.
+				socket.resetAndDestroy();
+				await new Promise((r) => setTimeout(r, 10));
+			}
+
+			// The event loop must still be alive and the server still serving.
+			const token = mintChannelToken(CHANNEL, LOCAL_TOKEN_SECRET);
+			const { ws, reply } = await subscribe({ channel: CHANNEL, token });
+			assert.strictEqual(reply.type, 'subscribe_success');
+			ws.close();
+
+			assert.deepStrictEqual(unhandled, [], 'raw-socket errors during upgrade must not go unhandled');
+		} finally {
+			process.off('uncaughtException', onUnhandled);
+		}
+	});
+
+	it('attaches a socket error listener before routing, and error triggers destroy', async () => {
+		const probe = new PassThrough();
+
+		// Drive the server's own upgrade listeners with a non-/realtime path so the
+		// handler returns immediately after attaching its error listener.
+		const req = { url: '/not-realtime', headers: { host: `localhost:${port}` } };
+		for (const listener of httpServer.listeners('upgrade')) {
+			(listener as (r: unknown, s: unknown, h: unknown) => void)(req, probe, Buffer.alloc(0));
+		}
+
+		assert.ok(probe.listenerCount('error') > 0, 'upgrade handler must attach a socket error listener');
+		assert.doesNotThrow(() => probe.emit('error', new Error('ECONNRESET')));
+		assert.strictEqual(probe.destroyed, true, 'socket error must destroy the socket');
 	});
 });
 

--- a/packages/bb-realtime/src/ws-server.ts
+++ b/packages/bb-realtime/src/ws-server.ts
@@ -28,9 +28,16 @@ export function attach(httpServer: Server) {
 	if (wss) return; // Already attached — multiple BBs may register the same dev attachment
 	wss = new WebSocketServer({ noServer: true });
 
+	// Server-level WS errors must be logged, never left to crash the dev process.
+	wss.on('error', (err) => { console.error('[Realtime WS] Server error:', err); });
+
 	// Only handle /realtime upgrades — ignore all others so HMR (Next.js, Vite)
 	// WebSocket upgrades pass through to the frontend proxy unharmed.
 	httpServer.on('upgrade', (req, socket, head) => {
+		// A client resetting the connection during the upgrade window (ECONNRESET)
+		// emits 'error' on the raw socket. Without this listener Node's default
+		// unhandled-error behaviour tears down the whole dev server process.
+		socket.on('error', () => socket.destroy());
 		const pathname = new URL(req.url || '/', `http://${req.headers.host || 'localhost'}`).pathname;
 		if (pathname !== '/realtime') return;
 		wss!.handleUpgrade(req, socket, head, (ws) => wss!.emit('connection', ws, req));

--- a/packages/core/src/scripts/dev-server.ts
+++ b/packages/core/src/scripts/dev-server.ts
@@ -6,7 +6,8 @@ import { pathToFileURL, URL } from 'node:url';
 import { resolve, dirname, join } from 'node:path';
 import { writeFileSync, mkdirSync, readFileSync, unlinkSync, renameSync } from 'node:fs';
 import { spawn, type ChildProcess } from 'node:child_process';
-import { createConnection } from 'node:net';
+import { createConnection, type Socket } from 'node:net';
+import type { Duplex } from 'node:stream';
 import httpProxy from 'http-proxy';
 import { writeClientCode } from './generate-client.js';
 import { ApiError } from '../errors.js';
@@ -952,6 +953,10 @@ export async function startDevServer(options: DevServerOptions) {
 
   // WebSocket upgrade — route to frontend (HMR) or dev attachments
   server.on('upgrade', (req, socket, head) => {
+    // A stale client can reset the connection mid-upgrade (ECONNRESET). The raw
+    // socket has no 'error' listener at this point, so Node's default handler
+    // would kill the dev server. Attach one before any parsing/routing.
+    socket.on('error', () => socket.destroy());
     const url = new URL(req.url || '/', `http://${req.headers.host || 'localhost'}`);
     if (url.pathname === '/realtime') return; // handled by dev attachment (noServer mode)
     if (frontendProxy) {
@@ -1043,6 +1048,12 @@ export async function startDevServer(options: DevServerOptions) {
     onExhausted: () => process.exit(1),
     warn: (msg) => console.error(msg),
   });
+  // Malformed/aborted requests must not become unhandled socket errors.
+  server.on('clientError', (_err: Error, socket: Duplex) => {
+    if ((socket as Socket).writable) socket.end('HTTP/1.1 400 Bad Request\r\n\r\n');
+    else socket.destroy();
+  });
+
   server.on('error', (err: NodeJS.ErrnoException) => {
     if (err.code === 'EADDRINUSE') {
       // Keep the telemetry signal (unchanged) …


### PR DESCRIPTION
Fixes the dev-server crash reported in aws-amplify/private-amplify-backend-staging#1108 (bug: dev server crashes on ECONNRESET during WebSocket upgrade).

## Root cause

The dev server routes the HTTP `upgrade` event without attaching a raw-socket `'error'` listener before `handleUpgrade`. When a stale WebSocket client reconnects and resets the connection inside the upgrade window, ECONNRESET is emitted on the raw `net.Socket` — which has no `'error'` handler at that point. Node's default unhandled-`'error'` behaviour then tears down the whole process, right after port bind.

Two upgrade paths were vulnerable:

- `packages/core/src/scripts/dev-server.ts` — `server.on('upgrade', ...)` parsed the URL and routed to the frontend proxy with no socket error handler. The existing `server.on('error', ...)` only covers bind-time errors (EADDRINUSE).
- `packages/bb-realtime/src/ws-server.ts` — `httpServer.on('upgrade', ...)` called `wss.handleUpgrade(...)` directly. The post-handshake `ws.on('error', ...)` exists, but that is too late for a socket that resets *during* the upgrade.

## Fix

1. `dev-server.ts` upgrade handler: `socket.on('error', () => socket.destroy())` as the first statement, before any URL parsing or routing.
2. `dev-server.ts`: added a `clientError` handler on the HTTP server so malformed/aborted requests reply `400` (or destroy an unwritable socket) instead of surfacing as unhandled socket errors.
3. `ws-server.ts` upgrade handler: the same `socket.on('error', () => socket.destroy())` as the first statement.
4. `ws-server.ts`: `wss.on('error', ...)` on the `WebSocketServer({ noServer: true })` instance — logs server-level WS errors rather than crashing.

## Why this instead of `process.on('uncaughtException')`

- **Scoped to the vulnerable socket.** Only errors on the specific raw socket in the upgrade window are handled; nothing else in the process changes behaviour.
- **Cleans up properly.** `socket.destroy()` releases the half-open connection instead of leaving it dangling.
- **Preserves crash-on-real-error semantics.** A process-wide `uncaughtException` swallow would mask genuine bugs anywhere in the dev server and leave the process in an undefined state. This is the idiomatic Node pattern documented for `server.on('upgrade')` / `clientError`.

## Tests

Added a regression suite to `packages/bb-realtime/src/ws-server.test.ts`, following the existing setup/teardown patterns:

- **Raw-socket repro** — opens 20 real TCP connections, writes a partial WS upgrade request for `/realtime`, then aborts each with `resetAndDestroy()` during the upgrade window while an `uncaughtException` listener records anything that escapes. It then asserts the server is still serving (a valid token still gets `subscribe_success`) and that nothing went unhandled.
- **Focused unit assertion** — drives the server's registered `upgrade` listeners with a probe duplex and asserts an `'error'` listener is attached before routing, and that emitting `'error'` destroys the socket without throwing.

Verified the test has teeth: with the `socket.on('error', ...)` line removed from the built `ws-server.js`, the new regression test fails (`# pass 7 / # fail 1`); with the fix in place all 8 pass.

## Verification

```
npm install
npm run build                                    # full monorepo build (tsc --build) — green
node --test dist/*.test.js                        # packages/bb-realtime → tests 80, pass 80, fail 0
node --test dist/ws-server.test.js                # packages/bb-realtime → tests 8, pass 8, fail 0
node --test dist/*.test.js dist/scripts/*.test.js dist/common/*.test.js
                                                  # packages/core → tests 613, pass 609, fail 4
```

The 4 `packages/core` failures are `blocks-generate-spec CLI` / `generateSpec — @blocksSkipCodegen` and are **pre-existing** — confirmed by stashing this change and re-running on clean `main` (same failures).

## Changed files

- `packages/core/src/scripts/dev-server.ts`
- `packages/bb-realtime/src/ws-server.ts`
- `packages/bb-realtime/src/ws-server.test.ts`

## Note

The root cause was identified by static analysis of the two upgrade paths; the original crash was **not independently reproduced** from a live stale-client reconnect. The added raw-socket regression test reproduces the vulnerable condition directly and fails without the fix, which is the evidence backing this change.
