### PR TITLE
feat(hosting): opt-in CloudFront standard logging v2

### DIFF
--- a/.changeset/hosting-standard-logging-v2.md
+++ b/.changeset/hosting-standard-logging-v2.md
@@ -1,0 +1,5 @@
+---
+"@aws-blocks/hosting": minor
+---
+
+Add opt-in CloudFront **standard logging v2** for hosting access logs. Set `logging.version: 'v2'` to deliver access logs through the CloudWatch Logs vended-logs delivery pipeline instead of legacy inline logging. v2 removes the log bucket's ACL requirement (`BUCKET_OWNER_ENFORCED` instead of `BUCKET_OWNER_PREFERRED`), delivers a partitioned S3 key layout (`logging.partitioning: 'date' | 'hive'`), and supports selectable record formats (`logging.format: 'w3c' | 'plain' | 'json' | 'parquet'`). The default remains `'v1'` (no behavior or billing change). Standard logging v2's delivery source must be created in us-east-1; synth throws `LoggingV2RegionError` in any other Region.

--- a/packages/hosting/README.md
+++ b/packages/hosting/README.md
@@ -345,6 +345,41 @@ new HostingConstruct(stack, 'Hosting', {
 });
 ```
 
+## Access logging
+
+CloudFront access logs are delivered to a dedicated, private S3 bucket. Two
+pipelines are supported via `logging.version`:
+
+| | `'v1'` (default) | `'v2'` |
+| --- | --- | --- |
+| Mechanism | Legacy standard logging (inline on the distribution) | Standard logging v2 (CloudWatch Logs vended-logs delivery) |
+| Log bucket ACLs | Required (`BUCKET_OWNER_PREFERRED`) | **None** (`BUCKET_OWNER_ENFORCED`) |
+| S3 key layout | Flat prefix | **Partitioned** — `date` or Hive-compatible (`logging.partitioning`) |
+| Record format | W3C tab-separated | `w3c` \| `plain` \| `json` \| `parquet` (`logging.format`) |
+| CloudFront charge | None (S3 storage only) | Per-GB vended-logs delivery charge |
+| Region constraint | Any | Delivery source must be **us-east-1** |
+
+`v1` stays the default (no billing change). Opt into `v2` for an ACL-free log
+bucket and a partitioned, query-ready layout with no post-processing Lambda:
+
+```ts
+new HostingConstruct(stack, 'Hosting', {
+  manifest,
+  logging: {
+    enabled: true,
+    version: 'v2',
+    partitioning: 'hive',   // or 'date' (default). Athena/Glue-friendly.
+    format: 'parquet',      // or 'w3c' (default), 'json', 'plain'
+    retentionDays: 90,
+  },
+});
+```
+
+> **Region:** because CloudFront is a global service, standard logging v2's
+> delivery source must be created in **us-east-1** (same constraint as ACM
+> certificates). Synth throws `LoggingV2RegionError` in any other Region — deploy
+> the hosting stack to us-east-1 or use `version: 'v1'`.
+
 ## Custom domains
 
 Configure a custom domain through the `domain` prop on `HostingConstruct`

--- a/packages/hosting/src/constructs/access_logging.test.ts
+++ b/packages/hosting/src/constructs/access_logging.test.ts
@@ -1,0 +1,209 @@
+import assert from 'node:assert';
+import { describe, it } from 'node:test';
+import { App, Stack } from 'aws-cdk-lib';
+import { Match, Template } from 'aws-cdk-lib/assertions';
+import { Bucket, ObjectOwnership } from 'aws-cdk-lib/aws-s3';
+import { CdnConstruct } from './cdn_construct.js';
+import { createSecurityHeadersPolicy } from './security_headers.js';
+import { StorageConstruct } from './storage_construct.js';
+import { HostingError } from '../hosting_error.js';
+import type { DeployManifest } from '../manifest/types.js';
+import { resolveSuffixPath } from './access_logging.js';
+
+const spaManifest: DeployManifest = {
+  version: 1,
+  compute: {},
+  staticAssets: { directory: '/tmp/assets' },
+  routes: [{ pattern: '/*', target: 'static' }],
+  buildId: 'test-log-1',
+};
+
+const envStack = (region = 'us-east-1', account = '123456789012'): Stack =>
+  new Stack(new App(), 'TestStack', { env: { account, region } });
+
+/** Build a CdnConstruct with a log bucket and the given logging options. */
+const cdnWithLogging = (
+  stack: Stack,
+  logging: {
+    accessLogVersion?: 'v1' | 'v2';
+    accessLogPartitioning?: 'date' | 'hive';
+    accessLogFormat?: 'plain' | 'w3c' | 'json' | 'parquet';
+  },
+): CdnConstruct => {
+  const bucket = new Bucket(stack, 'Bucket');
+  const logBucket = new Bucket(stack, 'LogBucket', {
+    objectOwnership:
+      logging.accessLogVersion === 'v2'
+        ? ObjectOwnership.BUCKET_OWNER_ENFORCED
+        : ObjectOwnership.BUCKET_OWNER_PREFERRED,
+  });
+  const policy = createSecurityHeadersPolicy(stack, 'SH', {});
+  return new CdnConstruct(stack, 'Cdn', {
+    bucket,
+    manifest: spaManifest,
+    securityHeadersPolicy: policy,
+    accessLogBucket: logBucket,
+    ...logging,
+  });
+};
+
+void describe('access logging', () => {
+  // ---- resolveSuffixPath ----
+
+  void describe('resolveSuffixPath', () => {
+    void it('date partitioning is non-hive and partitions by y/m/d/h', () => {
+      const { suffixPath, hiveCompatible } = resolveSuffixPath('date');
+      assert.equal(hiveCompatible, false);
+      assert.equal(suffixPath, '{DistributionId}/{yyyy}/{MM}/{dd}/{HH}');
+    });
+
+    void it('hive partitioning emits key=value segments', () => {
+      const { suffixPath, hiveCompatible } = resolveSuffixPath('hive');
+      assert.equal(hiveCompatible, true);
+      assert.match(suffixPath, /year=\{yyyy\}/);
+      assert.match(suffixPath, /month=\{MM\}/);
+    });
+  });
+
+  // ---- v1 (default) ----
+
+  void describe('v1 (default legacy logging)', () => {
+    void it('enables inline distribution logging and no delivery pipeline', () => {
+      const stack = envStack();
+      cdnWithLogging(stack, {});
+      const template = Template.fromStack(stack);
+
+      // Distribution carries the inline Logging config...
+      template.hasResourceProperties('AWS::CloudFront::Distribution', {
+        DistributionConfig: Match.objectLike({
+          Logging: Match.objectLike({ Bucket: Match.anyValue() }),
+        }),
+      });
+      // ...and no v2 delivery resources exist.
+      template.resourceCountIs('AWS::Logs::DeliverySource', 0);
+      template.resourceCountIs('AWS::Logs::DeliveryDestination', 0);
+      template.resourceCountIs('AWS::Logs::Delivery', 0);
+    });
+  });
+
+  // ---- v2 ----
+
+  void describe('v2 (standard logging v2)', () => {
+    void it('provisions the delivery pipeline and omits inline logging', () => {
+      const stack = envStack();
+      cdnWithLogging(stack, { accessLogVersion: 'v2' });
+      const template = Template.fromStack(stack);
+
+      // The distribution must NOT set inline Logging under v2.
+      const dist = Object.values(
+        template.findResources('AWS::CloudFront::Distribution'),
+      )[0] as { Properties: { DistributionConfig: { Logging?: unknown } } };
+      assert.equal(
+        dist.Properties.DistributionConfig.Logging,
+        undefined,
+        'v2 must not enable inline distribution logging',
+      );
+
+      // Delivery source is the distribution, typed as CloudFront access logs.
+      template.hasResourceProperties('AWS::Logs::DeliverySource', {
+        LogType: 'ACCESS_LOGS',
+        ResourceArn: Match.anyValue(),
+      });
+      // Delivery destination is the log bucket; default format is w3c.
+      template.hasResourceProperties('AWS::Logs::DeliveryDestination', {
+        OutputFormat: 'w3c',
+        DestinationResourceArn: Match.anyValue(),
+      });
+      // Delivery binds them with date partitioning by default.
+      template.hasResourceProperties('AWS::Logs::Delivery', {
+        S3SuffixPath: '{DistributionId}/{yyyy}/{MM}/{dd}/{HH}',
+        S3EnableHiveCompatiblePath: false,
+      });
+    });
+
+    void it('grants the delivery service principal write access to the bucket', () => {
+      const stack = envStack();
+      cdnWithLogging(stack, { accessLogVersion: 'v2' });
+      const template = Template.fromStack(stack);
+
+      template.hasResourceProperties('AWS::S3::BucketPolicy', {
+        PolicyDocument: Match.objectLike({
+          Statement: Match.arrayWith([
+            Match.objectLike({
+              Effect: 'Allow',
+              Principal: { Service: 'delivery.logs.amazonaws.com' },
+              Action: 's3:PutObject',
+            }),
+          ]),
+        }),
+      });
+    });
+
+    void it('honors partitioning and format options', () => {
+      const stack = envStack();
+      cdnWithLogging(stack, {
+        accessLogVersion: 'v2',
+        accessLogPartitioning: 'hive',
+        accessLogFormat: 'parquet',
+      });
+      const template = Template.fromStack(stack);
+
+      template.hasResourceProperties('AWS::Logs::DeliveryDestination', {
+        OutputFormat: 'parquet',
+      });
+      template.hasResourceProperties('AWS::Logs::Delivery', {
+        S3EnableHiveCompatiblePath: true,
+      });
+    });
+
+    void it('throws outside us-east-1 (delivery-source Region constraint)', () => {
+      const stack = envStack('eu-west-1');
+      assert.throws(
+        () => cdnWithLogging(stack, { accessLogVersion: 'v2' }),
+        (err: unknown) =>
+          err instanceof HostingError &&
+          err.name === 'LoggingV2RegionError',
+      );
+    });
+  });
+
+  // ---- storage bucket ownership ----
+
+  void describe('StorageConstruct access-log bucket ownership', () => {
+    // The access-log bucket is uniquely identified by its `ExpireAccessLogs`
+    // lifecycle rule (the primary hosting bucket also sets OwnershipControls,
+    // so we can't select on that alone).
+    const ownership = (version: 'v1' | 'v2'): string => {
+      const stack = envStack();
+      new StorageConstruct(stack, 'Storage', {
+        accessLogging: true,
+        accessLogVersion: version,
+      });
+      const template = Template.fromStack(stack);
+      type BucketProps = {
+        Properties: {
+          OwnershipControls?: { Rules: { ObjectOwnership: string }[] };
+          LifecycleConfiguration?: { Rules: { Id?: string }[] };
+        };
+      };
+      const logBucket = Object.values(
+        template.findResources('AWS::S3::Bucket'),
+      ).find((b) =>
+        (b as BucketProps).Properties.LifecycleConfiguration?.Rules.some(
+          (r) => r.Id === 'ExpireAccessLogs',
+        ),
+      ) as BucketProps | undefined;
+      assert.ok(logBucket, 'access-log bucket should exist');
+      assert.ok(logBucket.Properties.OwnershipControls);
+      return logBucket.Properties.OwnershipControls.Rules[0].ObjectOwnership;
+    };
+
+    void it('v1 keeps ACLs (BucketOwnerPreferred)', () => {
+      assert.equal(ownership('v1'), 'BucketOwnerPreferred');
+    });
+
+    void it('v2 disables ACLs (BucketOwnerEnforced)', () => {
+      assert.equal(ownership('v2'), 'BucketOwnerEnforced');
+    });
+  });
+});

--- a/packages/hosting/src/constructs/access_logging.ts
+++ b/packages/hosting/src/constructs/access_logging.ts
@@ -1,0 +1,178 @@
+import type { Construct } from 'constructs';
+import { Stack, Token } from 'aws-cdk-lib';
+import type { IBucket } from 'aws-cdk-lib/aws-s3';
+import {
+  CfnDelivery,
+  CfnDeliveryDestination,
+  CfnDeliverySource,
+} from 'aws-cdk-lib/aws-logs';
+import { Effect, PolicyStatement, ServicePrincipal } from 'aws-cdk-lib/aws-iam';
+import { HostingError } from '../hosting_error.js';
+
+/**
+ * CloudFront **standard logging v2** wiring (the CloudWatch Logs *vended-logs
+ * delivery* pipeline), as an alternative to the legacy v1 logging that the
+ * distribution enables via `enableLogging` / `logBucket`.
+ *
+ * v2 has three advantages over v1 for hosting access logs:
+ *
+ * 1. **No bucket ACLs.** v1 delivery writes through the `awslogsdelivery`
+ *    canonical user and therefore forces the log bucket to keep ACLs enabled
+ *    (`BUCKET_OWNER_PREFERRED`). v2 delivers through a service principal
+ *    (`delivery.logs.amazonaws.com`) authorized by a bucket *policy*, so the
+ *    log bucket can adopt the modern, ACL-disabled `BUCKET_OWNER_ENFORCED`
+ *    ownership — one fewer S3 Block-Public-Access exception to reason about.
+ * 2. **Configurable, partitioned S3 key layout.** The delivered object key is
+ *    templated (`s3SuffixPath`), so logs land under `{DistributionId}/{yyyy}/
+ *    {MM}/{dd}/{HH}/…` (or a Hive-compatible `year=…/month=…/` layout) with no
+ *    post-processing Lambda re-organizing a flat prefix after the fact.
+ * 3. **Selectable record format** (`w3c`, `plain`, `json`, `parquet`) — Athena
+ *    / Glue can query `parquet` or `json` directly.
+ *
+ * @remarks
+ * CloudFront is a global service whose access-log **delivery source** must be
+ * created in **us-east-1** (mirrors the ACM-certificate constraint the hosting
+ * construct already enforces). {@link wireStandardLoggingV2} validates this and
+ * throws {@link HostingError} `LoggingV2RegionError` unless
+ * `skipRegionValidation` is set (or the stack region is an unresolved token).
+ */
+
+/** Delivered log record formats supported by CloudFront standard logging v2. */
+export type AccessLogFormat = 'plain' | 'w3c' | 'json' | 'parquet';
+
+/** S3 key-layout strategy for delivered logs. */
+export type AccessLogPartitioning = 'date' | 'hive';
+
+/** CloudFront logs its access logs under this delivery `logType`. */
+const CLOUDFRONT_ACCESS_LOGS_TYPE = 'ACCESS_LOGS';
+
+/** The only Region in which a CloudFront delivery source may be created. */
+const CLOUDFRONT_DELIVERY_REGION = 'us-east-1';
+
+/**
+ * Resolve the `(s3SuffixPath, s3EnableHiveCompatiblePath)` pair for a
+ * partitioning strategy. Both strategies partition by day and hour so a
+ * downstream query engine can prune on date; `hive` additionally emits the
+ * `key=value` segment names Athena/Glue partition-projection expects.
+ *
+ * The `{DistributionId}` prefix keeps multiple distributions from colliding in
+ * a shared bucket; `{yyyy}/{MM}/{dd}/{HH}` are the CloudFront-supported
+ * delivery template variables.
+ */
+export const resolveSuffixPath = (
+  partitioning: AccessLogPartitioning,
+): { suffixPath: string; hiveCompatible: boolean } =>
+  partitioning === 'hive'
+    ? {
+        suffixPath:
+          '{DistributionId}/year={yyyy}/month={MM}/day={dd}/hour={HH}',
+        hiveCompatible: true,
+      }
+    : {
+        suffixPath: '{DistributionId}/{yyyy}/{MM}/{dd}/{HH}',
+        hiveCompatible: false,
+      };
+
+/** Options for {@link wireStandardLoggingV2}. */
+export type StandardLoggingV2Options = {
+  /** The CloudFront distribution ARN whose access logs are delivered. */
+  distributionArn: string;
+  /** The distribution id, used to name the delivery resources uniquely. */
+  distributionId: string;
+  /** The destination log bucket (must be `BUCKET_OWNER_ENFORCED`). */
+  logBucket: IBucket;
+  /** S3 key layout. @default 'date' */
+  partitioning?: AccessLogPartitioning;
+  /** Delivered record format. @default 'w3c' */
+  format?: AccessLogFormat;
+  /**
+   * Skip the us-east-1 region check. Only set this when you know the stack
+   * is (or will synth into) us-east-1 but the region is unavailable at synth.
+   * @default false
+   */
+  skipRegionValidation?: boolean;
+};
+
+/**
+ * Provision the standard-logging-v2 delivery pipeline for a CloudFront
+ * distribution: a `DeliverySource` (the distribution), a `DeliveryDestination`
+ * (the S3 bucket), the `Delivery` that binds them with the partitioned key
+ * layout, and the bucket policy that lets the delivery service write.
+ *
+ * @throws {@link HostingError} `LoggingV2RegionError` when the stack's Region is
+ * resolved and is not us-east-1 (unless `skipRegionValidation`).
+ */
+export const wireStandardLoggingV2 = (
+  scope: Construct,
+  options: StandardLoggingV2Options,
+): void => {
+  const {
+    distributionArn,
+    distributionId,
+    logBucket,
+    partitioning = 'date',
+    format = 'w3c',
+    skipRegionValidation = false,
+  } = options;
+
+  const stack = Stack.of(scope);
+
+  if (
+    !skipRegionValidation &&
+    !Token.isUnresolved(stack.region) &&
+    stack.region !== CLOUDFRONT_DELIVERY_REGION
+  ) {
+    throw new HostingError('LoggingV2RegionError', {
+      message: `CloudFront standard logging v2 requires the stack to be in ${CLOUDFRONT_DELIVERY_REGION} (the delivery source Region for the global CloudFront service), but this stack is in ${stack.region}.`,
+      resolution: `Deploy this hosting stack to ${CLOUDFRONT_DELIVERY_REGION}, use v1 logging (\`logging: { version: 'v1' }\`), or set \`skipRegionValidation\` if you know the deploy Region resolves to ${CLOUDFRONT_DELIVERY_REGION}.`,
+    });
+  }
+
+  // Authorize the vended-logs delivery service to write to the bucket. With
+  // BUCKET_OWNER_ENFORCED there are no ACLs, so authorization is entirely by
+  // this resource policy: the SourceAccount + SourceArn conditions scope the
+  // grant to THIS account's THIS distribution, preventing a confused-deputy
+  // write from any other account or distribution.
+  logBucket.addToResourcePolicy(
+    new PolicyStatement({
+      sid: 'AllowCloudFrontStandardLoggingV2',
+      effect: Effect.ALLOW,
+      principals: [new ServicePrincipal('delivery.logs.amazonaws.com')],
+      actions: ['s3:PutObject'],
+      resources: [logBucket.arnForObjects('*')],
+      conditions: {
+        StringEquals: { 'aws:SourceAccount': stack.account },
+        ArnLike: { 'aws:SourceArn': distributionArn },
+      },
+    }),
+  );
+
+  const source = new CfnDeliverySource(scope, 'AccessLogDeliverySource', {
+    name: `hosting-cf-${distributionId}`,
+    logType: CLOUDFRONT_ACCESS_LOGS_TYPE,
+    resourceArn: distributionArn,
+  });
+
+  const destination = new CfnDeliveryDestination(
+    scope,
+    'AccessLogDeliveryDestination',
+    {
+      name: `hosting-cf-s3-${distributionId}`,
+      destinationResourceArn: logBucket.bucketArn,
+      outputFormat: format,
+    },
+  );
+
+  const { suffixPath, hiveCompatible } = resolveSuffixPath(partitioning);
+  const delivery = new CfnDelivery(scope, 'AccessLogDelivery', {
+    deliverySourceName: source.name,
+    deliveryDestinationArn: destination.attrArn,
+    s3SuffixPath: suffixPath,
+    s3EnableHiveCompatiblePath: hiveCompatible,
+  });
+
+  // The Delivery references the source by NAME (not by ref), so CloudFormation
+  // does not infer the create-order dependency; make it explicit.
+  delivery.addDependency(source);
+  delivery.addDependency(destination);
+};

