### PR TITLE
docs(bb-dashboard): correct metrics source example

### DIFF
--- a/.changeset/tidy-dashboard-metrics-source.md
+++ b/.changeset/tidy-dashboard-metrics-source.md
@@ -1,0 +1,5 @@
+---
+'@aws-blocks/bb-dashboard': patch
+---
+
+docs(bb-dashboard): correct the metrics source example

--- a/packages/bb-dashboard/README.md
+++ b/packages/bb-dashboard/README.md
@@ -223,7 +223,7 @@ The Metrics BB resolves this internally from its options (explicit `namespace` o
 
 ```typescript
 const metrics = new Metrics(scope, 'metrics', { namespace: 'MyApp/Orders' });
-const dashboard = new Dashboard(scope, 'dashboard', { metrics });
+const dashboard = new Dashboard(scope, 'dashboard', { metrics: { metrics } });
 // Dashboard uses 'MyApp/Orders' as the CloudWatch namespace
 ```
 


### PR DESCRIPTION
## Problem

The `bb-dashboard` README's Namespace Resolution example passes a `Metrics` instance directly as `DashboardOptions.metrics`:

```ts
new Dashboard(scope, 'dashboard', { metrics });
```

The current public type requires a `MetricsSource` (`{ metrics, metricConfigs? }`), so this copied example does not type-check: the required `metrics` property of `MetricsSource` is missing.

**Issue #:** N/A

## Changes

- Wrap the example's `Metrics` instance in the documented `MetricsSource` shape: `metrics: { metrics }`.
- Add a patch changeset so the corrected published README is included in the next `@aws-blocks/bb-dashboard` release.

## Validation

- Verified the revised example against `DashboardOptions.metrics: MetricsSource | MetricsSource[]` and the required `MetricsSource.metrics` field.
- `npm run sync-docs:check`
- `npm run lint`
- `npm run lint:deps`
- `changeset status --since=origin/main`
- `git diff --check`

## Checklist

- [x] PR description included
- [ ] Tests are changed or added (not applicable: documentation-only correction)
- [x] Relevant documentation is changed or added (and PR referenced)

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._