### PR TITLE
chore(test-apps/pipeline): remove redundant @aws-blocks/core dependency

### DIFF
--- a/test-apps/pipeline/package.json
+++ b/test-apps/pipeline/package.json
@@ -10,7 +10,6 @@
   },
   "dependencies": {
     "@aws-blocks/blocks": "*",
-    "@aws-blocks/core": "*",
     "@aws-blocks/pipeline": "*",
     "aws-cdk-lib": "2.257.0",
     "constructs": "^10.6.0"


### PR DESCRIPTION
## What

Removes the direct `"@aws-blocks/core": "*"` entry from the `dependencies` block of `test-apps/pipeline/package.json`.

## Why

`@aws-blocks/core` is already pulled in transitively: this test-app depends on `@aws-blocks/blocks`, and `packages/blocks/package.json` declares `"@aws-blocks/core": "^0.4.0"`. The direct entry is therefore redundant.

## Diff

```diff
   "dependencies": {
     "@aws-blocks/blocks": "*",
-    "@aws-blocks/core": "*",
     "@aws-blocks/pipeline": "*",
     "aws-cdk-lib": "2.257.0",
     "constructs": "^10.6.0"
   },
```

## Note for reviewers

The generated files under `test-apps/pipeline/aws-blocks/` (`index.ts`, `pipeline.cdk.ts`, `pipeline-default.cdk.ts`) import from `@aws-blocks/core/cdk` directly, so resolution now relies on workspace hoisting of the transitive dependency. Please confirm the pipeline synth test job stays green before merging.