### PR TITLE
fix(bb-dashboard): depend on @aws-blocks/bb-lambda-compute ^0.4.0

### DIFF
--- a/.changeset/bb-dashboard-lambda-compute-dep.md
+++ b/.changeset/bb-dashboard-lambda-compute-dep.md
@@ -1,0 +1,17 @@
+---
+"@aws-blocks/bb-dashboard": patch
+"@aws-blocks/blocks": patch
+---
+
+fix(bb-dashboard): depend on `@aws-blocks/bb-lambda-compute@^0.4.0`
+
+`bb-dashboard` declared its `@aws-blocks/bb-lambda-compute` devDependency as
+`^0.3.0`, which excludes the current workspace version (`0.4.0`). npm therefore
+installed the published `0.3.0` tarball into `bb-dashboard` instead of linking
+the local workspace, and two failures followed: the root `package-lock.json`
+fell out of sync (breaking `npm ci` repo-wide), and `bb-dashboard`'s CDK test
+crashed with `ERR_PACKAGE_PATH_NOT_EXPORTED` importing
+`@aws-blocks/bb-lambda-compute/cdk` — a subpath the old `0.3.0` did not export.
+
+Aligning the range to `^0.4.0` links the local workspace (which exports
+`./cdk`), fixing both. Dev-dependency-only; no runtime or API change.

--- a/package-lock.json
+++ b/package-lock.json
@@ -55974,7 +55974,7 @@
         "@aws-blocks/core": "^0.4.0"
       },
       "devDependencies": {
-        "@aws-blocks/bb-lambda-compute": "^0.3.0",
+        "@aws-blocks/bb-lambda-compute": "^0.4.0",
         "@types/node": "^20.0.0",
         "typescript": "^5.3.0"
       },

--- a/packages/bb-dashboard/package.json
+++ b/packages/bb-dashboard/package.json
@@ -38,7 +38,7 @@
     "@aws-blocks/core": "^0.4.0"
   },
   "devDependencies": {
-    "@aws-blocks/bb-lambda-compute": "^0.3.0",
+    "@aws-blocks/bb-lambda-compute": "^0.4.0",
     "@types/node": "^20.0.0",
     "typescript": "^5.3.0"
   },


### PR DESCRIPTION
`bb-dashboard` pinned its `@aws-blocks/bb-lambda-compute` **devDependency** at `^0.3.0`, which excludes the current workspace version `0.4.0`. So npm installed the published `0.3.0` tarball into `bb-dashboard` instead of linking the local workspace, causing two failures:

1. Root `package-lock.json` fell out of sync → **`npm ci` failed repo-wide** (`EUSAGE`, `Missing @aws-blocks/bb-lambda-compute@0.3.0`), taking down every TS build/e2e job.
2. `bb-dashboard`'s CDK test crashed with `ERR_PACKAGE_PATH_NOT_EXPORTED` on `import { LambdaCompute } from '@aws-blocks/bb-lambda-compute/cdk'` — a subpath the old `0.3.0` never exported (`0.4.0` does).

Aligning the range to `^0.4.0` links the local workspace and fixes both. Regenerated `package-lock.json`; added a changeset (`bb-dashboard` + umbrella `blocks`, patch). Dev-dependency-only — no runtime or API change.

Verified locally: `npm run build`, `npm test -w @aws-blocks/bb-dashboard` (**63/63 pass**), `npm ci --dry-run` in sync, and all four changeset guards pass.

Introduced in #507.