### PR TITLE
fix(astro): allow an empty dist/client for pure-SSR builds

### DIFF
--- a/.changeset/astro-empty-client-ssr.md
+++ b/.changeset/astro-empty-client-ssr.md
@@ -1,0 +1,13 @@
+---
+'@aws-blocks/hosting': patch
+---
+
+fix(astro): allow an empty `dist/client` for pure-SSR builds
+
+A server/hybrid Astro app with no static assets — no `public/` files and no
+prerendered pages — produces an empty `dist/client`. The adapter treated that as
+a missing build output and threw `AstroBuildOutputMissingError`, blocking synth
+and deploy. `dist/server/entry.mjs` is the real required artifact; an empty (or
+absent) `dist/client` is valid, since CloudFront routes every request to the SSR
+Lambda. The adapter now requires only the server entry and ensures `dist/client`
+exists (creating it when absent) instead of failing.

--- a/packages/hosting/src/adapters/astro.test.ts
+++ b/packages/hosting/src/adapters/astro.test.ts
@@ -15,6 +15,7 @@ import {
   installSharpForAstroSsr,
   patchAstroRemoteImageRedirects,
   ASTRO_REDIRECT_PATCH_MARKER,
+  ensureSsrBuildOutput,
 } from './astro.js';
 
 void describe('astroUsesSharpService — decide whether to ship sharp (issue #3)', () => {
@@ -206,5 +207,58 @@ export { loadRemoteImage };
     const { okStatus, badStatus } = (await fn()) as { okStatus: number; badStatus: number };
     assert.equal(okStatus, 200, 'allowed redirect (picsum→fastly) is followed to the 200');
     assert.equal(badStatus, 302, 'disallowed redirect (picsum→evil) is NOT followed; returns the 3xx for Astro to reject');
+  });
+});
+
+void describe('ensureSsrBuildOutput — empty dist/client is valid for pure SSR', () => {
+  let tmp: string;
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'astro-ssr-out-'));
+  });
+  afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  const scaffold = (opts: { entry: boolean; client: 'absent' | 'empty' | 'files' }) => {
+    const distDir = path.join(tmp, 'dist');
+    const serverDir = path.join(distDir, 'server');
+    const clientDir = path.join(distDir, 'client');
+    const serverEntry = path.join(serverDir, 'entry.mjs');
+    if (opts.entry) {
+      fs.mkdirSync(serverDir, { recursive: true });
+      fs.writeFileSync(serverEntry, 'export const handler = () => {};');
+    }
+    if (opts.client === 'empty') fs.mkdirSync(clientDir, { recursive: true });
+    if (opts.client === 'files') {
+      fs.mkdirSync(clientDir, { recursive: true });
+      fs.writeFileSync(path.join(clientDir, 'favicon.svg'), '<svg/>');
+    }
+    return { clientDir, serverDir, serverEntry };
+  };
+
+  it('does NOT throw when dist/client is empty (no static assets)', () => {
+    const { clientDir, serverDir, serverEntry } = scaffold({ entry: true, client: 'empty' });
+    assert.doesNotThrow(() => ensureSsrBuildOutput(clientDir, serverDir, serverEntry, 'server'));
+    assert.equal(fs.existsSync(clientDir), true);
+  });
+
+  it('creates dist/client when it is absent, without throwing', () => {
+    const { clientDir, serverDir, serverEntry } = scaffold({ entry: true, client: 'absent' });
+    assert.equal(fs.existsSync(clientDir), false);
+    assert.doesNotThrow(() => ensureSsrBuildOutput(clientDir, serverDir, serverEntry, 'server'));
+    assert.equal(fs.existsSync(clientDir), true);
+  });
+
+  it('does NOT throw when dist/client has static assets', () => {
+    const { clientDir, serverDir, serverEntry } = scaffold({ entry: true, client: 'files' });
+    assert.doesNotThrow(() => ensureSsrBuildOutput(clientDir, serverDir, serverEntry, 'server'));
+  });
+
+  it('throws AstroBuildOutputMissingError when the server entry is missing', () => {
+    const { clientDir, serverDir, serverEntry } = scaffold({ entry: false, client: 'empty' });
+    assert.throws(
+      () => ensureSsrBuildOutput(clientDir, serverDir, serverEntry, 'server'),
+      /AstroBuildOutputMissingError|build output is missing or empty/,
+    );
   });
 });

