### PR TITLE
fix(bb-dashboard): align bb-lambda-compute devDependency with 0.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55974,7 +55974,7 @@
         "@aws-blocks/core": "^0.4.0"
       },
       "devDependencies": {
-        "@aws-blocks/bb-lambda-compute": "^0.3.0",
+        "@aws-blocks/bb-lambda-compute": "^0.4.0",
         "@types/node": "^20.0.0",
         "typescript": "^5.3.0"
       },

--- a/packages/bb-dashboard/package.json
+++ b/packages/bb-dashboard/package.json
@@ -38,7 +38,7 @@
     "@aws-blocks/core": "^0.4.0"
   },
   "devDependencies": {
-    "@aws-blocks/bb-lambda-compute": "^0.3.0",
+    "@aws-blocks/bb-lambda-compute": "^0.4.0",
     "@types/node": "^20.0.0",
     "typescript": "^5.3.0"
   },


### PR DESCRIPTION
## Problem
The `Release` (Version & Publish) workflow on `main` fails at `npm ci`:

```
npm error `npm ci` can only install packages when your package.json and
package-lock.json ... are in sync.
npm error Missing: @aws-blocks/bb-lambda-compute@0.3.0 from lock file
npm error Missing: @aws-blocks/core@0.3.0 from lock file
```

(run: https://github.com/aws-devtools-labs/aws-blocks/actions/runs/34463601420/job/102826907063)

## Root cause
The compute-driven observability change (#507) added `@aws-blocks/bb-lambda-compute`
as a `bb-dashboard` **devDependency**, pinned at `^0.3.0` — the version live when
that branch was cut. On `main`, `bb-lambda-compute` (and `core`) are already at
`0.4.0` from the previous release cycle, and #507's version bumps are still pending
in an unmerged "Version Packages" PR. `^0.3.0` does not allow `0.4.0`, so `npm ci`
can't satisfy the range from the workspace and instead resolves
`bb-lambda-compute@0.3.0` (plus its transitive `core@0.3.0`) from the registry —
neither of which is in the lockfile.

## Fix
- Bump the `bb-dashboard` devDependency range to `^0.4.0` to match the current
  workspace version.
- Regenerate `package-lock.json` (one line) so it is back in sync.

The corrected range is carried forward correctly by changesets on the next version
bump. bb-dashboard is already covered by the pending `observability-compute-driven`
changeset, so no new changeset is needed (the coverage guard passes).

## Verification (Node 22)
- `npm ci` now completes (was failing) — lock is in sync.
- `npm run build` passes.