### PR TITLE
fix(dart): Require flutter_secure_storage ^11.1.0

### DIFF
--- a/native/dart/packages/blocks_runtime_flutter/CHANGELOG.md
+++ b/native/dart/packages/blocks_runtime_flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Require `flutter_secure_storage` `^11.1.0`; 11.1.0 targets a compileSdk supported by current stable Flutter/AGP, fixing the Android build break that forced the earlier 10.x pin ([flutter_secure_storage#1224](https://github.com/juliansteenbakker/flutter_secure_storage/issues/1224))
+
 ## 0.1.3
 
 - Pin `flutter_secure_storage` to `^10.3.1`; 11.x requires Android compileSdk 37, which breaks Android builds on current stable Flutter/AGP ([flutter_secure_storage#1224](https://github.com/juliansteenbakker/flutter_secure_storage/issues/1224))

--- a/native/dart/packages/blocks_runtime_flutter/pubspec.yaml
+++ b/native/dart/packages/blocks_runtime_flutter/pubspec.yaml
@@ -13,9 +13,7 @@ dependencies:
   flutter:
     sdk: flutter
   blocks_runtime: ^0.1.3
-  # 11.x needs compileSdk 37, which current stable Flutter/AGP can't target.
-  # Upstream: https://github.com/juliansteenbakker/flutter_secure_storage/issues/1224
-  flutter_secure_storage: ^10.3.1
+  flutter_secure_storage: ^11.1.0
   url_launcher: ^6.2.0
   app_links: ^7.0.0
 

--- a/native/dart/packages/blocks_runtime_flutter/test/flutter_secure_store_test.mocks.dart
+++ b/native/dart/packages/blocks_runtime_flutter/test/flutter_secure_store_test.mocks.dart
@@ -3,10 +3,13 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'dart:async' as _i4;
 
-import 'package:flutter/foundation.dart' as _i3;
+import 'dart:async' as _i5;
+
+import 'package:flutter/foundation.dart' as _i4;
 import 'package:flutter_secure_storage/flutter_secure_storage.dart' as _i2;
+import 'package:flutter_secure_storage_platform_interface/flutter_secure_storage_platform_interface.dart'
+    as _i3;
 import 'package:mockito/mockito.dart' as _i1;
 
 // ignore_for_file: type=lint
@@ -54,6 +57,12 @@ class _FakeWebOptions_4 extends _i1.SmartFake implements _i2.WebOptions {
 
 class _FakeAppleOptions_5 extends _i1.SmartFake implements _i2.AppleOptions {
   _FakeAppleOptions_5(Object parent, Invocation parentInvocation)
+    : super(parent, parentInvocation);
+}
+
+class _FakeSecureStorageUpgradeStatus_6 extends _i1.SmartFake
+    implements _i3.SecureStorageUpgradeStatus {
+  _FakeSecureStorageUpgradeStatus_6(Object parent, Invocation parentInvocation)
     : super(parent, parentInvocation);
 }
 
@@ -130,17 +139,17 @@ class MockFlutterSecureStorage extends _i1.Mock
           as _i2.AppleOptions);
 
   @override
-  Map<String, List<_i3.ValueChanged<String?>>> get getListeners =>
+  Map<String, List<_i4.ValueChanged<String?>>> get getListeners =>
       (super.noSuchMethod(
             Invocation.getter(#getListeners),
-            returnValue: <String, List<_i3.ValueChanged<String?>>>{},
+            returnValue: <String, List<_i4.ValueChanged<String?>>>{},
           )
-          as Map<String, List<_i3.ValueChanged<String?>>>);
+          as Map<String, List<_i4.ValueChanged<String?>>>);
 
   @override
   void registerListener({
     required String? key,
-    required _i3.ValueChanged<String?>? listener,
+    required _i4.ValueChanged<String?>? listener,
   }) => super.noSuchMethod(
     Invocation.method(#registerListener, [], {#key: key, #listener: listener}),
     returnValueForMissingStub: null,
@@ -149,7 +158,7 @@ class MockFlutterSecureStorage extends _i1.Mock
   @override
   void unregisterListener({
     required String? key,
-    required _i3.ValueChanged<String?>? listener,
+    required _i4.ValueChanged<String?>? listener,
   }) => super.noSuchMethod(
     Invocation.method(#unregisterListener, [], {
       #key: key,
@@ -172,7 +181,7 @@ class MockFlutterSecureStorage extends _i1.Mock
   );
 
   @override
-  _i4.Future<void> write({
+  _i5.Future<void> write({
     required String? key,
     required String? value,
     _i2.AppleOptions? iOptions,
@@ -193,13 +202,13 @@ class MockFlutterSecureStorage extends _i1.Mock
               #mOptions: mOptions,
               #wOptions: wOptions,
             }),
-            returnValue: _i4.Future<void>.value(),
-            returnValueForMissingStub: _i4.Future<void>.value(),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
           )
-          as _i4.Future<void>);
+          as _i5.Future<void>);
 
   @override
-  _i4.Future<String?> read({
+  _i5.Future<String?> read({
     required String? key,
     _i2.AppleOptions? iOptions,
     _i2.AndroidOptions? aOptions,
@@ -218,12 +227,12 @@ class MockFlutterSecureStorage extends _i1.Mock
               #mOptions: mOptions,
               #wOptions: wOptions,
             }),
-            returnValue: _i4.Future<String?>.value(),
+            returnValue: _i5.Future<String?>.value(),
           )
-          as _i4.Future<String?>);
+          as _i5.Future<String?>);
 
   @override
-  _i4.Future<bool> containsKey({
+  _i5.Future<bool> containsKey({
     required String? key,
     _i2.AppleOptions? iOptions,
     _i2.AndroidOptions? aOptions,
@@ -242,12 +251,12 @@ class MockFlutterSecureStorage extends _i1.Mock
               #mOptions: mOptions,
               #wOptions: wOptions,
             }),
-            returnValue: _i4.Future<bool>.value(false),
+            returnValue: _i5.Future<bool>.value(false),
           )
-          as _i4.Future<bool>);
+          as _i5.Future<bool>);
 
   @override
-  _i4.Future<void> delete({
+  _i5.Future<void> delete({
     required String? key,
     _i2.AppleOptions? iOptions,
     _i2.AndroidOptions? aOptions,
@@ -266,13 +275,13 @@ class MockFlutterSecureStorage extends _i1.Mock
               #mOptions: mOptions,
               #wOptions: wOptions,
             }),
-            returnValue: _i4.Future<void>.value(),
-            returnValueForMissingStub: _i4.Future<void>.value(),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
           )
-          as _i4.Future<void>);
+          as _i5.Future<void>);
 
   @override
-  _i4.Future<Map<String, String>> readAll({
+  _i5.Future<Map<String, String>> readAll({
     _i2.AppleOptions? iOptions,
     _i2.AndroidOptions? aOptions,
     _i2.LinuxOptions? lOptions,
@@ -289,14 +298,14 @@ class MockFlutterSecureStorage extends _i1.Mock
               #mOptions: mOptions,
               #wOptions: wOptions,
             }),
-            returnValue: _i4.Future<Map<String, String>>.value(
+            returnValue: _i5.Future<Map<String, String>>.value(
               <String, String>{},
             ),
           )
-          as _i4.Future<Map<String, String>>);
+          as _i5.Future<Map<String, String>>);
 
   @override
-  _i4.Future<void> deleteAll({
+  _i5.Future<void> deleteAll({
     _i2.AppleOptions? iOptions,
     _i2.AndroidOptions? aOptions,
     _i2.LinuxOptions? lOptions,
@@ -313,16 +322,50 @@ class MockFlutterSecureStorage extends _i1.Mock
               #mOptions: mOptions,
               #wOptions: wOptions,
             }),
-            returnValue: _i4.Future<void>.value(),
-            returnValueForMissingStub: _i4.Future<void>.value(),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
           )
-          as _i4.Future<void>);
+          as _i5.Future<void>);
 
   @override
-  _i4.Future<bool?> isCupertinoProtectedDataAvailable() =>
+  _i5.Future<bool?> isCupertinoProtectedDataAvailable() =>
       (super.noSuchMethod(
             Invocation.method(#isCupertinoProtectedDataAvailable, []),
-            returnValue: _i4.Future<bool?>.value(),
+            returnValue: _i5.Future<bool?>.value(),
           )
-          as _i4.Future<bool?>);
+          as _i5.Future<bool?>);
+
+  @override
+  _i5.Future<_i3.SecureStorageUpgradeStatus> checkUpgradeStatus({
+    _i2.AppleOptions? iOptions,
+    _i2.AndroidOptions? aOptions,
+    _i2.LinuxOptions? lOptions,
+    _i2.WebOptions? webOptions,
+    _i2.AppleOptions? mOptions,
+    _i2.WindowsOptions? wOptions,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(#checkUpgradeStatus, [], {
+              #iOptions: iOptions,
+              #aOptions: aOptions,
+              #lOptions: lOptions,
+              #webOptions: webOptions,
+              #mOptions: mOptions,
+              #wOptions: wOptions,
+            }),
+            returnValue: _i5.Future<_i3.SecureStorageUpgradeStatus>.value(
+              _FakeSecureStorageUpgradeStatus_6(
+                this,
+                Invocation.method(#checkUpgradeStatus, [], {
+                  #iOptions: iOptions,
+                  #aOptions: aOptions,
+                  #lOptions: lOptions,
+                  #webOptions: webOptions,
+                  #mOptions: mOptions,
+                  #wOptions: wOptions,
+                }),
+              ),
+            ),
+          )
+          as _i5.Future<_i3.SecureStorageUpgradeStatus>);
 }


### PR DESCRIPTION
Bumps `blocks_runtime_flutter`'s `flutter_secure_storage` floor from `^10.3.1` to `^11.1.0`, lifting the earlier pin from #457.

**Why 11.1.0 is safe:** the plugin's `android/build.gradle` now inherits `compileSdk = flutter.compileSdkVersion` instead of hardcoding `compileSdk 37`, so it builds on current stable Flutter/AGP.

Also regenerated the mockito mocks against the 11.x `FlutterSecureStorage` API.

**Verified** with a Flutter reproducer: `flutter build apk` succeeds and an on-device integration test round-trips through the Android Keystore via `FlutterSecureStore` alongside a build_runner-generated Blocks client.

Refs: https://github.com/juliansteenbakker/flutter_secure_storage/issues/1224