--- a/packages/hosting/src/adapters/astro.ts
+++ b/packages/hosting/src/adapters/astro.ts
@@ -186,12 +186,7 @@ export const astroAdapter = (options: AstroAdapterOptions): DeployManifest => {
       throw buildOutputMissingError(distDir, 'static');
     }
   } else {
-    if (!fs.existsSync(serverEntry)) {
-      throw buildOutputMissingError(serverDir, output);
-    }
-    if (!directoryHasFiles(clientDir)) {
-      throw buildOutputMissingError(clientDir, output);
-    }
+    ensureSsrBuildOutput(clientDir, serverDir, serverEntry, output);
   }
 
   const manifest: DeployManifest =
@@ -695,6 +690,33 @@ const liftAstroRedirects = (config: Record<string, unknown>): Redirect[] => {
 const directoryHasFiles = (dir: string): boolean => {
   if (!fs.existsSync(dir)) return false;
   return fs.readdirSync(dir).length > 0;
+};
+
+/**
+ * Validate a server/hybrid build output.
+ *
+ * `dist/server/entry.mjs` is the required artifact — its absence means the
+ * @astrojs/node standalone build didn't run (throws). An EMPTY `dist/client`,
+ * however, is valid: a pure-SSR app with no static assets (no `public/` files,
+ * no prerendered pages) produces one, and CloudFront simply routes every
+ * request to the SSR Lambda. So do NOT treat an empty client dir as missing —
+ * just ensure it exists (Astro normally creates it) so downstream asset
+ * handling (`staticAssets.directory`, prerender globbing) has a valid path.
+ *
+ * Exported for unit testing.
+ */
+export const ensureSsrBuildOutput = (
+  clientDir: string,
+  serverDir: string,
+  serverEntry: string,
+  output: AstroOutput,
+): void => {
+  if (!fs.existsSync(serverEntry)) {
+    throw buildOutputMissingError(serverDir, output);
+  }
+  if (!fs.existsSync(clientDir)) {
+    fs.mkdirSync(clientDir, { recursive: true });
+  }
 };
 
 const buildOutputMissingError = (


### PR DESCRIPTION
A server/hybrid Astro app with **no static assets** — no `public/` files and no prerendered pages — produces an **empty `dist/client`**. The astro adapter treated that as a missing build output and threw:

```
[AstroBuildOutputMissingError] Astro server build output is missing or empty at <projectDir>/dist/client.
```

which blocks synth/deploy for an otherwise-valid SSR app.

## Why it is wrong

For `output: 'server'` (or `'hybrid'`), the required artifact is `dist/server/entry.mjs`. `dist/client` only holds static assets (files under `public/`, prerendered pages, hashed client JS/CSS). A pure-SSR page with none of those legitimately yields an empty `dist/client`, and that is fine: CloudFront routes every request to the SSR Lambda, and the downstream manifest handling (`staticAssets.directory`, prerender globbing, error-page detection) all tolerate an empty/absent client dir.

## Fix

Extract the server/hybrid output validation into `ensureSsrBuildOutput`:

- require `dist/server/entry.mjs` (the real SSR artifact) — throw if missing;
- **ensure `dist/client` exists** (create it when absent) instead of throwing when it is empty.

The `static` output path is unchanged (an empty `dist/` there is still a real failure).

## Tests

Added unit tests for `ensureSsrBuildOutput` covering empty / absent / populated `dist/client` (no throw) and a missing server entry (still throws). Adapter tests: 14/14 pass.

## Repro

An Astro `output: 'server'` project whose only page is fully server-rendered (no `public/` dir) builds `dist/server/entry.mjs` + an empty `dist/client`, and previously failed synth with `AstroBuildOutputMissingError`; adding any file under `public/` was the only workaround. With this change it builds and deploys as-is.