--- a/packages/hosting/src/constructs/cdn_construct.ts
+++ b/packages/hosting/src/constructs/cdn_construct.ts
@@ -4,21 +4,21 @@ import { CfnOutput, Duration, Fn, Stack } from 'aws-cdk-lib';
 import * as iam from 'aws-cdk-lib/aws-iam';
 import {
   AllowedMethods,
-  BehaviorOptions,
+  type BehaviorOptions,
   CacheCookieBehavior,
   CacheHeaderBehavior,
   CachePolicy,
   CacheQueryStringBehavior,
   Function as CloudFrontFunction,
   Distribution,
-  ErrorResponse,
+  type ErrorResponse,
   FunctionCode,
   FunctionEventType,
   FunctionRuntime,
   GeoRestriction,
   HttpVersion,
-  IOrigin,
-  IResponseHeadersPolicy,
+  type IOrigin,
+  type IResponseHeadersPolicy,
   KeyValueStore,
   LambdaEdgeEventType,
   OriginRequestCookieBehavior,
@@ -34,16 +34,16 @@ import {
   HttpOrigin,
   S3BucketOrigin,
 } from 'aws-cdk-lib/aws-cloudfront-origins';
-import { IBucket } from 'aws-cdk-lib/aws-s3';
+import type { IBucket } from 'aws-cdk-lib/aws-s3';
 import { BucketDeployment } from 'aws-cdk-lib/aws-s3-deployment';
 import {
   CfnPermission,
-  IFunction,
-  IFunctionUrl,
-  IVersion,
+  type IFunction,
+  type IFunctionUrl,
+  type IVersion,
 } from 'aws-cdk-lib/aws-lambda';
-import { ICertificate } from 'aws-cdk-lib/aws-certificatemanager';
-import { CfnWebACL } from 'aws-cdk-lib/aws-wafv2';
+import type { ICertificate } from 'aws-cdk-lib/aws-certificatemanager';
+import type { CfnWebACL } from 'aws-cdk-lib/aws-wafv2';
 import {
   EndpointType,
   LambdaIntegration,
@@ -52,9 +52,9 @@ import {
 } from 'aws-cdk-lib/aws-apigateway';
 import { HostingError } from '../hosting_error.js';
 import { prependBasePath } from '../adapters/shared/basepath.js';
-import { DeployManifest } from '../manifest/types.js';
+import type { DeployManifest } from '../manifest/types.js';
 import { ERROR_PAGE_KEY, NOT_FOUND_PAGE_KEY } from '../defaults.js';
-import { SkewProtectionConfig } from './skew_protection.js';
+import type { SkewProtectionConfig } from './skew_protection.js';
 import { QuotaBudget, type QuotaOverrides } from './quota_budget.js';
 import {
   ORIGIN_ID,
@@ -66,6 +66,11 @@ import {
   routeSpecificity,
 } from './kvs_router.js';
 import { KvKeys } from './kv_keys.js';
+import {
+  type AccessLogFormat,
+  type AccessLogPartitioning,
+  wireStandardLoggingV2,
+} from './access_logging.js';
 import {
   AwsCustomResource,
   AwsCustomResourcePolicy,
@@ -147,6 +152,23 @@ export type CdnConstructProps = {
   wwwRedirect?: 'toApex' | 'toWww' | 'none';
   /** S3 bucket for CloudFront access logging. */
   accessLogBucket?: IBucket;
+  /**
+   * CloudFront logging pipeline. `'v1'` (default) enables legacy standard
+   * logging inline on the distribution (`enableLogging`/`logBucket`); `'v2'`
+   * provisions the standard-logging-v2 delivery pipeline instead (see
+   * {@link wireStandardLoggingV2}). Only takes effect when
+   * {@link accessLogBucket} is set.
+   * @default 'v1'
+   */
+  accessLogVersion?: 'v1' | 'v2';
+  /** (v2 only) S3 key layout for delivered logs. @default 'date' */
+  accessLogPartitioning?: AccessLogPartitioning;
+  /** (v2 only) Delivered log record format. @default 'w3c' */
+  accessLogFormat?: AccessLogFormat;
+  /**
+   * (v2 only) Skip the us-east-1 delivery-source Region check. @default false
+   */
+  skipLoggingRegionValidation?: boolean;
   /** CloudFront price class. Default: PRICE_CLASS_100 (US, Canada, Europe). */
   priceClass?: PriceClass;
   /** Geo-restriction configuration. */
@@ -1135,7 +1157,10 @@ export class CdnConstruct extends Construct {
         : props.webAcl
           ? { webAclId: props.webAcl.attrArn }
           : {}),
-      ...(props.accessLogBucket
+      // v1 (legacy) logging is enabled inline on the distribution. v2 logging
+      // is provisioned separately via the delivery pipeline after the
+      // distribution exists (see below), so it must NOT set enableLogging here.
+      ...(props.accessLogBucket && props.accessLogVersion !== 'v2'
         ? { enableLogging: true, logBucket: props.accessLogBucket }
         : {}),
       ...(props.geoRestriction
@@ -1148,6 +1173,30 @@ export class CdnConstruct extends Construct {
         : {}),
       errorResponses: errorResponses.length > 0 ? errorResponses : undefined,
     });
+
+    // ---- Standard logging v2 (opt-in) ----
+    // v1 logging was enabled inline above. For v2, provision the CloudWatch
+    // Logs vended-logs delivery pipeline (DeliverySource → DeliveryDestination
+    // → Delivery + bucket policy) against the now-created distribution. The
+    // log bucket is provisioned with BUCKET_OWNER_ENFORCED by the storage
+    // construct when v2 is selected, so no ACLs are involved.
+    if (props.accessLogBucket && props.accessLogVersion === 'v2') {
+      const distributionArn = Stack.of(this).formatArn({
+        service: 'cloudfront',
+        region: '',
+        account,
+        resource: 'distribution',
+        resourceName: this.distribution.distributionId,
+      });
+      wireStandardLoggingV2(this, {
+        distributionArn,
+        distributionId: this.distribution.distributionId,
+        logBucket: props.accessLogBucket,
+        partitioning: props.accessLogPartitioning,
+        format: props.accessLogFormat,
+        skipRegionValidation: props.skipLoggingRegionValidation,
+      });
+    }
 
     // ---- OAC: S3 bucket policy ----
     // GetObject for serving assets, plus ListBucket so S3 returns a real

--- a/packages/hosting/src/constructs/hosting_construct.ts
+++ b/packages/hosting/src/constructs/hosting_construct.ts
@@ -49,6 +49,10 @@ import {
 } from '../secret-resolve.js';
 import type { HostingResources } from '../types.js';
 import { CdnConstruct } from './cdn_construct.js';
+import type {
+  AccessLogFormat,
+  AccessLogPartitioning,
+} from './access_logging.js';
 import { ComputeConstruct } from './compute_construct.js';
 import { DnsConstruct } from './dns_construct.js';
 import { MonitoringConstruct } from './monitoring_construct.js';
@@ -269,6 +273,17 @@ export type HostingConstructProps = {
   logging?: {
     enabled: boolean;
     retentionDays?: number;
+    /**
+     * CloudFront logging pipeline: `'v1'` (default, legacy standard logging) or
+     * `'v2'` (standard logging v2 via the CloudWatch Logs delivery pipeline —
+     * ACL-free bucket, partitioned S3 layout, selectable format). See the
+     * public `HostingProps.logging` docs for trade-offs. @default 'v1'
+     */
+    version?: 'v1' | 'v2';
+    /** (v2 only) S3 key layout for delivered logs. @default 'date' */
+    partitioning?: AccessLogPartitioning;
+    /** (v2 only) Delivered log record format. @default 'w3c' */
+    format?: AccessLogFormat;
   };
   /**
    * Custom environment variables for all compute functions. A value may be:
@@ -462,6 +477,7 @@ export class HostingConstruct extends Construct {
     const storage = new StorageConstruct(this, 'Storage', {
       retainOnDelete: props.storage?.retainOnDelete,
       accessLogging: props.logging?.enabled ?? true,
+      accessLogVersion: props.logging?.version,
       encryption: props.storage?.encryption,
       encryptionKey: props.storage?.encryptionKey,
       buildRetentionDays: props.storage?.buildRetentionDays,
@@ -1111,6 +1127,10 @@ export class HostingConstruct extends Construct {
       domainName: resolvedDomainNames.length > 0 ? resolvedDomainNames : undefined,
       wwwRedirect: props.domain?.wwwRedirect,
       accessLogBucket: storage.accessLogBucket,
+      accessLogVersion: props.logging?.version,
+      accessLogPartitioning: props.logging?.partitioning,
+      accessLogFormat: props.logging?.format,
+      skipLoggingRegionValidation: props.skipRegionValidation,
       priceClass: props.cdn?.priceClass,
       geoRestriction: props.cdn?.geoRestriction,
       skewProtection: props.skewProtection ?? { enabled: true },

--- a/packages/hosting/src/constructs/storage_construct.ts
+++ b/packages/hosting/src/constructs/storage_construct.ts
@@ -8,7 +8,7 @@ import {
   InventoryFrequency,
   ObjectOwnership,
 } from 'aws-cdk-lib/aws-s3';
-import { IKey } from 'aws-cdk-lib/aws-kms';
+import type { IKey } from 'aws-cdk-lib/aws-kms';
 import { BUILD_STATE_TAG_KEY, BUILD_STATE_SUPERSEDED } from './build_tags.js';
 
 // ---- Constants ----
@@ -46,6 +46,16 @@ export type StorageConstructProps = {
   retainOnDelete?: boolean;
   /** Enable CloudFront access logging to a dedicated S3 bucket. Default: false. */
   accessLogging?: boolean;
+  /**
+   * Which CloudFront logging pipeline the access log bucket must support.
+   * Determines bucket object ownership:
+   * - `'v1'` (default) → `BUCKET_OWNER_PREFERRED` (ACLs on) — legacy logging
+   *   delivers via the `awslogsdelivery` canonical user and needs ACLs.
+   * - `'v2'` → `BUCKET_OWNER_ENFORCED` (ACLs off) — standard logging v2
+   *   delivers via a service principal authorized by a bucket policy (wired
+   *   by the CDN construct), so no ACLs are required.
+   */
+  accessLogVersion?: 'v1' | 'v2';
   /** Encryption type for the hosting bucket. Default: S3_MANAGED. */
   encryption?: 'S3_MANAGED' | 'KMS';
   /** BYO KMS key for bucket encryption (requires encryption: 'KMS'). */
@@ -197,15 +207,24 @@ export class StorageConstruct extends Construct {
       const logRetentionDays =
         props.logRetentionDays ?? DEFAULT_ACCESS_LOG_RETENTION_DAYS;
 
-      // CloudFront standard logging requires ACL-based writes via the
-      // awslogsdelivery canonical user. BUCKET_OWNER_ENFORCED disables ACLs
-      // entirely, which would silently prevent log delivery. The hosting
-      // bucket uses BUCKET_OWNER_ENFORCED (modern default) but the access
-      // log bucket must use BUCKET_OWNER_PREFERRED to support CloudFront logging.
+      // Bucket ownership depends on the logging pipeline:
+      //
+      // - v1 (legacy CloudFront standard logging) writes through the
+      //   awslogsdelivery canonical user and requires ACLs, so the bucket must
+      //   use BUCKET_OWNER_PREFERRED — BUCKET_OWNER_ENFORCED disables ACLs
+      //   entirely and would silently prevent log delivery.
+      // - v2 (standard logging v2) delivers via the delivery.logs.amazonaws.com
+      //   service principal authorized by a bucket policy (added in the CDN
+      //   construct), needs no ACLs, and therefore uses the modern, more
+      //   secure BUCKET_OWNER_ENFORCED — matching the hosting bucket.
+      const logObjectOwnership =
+        props.accessLogVersion === 'v2'
+          ? ObjectOwnership.BUCKET_OWNER_ENFORCED
+          : ObjectOwnership.BUCKET_OWNER_PREFERRED;
       this.accessLogBucket = new Bucket(this, 'AccessLogBucket', {
         blockPublicAccess: BlockPublicAccess.BLOCK_ALL,
         encryption: BucketEncryption.S3_MANAGED,
-        objectOwnership: ObjectOwnership.BUCKET_OWNER_PREFERRED,
+        objectOwnership: logObjectOwnership,
         enforceSSL: true,
         removalPolicy: RemovalPolicy.DESTROY,
         autoDeleteObjects: true,

--- a/packages/hosting/src/types.ts
+++ b/packages/hosting/src/types.ts
@@ -338,6 +338,52 @@ export type HostingProps = {
     enabled: boolean;
     /** Days to retain access logs. Default: 90. */
     retentionDays?: number;
+    /**
+     * CloudFront logging pipeline to use.
+     *
+     * - `'v1'` (**default**) — legacy CloudFront standard logging. The
+     *   distribution writes logs directly to S3 through the `awslogsdelivery`
+     *   canonical user, so the log bucket must keep ACLs enabled
+     *   (`BUCKET_OWNER_PREFERRED`). No CloudFront charge; you pay only S3
+     *   storage.
+     * - `'v2'` — CloudFront **standard logging v2** via the CloudWatch Logs
+     *   vended-logs delivery pipeline. Delivers through the
+     *   `delivery.logs.amazonaws.com` service principal (authorized by a bucket
+     *   policy), so the log bucket uses the modern, ACL-disabled
+     *   `BUCKET_OWNER_ENFORCED`. Adds a **partitioned S3 key layout** (see
+     *   {@link logging.partitioning}) and a **selectable record format** (see
+     *   {@link logging.format}) with no post-processing Lambda.
+     *
+     * @remarks
+     * v2 delivery bills through CloudWatch vended-logs delivery (per-GB), and
+     * the delivery source for the global CloudFront service must be created in
+     * **us-east-1** — synth throws `LoggingV2RegionError` in any other Region.
+     * Default stays `'v1'` to preserve existing (free, ACL-based) behavior;
+     * opt in explicitly.
+     *
+     * @default 'v1'
+     */
+    version?: 'v1' | 'v2';
+    /**
+     * (v2 only) S3 key layout for delivered logs.
+     *
+     * - `'date'` (default) — `{DistributionId}/{yyyy}/{MM}/{dd}/{HH}/…`.
+     * - `'hive'` — Hive-compatible `year=…/month=…/day=…/hour=…` segments so
+     *   Athena/Glue partition projection works without a crawler.
+     *
+     * Ignored when `version` is `'v1'`.
+     *
+     * @default 'date'
+     */
+    partitioning?: 'date' | 'hive';
+    /**
+     * (v2 only) Delivered log record format: `'w3c'` (legacy-compatible
+     * tab-separated), `'plain'`, `'json'`, or `'parquet'` (columnar, queryable
+     * directly by Athena). Ignored when `version` is `'v1'`.
+     *
+     * @default 'w3c'
+     */
+    format?: 'plain' | 'w3c' | 'json' | 'parquet';
   };
 
   /**


### PR DESCRIPTION
## Summary

Adds **opt-in CloudFront standard logging v2** to the `Hosting` block. Set `logging.version: 'v2'` to deliver access logs through the CloudWatch Logs *vended-logs delivery* pipeline instead of legacy inline logging.

The default stays `'v1'` — **no behavior or billing change** for existing users. Flipping the default is intentionally left as a separate maintainer decision (v2 adds a per-GB delivery charge), which is why this ships as a draft for discussion.

### Why v2 (benefits over v1)
- **No log-bucket ACLs.** v1 delivers via the `awslogsdelivery` canonical user and forces `BUCKET_OWNER_PREFERRED`. v2 delivers via the `delivery.logs.amazonaws.com` service principal authorized by a bucket *policy*, so the log bucket adopts the modern, ACL-disabled `BUCKET_OWNER_ENFORCED`.
- **Partitioned S3 key layout** at delivery time (`logging.partitioning: 'date' | 'hive'`) — no post-processing Lambda to reorganize a flat prefix.
- **Selectable record format** (`logging.format: 'w3c' | 'plain' | 'json' | 'parquet'`) — Athena/Glue can query parquet/json directly.

### Usage
```ts
new HostingConstruct(stack, 'Hosting', {
  manifest,
  logging: { enabled: true, version: 'v2', partitioning: 'hive', format: 'parquet' },
});
```

## What's in the diff
- `access_logging.ts` — new: `wireStandardLoggingV2()` (DeliverySource → DeliveryDestination → Delivery + bucket policy) and `resolveSuffixPath()`; us-east-1 validation.
- `cdn_construct.ts` — gate inline v1 logging to `version !== 'v2'`; wire v2 after the distribution is created.
- `storage_construct.ts` — access-log bucket uses `BUCKET_OWNER_ENFORCED` under v2, `BUCKET_OWNER_PREFERRED` under v1.
- `hosting_construct.ts` / `types.ts` — thread `version` / `partitioning` / `format` through the public `logging` config.
- `access_logging.test.ts` — 9 unit tests (delivery resources, bucket policy, partitioning/format, region guard, bucket ownership).
- README + changeset (minor).

> Some pre-existing `import type` lint violations in `cdn_construct.ts` / `storage_construct.ts` were auto-fixed because CI lints changed files whole. Mechanical only.

### Known constraint / open question
CloudFront standard logging v2's **delivery source must be created in us-east-1** (global-service quirk, same as ACM certs). Synth throws `LoggingV2RegionError` elsewhere. Cross-region support (via a us-east-1 support stack) is a possible follow-up — flagging for maintainer input.

## Verification
- `npm run build`, hosting unit tests (868 pass, +9 new), CI-style `npm run lint` (no errors) all pass.
- Not yet validated on a live sandbox deploy — will do before marking ready.

---

## Related asks in this investigation (not code in this PR)

**Private VPC origins (re #286):** #286 adds VPC placement for Blocks *compute/data* + VPC endpoints — that's a different feature from the CloudFront **VPC origins** capability (CF reaching a private ALB/EC2). The hosting CDN routes to S3 (OAC) and Lambda Function URLs, neither of which is a private in-VPC origin, so #286 does **not** change the recommendation to skip CloudFront VPC origins for hosting today. It does lay VPC plumbing that a future private-ALB compute origin could build on.

**Signed URLs / signed cookies — importance:** Medium, and a genuine gap. There's no built-in way to serve gated/private assets (paid downloads, per-user files) — access is currently public-via-OAC or app-gated. Worth prioritizing only if private asset delivery is on the roadmap (e.g. a `FileBucket`-backed download that must be restricted); otherwise lower than this logging work.
